### PR TITLE
Bugfix: Allow using a Union multiple times

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Fixed bug where you couldn't use the same Union type multiple times in a schema.

--- a/strawberry/federation.py
+++ b/strawberry/federation.py
@@ -15,6 +15,7 @@ from strawberry.enum import EnumDefinition
 from strawberry.permission import BasePermission
 from strawberry.schema.types.types import TypeMap
 from strawberry.types.types import TypeDefinition
+from strawberry.union import StrawberryUnion
 
 from .field import FederationFieldParams, field as base_field
 from .printer import print_schema
@@ -62,7 +63,7 @@ def field(
 
 
 def _has_federation_keys(
-    definition: Union[TypeDefinition, ScalarDefinition, EnumDefinition]
+    definition: Union[TypeDefinition, ScalarDefinition, EnumDefinition, StrawberryUnion]
 ) -> bool:
     if isinstance(definition, TypeDefinition):
         return len(definition.federation.keys) > 0

--- a/strawberry/schema/base.py
+++ b/strawberry/schema/base.py
@@ -6,6 +6,7 @@ from graphql.error.graphql_error import GraphQLError
 from strawberry.custom_scalar import ScalarDefinition
 from strawberry.enum import EnumDefinition
 from strawberry.types.types import TypeDefinition
+from strawberry.union import StrawberryUnion
 from typing_extensions import Protocol
 
 
@@ -53,7 +54,9 @@ class BaseSchema(Protocol):
     @abstractmethod
     def get_type_by_name(
         self, name: str
-    ) -> Optional[Union[TypeDefinition, ScalarDefinition, EnumDefinition]]:
+    ) -> Optional[
+        Union[TypeDefinition, ScalarDefinition, EnumDefinition, StrawberryUnion]
+    ]:
         raise NotImplementedError
 
     @abstractmethod

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -7,6 +7,7 @@ from strawberry.custom_scalar import ScalarDefinition
 from strawberry.enum import EnumDefinition
 from strawberry.extensions import Extension
 from strawberry.types.types import TypeDefinition
+from strawberry.union import StrawberryUnion
 
 from ..middleware import DirectivesMiddleware, Middleware
 from ..printer import print_schema
@@ -53,7 +54,9 @@ class Schema:
 
     def get_type_by_name(
         self, name: str
-    ) -> Optional[Union[TypeDefinition, ScalarDefinition, EnumDefinition]]:
+    ) -> Optional[
+        Union[TypeDefinition, ScalarDefinition, EnumDefinition, StrawberryUnion]
+    ]:
         if name in self.type_map:
             return self.type_map[name].definition
 

--- a/strawberry/schema/types/types.py
+++ b/strawberry/schema/types/types.py
@@ -5,6 +5,7 @@ from graphql import GraphQLField, GraphQLInputField, GraphQLType  # noqa
 from strawberry.custom_scalar import ScalarDefinition
 from strawberry.enum import EnumDefinition
 from strawberry.type import TypeDefinition
+from strawberry.union import StrawberryUnion
 
 
 Field = Union[GraphQLInputField, GraphQLField]
@@ -12,7 +13,7 @@ Field = Union[GraphQLInputField, GraphQLField]
 
 @dataclasses.dataclass
 class ConcreteType:
-    definition: Union[TypeDefinition, EnumDefinition, ScalarDefinition]
+    definition: Union[TypeDefinition, EnumDefinition, ScalarDefinition, StrawberryUnion]
     implementation: GraphQLType
 
 

--- a/strawberry/schema/types/union.py
+++ b/strawberry/schema/types/union.py
@@ -11,7 +11,7 @@ from strawberry.utils.typing import (
     is_type_var,
 )
 
-from .types import TypeMap, ConcreteType
+from .types import ConcreteType, TypeMap
 
 
 def _get_type_mapping_from_actual_type(root) -> typing.Dict[typing.Any, typing.Type]:

--- a/tests/schema/test_union.py
+++ b/tests/schema/test_union.py
@@ -1,3 +1,4 @@
+from textwrap import dedent
 from typing import Optional, Union
 
 import strawberry
@@ -312,3 +313,40 @@ def test_multiple_unions():
         "fields": [{"name": "field1"}, {"name": "field2"}],
         "name": "CoolType",
     }
+
+
+def test_union_used_multiple_times():
+    @strawberry.type
+    class A:
+        a: int
+
+    @strawberry.type
+    class B:
+        b: int
+
+    MyUnion = strawberry.union("MyUnion", types=(A, B))
+
+    @strawberry.type
+    class Query:
+        field1: MyUnion
+        field2: MyUnion
+
+    schema = strawberry.Schema(query=Query)
+
+    assert schema.as_str() == dedent(
+        """\
+        type A {
+          a: Int!
+        }
+
+        type B {
+          b: Int!
+        }
+
+        union MyUnion = A | B
+
+        type Query {
+          field1: MyUnion!
+          field2: MyUnion!
+        }"""
+    )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This PR fixes a bug where if you used the same Union type in multiple fields graphql-core would raise an exception that the schema must contain uniquely named types.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
