### PR TITLE
Fix issue that prevented using InitVar as field type

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,19 @@
+Release type: minor
+
+Fixed issue that was prevent usage of InitVars.
+Now you can safely use InitVar to prevent fields from showing up in the schema:
+
+
+```python
+@strawberry.type
+class Category:
+    name: str
+    id: InitVar[str]
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def category(self, info) -> Category:
+        return Category(name="example", id="123")
+```
+

--- a/strawberry/type.py
+++ b/strawberry/type.py
@@ -17,9 +17,7 @@ def _get_resolver(cls, field_name):
         return class_field.resolver
 
     def _resolver(root, info):
-        field_resolver = getattr(
-            cls(**(root.__dict__ if root else {})), field_name, None
-        )
+        field_resolver = getattr(root or cls(), field_name, None)
 
         if getattr(field_resolver, IS_STRAWBERRY_FIELD, False):
             return field_resolver(root, info)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -4,6 +4,7 @@ from enum import Enum
 import pytest
 
 import strawberry
+from dataclasses import InitVar
 from graphql import graphql, graphql_sync
 
 
@@ -20,6 +21,28 @@ def test_simple_type():
 
     assert not result.errors
     assert result.data["hello"] == "strawberry"
+
+
+def test_init_var():
+    @strawberry.type
+    class Category:
+        name: str
+        id: InitVar[str]
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def category(self, info) -> Category:
+            return Category(name="example", id="123")  # type:ignore
+
+    schema = strawberry.Schema(query=Query)
+
+    query = "{ category { name } }"
+
+    result = graphql_sync(schema, query)
+
+    assert not result.errors
+    assert result.data["category"]["name"] == "example"
 
 
 def test_resolver():


### PR DESCRIPTION
This now works fine: 

```python
@strawberry.type
class Category:
    name: str
    id: InitVar[str]

@strawberry.type
class Query:
    @strawberry.field
    def category(self, info) -> Category:
        return Category(name="example", id="123")
```