### PR TITLE
Always return 200 in Flask view

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+This release fixes the Flask view that was returning 400 when there were errors
+in the GraphQL results. Now it always returns 200.

--- a/strawberry/flask/views.py
+++ b/strawberry/flask/views.py
@@ -61,7 +61,5 @@ class GraphQLView(View):
         response_data = self.process_result(result)
 
         return Response(
-            json.dumps(response_data),
-            status=400 if result.errors else 200,
-            content_type="application/json",
+            json.dumps(response_data), status=200, content_type="application/json",
         )


### PR DESCRIPTION
Fix for flask returning 400 when there were errors in the GraphQL response. 

Thanks @Ambro17 for the report!