### PR TITLE
Add support for setting `root_value` in asgi.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,9 @@
+Release type: patch
+
+Add support for setting `root_value` in asgi.
+
+Usage:
+```python
+schema = strawberry.Schema(query=Query)
+app = strawberry.asgi.GraphQL(schema, root_value=Query())
+```

--- a/strawberry/asgi/__init__.py
+++ b/strawberry/asgi/__init__.py
@@ -26,6 +26,7 @@ class GraphQL:
     def __init__(
         self,
         schema: GraphQLSchema,
+        root_value: typing.Any = None,
         graphiql: bool = True,
         keep_alive: bool = False,
         keep_alive_interval: float = 1,
@@ -33,6 +34,7 @@ class GraphQL:
     ) -> None:
         self.schema = schema
         self.graphiql = graphiql
+        self.root_value = root_value
         self.keep_alive = keep_alive
         self.keep_alive_interval = keep_alive_interval
         self._keep_alive_task = None
@@ -149,6 +151,7 @@ class GraphQL:
         return await execute(
             self.schema,
             query,
+            root_value=self.root_value,
             variable_values=variables,
             operation_name=operation_name,
             context_value=context,

--- a/strawberry/graphql.py
+++ b/strawberry/graphql.py
@@ -18,6 +18,7 @@ from .middleware import DirectivesMiddleware
 async def execute(
     schema: GraphQLSchema,
     query: str,
+    root_value: typing.Any = None,
     context_value: typing.Any = None,
     variable_values: typing.Dict[str, typing.Any] = None,
     operation_name: str = None,
@@ -42,6 +43,7 @@ async def execute(
     result = graphql_excute(
         schema,
         parse(query),
+        root_value=root_value,
         middleware=[DirectivesMiddleware()],
         variable_values=variable_values,
         operation_name=operation_name,

--- a/tests/asgi/test_query.py
+++ b/tests/asgi/test_query.py
@@ -45,3 +45,9 @@ def test_returns_errors_and_data(schema, test_client):
             }
         ],
     }
+
+
+def test_root_value(schema, test_client):
+    response = test_client.post("/", json={"query": "{ rootName }"})
+
+    assert response.json() == {"data": {"rootName": "Query"}}


### PR DESCRIPTION
Add support for setting `root_value` in asgi.

## Description
Setting `root_value` is allowed when directly executing a schema, but there was no way to set it in the `asgi.GraphQL` app.

## Types of Changes
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #315 

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).