### PR TITLE
Add support for named unions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,12 @@
+Release type: minor
+
+This release add supports for named unions, now you can create
+a new union type by writing:
+
+```python
+Result = strawberry.union("Result", (A, B), description="Example Result")
+```
+
+This also improves the support for Union and Generic types, as it 
+was broken before.
+

--- a/strawberry/__init__.py
+++ b/strawberry/__init__.py
@@ -11,3 +11,4 @@ from .type import input, type, interface  # noqa
 from .types import *  # noqa
 from .permission import BasePermission  # noqa
 from .directive import directive  # noqa
+from .union import union  # noqa

--- a/strawberry/enum.py
+++ b/strawberry/enum.py
@@ -17,7 +17,7 @@ def _process_enum(cls, name=None, description=None):
 
     description = description or cls.__doc__
 
-    cls.field = GraphQLEnumType(
+    cls.graphql_type = GraphQLEnumType(
         name=name,
         values=[(item.name, GraphQLEnumValue(item.value)) for item in cls],
         description=description,

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -100,7 +100,7 @@ class LazyFieldWrapper:
                 raise PermissionError(message)
 
     @lazy_property
-    def field(self):
+    def graphql_type(self):
         return _get_field(
             self._wrapped_obj,
             is_input=self.is_input,

--- a/strawberry/printer.py
+++ b/strawberry/printer.py
@@ -4,4 +4,4 @@ from graphql.utilities.print_schema import print_type as graphql_print
 def print_type(type_) -> str:
     """Returns a string representation of a strawberry type"""
 
-    return graphql_print(type_.field)
+    return graphql_print(type_.graphql_type)

--- a/strawberry/schema.py
+++ b/strawberry/schema.py
@@ -23,12 +23,12 @@ class Schema(GraphQLSchema):
                       to be manually registered
         """
         super().__init__(
-            query=query.field,
-            mutation=mutation.field if mutation else None,
-            subscription=subscription.field if subscription else None,
+            query=query.graphql_type,
+            mutation=mutation.graphql_type if mutation else None,
+            subscription=subscription.graphql_type if subscription else None,
             directives=specified_directives
             + [directive.directive for directive in directives],
-            types=[type.field for type in types],
+            types=[type.graphql_type for type in types],
         )
 
     def __repr__(self):

--- a/strawberry/type.py
+++ b/strawberry/type.py
@@ -12,7 +12,7 @@ from .utils.typing import get_actual_type
 
 def _interface_resolve_type(result, info, return_type):
     """Resolves the correct type for an interface"""
-    return result.__class__.field
+    return result.__class__.graphql_type
 
 
 def _get_resolver(cls, field_name):
@@ -66,7 +66,7 @@ def _process_type(cls, *, is_input=False, is_interface=False, description=None):
                 is_input=is_input,
                 description=description,
                 permission_classes=permission_classes,
-            ).field
+            ).graphql_type
 
         strawberry_fields = {}
 
@@ -82,7 +82,7 @@ def _process_type(cls, *, is_input=False, is_interface=False, description=None):
         for key, value in strawberry_fields.items():
             name = getattr(value, "field_name", None) or to_camel_case(key)
 
-            fields[name] = value.field
+            fields[name] = value.graphql_type
 
         return fields
 
@@ -108,12 +108,12 @@ def _process_type(cls, *, is_input=False, is_interface=False, description=None):
         TypeClass = GraphQLObjectType
 
         extra_kwargs["interfaces"] = [
-            klass.field
+            klass.graphql_type
             for klass in cls.__bases__
             if hasattr(klass, IS_STRAWBERRY_INTERFACE)
         ]
 
-    wrapped.field = TypeClass(
+    wrapped.graphql_type = TypeClass(
         name,
         lambda types_replacement_map=None: _get_fields(wrapped, types_replacement_map),
         **extra_kwargs

--- a/strawberry/type_converter.py
+++ b/strawberry/type_converter.py
@@ -64,7 +64,14 @@ def copy_annotation_with_types(annotation, *types):
 
         return fields
 
-    return TypeClass(copied_name, get_fields, **extra_kwargs)
+    new_type = TypeClass(copied_name, get_fields, **extra_kwargs)
+
+    if not hasattr(origin, "_copies"):
+        origin._copies = {}
+
+    origin._copies[types] = new_type
+
+    return new_type
 
 
 # TODO: make so that we don't pass force optional

--- a/strawberry/type_converter.py
+++ b/strawberry/type_converter.py
@@ -14,7 +14,7 @@ from graphql import (
 from .exceptions import MissingTypesForGenericError
 from .scalars import ID
 from .union import union
-from .utils.str_converters import to_camel_case
+from .utils.str_converters import capitalize_first, to_camel_case
 from .utils.typing import is_generic, is_union
 
 
@@ -40,7 +40,7 @@ def copy_annotation_with_types(annotation, *types):
         zip([param.__name__ for param in origin.__parameters__], types)
     )
     copied_name = (
-        "".join([type.__name__.capitalize() for type in types]) + graphql_type.name
+        "".join([capitalize_first(type.__name__) for type in types]) + graphql_type.name
     )
 
     extra_kwargs = {

--- a/strawberry/type_converter.py
+++ b/strawberry/type_converter.py
@@ -66,6 +66,11 @@ def copy_annotation_with_types(annotation, *types):
 
     new_type = TypeClass(copied_name, get_fields, **extra_kwargs)
 
+    # we use _copied to easily find a previously created type,
+    # this is used by unions when needing to find the proper GraphQL
+    # type when returning something
+    # TODO: we could use this to prevent running all the code above
+
     if not hasattr(origin, "_copies"):
         origin._copies = {}
 

--- a/strawberry/union.py
+++ b/strawberry/union.py
@@ -3,6 +3,20 @@ import typing
 from graphql import GraphQLUnionType
 
 from .exceptions import UnallowedReturnTypeForUnion, WrongReturnTypeForUnion
+from .utils.typing import is_generic, is_type_var
+
+
+def _find_type_for_generic_union(root):
+    # might need to preserve ordering (typing.Generic[T, V] vs typing.Generic[V, T])
+    type_var_fields = [
+        field_name
+        for field_name, field_type in root.__annotations__.items()
+        if is_type_var(field_type)
+    ]
+
+    types = tuple(type(getattr(root, field)) for field in type_var_fields)
+
+    return root._copies[types]
 
 
 def union(name: str, types: typing.Tuple[typing.Type], *, description=None):
@@ -21,22 +35,33 @@ def union(name: str, types: typing.Tuple[typing.Type], *, description=None):
     >>> )
     """
 
-    def _resolve_type(self, value, _type):
-        if not hasattr(self, "graphql_type"):
-            raise WrongReturnTypeForUnion(value.field_name, str(type(self)))
+    from .type_converter import get_graphql_type_for_annotation
 
-        if self.graphql_type not in _type.types:
+    def _resolve_type(root, info, _type):
+        if not hasattr(root, "graphql_type"):
+            raise WrongReturnTypeForUnion(info.field_name, str(type(root)))
+
+        if is_generic(type(root)):
+            return _find_type_for_generic_union(root)
+
+        if root.graphql_type not in _type.types:
             raise UnallowedReturnTypeForUnion(
-                value.field_name, str(type(self)), _type.types
+                info.field_name, str(type(root)), _type.types
             )
 
-        return self.graphql_type
+        return root.graphql_type
 
     # TODO: union types don't work with scalar types
     # so we want to return a nice error
     # also we want to make sure we have been passed
     # strawberry types
-    graphql_type = GraphQLUnionType(name, [type.graphql_type for type in types])
+    graphql_type = GraphQLUnionType(
+        name,
+        [
+            get_graphql_type_for_annotation(type, name, force_optional=True)
+            for type in types
+        ],
+    )
     graphql_type.resolve_type = _resolve_type
 
     class X:

--- a/strawberry/union.py
+++ b/strawberry/union.py
@@ -75,6 +75,7 @@ def union(name: str, types: typing.Tuple[typing.Type], *, description=None):
             get_graphql_type_for_annotation(type, name, force_optional=True)
             for type in types
         ],
+        description=description,
     )
     graphql_type.resolve_type = _resolve_type
 

--- a/strawberry/union.py
+++ b/strawberry/union.py
@@ -1,0 +1,44 @@
+import typing
+
+from graphql import GraphQLUnionType
+
+from .exceptions import UnallowedReturnTypeForUnion, WrongReturnTypeForUnion
+
+
+def union(name: str, types: typing.Tuple[typing.Type], *, description=None):
+    """Creates a new named Union type.
+
+    Example usages:
+
+    >>> strawberry.union(
+    >>>     "Name",
+    >>>     (A, B),
+    >>> )
+
+    >>> strawberry.union(
+    >>>     "Name",
+    >>>     (A, B),
+    >>> )
+    """
+
+    def _resolve_type(self, value, _type):
+        if not hasattr(self, "field"):
+            raise WrongReturnTypeForUnion(value.field_name, str(type(self)))
+
+        if self.field not in _type.types:
+            raise UnallowedReturnTypeForUnion(
+                value.field_name, str(type(self)), _type.types
+            )
+
+        return self.field
+
+    # TODO: union types don't work with scalar types
+    # so we want to return a nice error
+    # also we want to make sure we have been passed
+    # strawberry types
+    field = GraphQLUnionType(name, [type.field for type in types])
+    field.resolve_type = _resolve_type
+    # HACK !!!1
+    field.field = field
+
+    return field

--- a/strawberry/union.py
+++ b/strawberry/union.py
@@ -79,6 +79,12 @@ def union(name: str, types: typing.Tuple[typing.Type], *, description=None):
     )
     graphql_type.resolve_type = _resolve_type
 
+    # This is currently a temporary solution, this is ok for now
+    # But in future we might want to change this so that it works
+    # properly with mypy, but there's no way to return a type like NewType does
+    # so we return this class instance as it allows us to reuse the rest of
+    # our code without doing too many changes
+
     class X:
         def __init__(self, graphql_type):
             self.graphql_type = graphql_type

--- a/strawberry/union.py
+++ b/strawberry/union.py
@@ -22,23 +22,25 @@ def union(name: str, types: typing.Tuple[typing.Type], *, description=None):
     """
 
     def _resolve_type(self, value, _type):
-        if not hasattr(self, "field"):
+        if not hasattr(self, "graphql_type"):
             raise WrongReturnTypeForUnion(value.field_name, str(type(self)))
 
-        if self.field not in _type.types:
+        if self.graphql_type not in _type.types:
             raise UnallowedReturnTypeForUnion(
                 value.field_name, str(type(self)), _type.types
             )
 
-        return self.field
+        return self.graphql_type
 
     # TODO: union types don't work with scalar types
     # so we want to return a nice error
     # also we want to make sure we have been passed
     # strawberry types
-    field = GraphQLUnionType(name, [type.field for type in types])
-    field.resolve_type = _resolve_type
-    # HACK !!!1
-    field.field = field
+    graphql_type = GraphQLUnionType(name, [type.graphql_type for type in types])
+    graphql_type.resolve_type = _resolve_type
 
-    return field
+    class X:
+        def __init__(self, graphql_type):
+            self.graphql_type = graphql_type
+
+    return X(graphql_type)

--- a/strawberry/utils/str_converters.py
+++ b/strawberry/utils/str_converters.py
@@ -3,7 +3,7 @@ import re
 
 # Adapted from this response in Stackoverflow
 # http://stackoverflow.com/a/19053800/1072990
-def to_camel_case(snake_str):
+def to_camel_case(snake_str: str) -> str:
     components = snake_str.split("_")
     # We capitalize the first letter of each component except the first one
     # with the 'capitalize' method and join them together.
@@ -12,10 +12,14 @@ def to_camel_case(snake_str):
 
 # From this response in Stackoverflow
 # http://stackoverflow.com/a/1176023/1072990
-def to_snake_case(name):
+def to_snake_case(name: str) -> str:
     s1 = re.sub(r"(.)([A-Z][a-z]+)", r"\1_\2", name)
     return re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", s1).lower()
 
 
-def to_const(string):
+def to_const(string: str) -> str:
     return re.sub(r"[\W|^]+", "_", string).upper()
+
+
+def capitalize_first(name: str) -> str:
+    return name[0].upper() + name[1:]

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -16,12 +16,12 @@ def test_create_enum():
         C = "a"
         D = "o"
 
-    assert StringTest.field
+    assert StringTest.graphql_type
 
-    assert type(StringTest.field) == GraphQLEnumType
-    assert StringTest.field.name == "StringTest"
+    assert type(StringTest.graphql_type) == GraphQLEnumType
+    assert StringTest.graphql_type.name == "StringTest"
 
-    assert StringTest.field.values == {
+    assert StringTest.graphql_type.values == {
         "A": GraphQLEnumValue("c"),
         "B": GraphQLEnumValue("i"),
         "C": GraphQLEnumValue("a"),
@@ -34,12 +34,12 @@ def test_create_enum():
         B = 2
         C = 3
 
-    assert IntTest.field
+    assert IntTest.graphql_type
 
-    assert type(IntTest.field) == GraphQLEnumType
-    assert IntTest.field.name == "IntTest"
+    assert type(IntTest.graphql_type) == GraphQLEnumType
+    assert IntTest.graphql_type.name == "IntTest"
 
-    assert IntTest.field.values == {
+    assert IntTest.graphql_type.values == {
         "A": GraphQLEnumValue(1),
         "B": GraphQLEnumValue(2),
         "C": GraphQLEnumValue(3),
@@ -65,12 +65,12 @@ def test_create_enum():
             G = 6.67300e-11
             return G * self.mass / (self.radius * self.radius)
 
-    assert ComplexTest.field
+    assert ComplexTest.graphql_type
 
-    assert type(ComplexTest.field) == GraphQLEnumType
-    assert ComplexTest.field.name == "ComplexTest"
+    assert type(ComplexTest.graphql_type) == GraphQLEnumType
+    assert ComplexTest.graphql_type.name == "ComplexTest"
 
-    assert ComplexTest.field.values == {
+    assert ComplexTest.graphql_type.values == {
         "MERCURY": GraphQLEnumValue((3.303e23, 2.4397e6)),
         "VENUS": GraphQLEnumValue((4.869e24, 6.0518e6)),
         "EARTH": GraphQLEnumValue((5.976e24, 6.37814e6)),
@@ -89,10 +89,10 @@ def test_create_enum_with_custom_name():
         B = 2
         C = 3
 
-    assert Test.field
+    assert Test.graphql_type
 
-    assert type(Test.field) == GraphQLEnumType
-    assert Test.field.name == "NewName"
+    assert type(Test.graphql_type) == GraphQLEnumType
+    assert Test.graphql_type.name == "NewName"
 
 
 def test_create_enum_with_arguments():
@@ -102,11 +102,11 @@ def test_create_enum_with_arguments():
         B = 2
         C = 3
 
-    assert Test.field
+    assert Test.graphql_type
 
-    assert type(Test.field) == GraphQLEnumType
-    assert Test.field.name == "NewName"
-    assert Test.field.description == "This is the description"
+    assert type(Test.graphql_type) == GraphQLEnumType
+    assert Test.graphql_type.name == "NewName"
+    assert Test.graphql_type.description == "This is the description"
 
     @strawberry.enum(name="Example")
     class Test2(Enum):
@@ -116,11 +116,11 @@ def test_create_enum_with_arguments():
         B = 2
         C = 3
 
-    assert Test.field
+    assert Test.graphql_type
 
-    assert type(Test2.field) == GraphQLEnumType
-    assert Test2.field.name == "Example"
-    assert Test2.field.description == "Example"
+    assert type(Test2.graphql_type) == GraphQLEnumType
+    assert Test2.graphql_type.name == "Example"
+    assert Test2.graphql_type.description == "Example"
 
 
 def test_raises_error_when_using_enum_with_a_not_enum_class():

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -24,14 +24,14 @@ def test_field_arguments():
     def hello(self, info, id: int) -> str:
         return "I'm a resolver"
 
-    assert hello.field
+    assert hello.graphql_type
 
-    assert type(hello.field) == GraphQLField
-    assert type(hello.field.type) == GraphQLNonNull
-    assert hello.field.type.of_type.name == "String"
+    assert type(hello.graphql_type) == GraphQLField
+    assert type(hello.graphql_type.type) == GraphQLNonNull
+    assert hello.graphql_type.type.of_type.name == "String"
 
-    assert type(hello.field.args["id"].type) == GraphQLNonNull
-    assert hello.field.args["id"].type.of_type.name == "Int"
+    assert type(hello.graphql_type.args["id"].type) == GraphQLNonNull
+    assert hello.graphql_type.args["id"].type.of_type.name == "Int"
 
 
 def test_field_default_arguments_are_optional():
@@ -39,17 +39,17 @@ def test_field_default_arguments_are_optional():
     def hello(self, info, test: int, id: int = 1, asdf: str = "hello") -> str:
         return "I'm a resolver"
 
-    assert hello.field
+    assert hello.graphql_type
 
-    assert type(hello.field) == GraphQLField
-    assert type(hello.field.type) == GraphQLNonNull
-    assert hello.field.type.of_type.name == "String"
+    assert type(hello.graphql_type) == GraphQLField
+    assert type(hello.graphql_type.type) == GraphQLNonNull
+    assert hello.graphql_type.type.of_type.name == "String"
 
-    assert type(hello.field.args["id"].type) == GraphQLScalarType
-    assert hello.field.args["id"].type.name == "Int"
+    assert type(hello.graphql_type.args["id"].type) == GraphQLScalarType
+    assert hello.graphql_type.args["id"].type.name == "Int"
 
-    assert type(hello.field.args["asdf"].type) == GraphQLScalarType
-    assert hello.field.args["asdf"].type.name == "String"
+    assert type(hello.graphql_type.args["asdf"].type) == GraphQLScalarType
+    assert hello.graphql_type.args["asdf"].type.name == "String"
 
 
 def test_field_default_optional_argument_custom_type():
@@ -63,17 +63,17 @@ def test_field_default_optional_argument_custom_type():
     ) -> str:
         return "I'm a resolver"
 
-    assert hello.field
+    assert hello.graphql_type
 
-    assert type(hello.field) == GraphQLField
-    assert type(hello.field.type) == GraphQLNonNull
-    assert hello.field.type.of_type.name == "String"
+    assert type(hello.graphql_type) == GraphQLField
+    assert type(hello.graphql_type.type) == GraphQLNonNull
+    assert hello.graphql_type.type.of_type.name == "String"
 
-    assert type(hello.field.args["required"].type) == GraphQLNonNull
-    assert hello.field.args["required"].type.of_type.name == "CustomInputType"
+    assert type(hello.graphql_type.args["required"].type) == GraphQLNonNull
+    assert hello.graphql_type.args["required"].type.of_type.name == "CustomInputType"
 
-    assert type(hello.field.args["optional"].type) == GraphQLInputObjectType
-    assert hello.field.args["optional"].type.name == "CustomInputType"
+    assert type(hello.graphql_type.args["optional"].type) == GraphQLInputObjectType
+    assert hello.graphql_type.args["optional"].type.name == "CustomInputType"
 
 
 def test_raises_error_when_return_annotation_missing():

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -373,3 +373,43 @@ def test_supports_generic_in_unions():
     assert result.data == {
         "example": {"__typename": "IntEdge", "cursor": "1", "node": 1}
     }
+
+
+def test_supports_generic_in_unions_multiple_vars():
+    A = typing.TypeVar("A")
+    B = typing.TypeVar("B")
+
+    @strawberry.type
+    class Edge(typing.Generic[A, B]):
+        node: B
+        info: A
+
+    @strawberry.type
+    class Fallback:
+        node: str
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def example(self, info, **kwargs) -> typing.Union[Fallback, Edge[int, str]]:
+            return Edge(node="string", info=1)
+
+    schema = strawberry.Schema(query=Query)
+
+    query = """{
+        example {
+            __typename
+
+            ... on IntStrEdge {
+                node
+                info
+            }
+        }
+    }"""
+
+    result = graphql_sync(schema, query)
+
+    assert not result.errors
+    assert result.data == {
+        "example": {"__typename": "IntStrEdge", "node": "string", "info": 1}
+    }

--- a/tests/test_type_converter.py
+++ b/tests/test_type_converter.py
@@ -40,13 +40,11 @@ def test_union():
 
     assert field.of_type.name == "Example1"
 
-    assert A.field in field.of_type.types
-    assert B.field in field.of_type.types
+    assert A.graphql_type in field.of_type.types
+    assert B.graphql_type in field.of_type.types
 
 
 def test_optional_scalar():
-    # import pdb; pdb.set_trace()
-
     field = get_graphql_type_for_annotation(Optional[str], "Example2")
 
     assert type(field) == GraphQLScalarType

--- a/tests/test_type_converter.py
+++ b/tests/test_type_converter.py
@@ -34,18 +34,20 @@ def test_union():
     class B:
         x: int
 
-    field = get_graphql_type_for_annotation(Union[A, B], "Example")
+    field = get_graphql_type_for_annotation(Union[A, B], "Example1")
 
     assert type(field) == GraphQLNonNull
 
-    assert field.of_type.name == "Example"
+    assert field.of_type.name == "Example1"
 
     assert A.field in field.of_type.types
     assert B.field in field.of_type.types
 
 
 def test_optional_scalar():
-    field = get_graphql_type_for_annotation(Optional[str], "Example")
+    # import pdb; pdb.set_trace()
+
+    field = get_graphql_type_for_annotation(Optional[str], "Example2")
 
     assert type(field) == GraphQLScalarType
     assert field.name == "String"
@@ -56,14 +58,14 @@ def test_optional_object_type():
     class A:
         x: int
 
-    field = get_graphql_type_for_annotation(Optional[A], "Example")
+    field = get_graphql_type_for_annotation(Optional[A], "Example3")
 
     assert type(field) == GraphQLObjectType
     assert field.name == "A"
 
 
 def test_list_of_scalar():
-    field = get_graphql_type_for_annotation(Optional[List[str]], "Example")
+    field = get_graphql_type_for_annotation(Optional[List[str]], "Example4")
 
     assert type(field) == GraphQLList
     assert type(field.of_type) == GraphQLNonNull


### PR DESCRIPTION
This PR adds support for creating named unions:

```
strawberry.union(
    "Name",
    (A, B),
)
```

TODO: 

- [ ] MyPy support (not sure yet how to do this)
- [x] Add support for adding a description

I also changed how we store the GrahpQL type on our strawberry types as the name `field` was misleading :) 