### PR TITLE
Add support for `default_value` on input fields.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,16 @@
+Release type: patch
+
+Support for `default_value` on inputs.
+
+Usage:
+```python
+class MyInput:
+    s: Optional[str] = None
+    i: int = 0
+```
+```graphql
+input MyInput {
+  s: String = null
+  i: Int! = 0
+}
+```

--- a/strawberry/schema/types/fields.py
+++ b/strawberry/schema/types/fields.py
@@ -3,6 +3,7 @@ import typing
 from graphql import GraphQLField, GraphQLInputField
 from strawberry.field import FieldDefinition
 from strawberry.resolvers import get_resolver
+from strawberry.types.types import undefined
 
 from .arguments import convert_arguments
 from .type import get_graphql_type
@@ -24,6 +25,8 @@ def get_field(field: FieldDefinition, is_input: bool, type_map: TypeMap,) -> Fie
 
     if is_input:
         TypeClass = GraphQLInputField
+        if field.default_value is not undefined:
+            kwargs["default_value"] = field.default_value
     elif field.is_subscription:
         kwargs["args"] = convert_arguments(field.arguments, type_map)
         kwargs["subscribe"] = resolver

--- a/strawberry/types/type_resolver.py
+++ b/strawberry/types/type_resolver.py
@@ -22,7 +22,7 @@ from strawberry.utils.typing import (
 )
 
 from .generics import copy_type_with, get_name_from_types
-from .types import ArgumentDefinition, FieldDefinition
+from .types import ArgumentDefinition, FieldDefinition, undefined
 
 
 def _resolve_generic_type(type: Type, field_name: str) -> Type:
@@ -257,6 +257,7 @@ def _get_fields(cls: Type) -> List[FieldDefinition]:
                 name=to_camel_case(field.name),
                 type=field.type,
                 origin=cls,
+                default_value=getattr(cls, field.name, undefined),
             )
 
         fields.append(field_definition)

--- a/strawberry/types/types.py
+++ b/strawberry/types/types.py
@@ -98,3 +98,4 @@ class FieldDefinition:
     permission_classes: List[Type[BasePermission]] = dataclasses.field(
         default_factory=list
     )
+    default_value: Any = undefined

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -100,34 +100,32 @@ def test_input_simple_required_types():
     assert print_schema(schema) == textwrap.dedent(expected_type).strip()
 
 
-# def test_input_optional_default():
-#     @strawberry.input
-#     class MyInput:
-#         s: Optional[str]
-#         i: int = 0
-#         f: float = None
+def test_input_defaults():
+    @strawberry.input
+    class MyInput:
+        s: Optional[str] = None
+        i: int = 0
 
-#     @strawberry.type
-#     class Query:
-#         @strawberry.field
-#         def search(self, input: MyInput) -> str:
-#             return input.s
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def search(self, input: MyInput) -> int:
+            return input.i
 
-#     expected_type = """
-#     input MyInput {
-#       s: String
-#       i: Int! = 0
-#       f: Float
-#     }
+    expected_type = """
+    input MyInput {
+      s: String = null
+      i: Int! = 0
+    }
 
-#     type Query {
-#       search(input: MyInput!): String!
-#     }
-#     """
+    type Query {
+      search(input: MyInput!): Int!
+    }
+    """
 
-#     schema = strawberry.Schema(query=Query)
+    schema = strawberry.Schema(query=Query)
 
-#     assert print_schema(schema) == textwrap.dedent(expected_type).strip()
+    assert print_schema(schema) == textwrap.dedent(expected_type).strip()
 
 
 def test_interface():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The field refactoring removed support for default values on input types.  This doesn't change the dataclass or nullable behavior; just registers the default in the schema.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #306 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).