### PR TITLE
Type and field descriptions default to docstrings.

### DIFF
--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -54,6 +54,7 @@ class StrawberryField(dataclasses.Field):
         f._field_definition.arguments = get_arguments_from_resolver(
             f, f._field_definition.name
         )
+        f._field_definition.description = f._field_definition.description or f.__doc__
 
         check_return_annotation(f._field_definition)
 

--- a/strawberry/type.py
+++ b/strawberry/type.py
@@ -75,7 +75,7 @@ def type(
             name=name,
             is_input=is_input,
             is_interface=is_interface,
-            description=description,
+            description=description or cls.__doc__,
             federation=federation,
         )
 

--- a/tests/schema/test_basic.py
+++ b/tests/schema/test_basic.py
@@ -109,8 +109,15 @@ def test_type_description():
         a: str
 
     @strawberry.type
+    class TypeB:
+        """Docstring description"""
+
+        b: str
+
+    @strawberry.type
     class Query:
         a: TypeA
+        b: TypeB
 
     schema = strawberry.Schema(query=Query)
 
@@ -129,6 +136,21 @@ def test_type_description():
         "description": "Decorator argument description",
     }
 
+    query = """{
+        __type(name: "TypeB") {
+            name
+            description
+        }
+    }"""
+
+    result = schema.execute_sync(query)
+    assert not result.errors
+
+    assert result.data["__type"] == {
+        "name": "TypeB",
+        "description": "Docstring description",
+    }
+
 
 def test_field_description():
     @strawberry.type
@@ -141,6 +163,11 @@ def test_field_description():
 
         @strawberry.field(description="Example C")
         def c(self, info, id: int) -> str:
+            return "I'm a resolver"
+
+        @strawberry.field
+        def d(self, info, id: int) -> str:
+            """Example D"""
             return "I'm a resolver"
 
     schema = strawberry.Schema(query=Query)
@@ -162,6 +189,7 @@ def test_field_description():
         {"name": "a", "description": "Example"},
         {"name": "b", "description": None},
         {"name": "c", "description": "Example C"},
+        {"name": "d", "description": "Example D"},
     ]
 
 


### PR DESCRIPTION
## Description
Prior to 0.28, docstrings were used as descriptions when not explicitly supplied. 
 
## Types of Changes
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR
* #391 

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).