### PR TITLE
WIP improvements for finding interfaces implementations

### DIFF
--- a/tests/schema/test_interface.py
+++ b/tests/schema/test_interface.py
@@ -25,7 +25,7 @@ def test_query_interface():
                 Swiss(name="Tomme", canton="Vaud"),
             ]
 
-    schema = strawberry.Schema(query=Root, types=[Swiss, Italian])
+    schema = strawberry.Schema(query=Root)
 
     query = """{
         assortment {
@@ -34,6 +34,8 @@ def test_query_interface():
             ... on Swiss { canton }
         }
     }"""
+
+    print(schema.as_str())
 
     result = schema.execute_sync(query)
 


### PR DESCRIPTION
This PR improves support for interfaces, removing the requirement of declaring the implementations of the interfaces manually.

Current PR is broken as we rely too much on GraphQL core for finding the types. Will update the code to traverse our schema tree and find the implementations one by one :)