### PR TITLE
Fix schema-basics.md example

### DIFF
--- a/docs/01_general/schema-basics.md
+++ b/docs/01_general/schema-basics.md
@@ -60,16 +60,18 @@ import strawberry
 @strawberry.type
 class Book:
   title: str
-  author: Author
+  author: 'Author'
 
 @strawberry.type
 class Author:
   name: str
-  books: typing.List[Book]
+  books: typing.List['Book']
 ```
 
 As you can see the code maps almost one to one with the schema, thanks to
-python’s type hints feature.
+python’s type hints feature. However, note that we need to wrap our custom
+strawberry types with quotes in order to avoid a 'name Author not defined' 
+TypeError.
 
 Note that here we are also not specifying how to fetch data, that will be
 explained in the resolvers section.


### PR DESCRIPTION
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

Example on line 56 does not in fact work.

Issue #340 - given that importing `__future__.annotations` is not yet supported,
I refactored the example to include @patrick91 suggestion of wrapping types in quotes:

> I mean in general. Personally I haven’t used them much blush
> 
> The alternative would be to use quotes around types, which I think should work


## Issues Fixed or Closed by This PR

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).