### PR TITLE
Remove support for async resolvers in django view

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -11,5 +11,5 @@ known_pytest=pytest
 known_future_library=future
 known_standard_library=types,requests
 default_section=THIRDPARTY
-known_third_party = aniso8601,asgiref,base,click,config,github_release,graphql,httpx,hupper,mypy,pygments,release,starlette,uvicorn
+known_third_party = aniso8601,base,click,config,github_release,graphql,httpx,hupper,mypy,pygments,release,starlette,uvicorn
 sections=FUTURE,STDLIB,PYTEST,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+This releases removes support for async resolver in django
+as they causes issues when accessing the databases.

--- a/strawberry/django/views.py
+++ b/strawberry/django/views.py
@@ -7,8 +7,7 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
 
-from asgiref.sync import async_to_sync
-from graphql import graphql
+from graphql import graphql_sync
 from graphql.error import format_error as format_graphql_error
 from graphql.type.schema import GraphQLSchema
 
@@ -50,7 +49,7 @@ class GraphQLView(View):
 
         context = {"request": request}
 
-        result = async_to_sync(graphql)(
+        result = graphql_sync(
             self.schema,
             query,
             variable_values=variables,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,2 @@
+def pytest_emoji_xfailed(config):
+    return "🤷‍♂️ ", "XFAIL 🤷‍♂️ "

--- a/tests/django/app/models.py
+++ b/tests/django/app/models.py
@@ -1,0 +1,5 @@
+from django.db import models
+
+
+class Example(models.Model):
+    name = models.CharField(max_length=100)

--- a/tests/django/django_settings.py
+++ b/tests/django/django_settings.py
@@ -10,6 +10,4 @@ TEMPLATES = [
     }
 ]
 
-DATABASES = {
-    "default": {"ENGINE": "django.db.backends.sqlite3", "NAME": "tests/django.sqlite"}
-}
+DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}}


### PR DESCRIPTION
🤷‍♂️ I didn't realise the database doesn't work in a normal async_to_sync wrapper, so for now we'll remove support for async resolvers in django.