### PR TITLE
passthrough websocket in the context

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Add websocket object to the subscription context.

--- a/strawberry/asgi/__init__.py
+++ b/strawberry/asgi/__init__.py
@@ -90,8 +90,14 @@ class GraphQL:
         if self.debug:
             pretty_print_graphql_operation(operation_name, query, variables)
 
+        context = {"websocket": websocket}
+
         data = await subscribe(
-            self.schema, query, variable_values=variables, operation_name=operation_name
+            self.schema,
+            query,
+            variable_values=variables,
+            operation_name=operation_name,
+            context_value=context,
         )
 
         try:


### PR DESCRIPTION
Passthrough the WebSocket to the resolvers so we can access things like connection headers etc.