### PR TITLE
Add support for optional arguments when a default value is provided

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,18 @@
+Release type: minor
+
+Added support for optional fields with default arguments in the GraphQL schema when default arguments are passed to the resolver.
+
+Example:
+ ```python
+@strawberry.type
+class Query:
+    @strawberry.field
+    def hello(self, info, name: str = "world") -> str:
+        return name
+```
+
+```graphql
+type Query {
+    hello(name: String = "world"): String
+}
+```

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -202,6 +202,7 @@ def _get_field(
     name = wrap.__name__
 
     annotations = typing.get_type_hints(wrap, None, REGISTRY)
+    default_argument_start_index = len(annotations) - len(wrap.__defaults__) - 1
     field_type = get_graphql_type_for_annotation(annotations["return"], name)
 
     arguments_annotations = {
@@ -211,8 +212,10 @@ def _get_field(
     }
 
     arguments = {
-        to_camel_case(name): get_graphql_type_for_annotation(annotation, name)
-        for name, annotation in arguments_annotations.items()
+        to_camel_case(name): get_graphql_type_for_annotation(
+            arguments_annotations[name], name, index >= default_argument_start_index
+        )
+        for index, name in enumerate(arguments_annotations.keys())
     }
 
     def resolver(source, info, **args):

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -1,7 +1,12 @@
 import pytest
 
 import strawberry
-from graphql import GraphQLField, GraphQLNonNull, GraphQLScalarType
+from graphql import (
+    GraphQLField,
+    GraphQLInputObjectType,
+    GraphQLNonNull,
+    GraphQLScalarType,
+)
 from strawberry.exceptions import (
     MissingArgumentsAnnotationsError,
     MissingReturnAnnotationError,
@@ -45,6 +50,30 @@ def test_field_default_arguments_are_optional():
 
     assert type(hello.field.args["asdf"].type) == GraphQLScalarType
     assert hello.field.args["asdf"].type.name == "String"
+
+
+def test_field_default_optional_argument_custom_type():
+    @strawberry.input
+    class CustomInputType:
+        field: str
+
+    @strawberry.field
+    def hello(
+        self, info, required: CustomInputType, optional: CustomInputType = None
+    ) -> str:
+        return "I'm a resolver"
+
+    assert hello.field
+
+    assert type(hello.field) == GraphQLField
+    assert type(hello.field.type) == GraphQLNonNull
+    assert hello.field.type.of_type.name == "String"
+
+    assert type(hello.field.args["required"].type) == GraphQLNonNull
+    assert hello.field.args["required"].type.of_type.name == "CustomInputType"
+
+    assert type(hello.field.args["optional"].type) == GraphQLInputObjectType
+    assert hello.field.args["optional"].type.name == "CustomInputType"
 
 
 def test_raises_error_when_return_annotation_missing():

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -1,7 +1,7 @@
 import pytest
 
 import strawberry
-from graphql import GraphQLField, GraphQLNonNull
+from graphql import GraphQLField, GraphQLNonNull, GraphQLScalarType
 from strawberry.exceptions import (
     MissingArgumentsAnnotationsError,
     MissingReturnAnnotationError,
@@ -27,6 +27,24 @@ def test_field_arguments():
 
     assert type(hello.field.args["id"].type) == GraphQLNonNull
     assert hello.field.args["id"].type.of_type.name == "Int"
+
+
+def test_field_default_arguments_are_optional():
+    @strawberry.field
+    def hello(self, info, test: int, id: int = 1, asdf: str = "hello") -> str:
+        return "I'm a resolver"
+
+    assert hello.field
+
+    assert type(hello.field) == GraphQLField
+    assert type(hello.field.type) == GraphQLNonNull
+    assert hello.field.type.of_type.name == "String"
+
+    assert type(hello.field.args["id"].type) == GraphQLScalarType
+    assert hello.field.args["id"].type.name == "Int"
+
+    assert type(hello.field.args["asdf"].type) == GraphQLScalarType
+    assert hello.field.args["asdf"].type.name == "String"
 
 
 def test_raises_error_when_return_annotation_missing():


### PR DESCRIPTION
This PR adds support for marking an argument as optional when a default value is provided, resolving #9.

A couple of comments on this approach:
1) It relies on the return value of `typing.get_type_hints(...)` maintaining the order of the arguments when iterated through. I haven't been able to find this behavior documented, but it seems to be the case in the testing I've done. 
2) It makes use of the `force_optional` argument in `get_graphql_type_for_annotation`. I noticed some comments mentioning that `force_optional` might have some edge cases that would lead to unwanted behavior. Is there a better way to mark a field as optional?