### PR TITLE
Serve debug API also on /

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+This releases updates the _debug server_ to serve the API on '/' as well as '/graphql'.
+

--- a/strawberry/cli/commands/server.py
+++ b/strawberry/cli/commands/server.py
@@ -1,20 +1,16 @@
-import click
+import importlib
+import os
 import sys
 
-import os
+import click
+import hupper
+import uvicorn
 from starlette.applications import Starlette
 from starlette.middleware.cors import CORSMiddleware
-
-import importlib
-
-import uvicorn
-
-import hupper
-
 from strawberry.asgi import GraphQL
 
 
-@click.command("server", short_help='Starts debug server')
+@click.command("server", short_help="Starts debug server")
 @click.argument("module", type=str)
 @click.option("-h", "--host", default="0.0.0.0", type=str)
 @click.option("-p", "--port", default=8000, type=int)
@@ -35,9 +31,12 @@ def server(module, host, port):
 
     graphql_app = GraphQL(schema_module.schema, debug=True)
 
-    app.add_route("/graphql", graphql_app)
-    app.add_websocket_route("/graphql", graphql_app)
+    paths = ["/", "/graphql"]
 
-    print(f"Running strawberry on http://{host}:{port}/graphql 🍓")
+    for path in paths:
+        app.add_route(path, graphql_app)
+        app.add_websocket_route(path, graphql_app)
+
+    print(f"Running strawberry on http://{host}:{port}/ 🍓")
 
     uvicorn.run(app, host=host, port=port, log_level="error")

--- a/tests/cli/test_server.py
+++ b/tests/cli/test_server.py
@@ -1,29 +1,27 @@
-from click.testing import CliRunner
-
-from strawberry.cli.commands.server import server as cmd_server
-
-import uvicorn
 import hupper
+import uvicorn
+from click.testing import CliRunner
+from strawberry.cli.commands.server import server as cmd_server
 
 
 def test_cli_cmd_server(mocker):
 
     # Mock of uvicorn.run
-    uvicorn_run_patch = mocker.patch('uvicorn.run')
+    uvicorn_run_patch = mocker.patch("uvicorn.run")
     uvicorn_run_patch.return_value = True
     # Mock to prevent the reloader from kicking in
-    hupper_reloader_patch = mocker.patch('hupper.start_reloader')
+    hupper_reloader_patch = mocker.patch("hupper.start_reloader")
     hupper_reloader_patch.return_value = MockReloader()
     runner = CliRunner()
 
-    result = runner.invoke(cmd_server, ['tests.cli.helpers.sample_schema'], "")
+    result = runner.invoke(cmd_server, ["tests.cli.helpers.sample_schema"], "")
     assert result.exit_code == 0
 
     # We started the reloader
     assert hupper.start_reloader.call_count == 1
     assert uvicorn.run.call_count == 1
 
-    assert result.output == 'Running strawberry on http://0.0.0.0:8000/graphql 🍓\n'
+    assert result.output == "Running strawberry on http://0.0.0.0:8000/ 🍓\n"
 
 
 class MockReloader:


### PR DESCRIPTION
I was playing with Glitch[1] and I was thinking it would be nice to have the debug server on / as well, so the preview is not a "Not found" page :)

This PR adds the route for the debug server on / as well as /graphql. I wasn't able to find a way to serve all paths to the GraphQL app with starlette. But this should be good enough :)

[1] https://glitch.com/~starter-strawberry