### PR TITLE
Fix input field not created correctly with strawberry.field

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,9 @@
+Release type: patch
+
+Fix field initialization not allowed when using `strawberry.field` in an `input` type
+
+```python
+@strawberry.input
+class Say:
+    what = strawberry.field(is_input=True)
+```

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -161,13 +161,13 @@ class strawberry_field(dataclasses.Field):
             # TODO:
             default=dataclasses.MISSING,
             default_factory=dataclasses.MISSING,
-            init=False,
+            init=is_input,
             repr=True,
             hash=None,
             # TODO: this needs to be False when init is False
             # we could turn it to True when and if we have a default
             # probably can't be True when passing a resolver
-            compare=False,
+            compare=is_input,
             metadata=metadata,
         )
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -191,6 +191,7 @@ def test_mutation_with_input_type():
     @strawberry.input
     class SayInput:
         name: str
+        age: int = strawberry.field(is_input=True)
 
     @strawberry.type
     class Query:
@@ -200,16 +201,16 @@ def test_mutation_with_input_type():
     class Mutation:
         @strawberry.mutation
         def say(self, info, input: SayInput) -> str:
-            return f"Hello {input.name}!"
+            return f"Hello {input.name} of {input.age} years old!"
 
     schema = strawberry.Schema(query=Query, mutation=Mutation)
 
-    query = 'mutation { say(input: { name: "Patrick"}) }'
+    query = 'mutation { say(input: { name: "Patrick", age: 10 }) }'
 
     result = graphql_sync(schema, query)
 
     assert not result.errors
-    assert result.data["say"] == "Hello Patrick!"
+    assert result.data["say"] == "Hello Patrick of 10 years old!"
 
 
 def test_does_camel_case_conversion():


### PR DESCRIPTION
When an input field is defined using `strawberry.field` the dataclass field is initialised using `init=False` making it impossible for the library to create a new instance of the dataclass with the value marked with `strawberry.field`.

This PR changes the field init using the `is_input` parameter.

It would be nice to infer from `strawberry.input` if a field is part of an input or not
