### PR TITLE
Fix autodeployer

### DIFF
--- a/scripts/base.py
+++ b/scripts/base.py
@@ -69,9 +69,7 @@ def get_release_info():
             sys.exit(1)
 
         type_ = match.group(1)
-        # duplicate .strip() :/ use PEP 572 when python 3.8 is out?
-        # (https://www.python.org/dev/peps/pep-0572/)
-        changelog = [l.strip() for l in f.readlines() if l.strip()]
+        changelog = "".join([l for l in f.readlines()]).strip()
 
     return type_, changelog
 

--- a/scripts/create_github_release.py
+++ b/scripts/create_github_release.py
@@ -46,6 +46,6 @@ if __name__ == "__main__":
         version,
         publish=True,
         name=f"{PROJECT_NAME} {version}",
-        body="\n".join(changelog),
+        body=changelog,
         asset_pattern="dist/*",
     )

--- a/scripts/prepare_release.py
+++ b/scripts/prepare_release.py
@@ -49,7 +49,7 @@ if __name__ == "__main__":
         f.write(f"\n{new_version_header}\n")
         f.write(f"{'-' * len(new_version_header)}\n\n")
 
-        f.write("\n".join(release_changelog))
+        f.write(release_changelog)
         f.write("\n")
 
         f.write("".join(old_changelog_data))

--- a/scripts/publish_changes.py
+++ b/scripts/publish_changes.py
@@ -20,7 +20,7 @@ if __name__ == "__main__":
 
     git(["add", PROJECT_TOML_FILE_NAME])
     git(["add", CHANGELOG_FILE_NAME])
-    git(["rm", RELEASE_FILE_NAME])
+    git(["rm", "--cached", RELEASE_FILE_NAME])
 
     git(["commit", "-m", f"Release 🍓 {version}"])
     git(["push", "origin", "HEAD"])


### PR DESCRIPTION
Fixes:

- [x] Other steps cannot read the RELEASE file because it gets deleted by `publish_changes`. I changed the commands to use `rm --cached` so it gets removed only on Git and other steps can still read it if needed
- [x] Fix indentation gets broken in markdown