### PR TITLE
Fix issue when trying to print type with UNSET as default value

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+This release fixes an issue when trying to print a type
+with a UNSET default value

--- a/strawberry/schema/types/fields.py
+++ b/strawberry/schema/types/fields.py
@@ -1,6 +1,7 @@
 import typing
 
 from graphql import GraphQLField, GraphQLInputField
+from strawberry.arguments import UNSET
 from strawberry.field import FieldDefinition
 from strawberry.resolvers import get_resolver
 from strawberry.types.types import undefined
@@ -25,7 +26,7 @@ def get_field(field: FieldDefinition, is_input: bool, type_map: TypeMap,) -> Fie
 
     if is_input:
         TypeClass = GraphQLInputField
-        if field.default_value is not undefined:
+        if field.default_value not in (undefined, UNSET):
             kwargs["default_value"] = field.default_value
     elif field.is_subscription:
         kwargs["args"] = convert_arguments(field.arguments, type_map)

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -3,6 +3,7 @@ from typing import Optional
 from uuid import UUID
 
 import strawberry
+from strawberry.arguments import UNSET
 from strawberry.printer import print_schema
 
 
@@ -89,6 +90,7 @@ def test_input_defaults():
     class MyInput:
         s: Optional[str] = None
         i: int = 0
+        x: Optional[int] = UNSET
 
     @strawberry.type
     class Query:
@@ -100,6 +102,7 @@ def test_input_defaults():
     input MyInput {
       s: String = null
       i: Int! = 0
+      x: Int
     }
 
     type Query {


### PR DESCRIPTION
GraphQL core was trying to serialize UNSET to the type of the field where it was being used when printing the type.