### PR TITLE
type: add is_type_of for GraphlQLObjectType

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -11,5 +11,5 @@ known_pytest=pytest
 known_future_library=future
 known_standard_library=types,requests
 default_section=THIRDPARTY
-known_third_party = base,click,config,github_release,graphql,httpx,hupper,mypy,pygments,release,starlette,uvicorn
+known_third_party = base,click,config,dataclasses,github_release,graphql,httpx,hupper,mypy,pygments,release,starlette,uvicorn
 sections=FUTURE,STDLIB,PYTEST,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Minimal support for registering types without fields and abstract interface querying.

--- a/strawberry/schema.py
+++ b/strawberry/schema.py
@@ -7,13 +7,16 @@ from graphql.utilities.schema_printer import print_schema
 
 
 class Schema(GraphQLSchema):
-    def __init__(self, query, mutation=None, subscription=None, directives=()):
+    def __init__(
+        self, query, mutation=None, subscription=None, directives=(), types=()
+    ):
         super().__init__(
             query=query.field,
             mutation=mutation.field if mutation else None,
             subscription=subscription.field if subscription else None,
             directives=specified_directives
             + [directive.directive for directive in directives],
+            types=[type.field for type in types],
         )
 
     def __repr__(self):

--- a/strawberry/schema.py
+++ b/strawberry/schema.py
@@ -10,6 +10,18 @@ class Schema(GraphQLSchema):
     def __init__(
         self, query, mutation=None, subscription=None, directives=(), types=()
     ):
+        """
+        Wrapper around the GraphQLSchema, but compatible
+        with Strawberry types and directives.
+
+        :param query: the root query to use for the schema
+        :param mutation: the basic mutation type (if any)
+        :param mutation: the subscription type (if any)
+        :param directives: (additional) Strawberry directives
+        :param types: additional Strawberry types to register, return values of fields
+                      are automatically registered while return types for interfaces have
+                      to be manually registered
+        """
         super().__init__(
             query=query.field,
             mutation=mutation.field if mutation else None,

--- a/strawberry/type.py
+++ b/strawberry/type.py
@@ -79,6 +79,8 @@ def _process_type(cls, *, is_input=False, is_interface=False, description=None):
 
     extra_kwargs = {"description": description or cls.__doc__}
 
+    wrapped = dataclasses.dataclass(cls)
+
     if is_input:
         TypeClass = GraphQLInputObjectType
     elif is_interface:
@@ -92,7 +94,10 @@ def _process_type(cls, *, is_input=False, is_interface=False, description=None):
             if hasattr(klass, IS_STRAWBERRY_INTERFACE)
         ]
 
-    wrapped = dataclasses.dataclass(cls)
+        # the user might want to register other classes,
+        # but for now let's just add our dataclass
+        extra_kwargs["is_type_of"] = lambda obj, _: isinstance(obj, wrapped)
+
     wrapped.field = TypeClass(name, lambda: _get_fields(wrapped), **extra_kwargs)
 
     return wrapped

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -459,3 +459,48 @@ def test_can_declare_directives():
     '''
 
     assert repr(schema) == textwrap.dedent(expected_schema).lstrip()
+
+
+def test_query_interface():
+    """Test that a query on an interface correctly detects instances of the dataclasses
+       as one of the inherited types, given that types are registered in addition to the
+       root type (since there is no field for them)"""
+
+    @strawberry.interface
+    class Cheese:
+        name: str
+
+    @strawberry.type
+    class Swiss(Cheese):
+        canton: str
+
+    @strawberry.type
+    class Italian(Cheese):
+        province: str
+
+    @strawberry.type
+    class Root:
+        @strawberry.field
+        def assortment(self, info) -> typing.List[Cheese]:
+            return [
+                Italian(name="Asiago", province="Friuli"),
+                Swiss(name="Tomme", canton="Vaud"),
+            ]
+
+    schema = strawberry.Schema(query=Root, types=[Swiss, Italian])
+
+    query = """{
+        assortment {
+            name
+            ... on Italian { province }
+            ... on Swiss { canton }
+        }
+    }"""
+
+    result = graphql_sync(schema, query)
+
+    assert not result.errors
+    assert result.data["assortment"] == [
+        {"name": "Asiago", "province": "Friuli"},
+        {"canton": "Vaud", "name": "Tomme"},
+    ]


### PR DESCRIPTION
fixes #190

## Description

Currently when returning types for an interface I get the error

```
Abstract type NodeIface must resolve to an Object type at runtime for field Root.nodes with value <Node instance>, received 'None'. Either the NodeIface type should provide a \"resolve_type\" function or each possible type should provide an \"is_type_of\" function.
```

this change adds a `is_type_of` for all `GraphQLObjectType` to return `True` when given the wrapped dataclass and forwards the `types` argument for the `GraphQLSchema`.

I don't know atm how to write a test for this :(

## Types of Changes

- [ ] Core
- [x] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #190

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).