### PR TITLE
Fix conversion of enums when value is falsy

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Fixed conversion of enum when value was falsy.

--- a/strawberry/utils/dict_to_type.py
+++ b/strawberry/utils/dict_to_type.py
@@ -31,7 +31,7 @@ def dict_to_type(dict, cls):
 
             # Convert Enum fields to instances using the value. This is safe
             # because graphql-core has already validated the input.
-            if isinstance(annotation, enum.EnumMeta) and kwargs[name]:
+            if isinstance(annotation, enum.EnumMeta) and kwargs[name] is not None:
                 kwargs[name] = annotation(kwargs[name])
 
     return cls(**kwargs)

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -1,3 +1,4 @@
+import typing
 from enum import Enum
 
 import pytest
@@ -235,3 +236,35 @@ def test_enum_arguments():
 
     assert not result.errors
     assert result.data["eatCone"] is True
+
+
+def test_enum_falsy_values():
+    @strawberry.enum
+    class IceCreamFlavour(Enum):
+        VANILLA = ""
+        STRAWBERRY = 0
+
+    @strawberry.input
+    class Input:
+        flavour: IceCreamFlavour
+        optionalFlavour: typing.Optional[IceCreamFlavour]
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def print_flavour(self, info, input: Input) -> str:
+            return f"{input.flavour.value}"
+
+    schema = strawberry.Schema(query=Query)
+
+    query = "{ printFlavour(input: { flavour: VANILLA }) }"
+    result = graphql_sync(schema, query)
+
+    assert not result.errors
+    assert result.data["printFlavour"] == ""
+
+    query = "{ printFlavour(input: { flavour: STRAWBERRY }) }"
+    result = graphql_sync(schema, query)
+
+    assert not result.errors
+    assert result.data["printFlavour"] == "0"


### PR DESCRIPTION
Just found out this small bug :)

There's an edge case that might be worth checking more in depth, don't know if this is something that's common, but if we use None as a value of one of the enums, the check that we have breaks. I guess we can leave like it is and maybe add a check in future that disallows None as a value. What do you think @sciyoshi?

```
@strawberry.enum
class IceCreamFlavour(Enum):
    VANILLA = ""
    STRAWBERRY = 0
    EXAMPLE = None
```
