### PR TITLE
Use get_context for subscriptions as well

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Fix ASGI view to call `get_context` during a websocket request

--- a/docs/05_integrations/asgi.md
+++ b/docs/05_integrations/asgi.md
@@ -28,7 +28,7 @@ The `GraphQLView` accepts two options at the moment:
 
 We allow to extend the base `GraphQLView`, by overriding the following methods:
 
-- `async get_context(self, request: Request) -> Any`
+- `async get_context(self, request: Union[Request, WebSocket]) -> Any`
 - `async get_root_value(self, request: Request) -> Any`
 - `async process_result(self, request: Request, result: ExecutionResult) -> GraphQLHTTPResponse`
 
@@ -40,7 +40,7 @@ the request.
 
 ```python
 class MyGraphQLView(GraphQLView):
-    async def get_context(self, request: Request) -> Any:
+    async def get_context(self, request: Union[Request, WebSocket]) -> Any:
         return {"example": 1}
 
 

--- a/strawberry/asgi/__init__.py
+++ b/strawberry/asgi/__init__.py
@@ -53,7 +53,9 @@ class GraphQL:
     async def get_root_value(self, request: Request) -> typing.Optional[typing.Any]:
         return None
 
-    async def get_context(self, request: Request) -> typing.Optional[typing.Any]:
+    async def get_context(
+        self, request: typing.Union[Request, WebSocket]
+    ) -> typing.Optional[typing.Any]:
         return {"request": request}
 
     async def handle_keep_alive(self, websocket):
@@ -98,7 +100,7 @@ class GraphQL:
         if self.debug:
             pretty_print_graphql_operation(operation_name, query, variables)
 
-        context = {"websocket": websocket}
+        context = await self.get_context(websocket)
 
         data = await self.schema.subscribe(
             query,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

Right now subscriptions just receive "websocket" in the context and not what you set using `get_context`

My initial idea was to use `get_context` and send either request or websocket, right now the implementation I pushed uses `get_websocket_context` but can change it back to use one method with two parameters, but it will break current code that uses `get_context`

## ToDo

I can update the documentation once we agree on what interface we like for `get_context`

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

-- None

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation. (?)
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).