### PR TITLE
PEP 563 compatibility ensured

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,18 @@
+Release type: patch
+
+This release fixes support for PEP-563, now you can safely use `from __future__ import annotations`,
+like the following example:
+
+
+```python
+from __future__ import annotations
+
+@strawberry.type
+class Query:
+    me: MyType = strawberry.field(name="myself")
+
+@strawberry.type
+class MyType:
+    id: strawberry.ID
+
+```

--- a/docs/01_general/schema-basics.md
+++ b/docs/01_general/schema-basics.md
@@ -54,24 +54,34 @@ As mentioned Strawberry uses a code first approach. The previous schema would
 look like this in Strawberry
 
 ```python
+from __future__ import annotations
+
 import typing
 import strawberry
 
 @strawberry.type
 class Book:
   title: str
-  author: 'Author'
+  author: Author
 
 @strawberry.type
 class Author:
   name: str
   books: typing.List['Book']
 ```
-
 As you can see the code maps almost one to one with the schema, thanks to
-python’s type hints feature. However, note that we need to wrap our custom
-strawberry types with quotes in order to avoid a 'name Author not defined' 
-TypeError.
+python’s type hints feature.
+
+The `__future__` import allows us to annotate types that are defined later in
+the file, as per [PEP 563](https://www.python.org/dev/peps/pep-0563/).
+If you can’t use this feature (because your other code is incompatible with it),
+you need to quote the `Author` annotation.
+
+```python
+    ...
+    author: 'Author'
+    ...
+```
 
 Note that here we are also not specifying how to fetch data, that will be
 explained in the resolvers section.

--- a/strawberry/types/type_resolver.py
+++ b/strawberry/types/type_resolver.py
@@ -238,6 +238,15 @@ def _get_fields(cls: Type) -> List[FieldDefinition]:
     for field in dataclass_fields:
         if hasattr(field, "_field_definition"):
             field_definition = field._field_definition  # type: ignore
+
+            # we make sure that the origin is either the field's resolver
+            # when called as:
+            # >>> @strawberry.field
+            # >>> def x(self): ...
+            # or the class where this field was defined, so we always have
+            # the correct origin for determining field types when resolving
+            # the types.
+
             field_definition.origin = field_definition.origin or cls
         else:
             # for fields that don't have a field definition, we create one

--- a/strawberry/types/type_resolver.py
+++ b/strawberry/types/type_resolver.py
@@ -238,6 +238,7 @@ def _get_fields(cls: Type) -> List[FieldDefinition]:
     for field in dataclass_fields:
         if hasattr(field, "_field_definition"):
             field_definition = field._field_definition  # type: ignore
+            field_definition.origin = field_definition.origin or cls
         else:
             # for fields that don't have a field definition, we create one
             # based on the dataclass field

--- a/tests/test_forward_references.py
+++ b/tests/test_forward_references.py
@@ -17,7 +17,7 @@ def test_forward_reference():
 
     @strawberry.type
     class Query:
-        me: MyType
+        me: MyType = strawberry.field(name="myself")
 
     expected_representation = """
     type MyType {
@@ -25,7 +25,7 @@ def test_forward_reference():
     }
 
     type Query {
-      me: MyType!
+      myself: MyType!
     }
     """
 

--- a/tests/test_forward_references.py
+++ b/tests/test_forward_references.py
@@ -12,12 +12,12 @@ def test_forward_reference():
     global MyType
 
     @strawberry.type
-    class MyType:
-        id: strawberry.ID
-
-    @strawberry.type
     class Query:
         me: MyType = strawberry.field(name="myself")
+
+    @strawberry.type
+    class MyType:
+        id: strawberry.ID
 
     expected_representation = """
     type MyType {

--- a/tests/test_forward_references.py
+++ b/tests/test_forward_references.py
@@ -1,20 +1,17 @@
+# type: ignore
 from __future__ import annotations
 
 import textwrap
-
-import pytest
+from typing import List
 
 import strawberry
 from strawberry.printer import print_schema
 
 
-# Need to investigate this more, see: https://bugs.python.org/issue34776
-# Looks like types are returned as strings, so we'd need to find the actual
-# class, maybe from the global namespace. Or maybe from our type map
-
-
-@pytest.mark.xfail(strict=True, reason="Future style annotation are currently broken")
 def test_forward_reference():
+
+    global MyType
+
     @strawberry.type
     class MyType:
         id: strawberry.ID
@@ -36,3 +33,26 @@ def test_forward_reference():
     schema = strawberry.Schema(Query)
 
     assert print_schema(schema) == textwrap.dedent(expected_representation).strip()
+
+
+def test_with_resolver():
+    @strawberry.type
+    class User:
+        name: str
+
+    def get_users():
+        return []
+
+    @strawberry.type
+    class Query:
+        users: List[User] = strawberry.field(resolver=get_users)
+
+    definition = Query._type_definition
+
+    assert definition.name == "Query"
+    assert len(definition.fields) == 1
+    assert definition.fields[0].name == "users"
+    assert definition.fields[0].is_list
+    assert definition.fields[0].type is None
+    assert definition.fields[0].is_optional is False
+    assert definition.fields[0].child.is_optional is False

--- a/tests/test_forward_references.py
+++ b/tests/test_forward_references.py
@@ -9,7 +9,6 @@ from strawberry.printer import print_schema
 
 
 def test_forward_reference():
-
     global MyType
 
     @strawberry.type
@@ -34,8 +33,12 @@ def test_forward_reference():
 
     assert print_schema(schema) == textwrap.dedent(expected_representation).strip()
 
+    del MyType
+
 
 def test_with_resolver():
+    global User
+
     @strawberry.type
     class User:
         name: str
@@ -56,3 +59,5 @@ def test_with_resolver():
     assert definition.fields[0].type is None
     assert definition.fields[0].is_optional is False
     assert definition.fields[0].child.is_optional is False
+
+    del User


### PR DESCRIPTION
Strawberry-graphql previously crashed if using `from __future__ import
annotations` with explicit `field` declarations. This has been fixed
here.

Note that the precise issue in #340 was probably already fixed by the
refactor.




## Description
Strawberry-graphql previously crashed if using `from __future__ import
annotations` with explicit `field` declarations. It was caused by the missing
`origin` field in the `FieldDefinition`, which crashed the resolution of the type string.
This has been fixed here.

The problem in #340 was probably already fixed by the refactor, but this fixes a different
issue with PEP 563 compatibility.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ x] Core
- [ x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ x] Documentation

## Issues Fixed or Closed by This PR

* Fixes: #340 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ x] I have updated the documentation accordingly.
- [x ] I have read the CONTRIBUTING document.
- [ x] I have added tests to cover my changes.
- [ x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).