### PR TITLE
No more dynamic classes with ._union_definitions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+Release type: minor
+
+* `UnionDefinition` has been renamed to `StrawberryUnion`
+* `strawberry.union` now returns an instance of `StrawberryUnion` instead of a
+dynamically generated class instance with a `_union_definition` attribute of
+type `UnionDefinition`.

--- a/strawberry/schema/types/type.py
+++ b/strawberry/schema/types/type.py
@@ -4,7 +4,7 @@ from graphql import GraphQLList, GraphQLNonNull, GraphQLType
 from strawberry.field import FieldDefinition
 from strawberry.scalars import is_scalar
 from strawberry.types.types import ArgumentDefinition
-from strawberry.union import UnionDefinition
+from strawberry.union import StrawberryUnion
 
 from .enum import get_enum_type
 from .scalar import get_scalar_type
@@ -55,8 +55,7 @@ def get_graphql_type(
         type = GraphQLList(get_graphql_type(child, type_map))
 
     elif field.is_union:
-        union_definition = cast(UnionDefinition, field_type._union_definition)
-
+        union_definition = cast(StrawberryUnion, field_type)
         type = get_union_type(union_definition, type_map)
     else:
         type = get_type_for_annotation(field_type, type_map)

--- a/strawberry/schema/types/union.py
+++ b/strawberry/schema/types/union.py
@@ -3,7 +3,7 @@ import typing
 from graphql import GraphQLUnionType
 from strawberry.exceptions import UnallowedReturnTypeForUnion, WrongReturnTypeForUnion
 from strawberry.type import TypeDefinition
-from strawberry.union import UnionDefinition
+from strawberry.union import StrawberryUnion
 from strawberry.utils.typing import (
     get_list_annotation,
     is_generic,
@@ -69,7 +69,7 @@ def _find_type_for_generic_union(root: typing.Any) -> TypeDefinition:
 
 
 def get_union_type(
-    union_definition: UnionDefinition, type_map: TypeMap,
+    union_definition: StrawberryUnion, type_map: TypeMap
 ) -> GraphQLUnionType:
     from .object_type import get_object_type
 
@@ -91,7 +91,7 @@ def get_union_type(
 
         return returned_type
 
-    types = union_definition.types  # type: ignore
+    types = union_definition.types
 
     return GraphQLUnionType(
         union_definition.name,

--- a/strawberry/types/generics.py
+++ b/strawberry/types/generics.py
@@ -2,7 +2,7 @@ import builtins
 import dataclasses
 from typing import Dict, Iterable, Tuple, Type, cast
 
-from strawberry.union import union
+from strawberry.union import StrawberryUnion, union
 from strawberry.utils.str_converters import capitalize_first
 from strawberry.utils.typing import is_type_var
 
@@ -19,19 +19,14 @@ def copy_type_with(
     if params_to_type is None:
         params_to_type = {}
 
-    if hasattr(base, "_union_definition"):
+    if isinstance(base, StrawberryUnion):
         types = cast(
-            Tuple[Type],
-            tuple(
-                copy_type_with(t, params_to_type=params_to_type)
-                for t in base._union_definition.types
-            ),
+            Tuple[Type, ...],
+            tuple(copy_type_with(t, params_to_type=params_to_type) for t in base.types),
         )
 
         return union(
-            name=get_name_from_types(types),
-            types=types,
-            description=base._union_definition.description,
+            name=get_name_from_types(types), types=types, description=base.description,
         )
 
     if hasattr(base, "_type_definition"):

--- a/strawberry/types/type_resolver.py
+++ b/strawberry/types/type_resolver.py
@@ -8,7 +8,7 @@ from strawberry.exceptions import (
     MissingTypesForGenericError,
 )
 from strawberry.lazy_type import LazyType
-from strawberry.union import union
+from strawberry.union import StrawberryUnion, union
 from strawberry.utils.str_converters import to_camel_case
 from strawberry.utils.typing import (
     get_args,
@@ -174,7 +174,7 @@ def resolve_type(field_definition: Union[FieldDefinition, ArgumentDefinition]) -
         if not all(is_type_var(a) for a in args):
             field_definition.type = copy_type_with(type, *args)
 
-    if hasattr(type, "_union_definition"):
+    if isinstance(type, StrawberryUnion):
         field_definition.is_union = True
 
 
@@ -188,8 +188,8 @@ def _get_type_params_for_field(
 
     type = cast(Type, field_definition.type)
 
-    if hasattr(type, "_union_definition"):
-        types = type._union_definition.types
+    if isinstance(type, StrawberryUnion):
+        types = type.types
         type_vars = [t for t in types if is_type_var(t)]
 
         if type_vars:

--- a/strawberry/types/types.py
+++ b/strawberry/types/types.py
@@ -2,6 +2,7 @@ import dataclasses
 from typing import Any, Callable, Dict, List, Optional, Type, Union
 
 from strawberry.permission import BasePermission
+from strawberry.union import StrawberryUnion
 
 
 undefined = object()
@@ -73,7 +74,7 @@ class FederationFieldParams:
 class FieldDefinition:
     name: Optional[str]
     origin_name: Optional[str]
-    type: Optional[Type]
+    type: Optional[Union[Type, StrawberryUnion]]
     origin: Union[Type, Callable]
     child: Optional["FieldDefinition"] = None
     is_subscription: bool = False

--- a/strawberry/union.py
+++ b/strawberry/union.py
@@ -22,6 +22,11 @@ class StrawberryUnion:
         return types
 
     def __call__(self, *_args, **_kwargs) -> NoReturn:
+        """Do not use.
+
+        Used to bypass
+        https://github.com/python/cpython/blob/5efb1a77e75648012f8b52960c8637fc296a5c6d/Lib/typing.py#L148-L149
+        """
         raise ValueError("Cannot use union type directly")
 
 

--- a/strawberry/union.py
+++ b/strawberry/union.py
@@ -37,15 +37,13 @@ def union(
 
     Example usages:
 
-    >>> strawberry.union(
-    ...      "Name",
-    ...      (A, B),
-    ... )
+    >>> strawberry.union("Some Thing", (int, str))
 
-    >>> strawberry.union(
-    ...     "Name",
-    ...     (A, B),
-    ... )
+    >>> @strawberry.type
+    ... class A: ...
+    >>> @strawberry.type
+    ... class B: ...
+    >>> strawberry.union("Name", (A, Optional[B]))
     """
 
     union_definition = StrawberryUnion(name=name, types=types, description=description)

--- a/strawberry/union.py
+++ b/strawberry/union.py
@@ -1,18 +1,16 @@
-from dataclasses import InitVar, dataclass
-from typing import Optional, Tuple, Type
+from typing import NoReturn, Optional, Tuple, Type
 
 
-@dataclass
-class UnionDefinition:
-    name: str
-    description: Optional[str]
-    types: InitVar[Tuple[Type]]
-
-    def __post_init__(self, types):
+class StrawberryUnion:
+    def __init__(
+        self, name: str, types: Tuple[Type, ...], description: Optional[str] = None
+    ):
+        self.name = name
         self._types = types
+        self.description = description
 
-    @property  # type: ignore
-    def types(self) -> Tuple[Type]:
+    @property
+    def types(self) -> Tuple[Type, ...]:
         from .types.type_resolver import _resolve_generic_type
 
         types = tuple(
@@ -21,38 +19,30 @@ class UnionDefinition:
             if t is not None.__class__
         )
 
-        return types  # type: ignore
+        return types
+
+    def __call__(self, *_args, **_kwargs) -> NoReturn:
+        raise ValueError("Cannot use union type directly")
 
 
-def union(name: str, types: Tuple[Type], *, description=None):
+def union(
+    name: str, types: Tuple[Type, ...], *, description: str = None
+) -> StrawberryUnion:
     """Creates a new named Union type.
 
     Example usages:
 
     >>> strawberry.union(
-    >>>     "Name",
-    >>>     (A, B),
-    >>> )
+    ...      "Name",
+    ...      (A, B),
+    ... )
 
     >>> strawberry.union(
-    >>>     "Name",
-    >>>     (A, B),
-    >>> )
+    ...     "Name",
+    ...     (A, B),
+    ... )
     """
 
-    union_definition = UnionDefinition(name=name, description=description, types=types)
+    union_definition = StrawberryUnion(name=name, types=types, description=description)
 
-    # This is currently a temporary solution, this is ok for now
-    # But in future we might want to change this so that it works
-    # properly with mypy, but there's no way to return a type like NewType does
-    # so we return this class instance as it allows us to reuse the rest of
-    # our code without doing too many changes
-
-    def _call(self):
-        raise ValueError("Cannot use union type directly")
-
-    union_class = type(
-        name, (), {"_union_definition": union_definition, "__call__": _call},
-    )
-
-    return union_class()
+    return union_definition

--- a/tests/types/test_generic.py
+++ b/tests/types/test_generic.py
@@ -5,6 +5,7 @@ import pytest
 import strawberry
 from strawberry.exceptions import MissingTypesForGenericError
 from strawberry.types.generics import copy_type_with
+from strawberry.union import StrawberryUnion
 
 
 T = TypeVar("T")
@@ -251,8 +252,8 @@ def test_generics_with_unions():
     assert len(definition.fields) == 1
 
     assert definition.fields[0].name == "node"
-    assert definition.fields[0].type._union_definition
-    assert definition.fields[0].type._union_definition.types == (Error, T)
+    assert isinstance(definition.fields[0].type, StrawberryUnion)
+    assert definition.fields[0].type.types == (Error, T)
 
     assert definition.type_params == {"node": T}
 
@@ -269,8 +270,12 @@ def test_generics_with_unions():
     assert len(definition.fields) == 1
 
     assert definition.fields[0].name == "node"
-    assert definition.fields[0].type._union_definition.types == (Error, str)
-    assert definition.fields[0].type._union_definition.name == "ErrorStr"
+
+    union_definition = definition.fields[0].type
+    assert isinstance(union_definition, StrawberryUnion)
+    assert union_definition.name == "ErrorStr"
+    assert union_definition.types == (Error, str)
+
     assert definition.fields[0].is_optional is False
 
 
@@ -460,8 +465,9 @@ def test_generics_inside_unions():
     assert definition.fields[0].name == "user"
     assert definition.fields[0].is_optional is False
 
-    union_definition = definition.fields[0].type._union_definition
+    union_definition = definition.fields[0].type
 
+    assert isinstance(union_definition, StrawberryUnion)
     assert union_definition.name == "StrEdgeError"
     assert union_definition.types[0]._type_definition.name == "StrEdge"
     assert union_definition.types[0]._type_definition.is_generic is False
@@ -485,8 +491,9 @@ def test_multiple_generics_inside_unions():
     assert definition.fields[0].name == "user"
     assert definition.fields[0].is_optional is False
 
-    union_definition = definition.fields[0].type._union_definition
+    union_definition = definition.fields[0].type
 
+    assert isinstance(union_definition, StrawberryUnion)
     assert union_definition.name == "IntEdgeStrEdge"
     assert union_definition.types[0]._type_definition.name == "IntEdge"
     assert union_definition.types[0]._type_definition.is_generic is False

--- a/tests/types/test_union.py
+++ b/tests/types/test_union.py
@@ -3,6 +3,7 @@ from typing import Generic, List, Optional, TypeVar, Union
 import pytest
 
 import strawberry
+from strawberry.union import StrawberryUnion
 
 
 def test_unions():
@@ -25,8 +26,8 @@ def test_unions():
 
     assert definition.fields[0].name == "user"
 
-    union_type_definition = definition.fields[0].type._union_definition
-
+    union_type_definition = definition.fields[0].type
+    assert isinstance(union_type_definition, StrawberryUnion)
     assert union_type_definition.name == "UserError"
     assert union_type_definition.types == (User, Error)
 
@@ -52,8 +53,8 @@ def test_unions_inside_optional():
     assert definition.fields[0].name == "user"
     assert definition.fields[0].is_optional
 
-    union_type_definition = definition.fields[0].type._union_definition
-
+    union_type_definition = definition.fields[0].type
+    assert isinstance(union_type_definition, StrawberryUnion)
     assert union_type_definition.name == "UserError"
     assert union_type_definition.types == (User, Error)
 
@@ -79,8 +80,8 @@ def test_unions_inside_list():
     assert definition.fields[0].name == "user"
     assert definition.fields[0].is_list
 
-    union_type_definition = definition.fields[0].child.type._union_definition
-
+    union_type_definition = definition.fields[0].child.type
+    assert isinstance(union_type_definition, StrawberryUnion)
     assert union_type_definition.name == "UserError"
     assert union_type_definition.types == (User, Error)
 
@@ -96,8 +97,8 @@ def test_named_union():
 
     Result = strawberry.union("Result", (A, B))
 
-    union_type_definition = Result._union_definition
-
+    union_type_definition = Result
+    assert isinstance(union_type_definition, StrawberryUnion)
     assert union_type_definition.name == "Result"
     assert union_type_definition.types == (A, B)
 
@@ -115,8 +116,8 @@ def test_union_with_generic():
 
     Result = strawberry.union("Result", (Error, Edge[str]))
 
-    union_type_definition = Result._union_definition
-
+    union_type_definition = Result
+    assert isinstance(union_type_definition, StrawberryUnion)
     assert union_type_definition.name == "Result"
     assert union_type_definition.types[0] == Error
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

* `UnionDefinition` has been renamed to `StrawberryUnion`
* `strawberry.union` now returns an instance of `StrawberryUnion` instead of a dynamically generated class instance with a `_union_definition` attribute of type `UnionDefinition`.
* Widen `.types`' signature from `Tuple[Type]` to `Tuple[Type, ...]` so that it's allowed to actually contain more than one item.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).