### PR TITLE
Add support for generic types

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,20 @@
+Release type: minor
+
+This release adds support for generic types, allowing
+to reuse types easily, here's an example:
+
+```python
+T = typing.TypeVar("T")
+
+@strawberry.type
+class Edge(typing.Generic[T]):
+    cursor: strawberry.ID
+    node: T
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def int_edge(self, info, **kwargs) -> Edge[int]:
+        return Edge(cursor=strawberry.ID("1"), node=1)
+```
+

--- a/strawberry/exceptions.py
+++ b/strawberry/exceptions.py
@@ -72,6 +72,18 @@ class UnallowedReturnTypeForUnion(Exception):
         super().__init__(message)
 
 
+class MissingTypesForGenericError(Exception):
+    """Raised when a generic types was used without passing any type."""
+
+    def __init__(self, field_name: str, annotation):
+        message = (
+            f'The type "{annotation}" of the field "{field_name}" '
+            f"is generic, but no type has been passed"
+        )
+
+        super().__init__(message)
+
+
 class UnsupportedTypeError(Exception):
     def __init__(self, annotation):
         message = f"{annotation} conversion is not supported"

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -1,8 +1,8 @@
+import dataclasses
 import enum
 import inspect
 import typing
 
-import dataclasses
 from graphql import GraphQLField, GraphQLInputField
 
 from .constants import IS_STRAWBERRY_FIELD

--- a/strawberry/type.py
+++ b/strawberry/type.py
@@ -1,5 +1,4 @@
 import dataclasses
-import typing
 from functools import partial
 
 from graphql import GraphQLInputObjectType, GraphQLInterfaceType, GraphQLObjectType
@@ -8,6 +7,7 @@ from .constants import IS_STRAWBERRY_FIELD, IS_STRAWBERRY_INPUT, IS_STRAWBERRY_I
 from .field import field, strawberry_field
 from .type_converter import REGISTRY
 from .utils.str_converters import to_camel_case
+from .utils.typing import get_actual_type
 
 
 def _interface_resolve_type(result, info, return_type):
@@ -49,8 +49,7 @@ def _process_type(cls, *, is_input=False, is_interface=False, description=None):
         fields = {}
 
         for class_field in class_fields:
-            if isinstance(class_field.type, typing.TypeVar):
-                class_field.type = types_replacement_map[class_field.type.__name__]
+            class_field.type = get_actual_type(class_field.type, types_replacement_map)
 
             field_name = getattr(class_field, "field_name", None) or to_camel_case(
                 class_field.name
@@ -114,20 +113,11 @@ def _process_type(cls, *, is_input=False, is_interface=False, description=None):
             if hasattr(klass, IS_STRAWBERRY_INTERFACE)
         ]
 
-    def copy_with_type(*types):
-        types_replacement_map = dict(
-            zip([param.__name__ for param in wrapped.__parameters__], types)
-        )
-        copied_name = "".join([type.__name__.capitalize() for type in types]) + name
-
-        return TypeClass(
-            copied_name,
-            lambda: _get_fields(wrapped, types_replacement_map=types_replacement_map),
-            **extra_kwargs
-        )
-
-    wrapped.field = TypeClass(name, lambda: _get_fields(wrapped), **extra_kwargs)
-    wrapped.copy_with_type = copy_with_type
+    wrapped.field = TypeClass(
+        name,
+        lambda types_replacement_map=None: _get_fields(wrapped, types_replacement_map),
+        **extra_kwargs
+    )
 
     return wrapped
 

--- a/strawberry/type_converter.py
+++ b/strawberry/type_converter.py
@@ -12,7 +12,11 @@ from graphql import (
     GraphQLUnionType,
 )
 
-from .exceptions import UnallowedReturnTypeForUnion, WrongReturnTypeForUnion
+from .exceptions import (
+    MissingTypesForGenericError,
+    UnallowedReturnTypeForUnion,
+    WrongReturnTypeForUnion,
+)
 from .scalars import ID
 from .utils.str_converters import to_camel_case
 from .utils.typing import is_generic, is_union
@@ -72,7 +76,12 @@ def get_graphql_type_for_annotation(
     is_field_optional = force_optional
 
     if is_generic(annotation):
-        graphql_type = copy_annotation_with_types(annotation, *annotation.__args__)
+        types = getattr(annotation, "__args__", None)
+
+        if types is None:
+            raise MissingTypesForGenericError(field_name, annotation)
+
+        graphql_type = copy_annotation_with_types(annotation, *types)
     elif hasattr(annotation, "field"):
         graphql_type = annotation.field
     else:

--- a/strawberry/type_converter.py
+++ b/strawberry/type_converter.py
@@ -13,7 +13,7 @@ from graphql import (
 
 from .exceptions import UnallowedReturnTypeForUnion, WrongReturnTypeForUnion
 from .scalars import ID
-from .utils.typing import is_union
+from .utils.typing import is_generic, is_union
 
 
 REGISTRY = {
@@ -34,7 +34,10 @@ def get_graphql_type_for_annotation(
     # TODO: this might lead to issues with types that have a field value
     is_field_optional = force_optional
 
-    if hasattr(annotation, "field"):
+    if is_generic(annotation):
+        # TODO: now we are assuming we have this function, but we should check
+        graphql_type = annotation.copy_with_type(*annotation.__args__)
+    elif hasattr(annotation, "field"):
         graphql_type = annotation.field
     else:
         annotation_name = getattr(annotation, "_name", None)

--- a/strawberry/utils/typing.py
+++ b/strawberry/utils/typing.py
@@ -43,11 +43,12 @@ def get_list_annotation(annotation):
     return annotation.__args__[0]
 
 
-def is_generic(annotation):
+def is_generic(annotation) -> bool:
+    """Returns True if the annotation is or extends a generic."""
     return (
         isinstance(annotation, type)
-        and issubclass(annotation, typing.Generic)
-        or isinstance(annotation, typing._GenericAlias)
+        and issubclass(annotation, typing.Generic)  # type:ignore
+        or isinstance(annotation, typing._GenericAlias)  # type:ignore
         and annotation.__origin__
         not in (
             list,
@@ -60,10 +61,16 @@ def is_generic(annotation):
 
 
 def is_type_var(annotation) -> bool:
+    """Returns True if the annotation is a TypeVar."""
+
     return isinstance(annotation, typing.TypeVar)  # type:ignore
 
 
 def has_type_var(annotation) -> bool:
+    """
+    Returns True if the annotation or any of
+    its argument have a TypeVar as argument.
+    """
     return any(
         is_type_var(arg) or has_type_var(arg)
         for arg in getattr(annotation, "__args__", [])
@@ -71,6 +78,7 @@ def has_type_var(annotation) -> bool:
 
 
 def get_actual_type(annotation, types_replacement_map):
+    """Returns a copy of an annotation by replacing TypeVar"""
     if is_type_var(annotation):
         return types_replacement_map[annotation.__name__]
 

--- a/strawberry/utils/typing.py
+++ b/strawberry/utils/typing.py
@@ -53,3 +53,29 @@ def is_generic(annotation):
             return True
 
     return False
+
+
+def is_type_var(annotation) -> bool:
+    return isinstance(annotation, typing.TypeVar)  # type:ignore
+
+
+def has_type_var(annotation) -> bool:
+    return any(
+        is_type_var(arg) or has_type_var(arg)
+        for arg in getattr(annotation, "__args__", [])
+    )
+
+
+def get_actual_type(annotation, types_replacement_map):
+    if is_type_var(annotation):
+        return types_replacement_map[annotation.__name__]
+
+    if has_type_var(annotation):
+        return annotation.copy_with(
+            tuple(
+                get_actual_type(arg, types_replacement_map)
+                for arg in annotation.__args__
+            )
+        )
+
+    return annotation

--- a/strawberry/utils/typing.py
+++ b/strawberry/utils/typing.py
@@ -1,3 +1,4 @@
+import collections
 import typing
 
 
@@ -43,16 +44,19 @@ def get_list_annotation(annotation):
 
 
 def is_generic(annotation):
-    if isinstance(annotation, typing._GenericAlias):
-        bases = [
-            getattr(b, "__origin__", None)
-            for b in getattr(annotation.__origin__, "__orig_bases__", [])
-        ]
-
-        if any(base is typing.Generic for base in bases):
-            return True
-
-    return False
+    return (
+        isinstance(annotation, type)
+        and issubclass(annotation, typing.Generic)
+        or isinstance(annotation, typing._GenericAlias)
+        and annotation.__origin__
+        not in (
+            list,
+            typing.Union,
+            tuple,
+            typing.ClassVar,
+            collections.abc.AsyncGenerator,
+        )
+    )
 
 
 def is_type_var(annotation) -> bool:

--- a/strawberry/utils/typing.py
+++ b/strawberry/utils/typing.py
@@ -40,3 +40,16 @@ def get_optional_annotation(annotation):
 
 def get_list_annotation(annotation):
     return annotation.__args__[0]
+
+
+def is_generic(annotation):
+    if isinstance(annotation, typing._GenericAlias):
+        bases = [
+            getattr(b, "__origin__", None)
+            for b in getattr(annotation.__origin__, "__orig_bases__", [])
+        ]
+
+        if any(base is typing.Generic for base in bases):
+            return True
+
+    return False

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -1,0 +1,112 @@
+import typing
+
+import strawberry
+from graphql import graphql_sync
+
+
+def test_supports_generic_simple_type():
+    T = typing.TypeVar("T")
+
+    # TODO: we should forbid this to be used directly
+    @strawberry.type
+    class Edge(typing.Generic[T]):
+        cursor: strawberry.ID
+        node: T
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def int_edge(self, info, **kwargs) -> Edge[int]:
+            return Edge(cursor=strawberry.ID("1"), node=1)
+
+    schema = strawberry.Schema(query=Query)
+
+    query = """{
+        intEdge {
+            __typename
+            cursor
+            node
+        }
+    }"""
+
+    result = graphql_sync(schema, query)
+
+    assert not result.errors
+    assert result.data == {
+        "intEdge": {"__typename": "IntEdge", "cursor": "1", "node": 1}
+    }
+
+
+def test_supports_generic():
+    T = typing.TypeVar("T")
+
+    @strawberry.type
+    class Edge(typing.Generic[T]):
+        cursor: strawberry.ID
+        node: T
+
+    @strawberry.type
+    class Person:
+        name: str
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def person_edge(self, info, **kwargs) -> Edge[Person]:
+            return Edge(cursor=strawberry.ID("1"), node=Person(name="Example"))
+
+    schema = strawberry.Schema(query=Query)
+
+    query = """{
+        personEdge {
+            __typename
+            cursor
+            node {
+                name
+            }
+        }
+    }"""
+
+    result = graphql_sync(schema, query)
+
+    assert not result.errors
+    assert result.data == {
+        "personEdge": {
+            "__typename": "PersonEdge",
+            "cursor": "1",
+            "node": {"name": "Example"},
+        }
+    }
+
+
+def test_supports_multiple_generic():
+    A = typing.TypeVar("A")
+    B = typing.TypeVar("B")
+
+    @strawberry.type
+    class Multiple(typing.Generic[A, B]):
+        a: A
+        b: B
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def multiple(self, info, **kwargs) -> Multiple[int, str]:
+            return Multiple(a=123, b="123")
+
+    schema = strawberry.Schema(query=Query)
+
+    query = """{
+        multiple {
+            __typename
+            a
+            b
+        }
+    }"""
+
+    result = graphql_sync(schema, query)
+
+    assert not result.errors
+    assert result.data == {
+        "multiple": {"__typename": "IntStrMultiple", "a": 123, "b": "123"}
+    }


### PR DESCRIPTION
This PR adds support for generic types, allowing to reuse them in an easy and pythonic way:

```python
T = typing.TypeVar("T")

@strawberry.type
class Edge(typing.Generic[T]):
    cursor: strawberry.ID
    node: T

@strawberry.type
class Query:
    @strawberry.field
    def int_edge(self, info, **kwargs) -> Edge[int]:
        return Edge(cursor=strawberry.ID("1"), node=1)
```

This will allow us to add support for pagination: #175, since now we should be able to create generic types that can be reused (see above example for a simplified relay Edge type).