### PR TITLE
Default values make input arguments nullable when the default is None.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,14 @@
+Release type: patch
+
+Default values make input arguments nullable when the default is None.
+```python
+class Query:
+     @strawberry.field
+     def hello(self, i: int = 0, s: str = None) -> str:
+         return s
+```
+```graphql
+type Query {
+  hello(i: Int! = 0, s: String): String!
+}
+```

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -207,9 +207,7 @@ def _get_field(
     for name, annotation in arguments_annotations.items():
         default = parameters[name].default
         arguments[to_camel_case(name)] = GraphQLArgument(
-            get_graphql_type_for_annotation(
-                annotation, name, default != inspect._empty
-            ),
+            get_graphql_type_for_annotation(annotation, name, default is None),
             default_value=Undefined if default in (inspect._empty, None) else default,
         )
 

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -37,7 +37,7 @@ def test_field_arguments():
 
 def test_field_default_arguments_are_optional():
     @strawberry.field
-    def hello(self, info, test: int, id: int = 1, asdf: str = "hello") -> str:
+    def hello(self, info, test: int, id: int = 1, asdf: str = None) -> str:
         return "I'm a resolver"
 
     assert hello.graphql_type
@@ -46,13 +46,13 @@ def test_field_default_arguments_are_optional():
     assert type(hello.graphql_type.type) == GraphQLNonNull
     assert hello.graphql_type.type.of_type.name == "String"
 
-    assert type(hello.graphql_type.args["id"].type) == GraphQLScalarType
-    assert hello.graphql_type.args["id"].type.name == "Int"
+    assert type(hello.graphql_type.args["id"].type) == GraphQLNonNull
+    assert hello.graphql_type.args["id"].type.of_type.name == "Int"
     assert hello.graphql_type.args["id"].default_value == 1
 
     assert type(hello.graphql_type.args["asdf"].type) == GraphQLScalarType
     assert hello.graphql_type.args["asdf"].type.name == "String"
-    assert hello.graphql_type.args["asdf"].default_value == "hello"
+    assert hello.graphql_type.args["asdf"].default_value == Undefined
 
 
 def test_field_default_optional_argument_custom_type():


### PR DESCRIPTION
## Description
The next step for #306.  A default of `None` still makes an input arg implicitly nullable as always, but a non-`None` keeps the arg non-nullable.  This matches input type behavior, and the arg is still "optional", just not nullable.

Although technically not backwards-compatible, it should have minimal impact because users who want a nullable field typically use `None` as a default.

## Types of Changes
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #306 

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).