### PR TITLE
Fix permission_classes typo in the CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,7 +203,7 @@ class IsAdmin(BasePermission):
 
 @strawberry.type
 class Query:
-    @strawberry.field(permisson_classes=[IsAdmin])
+    @strawberry.field(permission_classes=[IsAdmin])
     def hello(self, info) -> str:
       return "Hello"
 ```


### PR DESCRIPTION
I wanted to use the field_permissions so I was looking at the release notes as it's sort-of the only of documentation we have for now and found a typo.

I already fixed the typo in the releases of github