### PR TITLE
Use absolute url for logo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="./.github/logo.png" width="124" height="150">
+<img src="https://github.com/strawberry-graphql/strawberry/raw/master/.github/logo.png" width="124" height="150">
 
 # Strawberry GraphQL
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Fixed logo on PyPI


### PR DESCRIPTION
This should fix the broken image on PyPI