### PR TITLE
Argument conversion doesn't populate missing args with defaults.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,8 @@
+Release type: patch
+
+Argument conversion doesn't populate missing args with defaults.
+```python
+@strawberry.field
+def hello(self, null_or_unset: Optional[str] = UNSET, nullable: str = None) -> None:
+    pass
+```

--- a/strawberry/type.py
+++ b/strawberry/type.py
@@ -1,6 +1,7 @@
 import copy
 import dataclasses
 from functools import partial
+from typing import Optional
 
 from graphql import GraphQLInputObjectType, GraphQLInterfaceType, GraphQLObjectType
 
@@ -57,6 +58,9 @@ def _process_type(cls, *, is_input=False, is_interface=False, description=None):
                 class_field.type = get_actual_type(
                     class_field.type, types_replacement_map
                 )
+            # like args, a None default implies Optional
+            if class_field.default is None:
+                class_field.type = Optional[class_field.type]
 
             field_name = getattr(class_field, "field_name", None) or to_camel_case(
                 class_field.name

--- a/strawberry/utils/arguments.py
+++ b/strawberry/utils/arguments.py
@@ -90,7 +90,8 @@ def convert_args(
             else:
                 field_type = field
 
-            kwargs[name] = convert_args(value.get(dict_name, UNSET), field_type)
+            if dict_name in value:
+                kwargs[name] = convert_args(value[dict_name], field_type)
 
         if is_dataclass(annotation):
             return annotation(**kwargs)  # type: ignore

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -247,7 +247,7 @@ def test_enum_falsy_values():
     @strawberry.input
     class Input:
         flavour: IceCreamFlavour
-        optionalFlavour: typing.Optional[IceCreamFlavour]
+        optionalFlavour: typing.Optional[IceCreamFlavour] = None
 
     @strawberry.type
     class Query:

--- a/tests/test_input_types.py
+++ b/tests/test_input_types.py
@@ -35,11 +35,13 @@ def test_optional_default():
     class MyInput:
         s: Optional[str]
         i: int = 0
+        f: float = None
 
     expected_type = """
     input MyInput {
       s: String
       i: Int! = 0
+      f: Float
     }
     """
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -7,7 +7,7 @@ import pytest
 
 import strawberry
 from graphql import DirectiveLocation, graphql, graphql_sync
-from strawberry.utils.arguments import is_unset
+from strawberry.utils.arguments import UNSET, is_unset
 
 
 def test_init_var():
@@ -206,12 +206,12 @@ def test_unset_types():
     @strawberry.input
     class InputExample:
         name: str
-        age: typing.Optional[int]
+        age: typing.Optional[int] = UNSET
 
     @strawberry.type
     class Mutation:
         @strawberry.mutation
-        def say(self, info, name: typing.Optional[str]) -> str:
+        def say(self, info, name: typing.Optional[str] = UNSET) -> str:  # type: ignore
             if is_unset(name):
                 return "Name is unset"
 
@@ -242,12 +242,14 @@ def test_unset_types_name_with_underscore():
     @strawberry.input
     class InputExample:
         first_name: str
-        age: typing.Optional[str]
+        age: typing.Optional[str] = UNSET
 
     @strawberry.type
     class Mutation:
         @strawberry.mutation
-        def say(self, info, first_name: typing.Optional[str]) -> str:
+        def say(
+            self, info, first_name: typing.Optional[str] = UNSET  # type: ignore
+        ) -> str:
             if is_unset(first_name):
                 return "Name is unset"
 
@@ -293,7 +295,9 @@ def test_unset_types_stringify_empty():
     @strawberry.type
     class Mutation:
         @strawberry.mutation
-        def say(self, info, first_name: typing.Optional[str]) -> str:
+        def say(
+            self, info, first_name: typing.Optional[str] = UNSET  # type: ignore
+        ) -> str:
             return f"Hello {first_name}!"
 
     schema = strawberry.Schema(query=Query, mutation=Mutation)
@@ -306,6 +310,15 @@ def test_unset_types_stringify_empty():
 
     assert not result.errors
     assert result.data["say"] == "Hello !"
+
+    query = """mutation {
+        say(firstName: null)
+    }"""
+
+    result = graphql_sync(schema, query)
+
+    assert not result.errors
+    assert result.data["say"] == "Hello None!"
 
 
 def test_does_camel_case_conversion():

--- a/tests/utils/test_arguments_converter.py
+++ b/tests/utils/test_arguments_converter.py
@@ -173,15 +173,15 @@ def test_nested_list_of_complex_types():
     }
 
 
-def test_uses_unset_for_optional_types_when_nothing_is_passed():
+def test_uses_default_for_optional_types_when_nothing_is_passed():
     @strawberry.input
     class Number:
         value: int
 
     @strawberry.input
     class Input:
-        numbers: typing.Optional[Number] = None
-        numbers_second: typing.Optional[Number] = None
+        numbers: typing.Optional[Number] = UNSET
+        numbers_second: typing.Optional[Number] = UNSET
 
     # case 1
     args = {"input": {}}


### PR DESCRIPTION
## Description
This allows resolvers to use a non-`None` sentinel to distinguish missing from explicitly null.
Input types also use `None` to imply optional, matching the function behavior.

## Types of Changes
- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #306 

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).