### PR TITLE
Update type definition to allow multiple types

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Improve type signature of `strawberry.union` to allow any number of types

--- a/strawberry/union.py
+++ b/strawberry/union.py
@@ -6,13 +6,13 @@ from typing import Optional, Tuple, Type
 class UnionDefinition:
     name: str
     description: Optional[str]
-    types: InitVar[Tuple[Type]]
+    types: InitVar[Tuple[Type, ...]]
 
     def __post_init__(self, types):
         self._types = types
 
     @property  # type: ignore
-    def types(self) -> Tuple[Type]:
+    def types(self) -> Tuple[Type, ...]:
         from .types.type_resolver import _resolve_generic_type
 
         types = tuple(
@@ -24,7 +24,7 @@ class UnionDefinition:
         return types  # type: ignore
 
 
-def union(name: str, types: Tuple[Type], *, description=None):
+def union(name: str, types: Tuple[Type, ...], *, description=None):
     """Creates a new named Union type.
 
     Example usages:

--- a/strawberry/union.py
+++ b/strawberry/union.py
@@ -21,7 +21,7 @@ class UnionDefinition:
             if t is not None.__class__
         )
 
-        return types  # type: ignore
+        return types
 
 
 def union(name: str, types: Tuple[Type, ...], *, description=None):


### PR DESCRIPTION
Update the type signature for `strawberry.union` to allow passing multiple type values.

## Description

Currently the type signature for `strawberry.union` only allows for 1 type to be passed to `strawberry.union`. By adding the `...` to the type signature it allows any number of types to be passed. Not sure why this wasn't caught in the typechecking of the project before but it came up after #465 was merged and I started using it in my project.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

-

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).