### PR TITLE
Implement `resolve_type` on interfaces

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+Set `is_type_of` only when the type implements an interface,
+this allows to return different (but compatibile) types in simple cases.


### PR DESCRIPTION
Implement `resolve_type` on interfaces

When specifying `is_type_of` we aren't able to return a type
other than the field one, this prevents for example to return
a django model instead of the strawberry type.

So now instead of implementing `is_type_of` on every type that
implements an interface we only implement `resolve_type` on the
interface itself.

See: https://github.com/pythonitalia/pycon/pull/1216#issuecomment-548923736



## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).