### PR TITLE
Fix paths within docs

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,13 @@
+name: Trigger Netlify Build
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: Request Netlify Webhook
+    runs-on: ubuntu-latest
+    steps:
+      - run: curl -X POST -d {} https://api.netlify.com/build_hooks/5ee257e252790c60d79734d7

--- a/docs/01_general/schema-basics.md
+++ b/docs/01_general/schema-basics.md
@@ -1,6 +1,6 @@
 ---
 title: Schema Basics
-path: /docs/schema-basic
+path: /docs/schema-basics
 ---
 
 # Schema basics

--- a/docs/01_general/schema-basics.md
+++ b/docs/01_general/schema-basics.md
@@ -103,7 +103,7 @@ default scalar types in GraphQL:
 
 <!--alex ignore-->
 These primitives work for the majority for the uses cases, but you can also
-specify your [own scalar types](...).
+specify your [own scalar types](/docs/types/scalars).
 
 ## Object types
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -85,7 +85,7 @@ that we can also reuse them to create the data objects.
 
 We now have a function that returns some books, but Strawberry doesn’t know it
 should use it when executing a query. To fix this we need to update our query to
-specify the [resolver](/docs/resolvers/) for our books. A resolver tells
+specify the [resolver](/docs/types/resolvers) for our books. A resolver tells
 Strawberry how to fetch the data associated with a particular field.
 
 Let’s update our Query:
@@ -170,5 +170,5 @@ Well done! You just created your first GraphQL API using Strawberry 🙌!
 Check out the following resources to learn more about GraphQL and Strawberry.
 
 - [Schema Basics](/docs/schema-basics)
-- [Resolvers](/docs/resolvers/)
-- [Deploy](/docs/deploy/)
+- [Resolvers](/docs/types/resolvers)
+- [Deployment](/docs/ops/deployment)


### PR DESCRIPTION
## Description

The Schema Basics doc page's path was missing the trailing `s`. This broke the [link](https://github.com/strawberry-graphql/strawberry/blame/2ac2fef5c32e75433fbd2e4d90db171d893b811f/docs/index.md#L172) at the bottom of the Getting Started page. 

Note: I didn't test the change as I'm not sure how to run the documentation server myself, but I don't think it will have broken anything.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

* N/A

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).