### PR TITLE
Fix check for unset values

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+This releases fixes the check for unset values.

--- a/strawberry/arguments.py
+++ b/strawberry/arguments.py
@@ -73,7 +73,7 @@ UNSET = _Unset()
 
 
 def is_unset(value: Any) -> bool:
-    return value is UNSET
+    return type(value) is _Unset
 
 
 def convert_argument(value: Any, argument_definition: ArgumentDefinition) -> Any:


### PR DESCRIPTION
This PR fixes how we change if a value is unset. Turns out in some cases the object is not the one we instanciated, for example when checking after a type has been converted to a dict using `dataclasses.todict`. Didn't check the source code but I guess they do a copy of the value.