### PR TITLE
Use origin name to check if field should be included or not

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+This release fixes another issue with extending types.

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -30,10 +30,7 @@ class StrawberryField(dataclasses.Field):
         field_definition = self._field_definition
         # note that field_definition.name is finalized in type_resolver._get_fields
 
-        resolver_name = to_camel_case(resolver.__name__)
-
-        field_definition.origin_name = resolver_name
-
+        field_definition.origin_name = resolver.__name__
         field_definition.origin = resolver
         field_definition.base_resolver = resolver
         field_definition.arguments = get_arguments_from_resolver(resolver)

--- a/strawberry/types/type_resolver.py
+++ b/strawberry/types/type_resolver.py
@@ -285,7 +285,7 @@ def _get_fields(cls: Type) -> List[FieldDefinition]:
     for base in cls.__bases__:
         if hasattr(base, "_type_definition"):
             base_field_definitions = {
-                field.name: field
+                field.origin_name: field
                 # TODO: we need to rename _fields to something else
                 for field in base._type_definition._fields  # type: ignore
             }
@@ -346,6 +346,7 @@ def _get_fields(cls: Type) -> List[FieldDefinition]:
 
             if not field_definition.name:
                 field_definition.name = to_camel_case(field_name)
+                field_definition.origin_name = field_name
 
             # we make sure that the origin is either the field's resolver when
             # called as:
@@ -375,6 +376,7 @@ def _get_fields(cls: Type) -> List[FieldDefinition]:
                 default_value=getattr(cls, field.name, undefined),
             )
 
+        field_name = cast(str, field_definition.origin_name)
         field_definitions[field_name] = field_definition
 
     return list(field_definitions.values())

--- a/tests/schema/test_resolvers.py
+++ b/tests/schema/test_resolvers.py
@@ -265,3 +265,32 @@ def test_bounded_instance_method_resolvers():
 
     assert not result.errors
     assert result.data == {"blah": "something"}
+
+
+def test_extending_type():
+    def name_resolver(id: strawberry.ID) -> str:
+        return "Name"
+
+    def name_2_resolver(id: strawberry.ID) -> str:
+        return "Name 2"
+
+    @strawberry.type
+    class NameQuery:
+        name: str = strawberry.field(permission_classes=[], resolver=name_resolver)
+
+    @strawberry.type
+    class ExampleQuery:
+        name_2: str = strawberry.field(permission_classes=[], resolver=name_2_resolver)
+
+    @strawberry.type
+    class RootQuery(NameQuery, ExampleQuery):
+        pass
+
+    schema = strawberry.Schema(query=RootQuery)
+
+    query = '{ name(id: "abc"), name2(id: "abc") }'
+
+    result = schema.execute_sync(query)
+
+    assert not result.errors
+    assert result.data == {"name": "Name", "name2": "Name 2"}

--- a/tests/types/test_arguments.py
+++ b/tests/types/test_arguments.py
@@ -148,6 +148,7 @@ def test_arguments_when_extending_a_type():
 
     assert definition.name == "Query"
 
+    assert len(definition.fields) == 1
     assert len(definition.fields[0].arguments) == 3
 
     assert definition.fields[0].arguments[0].name == "id"
@@ -161,3 +162,41 @@ def test_arguments_when_extending_a_type():
     assert definition.fields[0].arguments[2].name == "optionalArgument"
     assert definition.fields[0].arguments[2].type == str
     assert definition.fields[0].arguments[2].is_optional
+
+
+def test_arguments_when_extending_multiple_types():
+    def name_resolver(id: strawberry.ID) -> str:
+        return "Name"
+
+    def name_2_resolver(id: strawberry.ID) -> str:
+        return "Name 2"
+
+    @strawberry.type
+    class NameQuery:
+        name: str = strawberry.field(permission_classes=[], resolver=name_resolver)
+
+    @strawberry.type
+    class ExampleQuery:
+        name_2: str = strawberry.field(permission_classes=[], resolver=name_2_resolver)
+
+    @strawberry.type
+    class RootQuery(NameQuery, ExampleQuery):
+        pass
+
+    definition = RootQuery._type_definition
+
+    assert definition.name == "RootQuery"
+
+    assert len(definition.fields) == 2
+    assert len(definition.fields[0].arguments) == 1
+
+    assert definition.fields[0].arguments[0].name == "id"
+    assert definition.fields[0].arguments[0].type == strawberry.ID
+    assert definition.fields[0].arguments[0].is_optional is False
+
+    assert len(definition.fields[1].arguments) == 1
+
+    assert definition.fields[1].name == "name2"
+    assert definition.fields[1].arguments[0].name == "id"
+    assert definition.fields[1].arguments[0].type == strawberry.ID
+    assert definition.fields[1].arguments[0].is_optional is False


### PR DESCRIPTION
Found another issue when extending multiple classes, I should have noticed this issue earlier, my bad :)

Looks like we were using the wrong origin name (it should be the python field name), so the checks for if a field existed didn't work properly. 