### PR TITLE
Fix typo in Schema's docstring :cat:

### DIFF
--- a/strawberry/schema.py
+++ b/strawberry/schema.py
@@ -16,7 +16,7 @@ class Schema(GraphQLSchema):
 
         :param query: the root query to use for the schema
         :param mutation: the basic mutation type (if any)
-        :param mutation: the subscription type (if any)
+        :param subscription: the subscription type (if any)
         :param directives: (additional) Strawberry directives
         :param types: additional Strawberry types to register, return values of fields
                       are automatically registered while return types for interfaces have


### PR DESCRIPTION
# Description 
While looking over the codebase, I've found small typo in docstring.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).