### PR TITLE
Removes mention of sequential mutation execution in Schema Basics

### DIFF
--- a/docs/01_general/01_schema-basics.md
+++ b/docs/01_general/01_schema-basics.md
@@ -281,9 +281,6 @@ matches the mutation's structure, like so:
 Seuss" } } } }
 ```
 
-A single client request can include multiple mutations to execute. To prevent
-race conditions, mutations are executed serially in the order they're listed.
-
 ## Input types
 
 Input types are special object types that allow you to pass objects as arguments


### PR DESCRIPTION
## Description

Removes mention of sequential mutation execution in Schema Basics

Whilst correct, this mention doesn't sufficiently explain the behaviour -- namely that mutations themselves are executed sequentially, but the return values are resolved in a second breadth-first (and potentially parallel) pass (identical to normal query resolution). This is definitely worth explanation in the mutation part of the overall documentation, but feels out of place in a simple introduction to the basic concepts -- and is potentially confusing.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).