### PR TITLE
Fix asgi view to allow multiple subscriptions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Fix Strawberry to handle multiple subscriptions at the same time

--- a/strawberry/asgi/__init__.py
+++ b/strawberry/asgi/__init__.py
@@ -3,7 +3,7 @@ import typing
 
 from starlette.requests import Request
 from starlette.types import Receive, Scope, Send
-from starlette.websockets import WebSocket, WebSocketState
+from starlette.websockets import WebSocket, WebSocketDisconnect, WebSocketState
 
 from graphql import GraphQLError
 from graphql.error import format_error as format_graphql_error
@@ -39,7 +39,7 @@ class GraphQL:
         self.graphiql = graphiql
         self.keep_alive = keep_alive
         self.keep_alive_interval = keep_alive_interval
-        self._keep_alive_task = None
+        self._keep_alive_task: typing.Optional[asyncio.Task[typing.Any]] = None
         self.debug = debug
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send):
@@ -62,35 +62,65 @@ class GraphQL:
         if websocket.application_state == WebSocketState.DISCONNECTED:
             return
 
-        await websocket.send_json({"type": GQL_CONNECTION_KEEP_ALIVE})
         await asyncio.sleep(self.keep_alive_interval)
+        await websocket.send_json({"type": GQL_CONNECTION_KEEP_ALIVE})
 
         self._keep_alive_task = asyncio.create_task(self.handle_keep_alive(websocket))
 
     async def handle_websocket(self, scope: Scope, receive: Receive, send: Send):
         websocket = WebSocket(scope=scope, receive=receive, send=send)
 
+        subscriptions: typing.Dict[str, typing.AsyncGenerator] = {}
+        tasks = {}
+
         await websocket.accept(subprotocol="graphql-ws")
 
-        while websocket.application_state != WebSocketState.DISCONNECTED:
-            message = await websocket.receive_json()
+        try:
+            while (
+                websocket.client_state != WebSocketState.DISCONNECTED
+                and websocket.application_state != WebSocketState.DISCONNECTED
+            ):
+                message = await websocket.receive_json()
 
-            operation_id = message.get("id")
-            message_type = message.get("type")
+                operation_id = message.get("id")
+                message_type = message.get("type")
 
-            if message_type == GQL_CONNECTION_INIT:
-                await websocket.send_json({"type": GQL_CONNECTION_ACK})
+                if message_type == GQL_CONNECTION_INIT:
+                    await websocket.send_json({"type": GQL_CONNECTION_ACK})
 
-                if self.keep_alive:
-                    asyncio.create_task(self.handle_keep_alive(websocket))
-            elif message_type == GQL_CONNECTION_TERMINATE:
-                await websocket.close()
-            elif message_type == GQL_START:
-                await self.start_subscription(
-                    message.get("payload"), operation_id, websocket
-                )
-            elif message_type == GQL_STOP:
-                await websocket.close()
+                    if self.keep_alive:
+                        self._keep_alive_task = asyncio.create_task(
+                            self.handle_keep_alive(websocket)
+                        )
+                elif message_type == GQL_CONNECTION_TERMINATE:
+                    await websocket.close()
+                elif message_type == GQL_START:
+                    async_result = await self.start_subscription(
+                        message.get("payload"), operation_id, websocket
+                    )
+
+                    subscriptions[operation_id] = async_result
+
+                    tasks[operation_id] = asyncio.create_task(
+                        self.handle_async_results(async_result, operation_id, websocket)
+                    )
+                elif message_type == GQL_STOP:
+                    if operation_id not in subscriptions:
+                        return
+
+                    await subscriptions[operation_id].aclose()
+                    tasks[operation_id].cancel()
+                    del tasks[operation_id]
+                    del subscriptions[operation_id]
+        except WebSocketDisconnect:
+            pass
+        finally:
+            if self._keep_alive_task:
+                self._keep_alive_task.cancel()
+
+            for operation_id in subscriptions:
+                await subscriptions[operation_id].aclose()
+                tasks[operation_id].cancel()
 
     async def start_subscription(self, data, operation_id: str, websocket: WebSocket):
         query = data["query"]
@@ -109,14 +139,18 @@ class GraphQL:
             context_value=context,
         )
 
+    async def handle_async_results(
+        self, results: typing.AsyncGenerator, operation_id: str, websocket: WebSocket
+    ):
         try:
-            async for result in data:
+            async for result in results:
                 payload = {"data": result.data}
 
                 if result.errors:
                     payload["errors"] = [
                         format_graphql_error(err) for err in result.errors
                     ]
+
                 await self._send_message(websocket, GQL_DATA, payload, operation_id)
         except Exception as error:
             if not isinstance(error, GraphQLError):
@@ -129,12 +163,11 @@ class GraphQL:
                 operation_id,
             )
 
-        await self._send_message(websocket, GQL_COMPLETE, None, operation_id)
-
-        if self._keep_alive_task:
-            self._keep_alive_task.cancel()
-
-        await websocket.close()
+        if (
+            websocket.client_state != WebSocketState.DISCONNECTED
+            and websocket.application_state != WebSocketState.DISCONNECTED
+        ):
+            await self._send_message(websocket, GQL_COMPLETE, None, operation_id)
 
     async def _send_message(
         self,

--- a/strawberry/asgi/__init__.py
+++ b/strawberry/asgi/__init__.py
@@ -132,7 +132,7 @@ class GraphQL:
 
         context = await self.get_context(websocket)
 
-        data = await self.schema.subscribe(
+        return await self.schema.subscribe(
             query,
             variable_values=variables,
             operation_name=operation_name,

--- a/strawberry/asgi/__init__.py
+++ b/strawberry/asgi/__init__.py
@@ -47,7 +47,7 @@ class GraphQL:
             await self.handle_http(scope=scope, receive=receive, send=send)
         elif scope["type"] == "websocket":
             await self.handle_websocket(scope=scope, receive=receive, send=send)
-        else:
+        else:  # pragma: no cover
             raise ValueError("Unknown scope type: %r" % (scope["type"],))
 
     async def get_root_value(self, request: Request) -> typing.Optional[typing.Any]:
@@ -59,7 +59,9 @@ class GraphQL:
         return {"request": request}
 
     async def handle_keep_alive(self, websocket):
-        if websocket.application_state == WebSocketState.DISCONNECTED:
+        if (
+            websocket.application_state == WebSocketState.DISCONNECTED
+        ):  # pragma: no cover
             return
 
         await asyncio.sleep(self.keep_alive_interval)
@@ -104,7 +106,7 @@ class GraphQL:
                     tasks[operation_id] = asyncio.create_task(
                         self.handle_async_results(async_result, operation_id, websocket)
                     )
-                elif message_type == GQL_STOP:
+                elif message_type == GQL_STOP:  # pragma: no cover
                     if operation_id not in subscriptions:
                         return
 
@@ -112,7 +114,7 @@ class GraphQL:
                     tasks[operation_id].cancel()
                     del tasks[operation_id]
                     del subscriptions[operation_id]
-        except WebSocketDisconnect:
+        except WebSocketDisconnect:  # pragma: no cover
             pass
         finally:
             if self._keep_alive_task:

--- a/strawberry/types/fields/resolver.py
+++ b/strawberry/types/fields/resolver.py
@@ -1,5 +1,5 @@
 import inspect
-from inspect import iscoroutinefunction
+from inspect import isasyncgenfunction, iscoroutinefunction
 from typing import Callable, Generic, List, Optional, Type, TypeVar
 
 from cached_property import cached_property  # type: ignore
@@ -79,7 +79,9 @@ class StrawberryResolver(Generic[T]):
 
     @cached_property
     def is_async(self) -> bool:
-        return iscoroutinefunction(self.wrapped_func)
+        return iscoroutinefunction(self.wrapped_func) or isasyncgenfunction(
+            self.wrapped_func
+        )
 
 
 __all__ = ["StrawberryResolver"]

--- a/tests/asgi/test_subscription.py
+++ b/tests/asgi/test_subscription.py
@@ -82,12 +82,12 @@ def test_sends_keep_alive(test_client_keep_alive):
         assert response["type"] == GQL_CONNECTION_KEEP_ALIVE
 
         response = ws.receive_json()
-        assert response["type"] == GQL_CONNECTION_KEEP_ALIVE
-
-        response = ws.receive_json()
         assert response["type"] == GQL_DATA
         assert response["id"] == "demo"
         assert response["payload"]["data"] == {"example": "Hi"}
+
+        response = ws.receive_json()
+        assert response["type"] == GQL_CONNECTION_KEEP_ALIVE
 
         response = ws.receive_json()
         assert response["type"] == GQL_COMPLETE


### PR DESCRIPTION
Right now we cannot send multiple blocking subscriptions to the server because the ASGI hangs on the connection until the subscription is complete

- [ ] Make sure all the tasks are correctly cleaned up when the connection is closed both via Graphql's "STOP" and by force
- [ ] Add tests


Test schema:

```python
import asyncio
import typing
import strawberry


@strawberry.type
class User:
    name: str
    age: int


@strawberry.type
class Subscription:
    @strawberry.subscription
    async def sub1(self) -> typing.AsyncGenerator[User, None]:
        count = 0

        while True:
            count = count + 1
            yield User(name="A", age=count)
            await asyncio.sleep(5)

    @strawberry.subscription
    async def sub2(self) -> typing.AsyncGenerator[User, None]:
        count = 0

        while True:
            count = count + 1
            yield User(name="B", age=count)
            await asyncio.sleep(5)


@strawberry.type
class Query:
    @strawberry.field
    def user(self, info) -> User:
        return User(name="Patrick", age=100)


schema = strawberry.Schema(query=Query, subscription=Subscription)
```