### PR TITLE
Add `flake8-eradicate` to flake8 `pre-commit` hook

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -5,3 +5,9 @@ ignore = W503
 extend-ignore =
     # See https://github.com/PyCQA/pycodestyle/issues/373
     E203,
+
+per-file-ignores =
+    tests/test_forward_references.py:E800
+    tests/schema/test_resolvers.py:E800
+    tests/types/test_string_annotations.py:E800
+    tests/federation/test_printer.py:E800

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,7 @@ repos:
     rev: 3.8.2
     hooks:
       - id: flake8
+        additional_dependencies: ['flake8-eradicate==0.4.0']
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.770

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+ Improves tooling by adding `flake8-eradicate` to `flake8` `pre-commit` hook..

--- a/poetry.lock
+++ b/poetry.lock
@@ -32,13 +32,13 @@ description = "Classes Without Boilerplate"
 name = "attrs"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "19.3.0"
+version = "20.2.0"
 
 [package.extras]
-azure-pipelines = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "pytest-azurepipelines"]
-dev = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "sphinx", "pre-commit"]
-docs = ["sphinx", "zope.interface"]
-tests = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
+dev = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "sphinx", "sphinx-rtd-theme", "pre-commit"]
+docs = ["sphinx", "sphinx-rtd-theme", "zope.interface"]
+tests = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
+tests_no_zope = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
 
 [[package]]
 category = "dev"
@@ -76,7 +76,7 @@ description = "Validate configuration and produce human readable error messages.
 name = "cfgv"
 optional = false
 python-versions = ">=3.6.1"
-version = "3.1.0"
+version = "3.2.0"
 
 [[package]]
 category = "dev"
@@ -149,6 +149,14 @@ bcrypt = ["bcrypt"]
 
 [[package]]
 category = "dev"
+description = "Removes commented-out code."
+name = "eradicate"
+optional = false
+python-versions = "*"
+version = "1.0"
+
+[[package]]
+category = "dev"
 description = "colorful TAB completion for Python prompt"
 name = "fancycompleter"
 optional = false
@@ -195,6 +203,19 @@ version = "20.1.4"
 [package.dependencies]
 attrs = ">=19.2.0"
 flake8 = ">=3.0.0"
+
+[[package]]
+category = "dev"
+description = "Flake8 plugin to find commented out code"
+name = "flake8-eradicate"
+optional = false
+python-versions = ">=3.5,<4.0"
+version = "0.4.0"
+
+[package.dependencies]
+attrs = "*"
+eradicate = ">=1.0,<2.0"
+flake8 = ">=3.5,<4.0"
 
 [[package]]
 category = "main"
@@ -261,7 +282,7 @@ description = "File identification library for Python"
 name = "identify"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-version = "1.4.25"
+version = "1.5.0"
 
 [package.extras]
 license = ["editdistance"]
@@ -296,7 +317,7 @@ description = "iniconfig: brain-dead simple config-ini parsing"
 name = "iniconfig"
 optional = false
 python-versions = "*"
-version = "1.0.0"
+version = "1.0.1"
 
 [[package]]
 category = "dev"
@@ -355,7 +376,7 @@ description = "More routines for operating on iterables, beyond itertools"
 name = "more-itertools"
 optional = false
 python-versions = ">=3.5"
-version = "8.4.0"
+version = "8.5.0"
 
 [[package]]
 category = "dev"
@@ -387,7 +408,7 @@ description = "Node.js virtual environment builder"
 name = "nodeenv"
 optional = false
 python-versions = "*"
-version = "1.4.0"
+version = "1.5.0"
 
 [[package]]
 category = "dev"
@@ -818,7 +839,7 @@ description = "Virtual Python Environment builder"
 name = "virtualenv"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-version = "20.0.28"
+version = "20.0.31"
 
 [package.dependencies]
 appdirs = ">=1.4.3,<2"
@@ -880,8 +901,7 @@ django = ["django"]
 flask = ["flask"]
 
 [metadata]
-content-hash = "06ff7ea86a640f3f8b22d34f4f62dcc886b01f476eb4faa7c34015149b994098"
-lock-version = "1.0"
+content-hash = "091b50b8f1fee0e7809681fd999083120e8ec815b901992405dda52333bca6a2"
 python-versions = "^3.7"
 
 [metadata.files]
@@ -898,8 +918,8 @@ atomicwrites = [
     {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
 ]
 attrs = [
-    {file = "attrs-19.3.0-py2.py3-none-any.whl", hash = "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c"},
-    {file = "attrs-19.3.0.tar.gz", hash = "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"},
+    {file = "attrs-20.2.0-py2.py3-none-any.whl", hash = "sha256:fce7fc47dfc976152e82d53ff92fa0407700c21acd20886a13777a0d20e655dc"},
+    {file = "attrs-20.2.0.tar.gz", hash = "sha256:26b54ddbbb9ee1d34d5d3668dd37d6cf74990ab23c828c2888dccdceee395594"},
 ]
 black = [
     {file = "black-20.8b1-py3-none-any.whl", hash = "sha256:70b62ef1527c950db59062cda342ea224d772abdf6adc58b86a45421bab20a6b"},
@@ -910,8 +930,8 @@ certifi = [
     {file = "certifi-2020.6.20.tar.gz", hash = "sha256:5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3"},
 ]
 cfgv = [
-    {file = "cfgv-3.1.0-py2.py3-none-any.whl", hash = "sha256:1ccf53320421aeeb915275a196e23b3b8ae87dea8ac6698b1638001d4a486d53"},
-    {file = "cfgv-3.1.0.tar.gz", hash = "sha256:c8e8f552ffcc6194f4e18dd4f68d9aef0c0d58ae7e7be8c82bee3c5e9edfa513"},
+    {file = "cfgv-3.2.0-py2.py3-none-any.whl", hash = "sha256:32e43d604bbe7896fe7c248a9c2276447dbef840feb28fe20494f62af110211d"},
+    {file = "cfgv-3.2.0.tar.gz", hash = "sha256:cf22deb93d4bcf92f345a5c3cd39d3d41d6340adc60c78bbbd6588c384fda6a1"},
 ]
 chardet = [
     {file = "chardet-3.0.4-py2.py3-none-any.whl", hash = "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"},
@@ -973,6 +993,9 @@ django = [
     {file = "Django-3.1.1-py3-none-any.whl", hash = "sha256:b5fbb818e751f660fa2d576d9f40c34a4c615c8b48dd383f5216e609f383371f"},
     {file = "Django-3.1.1.tar.gz", hash = "sha256:59c8125ca873ed3bdae9c12b146fbbd6ed8d0f743e4cf5f5817af50c51f1fc2f"},
 ]
+eradicate = [
+    {file = "eradicate-1.0.tar.gz", hash = "sha256:4ffda82aae6fd49dfffa777a857cb758d77502a1f2e0f54c9ac5155a39d2d01a"},
+]
 fancycompleter = [
     {file = "fancycompleter-0.9.1-py3-none-any.whl", hash = "sha256:dd076bca7d9d524cc7f25ec8f35ef95388ffef9ef46def4d3d25e9b044ad7080"},
     {file = "fancycompleter-0.9.1.tar.gz", hash = "sha256:09e0feb8ae242abdfd7ef2ba55069a46f011814a80fe5476be48f51b00247272"},
@@ -988,6 +1011,10 @@ flake8 = [
 flake8-bugbear = [
     {file = "flake8-bugbear-20.1.4.tar.gz", hash = "sha256:bd02e4b009fb153fe6072c31c52aeab5b133d508095befb2ffcf3b41c4823162"},
     {file = "flake8_bugbear-20.1.4-py36.py37.py38-none-any.whl", hash = "sha256:a3ddc03ec28ba2296fc6f89444d1c946a6b76460f859795b35b77d4920a51b63"},
+]
+flake8-eradicate = [
+    {file = "flake8-eradicate-0.4.0.tar.gz", hash = "sha256:be5ea4521dfd4cb76837635f9ace57e12a7336c4b82054c99fd0394c00eef8ce"},
+    {file = "flake8_eradicate-0.4.0-py3-none-any.whl", hash = "sha256:804a39aef145c193e8d77770efc45df82e631b29c4456ecb5ff2e2e5996cf09a"},
 ]
 flask = [
     {file = "Flask-1.1.2-py2.py3-none-any.whl", hash = "sha256:8a4fdd8936eba2512e9c85df320a37e694c93945b33ef33c89946a340a238557"},
@@ -1020,8 +1047,8 @@ hupper = [
     {file = "hupper-1.10.2.tar.gz", hash = "sha256:3818f53dabc24da66f65cf4878c1c7a9b5df0c46b813e014abdd7c569eb9a02a"},
 ]
 identify = [
-    {file = "identify-1.4.25-py2.py3-none-any.whl", hash = "sha256:ccd88716b890ecbe10920659450a635d2d25de499b9a638525a48b48261d989b"},
-    {file = "identify-1.4.25.tar.gz", hash = "sha256:110ed090fec6bce1aabe3c72d9258a9de82207adeaa5a05cd75c635880312f9a"},
+    {file = "identify-1.5.0-py2.py3-none-any.whl", hash = "sha256:0868312cb7402b48cf44fe3f568259f804ef4e983c143d11bf7a51ca311ebc34"},
+    {file = "identify-1.5.0.tar.gz", hash = "sha256:009f92ba753c467a99f6fd3eb395412cbc34077dd5a64313b62ba04297f2ab8e"},
 ]
 idna = [
     {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
@@ -1032,7 +1059,8 @@ importlib-metadata = [
     {file = "importlib_metadata-1.7.0.tar.gz", hash = "sha256:90bb658cdbbf6d1735b6341ce708fc7024a3e14e99ffdc5783edea9f9b077f83"},
 ]
 iniconfig = [
-    {file = "iniconfig-1.0.0.tar.gz", hash = "sha256:aa0b40f50a00e72323cb5d41302f9c6165728fd764ac8822aa3fff00a40d56b4"},
+    {file = "iniconfig-1.0.1-py3-none-any.whl", hash = "sha256:80cf40c597eb564e86346103f609d74efce0f6b4d4f30ec8ce9e2c26411ba437"},
+    {file = "iniconfig-1.0.1.tar.gz", hash = "sha256:e5f92f89355a67de0595932a6c6c02ab4afddc6fcdc0bfc5becd0d60884d3f69"},
 ]
 isort = [
     {file = "isort-5.5.1-py3-none-any.whl", hash = "sha256:a200d47b7ee8b7f7d0a9646650160c4a51b6a91a9413fd31b1da2c4de789f5d3"},
@@ -1086,8 +1114,8 @@ mccabe = [
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
 ]
 more-itertools = [
-    {file = "more-itertools-8.4.0.tar.gz", hash = "sha256:68c70cc7167bdf5c7c9d8f6954a7837089c6a36bf565383919bb595efb8a17e5"},
-    {file = "more_itertools-8.4.0-py3-none-any.whl", hash = "sha256:b78134b2063dd214000685165d81c154522c3ee0a1c0d4d113c80361c234c5a2"},
+    {file = "more-itertools-8.5.0.tar.gz", hash = "sha256:6f83822ae94818eae2612063a5101a7311e68ae8002005b5e05f03fd74a86a20"},
+    {file = "more_itertools-8.5.0-py3-none-any.whl", hash = "sha256:9b30f12df9393f0d28af9210ff8efe48d10c94f73e5daf886f10c4b0b0b4f03c"},
 ]
 mypy = [
     {file = "mypy-0.782-cp35-cp35m-macosx_10_6_x86_64.whl", hash = "sha256:2c6cde8aa3426c1682d35190b59b71f661237d74b053822ea3d748e2c9578a7c"},
@@ -1110,8 +1138,8 @@ mypy-extensions = [
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
 ]
 nodeenv = [
-    {file = "nodeenv-1.4.0-py2.py3-none-any.whl", hash = "sha256:4b0b77afa3ba9b54f4b6396e60b0c83f59eaeb2d63dc3cc7a70f7f4af96c82bc"},
-    {file = "nodeenv-1.4.0.tar.gz", hash = "sha256:26941644654d8dd5378720e38f62a3bac5f9240811fb3b8913d2663a17baa91c"},
+    {file = "nodeenv-1.5.0-py2.py3-none-any.whl", hash = "sha256:5304d424c529c997bc888453aeaa6362d242b6b4631e90f3d4bf1b290f1c84a9"},
+    {file = "nodeenv-1.5.0.tar.gz", hash = "sha256:ab45090ae383b716c4ef89e690c41ff8c2b257b85b309f01f3654df3d084bd7c"},
 ]
 packaging = [
     {file = "packaging-20.4-py2.py3-none-any.whl", hash = "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"},
@@ -1310,8 +1338,8 @@ uvloop = [
     {file = "uvloop-0.14.0.tar.gz", hash = "sha256:123ac9c0c7dd71464f58f1b4ee0bbd81285d96cdda8bc3519281b8973e3a461e"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.0.28-py2.py3-none-any.whl", hash = "sha256:8f582a030156282a9ee9d319984b759a232b07f86048c1d6a9e394afa44e78c8"},
-    {file = "virtualenv-20.0.28.tar.gz", hash = "sha256:688a61d7976d82b92f7906c367e83bb4b3f0af96f8f75bfcd3da95608fe8ac6c"},
+    {file = "virtualenv-20.0.31-py2.py3-none-any.whl", hash = "sha256:e0305af10299a7fb0d69393d8f04cb2965dda9351140d11ac8db4e5e3970451b"},
+    {file = "virtualenv-20.0.31.tar.gz", hash = "sha256:43add625c53c596d38f971a465553f6318decc39d98512bc100fa1b1e839c8dc"},
 ]
 websockets = [
     {file = "websockets-8.1-cp36-cp36m-macosx_10_6_intel.whl", hash = "sha256:3762791ab8b38948f0c4d281c8b2ddfa99b7e510e46bd8dfa942a5fff621068c"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ pytest-asyncio = "^0.14.0"
 pytest-cov = "^2.10"
 mypy = "^0.782"
 flake8-bugbear = "^20.1"
+flake8-eradicate = "^0.4.0"
 pytest-mypy-plugins = "^1.4"
 pytest-mock = "^3.3"
 django = {version = ">=2,<4"}

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -28,7 +28,7 @@ class StrawberryField(dataclasses.Field):
         """Migrate the field definition to the resolver"""
 
         field_definition = self._field_definition
-        # Note: field_definition.name is finalized in type_resolver._get_fields
+        # note that field_definition.name is finalized in type_resolver._get_fields
 
         resolver_name = to_camel_case(resolver.__name__)
 

--- a/strawberry/types/type_resolver.py
+++ b/strawberry/types/type_resolver.py
@@ -300,7 +300,7 @@ def _get_fields(cls: Type) -> List[FieldDefinition]:
             # Make sure field and resolver types are the same if both are
             # defined
             # TODO: https://github.com/strawberry-graphql/strawberry/issues/396
-            # assert field.type == resolver.type
+            # >>> assert field.type == resolver.type
 
             # Grab the type from the field if the resolver has no type
             if field_definition.type is None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,25 +1,2 @@
-# import pytest
-
-# import strawberry
-
-
-# @strawberry.type
-# class User:
-#     name: str
-#     age: int
-
-
-# @strawberry.type
-# class Query:
-#     @strawberry.field
-#     def user(self, info) -> User:
-#         return User(name="Patrick", age=100)
-
-
-# @pytest.fixture
-# def schema():
-#     return strawberry.Schema(query=Query)
-
-
 def pytest_emoji_xfailed(config):
     return "🤷‍♂️ ", "XFAIL 🤷‍♂️ "

--- a/tests/federation/test_printer.py
+++ b/tests/federation/test_printer.py
@@ -66,20 +66,3 @@ def test_entities_type_when_no_type_has_keys():
     assert schema.as_str() == textwrap.dedent(expected).strip()
 
     del Review
-
-
-# type Review {
-#   body: String
-#   author: User @provides(fields: "username")
-#   product: Product
-# }
-
-# extend type User @key(fields: "id") {
-#   id: ID! @external
-#   reviews: [Review]
-# }
-
-# extend type Product @key(fields: "upc") {
-#   upc: String! @external
-#   reviews: [Review]
-# }

--- a/tests/schema/test_generics.py
+++ b/tests/schema/test_generics.py
@@ -349,44 +349,44 @@ def test_supports_generic_in_unions():
     }
 
 
-# def test_supports_generic_in_unions_multiple_vars():
-#     A = typing.TypeVar("A")
-#     B = typing.TypeVar("B")
+def test_supports_generic_in_unions_multiple_vars():
+    A = typing.TypeVar("A")
+    B = typing.TypeVar("B")
 
-#     @strawberry.type
-#     class Edge(typing.Generic[A, B]):
-#         node: B
-#         info: A
+    @strawberry.type
+    class Edge(typing.Generic[A, B]):
+        info: A
+        node: B
 
-#     @strawberry.type
-#     class Fallback:
-#         node: str
+    @strawberry.type
+    class Fallback:
+        node: str
 
-#     @strawberry.type
-#     class Query:
-#         @strawberry.field
-#         def example(self, info) -> typing.Union[Fallback, Edge[int, str]]:
-#             return Edge(node="string", info=1)
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def example(self, info) -> typing.Union[Fallback, Edge[int, str]]:
+            return Edge(node="string", info=1)
 
-#     schema = strawberry.Schema(query=Query)
+    schema = strawberry.Schema(query=Query)
 
-#     query = """{
-#         example {
-#             __typename
+    query = """{
+        example {
+            __typename
 
-#             ... on IntStrEdge {
-#                 node
-#                 info
-#             }
-#         }
-#     }"""
+            ... on IntStrEdge {
+                node
+                info
+            }
+        }
+    }"""
 
-#     result = schema.execute_sync(query)
+    result = schema.execute_sync(query)
 
-#     assert not result.errors
-#     assert result.data == {
-#         "example": {"__typename": "IntStrEdge", "node": "string", "info": 1}
-#     }
+    assert not result.errors
+    assert result.data == {
+        "example": {"__typename": "IntStrEdge", "node": "string", "info": 1}
+    }
 
 
 def test_supports_generic_in_unions_with_nesting():

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -32,22 +32,6 @@ def test_simple_required_types():
     assert print_schema(schema) == textwrap.dedent(expected_type).strip()
 
 
-# def test_recursive_type():
-#     @strawberry.type
-#     class Query:
-#         s: "Query"
-
-#     expected_type = """
-#     type Query {
-#       s: Query!
-#     }
-#     """
-
-#     schema = strawberry.Schema(query=Query)
-
-#     assert print_schema(schema) == textwrap.dedent(expected_type).strip()
-
-
 def test_optional():
     @strawberry.type
     class Query:


### PR DESCRIPTION
Add `flake8-eradicate` `pre-commit` hook to protect committing commented code.

## Description

- Added the `additional_dependency` to `flake8`;
- Also added to `pyproject.toml`, even if not needed, so we can manage version updates;

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Tooling
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

#430

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).