### PR TITLE
Don't try to convert optional arguments to dataclasses

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Fixed issue when trying to convert optional arguments to a type

--- a/strawberry/utils/dict_to_type.py
+++ b/strawberry/utils/dict_to_type.py
@@ -25,7 +25,11 @@ def dict_to_type(dict, cls):
             annotation = get_optional_annotation(annotation)
 
         if is_dataclass(annotation):
-            kwargs[name] = dict_to_type(dict.get(dict_name, {}), annotation)
+            value = dict.get(dict_name)
+
+            kwargs[name] = (
+                dict_to_type(value, annotation) if value is not None else None
+            )
         else:
             kwargs[name] = dict.get(dict_name)
 

--- a/tests/test_arguments_converter.py
+++ b/tests/test_arguments_converter.py
@@ -136,3 +136,19 @@ def test_nested_input_types():
             release_info=ReleaseInfo(change_type=ChangeType.MAJOR, changelog="example"),
         )
     }
+
+    args = {
+        "input": {
+            "prNumber": 12,
+            "status": ReleaseFileStatus.OK.value,
+            "releaseInfo": None,
+        }
+    }
+
+    annotations = {"input": AddReleaseFileCommentInput}
+
+    assert convert_args(args, annotations) == {
+        "input": AddReleaseFileCommentInput(
+            pr_number=12, status=ReleaseFileStatus.OK, release_info=None
+        )
+    }


### PR DESCRIPTION
This fixes an issue when trying to convert optional arguments to a type, we were always defaulting the value of the dataclass to a dict, but this wasn't ideal when the argument was optional.
