### PR TITLE
Add sentinel value to match unset client input

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+Added sentinel value for input parameters that aren't sent by the clients.
+It checks for when a field is unset.

--- a/strawberry/utils/arguments.py
+++ b/strawberry/utils/arguments.py
@@ -12,6 +12,9 @@ SCALAR_TYPES = [int, str, float, bytes, bool, datetime, date, time]
 
 
 class _Unset:
+    def __str__(self):
+        return ""
+
     def __bool__(self):
         return False
 

--- a/strawberry/utils/arguments.py
+++ b/strawberry/utils/arguments.py
@@ -60,7 +60,7 @@ def _to_type(value, annotation):
             else:
                 dict_name = to_camel_case(name)
 
-            kwargs[name] = _to_type(value.get(dict_name), field.type)
+            kwargs[name] = _to_type(value.get(dict_name, UNSET), field.type)
 
         return annotation(**kwargs)
 
@@ -75,13 +75,6 @@ def convert_args(args, annotations):
     for key, value in args.items():
         key = to_snake_case(key)
         annotation = annotations[key]
-
-        if not value:
-            value = UNSET
-        else:
-            if isinstance(value, dict):
-                if None in value.values():
-                    value = UNSET
 
         converted_args[key] = _to_type(value, annotation)
 

--- a/strawberry/utils/arguments.py
+++ b/strawberry/utils/arguments.py
@@ -78,6 +78,10 @@ def convert_args(args, annotations):
 
         if not value:
             value = UNSET
+        else:
+            if isinstance(value, dict):
+                if None in value.values():
+                    value = UNSET
 
         converted_args[key] = _to_type(value, annotation)
 

--- a/strawberry/utils/arguments.py
+++ b/strawberry/utils/arguments.py
@@ -10,9 +10,25 @@ from .typing import get_list_annotation, get_optional_annotation, is_list, is_op
 SCALAR_TYPES = [int, str, float, bytes, bool, datetime, date, time]
 
 
+class _Unset:
+    def __bool__(self):
+        return False
+
+
+UNSET = _Unset()
+
+
+# this utility might be useful, so we don't have to use an internal representation
+def is_unset(value):  # type Any
+    return value is UNSET
+
+
 def _to_type(value, annotation):
     if value is None:
         return None
+
+    if isinstance(value, _Unset):
+        return value
 
     if is_optional(annotation):
         annotation = get_optional_annotation(annotation)
@@ -59,6 +75,9 @@ def convert_args(args, annotations):
     for key, value in args.items():
         key = to_snake_case(key)
         annotation = annotations[key]
+
+        if not value:
+            value = UNSET
 
         converted_args[key] = _to_type(value, annotation)
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -285,6 +285,29 @@ def test_unset_types_name_with_underscore():
     assert result.data["sayAge"] == "Hello Patrick of age unset!"
 
 
+def test_unset_types_stringify_empty():
+    @strawberry.type
+    class Query:
+        hello: str = "Hello"
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        def say(self, info, first_name: typing.Optional[str]) -> str:
+            return f"Hello {first_name}!"
+
+    schema = strawberry.Schema(query=Query, mutation=Mutation)
+
+    query = """mutation {
+        say
+    }"""
+
+    result = graphql_sync(schema, query)
+
+    assert not result.errors
+    assert result.data["say"] == "Hello !"
+
+
 def test_does_camel_case_conversion():
     @strawberry.type
     class Query:

--- a/tests/utils/test_arguments_converter.py
+++ b/tests/utils/test_arguments_converter.py
@@ -2,7 +2,7 @@ import typing
 from enum import Enum
 
 import strawberry
-from strawberry.utils.arguments import convert_args
+from strawberry.utils.arguments import UNSET, convert_args
 
 
 def test_simple_types():
@@ -171,3 +171,19 @@ def test_nested_list_of_complex_types():
     assert convert_args(args, annotations) == {
         "input": Input(numbers=[Number(1), Number(2)])
     }
+
+
+def test_uses_unset_for_optional_types_when_nothing_is_passed():
+    @strawberry.input
+    class Number:
+        value: int
+
+    @strawberry.input
+    class Input:
+        numbers: typing.Optional[Number]
+
+    args = {"input": {}}
+
+    annotations = {"input": Input}
+
+    assert convert_args(args, annotations) == {"input": UNSET}

--- a/tests/utils/test_arguments_converter.py
+++ b/tests/utils/test_arguments_converter.py
@@ -148,11 +148,12 @@ def test_nested_input_types():
 
     annotations = {"input": AddReleaseFileCommentInput}
 
-    assert convert_args(args, annotations) == {
-        "input": AddReleaseFileCommentInput(
-            pr_number=12, status=ReleaseFileStatus.OK, release_info=None
-        )
-    }
+    # assert convert_args(args, annotations) == {
+    #     "input": AddReleaseFileCommentInput(
+    #         pr_number=12, status=ReleaseFileStatus.OK, release_info=None
+    #     )
+    # }
+    assert convert_args(args, annotations) == {"input": UNSET}
 
 
 def test_nested_list_of_complex_types():
@@ -180,9 +181,25 @@ def test_uses_unset_for_optional_types_when_nothing_is_passed():
 
     @strawberry.input
     class Input:
-        numbers: typing.Optional[Number]
+        numbers: typing.Optional[Number] = None
+        numbers_second: typing.Optional[Number] = None
 
+    # case 1
     args = {"input": {}}
+
+    annotations = {"input": Input}
+
+    assert convert_args(args, annotations) == {"input": UNSET}
+
+    # case 2
+    args = {"input": {"numbersSecond": None}}
+
+    annotations = {"input": Input}
+
+    assert convert_args(args, annotations) == {"input": UNSET}
+
+    # case 3
+    args = {"input": {"numbers": None, "numbersSecond": 5}}
 
     annotations = {"input": Input}
 

--- a/tests/utils/test_arguments_converter.py
+++ b/tests/utils/test_arguments_converter.py
@@ -20,9 +20,9 @@ def test_simple_types():
 
 def test_list():
     args = {
-        "integer_list": [1, 2],
-        "string_list": ["abc", "cde"],
-        "float_list": [1.2, 2.3],
+        "integerList": [1, 2],
+        "stringList": ["abc", "cde"],
+        "floatList": [1.2, 2.3],
     }
 
     annotations = {
@@ -74,7 +74,7 @@ def test_list_of_input_types():
     class MyInput:
         abc: str
 
-    args = {"input_list": [{"abc": "example"}]}
+    args = {"inputList": [{"abc": "example"}]}
 
     annotations = {"input_list": typing.List[MyInput]}
 
@@ -86,7 +86,7 @@ def test_optional_list_of_input_types():
     class MyInput:
         abc: str
 
-    args = {"input_list": [{"abc": "example"}]}
+    args = {"inputList": [{"abc": "example"}]}
 
     annotations = {"input_list": typing.Optional[typing.List[MyInput]]}
 

--- a/tests/utils/test_arguments_converter.py
+++ b/tests/utils/test_arguments_converter.py
@@ -148,12 +148,11 @@ def test_nested_input_types():
 
     annotations = {"input": AddReleaseFileCommentInput}
 
-    # assert convert_args(args, annotations) == {
-    #     "input": AddReleaseFileCommentInput(
-    #         pr_number=12, status=ReleaseFileStatus.OK, release_info=None
-    #     )
-    # }
-    assert convert_args(args, annotations) == {"input": UNSET}
+    assert convert_args(args, annotations) == {
+        "input": AddReleaseFileCommentInput(
+            pr_number=12, status=ReleaseFileStatus.OK, release_info=None
+        )
+    }
 
 
 def test_nested_list_of_complex_types():
@@ -189,18 +188,11 @@ def test_uses_unset_for_optional_types_when_nothing_is_passed():
 
     annotations = {"input": Input}
 
-    assert convert_args(args, annotations) == {"input": UNSET}
+    assert convert_args(args, annotations) == {"input": Input(UNSET, UNSET)}
 
     # case 2
     args = {"input": {"numbersSecond": None}}
 
     annotations = {"input": Input}
 
-    assert convert_args(args, annotations) == {"input": UNSET}
-
-    # case 3
-    args = {"input": {"numbers": None, "numbersSecond": 5}}
-
-    annotations = {"input": Input}
-
-    assert convert_args(args, annotations) == {"input": UNSET}
+    assert convert_args(args, annotations) == {"input": Input(UNSET, None)}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

> When using input types with optional fields we cannot differentiate by fields that have sent as null and fields that haven't been sent at all.
I've added a sentinel value that tells that a field is unset.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* fixes #321 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).