### PR TITLE
Update permissions to receive source and args

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,33 @@
+Release type: minor
+
+This release improves support for permissions (it is a breaking change).
+Now you will receive the source and the arguments in the `has_permission` method,
+so you can run more complex permission checks. It also allows to use permissions 
+on simple fields, here's an example:
+ 
+
+```python
+import strawberry
+
+from strawberry.permission import BasePermission
+
+class IsAdmin(BasePermission):
+    message = "You are not authorized"
+
+    def has_permission(self, source, info):
+      return source.name.lower() == "Patrick" or _is_admin(info)
+
+
+@strawberry.type
+class User:
+    name: str
+    email: str = strawberry.field(permission_classes=[IsAdmin])
+
+
+@strawberry.type
+class Query:
+    @strawberry.field(permission_classes=[IsAdmin])
+    def user(self, info) -> str:
+      return User(name="Patrick", email="example@email.com")
+```
+

--- a/strawberry/django/views.py
+++ b/strawberry/django/views.py
@@ -24,6 +24,9 @@ class GraphQLView(View):
 
         self.schema = schema
 
+    def get_root_value(self):
+        return None
+
     @method_decorator(csrf_exempt)
     def dispatch(self, request, *args, **kwargs):
         if request.method.lower() not in ("get", "post"):
@@ -52,6 +55,7 @@ class GraphQLView(View):
         result = graphql_sync(
             self.schema,
             query,
+            root_value=self.get_root_value(),
             variable_values=variables,
             context_value=context,
             operation_name=operation_name,

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -156,7 +156,7 @@ class strawberry_field(dataclasses.Field):
             # TODO:
             default=dataclasses.MISSING,
             default_factory=dataclasses.MISSING,
-            init=is_input,
+            init=resolver is None,
             repr=True,
             hash=None,
             # TODO: this needs to be False when init is False

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -89,13 +89,13 @@ class LazyFieldWrapper:
         """
         return (permission() for permission in self.permission_classes)
 
-    def _check_permissions(self, info):
+    def _check_permissions(self, source, info, **kwargs):
         """
         Checks if the permission should be accepted and
         raises an exception if not
         """
         for permission in self._get_permissions():
-            if not permission.has_permission(info):
+            if not permission.has_permission(source, info, **kwargs):
                 message = getattr(permission, "message", None)
                 raise PermissionError(message)
 
@@ -210,11 +210,12 @@ def _get_field(
         for name, annotation in arguments_annotations.items()
     }
 
-    def resolver(source, info, **args):
+    def resolver(source, info, **kwargs):
         if check_permission:
-            check_permission(info)
-        args = convert_args(args, arguments_annotations)
-        result = wrap(source, info, **args)
+            check_permission(source, info, **kwargs)
+
+        kwargs = convert_args(kwargs, arguments_annotations)
+        result = wrap(source, info, **kwargs)
 
         # graphql-core expects a resolver for an Enum type to return
         # the enum's *value* (not its name or an instance of the enum).
@@ -232,7 +233,8 @@ def _get_field(
 
             def _resolve(event, info):
                 if check_permission:
-                    check_permission(info)
+                    check_permission(event, info)
+
                 return event
 
             field_params.update({"subscribe": resolver, "resolve": _resolve})

--- a/strawberry/permission.py
+++ b/strawberry/permission.py
@@ -3,7 +3,7 @@ class BasePermission:
     Base class for creating permissions
     """
 
-    def has_permission(self, info):
+    def has_permission(self, source, info, **kwargs):
         raise NotImplementedError(
             "Permission classes should override has_permission method"
         )

--- a/strawberry/type.py
+++ b/strawberry/type.py
@@ -49,14 +49,17 @@ def _process_type(cls, *, is_input=False, is_interface=False, description=None):
                 class_field.name
             )
             description = getattr(class_field, "field_description", None)
-
+            permission_classes = getattr(class_field, "field_permission_classes", None)
             resolver = getattr(class_field, "field_resolver", None) or _get_resolver(
                 cls, class_field.name
             )
             resolver.__annotations__["return"] = class_field.type
 
             fields[field_name] = field(
-                resolver, is_input=is_input, description=description
+                resolver,
+                is_input=is_input,
+                description=description,
+                permission_classes=permission_classes,
             ).field
 
         strawberry_fields = {}

--- a/strawberry/type.py
+++ b/strawberry/type.py
@@ -21,7 +21,10 @@ def _get_resolver(cls, field_name):
         return class_field.resolver
 
     def _resolver(root, info):
-        field_resolver = getattr(root or cls(), field_name, None)
+        if not root:
+            return None
+
+        field_resolver = getattr(root, field_name, None)
 
         if getattr(field_resolver, IS_STRAWBERRY_FIELD, False):
             return field_resolver(root, info)

--- a/tests/asgi/conftest.py
+++ b/tests/asgi/conftest.py
@@ -13,7 +13,7 @@ from strawberry.permission import BasePermission
 class AlwaysFailPermission(BasePermission):
     message = "You are not authorized"
 
-    def has_permission(self, info):
+    def has_permission(self, source, info):
         return False
 
 

--- a/tests/django/test_views.py
+++ b/tests/django/test_views.py
@@ -6,7 +6,7 @@ import pytest
 from django.test.client import RequestFactory
 
 import strawberry
-from strawberry.django.views import GraphQLView
+from strawberry.django.views import GraphQLView as BaseGraphQLView
 from strawberry.permission import BasePermission
 
 from .app.models import Example
@@ -41,6 +41,11 @@ class Query:
 
 
 schema = strawberry.Schema(query=Query)
+
+
+class GraphQLView(BaseGraphQLView):
+    def get_root_value(self):
+        return Query()
 
 
 def test_playground_view():

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -24,8 +24,14 @@ async def test_handles_async_resolvers():
 @pytest.mark.asyncio
 async def test_runs_directives():
     @strawberry.type
-    class Query:
+    class Person:
         name: str = "Jess"
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def person(self, info) -> Person:
+            return Person()
 
     @strawberry.directive(
         locations=[DirectiveLocation.FIELD], description="Make string uppercase"
@@ -40,12 +46,16 @@ async def test_runs_directives():
     schema = strawberry.Schema(query=Query, directives=[uppercase, replace])
 
     query = """{
-        name @uppercase
-        jess: name @replace(old: "Jess", new: "Jessica")
+        person {
+            name @uppercase
+        }
+        jess: person {
+            name @replace(old: "Jess", new: "Jessica")
+        }
     }"""
 
     result = await execute(schema, query)
 
     assert not result.errors
-    assert result.data["name"] == "JESS"
-    assert result.data["jess"] == "Jessica"
+    assert result.data["person"]["name"] == "JESS"
+    assert result.data["jess"]["name"] == "Jessica"

--- a/tests/test_permission.py
+++ b/tests/test_permission.py
@@ -156,7 +156,7 @@ def test_can_use_on_simple_fields():
     @strawberry.type
     class User:
         name: str
-        email: str = strawberry.field(permission_classes=[CanSeeEmail], is_input=True)
+        email: str = strawberry.field(permission_classes=[CanSeeEmail])
 
     @strawberry.type
     class Query:

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -28,7 +28,7 @@ def test_union_as_field():
         }
     }"""
 
-    result = graphql_sync(schema, query)
+    result = graphql_sync(schema, query, root_value=Query())
 
     assert not result.errors
     assert result.data["ab"] == {"__typename": "A", "a": 5}
@@ -58,7 +58,7 @@ def test_cannot_use_non_strawberry_fields_for_the_union():
         }
     }"""
 
-    result = graphql_sync(schema, query)
+    result = graphql_sync(schema, query, root_value=Query())
 
     assert (
         result.errors[0].message


### PR DESCRIPTION
This PR adds source and arguments in `has_permission`. It also fixes a bug where you had to use `is_input` when declaring field with `a: str = strawberry.field()` :)