### PR TITLE
Fix issue when using unions and generics in the same type

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Fixes a bug when using unions and lists together


### PR DESCRIPTION
We weren't handling lists when trying to get the original type for a generic.

This PR fixes that, at least in the basic case, where we only have one
type per list :)