### PR TITLE
Fix conversion of Enum types in resolvers, arguments, and input types

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Fixes the conversion of Enums in resolvers, arguments and input types.

--- a/strawberry/utils/dict_to_type.py
+++ b/strawberry/utils/dict_to_type.py
@@ -1,3 +1,5 @@
+import enum
+
 from dataclasses import is_dataclass
 
 from .str_converters import to_camel_case
@@ -20,5 +22,10 @@ def dict_to_type(dict, cls):
             kwargs[name] = dict_to_type(dict.get(dict_name, {}), field.type)
         else:
             kwargs[name] = dict.get(dict_name)
+
+            # Convert Enum fields to instances using the value. This is safe
+            # because graphql-core has already validated the input.
+            if isinstance(field.type, enum.EnumMeta) and kwargs[name]:
+                kwargs[name] = field.type(kwargs[name])
 
     return cls(**kwargs)

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -132,7 +132,6 @@ def test_raises_error_when_using_enum_with_a_not_enum_class():
     assert ("strawberry.enum can only be used with subclasses of Enum",) == e.value.args
 
 
-@pytest.mark.xfail(strict=True)
 def test_enum_resolver():
     @strawberry.enum
     class IceCreamFlavour(Enum):
@@ -179,7 +178,6 @@ def test_enum_resolver():
     assert result.data["cone"]["flavour"] == "STRAWBERRY"
 
 
-@pytest.mark.xfail(strict=True)
 def test_enum_arguments():
     @strawberry.enum
     class IceCreamFlavour(Enum):

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -3,7 +3,7 @@ from enum import Enum
 import pytest
 
 import strawberry
-from graphql import GraphQLEnumType, GraphQLEnumValue
+from graphql import GraphQLEnumType, GraphQLEnumValue, graphql_sync
 from strawberry.exceptions import NotAnEnum
 
 
@@ -130,3 +130,110 @@ def test_raises_error_when_using_enum_with_a_not_enum_class():
             hello = "world"
 
     assert ("strawberry.enum can only be used with subclasses of Enum",) == e.value.args
+
+
+@pytest.mark.xfail(strict=True)
+def test_enum_resolver():
+    @strawberry.enum
+    class IceCreamFlavour(Enum):
+        VANILLA = "vanilla"
+        STRAWBERRY = "strawberry"
+        CHOCOLATE = "chocolate"
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def best_flavour(self, info) -> IceCreamFlavour:
+            return IceCreamFlavour.STRAWBERRY
+
+    assert Query().best_flavour(None) == IceCreamFlavour.STRAWBERRY
+
+    schema = strawberry.Schema(query=Query)
+
+    query = "{ bestFlavour }"
+
+    result = graphql_sync(schema, query)
+
+    assert not result.errors
+    assert result.data["bestFlavour"] == "STRAWBERRY"
+
+    @strawberry.type
+    class Cone:
+        flavour: IceCreamFlavour
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def cone(self, info) -> Cone:
+            return Cone(flavour=IceCreamFlavour.STRAWBERRY)
+
+    assert Query().cone(None).flavour == IceCreamFlavour.STRAWBERRY
+
+    schema = strawberry.Schema(query=Query)
+
+    query = "{ cone { flavour } }"
+
+    result = graphql_sync(schema, query)
+
+    assert not result.errors
+    assert result.data["cone"]["flavour"] == "STRAWBERRY"
+
+
+@pytest.mark.xfail(strict=True)
+def test_enum_arguments():
+    @strawberry.enum
+    class IceCreamFlavour(Enum):
+        VANILLA = "vanilla"
+        STRAWBERRY = "strawberry"
+        CHOCOLATE = "chocolate"
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def flavour_available(self, info, flavour: IceCreamFlavour) -> bool:
+            return flavour == IceCreamFlavour.STRAWBERRY
+
+    @strawberry.input
+    class ConeInput:
+        flavour: IceCreamFlavour
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        def eat_cone(self, info, input: ConeInput) -> bool:
+            return input.flavour == IceCreamFlavour.STRAWBERRY
+
+    assert Query().flavour_available(None, IceCreamFlavour.VANILLA) is False
+    assert Query().flavour_available(None, IceCreamFlavour.STRAWBERRY) is True
+
+    input_bad = ConeInput(flavour=IceCreamFlavour.VANILLA)
+    input_good = ConeInput(flavour=IceCreamFlavour.STRAWBERRY)
+
+    assert Mutation().eat_cone(None, input_bad) is False
+    assert Mutation().eat_cone(None, input_good) is True
+
+    schema = strawberry.Schema(query=Query, mutation=Mutation)
+
+    query = "{ flavourAvailable(flavour: VANILLA) }"
+    result = graphql_sync(schema, query)
+
+    assert not result.errors
+    assert result.data["flavourAvailable"] is False
+
+    query = "{ flavourAvailable(flavour: STRAWBERRY) }"
+    result = graphql_sync(schema, query)
+
+    assert not result.errors
+    assert result.data["flavourAvailable"] is True
+
+    query = "mutation { eatCone(input: { flavour: VANILLA }) }"
+    result = graphql_sync(schema, query)
+
+    assert not result.errors
+    assert result.data["eatCone"] is False
+
+    query = "mutation { eatCone(input: { flavour: STRAWBERRY }) }"
+    result = graphql_sync(schema, query)
+
+    assert not result.errors
+    assert result.data["eatCone"] is True


### PR DESCRIPTION
Currently, a field that is an Enum type will fail to resolve properly with an error inside `graphql-core`:

```python
>>> @strawberry.enum
... class IceCreamFlavour(enum.Enum):
...     VANILLA = "vanilla"
...     STRAWBERRY = "strawberry"
...     CHOCOLATE = "chocolate"
...
>>> @strawberry.type
... class Query:
...     flavour: IceCreamFlavour
...
>>> schema = strawberry.Schema(query=Query)
>>> await graphql(schema, '{ flavour }', root_value=Query(flavour=IceCreamFlavour.STRAWBERRY))
ExecutionResult(data=None, errors=[GraphQLError("Expected a value of type 'IceCreamFlavour' but received: <IceCreamFlavour instance>", locations=[SourceLocation(line=1, column=3)], path=['flavour'])])
```

This is because the resolver is expecting to see an Enum value (in this case, `"strawberry"`) rather than an instance of the Enum itself. A similar thing happens in arguments and input types as well. Enum handling has been a big pain point for me in Graphene, and I think Strawberry has an opportunity to get it right since it has better typing information available.

This PR adds some test cases showing the failures and implements the conversion. I haven't tested `Optional[Enum]` annotations yet for arguments and input types, which may still face a similar issue. The code path handling those conversions is separate, and doesn't seem to properly handle `List`s either yet. (I feel that `convert_args` and `dict_to_type` should be combined into one).