### PR TITLE
Fix bug when using multiple unions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+This PR fixes a bug when declaring multiple non-named union types

--- a/strawberry/type.py
+++ b/strawberry/type.py
@@ -38,6 +38,8 @@ def _get_resolver(cls, field_name):
 
         return field_resolver
 
+    _resolver.__name__ = field_name
+
     return _resolver
 
 

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -284,3 +284,49 @@ def test_cannot_use_union_directly():
 
     with pytest.raises(ValueError, match=r"Cannot use union type directly"):
         Result()
+
+
+def test_multiple_unions():
+    @strawberry.type
+    class CoolType:
+        @strawberry.type
+        class UnionA1:
+            value: int
+
+        @strawberry.type
+        class UnionA2:
+            value: int
+
+        @strawberry.type
+        class UnionB1:
+            value: int
+
+        @strawberry.type
+        class UnionB2:
+            value: int
+
+        field1: Union[UnionA1, UnionA2]
+        field2: Union[UnionB1, UnionB2]
+
+    schema = strawberry.Schema(query=CoolType)
+
+    query = """
+        {
+            __type(name:"CoolType") {
+                name
+                description
+                fields {
+                    name
+                }
+            }
+        }
+    """
+
+    result = graphql_sync(schema, query)
+
+    assert not result.errors
+    assert result.data["__type"] == {
+        "description": None,
+        "fields": [{"name": "field1"}, {"name": "field2"}],
+        "name": "CoolType",
+    }


### PR DESCRIPTION
Closes #377 

This is quick fix to add support for using multiple non-named union types. In #352 we have a better approach for naming anon union types (we use the type names for the name instead of the field), but this solutions works for now :)
