### PR TITLE
Pass query type as root value

### DIFF
--- a/strawberry/contrib/starlette/app/graphql_app.py
+++ b/strawberry/contrib/starlette/app/graphql_app.py
@@ -99,4 +99,5 @@ class GraphQLApp(BaseApp):
             variable_values=variables,
             operation_name=operation_name,
             context_value=context,
+            root_value=self.schema.query_type
         )


### PR DESCRIPTION
In current, the type of Query can not use instance method in resolver cause the `self` always be `None`.

```python
import strawberry


@strawberry.type
class User:
    name: str
    age: int


@strawberry.type
class Query:
    @strawberry.field
    def user(self, info) -> User:
        # raise exception here
        return self.get_user()

    def get_user(self):
        return User(name="Patrick", age=100)


schema = strawberry.Schema(query=Query)
```

Pass Query type as root value may solve this problem I think.