### PR TITLE
Check if we have a GitHub token before sending comments

### DIFF
--- a/.github/release-check-action/check.py
+++ b/.github/release-check-action/check.py
@@ -7,7 +7,7 @@ from comment_templates import (
     MISSING_RELEASE_FILE,
     RELEASE_FILE_ADDED,
 )
-from config import GITHUB_EVENT_PATH, GITHUB_WORKSPACE, RELEASE_FILE_PATH
+from config import GITHUB_EVENT_PATH, GITHUB_TOKEN, GITHUB_WORKSPACE, RELEASE_FILE_PATH
 from github import add_or_edit_comment, update_labels
 from release import InvalidReleaseFileError, get_release_info
 
@@ -35,8 +35,11 @@ else:
         exit_code = 2
         comment = INVALID_RELEASE_FILE
 
-
-add_or_edit_comment(event_data, comment)
-update_labels(event_data, release_info)
+if GITHUB_TOKEN != "":
+    add_or_edit_comment(event_data, comment)
+    update_labels(event_data, release_info)
+else:
+    print("No GitHub token set, skipping sending a comment")
+    print(comment)
 
 sys.exit(exit_code)

--- a/.github/release-check-action/check.py
+++ b/.github/release-check-action/check.py
@@ -16,6 +16,12 @@ with open(GITHUB_EVENT_PATH) as f:
     event_data = json.load(f)
 
 
+sender = event_data["sender"]["login"]
+
+if sender in ["dependabot-preview", "dependabot"]:
+    print("Skipping dependencies PRs for now.")
+    sys.exit(0)
+
 release_file = pathlib.Path(GITHUB_WORKSPACE) / RELEASE_FILE_PATH
 
 exit_code = 0

--- a/.github/release-check-action/github.py
+++ b/.github/release-check-action/github.py
@@ -87,8 +87,6 @@ def update_labels(github_event_data: dict, release_info: typing.Optional[Release
     ]
     labels_to_remove.update(release_labels_to_remove)
 
-    print("current_labels", current_labels, "labels_to_remove", labels_to_remove)
-
     if not current_labels.issuperset(labels_to_add):
         request = httpx.post(
             labels_url,


### PR DESCRIPTION
This is more a workaround GitHub not allowing secrets in PRs, hopefully we can enable commenting again soon :)

Also skips the check if the PR is coming from dependabot