### PR TITLE
Add __call__ method on result of strawberry.union

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,21 @@
+Release type: patch
+
+This release fixes an issue when using named union types in generic types,
+for example using an optional union. This is now properly supported:
+
+
+```python
+@strawberry.type
+class A:
+    a: int
+
+@strawberry.type
+class B:
+    b: int
+
+Result = strawberry.union("Result", (A, B))
+
+@strawberry.type
+class Query:
+    ab: Optional[Result] = None
+```

--- a/strawberry/union.py
+++ b/strawberry/union.py
@@ -116,4 +116,7 @@ def union(name: str, types: typing.Tuple[typing.Type], *, description=None):
         def __init__(self, graphql_type):
             self.graphql_type = graphql_type
 
+        def __call__(self):
+            raise ValueError("Cannot use union type directly")
+
     return X(graphql_type)


### PR DESCRIPTION
This fixes an issue when using named unions with generic types.

Error that was fixed:
![image](https://user-images.githubusercontent.com/667029/84394087-60a4bb80-abf4-11ea-9e66-1b64f046b801.png)
