### PR TITLE
Add support for passing a resolver function when declaring a field

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,15 @@
+Release Type: minor
+
+Added support for passing resolver functions
+
+```python
+def resolver(root, info, par: str) -> str:
+    return f"hello {par}"
+
+@strawberry.type
+class Query:
+    example: str = strawberry.field(resolver=resolver)
+```
+
+Also we updated some of the dependencies of the project
+

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -141,7 +141,10 @@ class strawberry_field(dataclasses.Field):
             init=False,
             repr=True,
             hash=None,
-            compare=True,
+            # TODO: this needs to be False when init is False
+            # we could turn it to True when and if we have a default
+            # probably can't be True when passing a resolver
+            compare=False,
             metadata=metadata,
         )
 

--- a/strawberry/type.py
+++ b/strawberry/type.py
@@ -21,14 +21,20 @@ def _get_resolver(cls, field_name):
     def _resolver(obj, info):
         # TODO: can we make this nicer?
         # does it work in all the cases?
+        instance = cls(**(obj.__dict__ if obj else {}))
 
-        field_resolver = getattr(cls(**(obj.__dict__ if obj else {})), field_name)
+        field_resolver = getattr(instance, field_name)
 
         if getattr(field_resolver, IS_STRAWBERRY_FIELD, False):
             return field_resolver(obj, info)
 
         elif field_resolver.__class__ is strawberry_field:
-            # TODO: support default values
+            resolver = getattr(field_resolver, "resolver", None)
+
+            if resolver:
+                return resolver(instance, info)
+
+            # TODO: support default values (@strawberry.field(default='123'))
             return None
 
         return field_resolver

--- a/strawberry/type.py
+++ b/strawberry/type.py
@@ -1,68 +1,34 @@
-import typing
 from functools import partial
 
-from dataclasses import dataclass
-from graphql import (
-    GraphQLField,
-    GraphQLInputField,
-    GraphQLInputObjectType,
-    GraphQLInterfaceType,
-    GraphQLObjectType,
-)
+import dataclasses
+from graphql import GraphQLInputObjectType, GraphQLInterfaceType, GraphQLObjectType
 from graphql.utilities.schema_printer import print_type
 
 from .constants import IS_STRAWBERRY_FIELD, IS_STRAWBERRY_INPUT, IS_STRAWBERRY_INTERFACE
-from .field import strawberry_field
-from .type_converter import REGISTRY, get_graphql_type_for_annotation
+from .field import field, strawberry_field
+from .type_converter import REGISTRY
 from .utils.str_converters import to_camel_case
 
 
 def _get_resolver(cls, field_name):
-    def _resolver(obj, info):
-        # TODO: can we make this nicer?
-        # does it work in all the cases?
-        instance = cls(**(obj.__dict__ if obj else {}))
+    class_field = getattr(cls, field_name, None)
 
-        field_resolver = getattr(instance, field_name)
+    if class_field and getattr(class_field, "resolver", None):
+        return class_field.resolver
+
+    def _resolver(root, info):
+        field_resolver = getattr(cls(**(root.__dict__ if root else {})), field_name)
 
         if getattr(field_resolver, IS_STRAWBERRY_FIELD, False):
-            return field_resolver(obj, info)
+            return field_resolver(root, info)
 
         elif field_resolver.__class__ is strawberry_field:
-            resolver = getattr(field_resolver, "resolver", None)
-
-            if resolver:
-                return resolver(instance, info)
-
-            # TODO: support default values (@strawberry.field(default='123'))
+            # TODO: support default values
             return None
 
         return field_resolver
 
     return _resolver
-
-
-def _convert_annotations_fields(cls, *, is_input=False):
-    FieldClass = GraphQLInputField if is_input else GraphQLField
-    annotations = typing.get_type_hints(cls, None, REGISTRY)
-
-    fields = {}
-
-    for key, annotation in annotations.items():
-        class_field = getattr(cls, key, None)
-
-        description = getattr(class_field, "description", None)
-        name = getattr(class_field, "name", None)
-
-        field_name = name or to_camel_case(key)
-
-        fields[field_name] = FieldClass(
-            get_graphql_type_for_annotation(annotation, key),
-            description=description,
-            **({} if is_input else {"resolve": _get_resolver(cls, key)})
-        )
-
-    return fields
 
 
 def _process_type(cls, *, is_input=False, is_interface=False, description=None):
@@ -74,8 +40,22 @@ def _process_type(cls, *, is_input=False, is_interface=False, description=None):
 
     setattr(cls, "__repr__", repr_)
 
-    def _get_fields():
-        fields = _convert_annotations_fields(cls, is_input=is_input)
+    def _get_fields(wrapped):
+        class_fields = dataclasses.fields(wrapped)
+
+        fields = {}
+
+        for class_field in class_fields:
+            f = getattr(cls, class_field.name, None)
+            field_name = getattr(f, "name", None) or to_camel_case(class_field.name)
+            description = getattr(f, "description", None)
+
+            resolver = _get_resolver(cls, class_field.name)
+            resolver.__annotations__["return"] = class_field.type
+
+            fields[field_name] = field(
+                resolver, is_input=is_input, description=description
+            ).field
 
         strawberry_fields = {
             key: value
@@ -110,9 +90,10 @@ def _process_type(cls, *, is_input=False, is_interface=False, description=None):
             if hasattr(klass, IS_STRAWBERRY_INTERFACE)
         ]
 
-    cls.field = TypeClass(name, lambda: _get_fields(), **extra_kwargs)
+    wrapped = dataclasses.dataclass(cls, repr=False)
+    wrapped.field = TypeClass(name, lambda: _get_fields(wrapped), **extra_kwargs)
 
-    return dataclass(cls, repr=False)
+    return wrapped
 
 
 def type(cls=None, *, is_input=False, is_interface=False, description=None):

--- a/tests/test_declaring_types.py
+++ b/tests/test_declaring_types.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import textwrap
 from typing import Optional
 
@@ -34,7 +32,7 @@ def test_simple_required_types():
 def test_recursive_type():
     @strawberry.type
     class MyType:
-        s: MyType
+        s: "MyType"
 
     expected_representation = """
     type MyType {

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -11,7 +11,7 @@ from strawberry.exceptions import (
 def test_field_as_function():
     field: str = strawberry.field()
 
-    assert field.description is None
+    assert field.field_description is None
 
 
 def test_field_arguments():

--- a/tests/test_forward_references.py
+++ b/tests/test_forward_references.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+import strawberry
+
+
+# Need to investigate this more, see: https://bugs.python.org/issue34776
+
+
+@pytest.mark.xfail(strict=True, reason="Future style annotation are currently broken")
+def test_forward_reference():
+    @strawberry.type
+    class MyType:
+        id: strawberry.ID
+
+    expected_representation = """
+    type MyType {
+      id: ID!
+    }
+    """
+
+    assert repr(MyType("a")) == textwrap.dedent(expected_representation).strip()

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -52,24 +52,34 @@ async def test_resolver_function():
     def resolve_name(root, info) -> str:
         return root.name
 
+    def resolve_say_hello(root, info, name: str) -> str:
+        return f"Hello {name}"
+
     @strawberry.type
     class Query:
         hello: str = strawberry.field(resolver=function_resolver)
         hello_async: str = strawberry.field(resolver=async_resolver)
         get_name: str = strawberry.field(resolver=resolve_name)
+        say_hello: str = strawberry.field(resolver=resolve_say_hello)
 
         name = "Patrick"
 
     schema = strawberry.Schema(query=Query)
 
-    query = "{ hello, helloAsync, getName }"
+    query = """{
+        hello
+        helloAsync
+        getName
+        sayHello(name: "Marco")
+    }"""
 
-    result = await graphql(schema, query)
+    result = await graphql(schema, query, root_value=Query())
 
     assert not result.errors
     assert result.data["hello"] == "I'm a function resolver"
     assert result.data["helloAsync"] == "I'm an async resolver"
     assert result.data["getName"] == "Patrick"
+    assert result.data["sayHello"] == "Hello Marco"
 
 
 def test_nested_types():


### PR DESCRIPTION
TODO: 

- [x] Check if it has correct annotations (return and arguments)
- [x] Support for arguments (now they are ignored)