### PR TITLE
Add support for `default_value` on inputs and arguments.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,16 @@
+Release type: patch
+
+Support for `default_value` on inputs and arguments.
+
+Usage:
+```python
+class MyInput:
+    s: Optional[str]
+    i: int = 0
+```
+```graphql
+input MyInput {
+  s: String
+  i: Int! = 0
+}
+```

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -3,7 +3,7 @@ import enum
 import inspect
 import typing
 
-from graphql import GraphQLField, GraphQLInputField
+from graphql import GraphQLArgument, GraphQLField, GraphQLInputField, Undefined
 
 from .constants import IS_STRAWBERRY_FIELD
 from .exceptions import MissingArgumentsAnnotationsError, MissingReturnAnnotationError
@@ -203,12 +203,13 @@ def _get_field(
         if key not in ["info", "return"]
     }
 
-    arguments = {
-        to_camel_case(name): get_graphql_type_for_annotation(
-            annotation, name, parameters[name].default != inspect._empty
+    arguments = {}
+    for name, annotation in arguments_annotations.items():
+        default = parameters[name].default
+        arguments[to_camel_case(name)] = GraphQLArgument(
+            get_graphql_type_for_annotation(annotation, name, default != inspect._empty),
+            default_value=Undefined if default in (inspect._empty, None) else default,
         )
-        for name, annotation in arguments_annotations.items()
-    }
 
     def resolver(source, info, **kwargs):
         if check_permission:

--- a/strawberry/type.py
+++ b/strawberry/type.py
@@ -74,6 +74,9 @@ def _process_type(cls, *, is_input=False, is_interface=False, description=None):
                 description=description,
                 permission_classes=permission_classes,
             ).graphql_type
+            # supply a graphql default_value if the type annotation has a default
+            if class_field.default not in (dataclasses.MISSING, None):
+                fields[field_name].default_value = class_field.default
 
         strawberry_fields = {}
 

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -6,6 +6,7 @@ from graphql import (
     GraphQLInputObjectType,
     GraphQLNonNull,
     GraphQLScalarType,
+    Undefined,
 )
 from strawberry.exceptions import (
     MissingArgumentsAnnotationsError,
@@ -47,9 +48,11 @@ def test_field_default_arguments_are_optional():
 
     assert type(hello.graphql_type.args["id"].type) == GraphQLScalarType
     assert hello.graphql_type.args["id"].type.name == "Int"
+    assert hello.graphql_type.args["id"].default_value == 1
 
     assert type(hello.graphql_type.args["asdf"].type) == GraphQLScalarType
     assert hello.graphql_type.args["asdf"].type.name == "String"
+    assert hello.graphql_type.args["asdf"].default_value == "hello"
 
 
 def test_field_default_optional_argument_custom_type():
@@ -71,9 +74,11 @@ def test_field_default_optional_argument_custom_type():
 
     assert type(hello.graphql_type.args["required"].type) == GraphQLNonNull
     assert hello.graphql_type.args["required"].type.of_type.name == "CustomInputType"
+    assert hello.graphql_type.args["required"].default_value == Undefined
 
     assert type(hello.graphql_type.args["optional"].type) == GraphQLInputObjectType
     assert hello.graphql_type.args["optional"].type.name == "CustomInputType"
+    assert hello.graphql_type.args["optional"].default_value == Undefined
 
 
 def test_raises_error_when_return_annotation_missing():

--- a/tests/test_input_types.py
+++ b/tests/test_input_types.py
@@ -1,3 +1,4 @@
+from typing import Optional
 import textwrap
 
 import strawberry
@@ -25,5 +26,24 @@ def test_simple_required_types():
 
     assert (
         print_type(MyInput("a", 1, True, 3.2, "123"))
+        == textwrap.dedent(expected_type).strip()
+    )
+
+
+def test_optional_default():
+    @strawberry.input
+    class MyInput:
+        s: Optional[str]
+        i: int = 0
+
+    expected_type = """
+    input MyInput {
+      s: String
+      i: Int! = 0
+    }
+    """
+
+    assert (
+        print_type(MyInput("a", 1))
         == textwrap.dedent(expected_type).strip()
     )


### PR DESCRIPTION
This doesn't change any of the optional or nullable logic.

## Description
A first step towards #306.  It only transforms Python defaults to `default_value` on inputs and arguments.

## Types of Changes
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR
* #306 

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).