### PR TITLE
Fix subscriptions when they accept input arguments

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Fix error when a subscription accepted input arguments

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -250,9 +250,9 @@ def _get_field(
 
         if is_subscription:
 
-            def _resolve(event, info):
+            def _resolve(event, info, **kwargs):
                 if check_permission:
-                    check_permission(event, info)
+                    check_permission(event, info, **kwargs)
 
                 return event
 

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -46,3 +46,26 @@ async def test_subscription():
 
     assert not result.errors
     assert result.data["example"] == "Hi"
+
+
+@pytest.mark.asyncio
+async def test_subscription_with_arguments():
+    @strawberry.type
+    class Query:
+        x: str = "Hello"
+
+    @strawberry.type
+    class Subscription:
+        @strawberry.subscription
+        async def example(self, info, name: str) -> typing.AsyncGenerator[str, None]:
+            yield f"Hi {name}"
+
+    schema = strawberry.Schema(query=Query, subscription=Subscription)
+
+    query = 'subscription { example(name: "Nina") }'
+
+    sub = await subscribe(schema, parse(query))
+    result = await sub.__anext__()
+
+    assert not result.errors
+    assert result.data["example"] == "Hi Nina"


### PR DESCRIPTION
Subscriptions with input arguments currently fail with

```
>       assert not result.errors
E       assert not [GraphQLError("_resolve() got an unexpected keyword argument 'name'", locations=[SourceLocation(line=1, column=16)], path=['example'])]
E        +  where [GraphQLError("_resolve() got an unexpected keyword argument 'name'", locations=[SourceLocation(line=1, column=16)], path=['example'])] = ExecutionResult(data=None, errors=[GraphQLError("_resolve() got an unexpected keyword argument 'name'", locations=[SourceLocation(line=1, column=16)], path=['example'])]).errors
```

because the resolver doesn't accept kwargs.

This PR adds support for it and sends the arguments to the `check_permissions` function
