### PR TITLE
Allow to omit info and/or root params in resolvers

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,33 @@
+Release type: minor
+
+This releases allows to use resolver without having 
+to specify root and info arguments:
+
+```python
+def function_resolver() -> str:
+    return "I'm a function resolver"
+
+def function_resolver_with_params(x: str) -> str:
+    return f"I'm {x}"
+
+@strawberry.type
+class Query:
+    hello: str = strawberry.field(resolver=function_resolver)
+    hello_with_params: str = strawberry.field(
+        resolver=function_resolver_with_params
+    )
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def hello(self) -> str:
+        return "I'm a function resolver"
+
+    @strawberry.field
+    def hello_with_params(self, x: str) -> str:
+        return f"I'm {x}"
+```
+
+This makes it easier to reuse existing functions and makes code
+cleaner when not using info or root.

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -214,8 +214,27 @@ def _get_field(
         if check_permission:
             check_permission(source, info, **kwargs)
 
+        # the following code allows to omit info and root arguments
+        # by inspecting the original resolver arguments,
+        # if it asks for self, the source will be passed as first argument
+        # if it asks for root, the source it will be passed as kwarg
+        # if it asks for info, the info will be passed as kwarg
+
         kwargs = convert_args(kwargs, arguments_annotations)
-        result = wrap(source, info, **kwargs)
+        function_args = get_func_args(wrap)
+
+        args = []
+
+        if "self" in function_args:
+            args.append(wrap)
+
+        if "root" in function_args:
+            kwargs["root"] = source
+
+        if "info" in function_args:
+            kwargs["info"] = info
+
+        result = wrap(*args, **kwargs)
 
         # graphql-core expects a resolver for an Enum type to return
         # the enum's *value* (not its name or an instance of the enum).


### PR DESCRIPTION
This PR adds the possibility of omitting info and/or root params in resolvers.

I think this feature makes the code a bit nicer when not using root and info:

```python
def function_resolver() -> str:
    return "I'm a function resolver"

def function_resolver_with_params(x: str) -> str:
    return f"I'm {x}"

@strawberry.type
class Query:
    hello: str = strawberry.field(resolver=function_resolver)
    hello_with_params: str = strawberry.field(
        resolver=function_resolver_with_params
    )
```

I'm doing this now as I'm working on the getting started documentation and I think it will be nicer to use resolvers with these two params there.

closes #257 