### PR TITLE
Fix extensions runner when using async resolvers

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+This release fixes an issue with the extension runner and async resolvers

--- a/strawberry/schema/execute.py
+++ b/strawberry/schema/execute.py
@@ -1,6 +1,6 @@
 from asyncio import ensure_future
 from inspect import isawaitable
-from typing import Any, Awaitable, Dict, List, Sequence, Tuple, Type, cast
+from typing import Any, Awaitable, Dict, List, Sequence, Type, cast
 
 from graphql import (
     ExecutionResult as GraphQLExecutionResult,
@@ -9,7 +9,6 @@ from graphql import (
     execute as original_execute,
     parse,
 )
-from graphql.pyutils import AwaitableOrValue
 from graphql.type import validate_schema
 from graphql.validation import validate
 from strawberry.extensions import Extension
@@ -27,19 +26,67 @@ async def execute(
     additional_middlewares: List[Any] = None,
     operation_name: str = None,
 ) -> ExecutionResult:
-    result, extensions_runner = base_execute(
-        schema=schema,
+    execution_context = ExecutionContext(
         query=query,
-        extensions=extensions,
-        root_value=root_value,
-        context_value=context_value,
-        variable_values=variable_values,
-        additional_middlewares=additional_middlewares,
+        context=context_value,
+        variables=variable_values,
         operation_name=operation_name,
     )
 
-    if isawaitable(result):
-        result = await cast(Awaitable[GraphQLExecutionResult], result)
+    extensions_runner = ExtensionsRunner(
+        execution_context=execution_context,
+        extensions=[extension() for extension in extensions],
+    )
+
+    additional_middlewares = additional_middlewares or []
+
+    with extensions_runner.request():
+        schema_validation_errors = validate_schema(schema)
+
+        if schema_validation_errors:
+            return ExecutionResult(
+                data=None,
+                errors=schema_validation_errors,
+                extensions=extensions_runner.get_extensions_results(),
+            )
+
+        try:
+            with extensions_runner.parsing():
+                document = parse(query)
+        except GraphQLError as error:
+            return ExecutionResult(
+                data=None,
+                errors=[error],
+                extensions=extensions_runner.get_extensions_results(),
+            )
+
+        except Exception as error:  # pragma: no cover
+            error = GraphQLError(str(error), original_error=error)
+
+            return ExecutionResult(
+                data=None,
+                errors=[error],
+                extensions=extensions_runner.get_extensions_results(),
+            )
+
+        with extensions_runner.validation():
+            validation_errors = validate(schema, document)
+
+        if validation_errors:
+            return ExecutionResult(data=None, errors=validation_errors)
+
+        result = original_execute(
+            schema,
+            document,
+            root_value=root_value,
+            middleware=extensions_runner.as_middleware_manager(*additional_middlewares),
+            variable_values=variable_values,
+            operation_name=operation_name,
+            context_value=context_value,
+        )
+
+        if isawaitable(result):
+            result = await cast(Awaitable[GraphQLExecutionResult], result)
 
     result = cast(GraphQLExecutionResult, result)
 
@@ -60,40 +107,6 @@ def execute_sync(
     additional_middlewares: List[Any] = None,
     operation_name: str = None,
 ) -> ExecutionResult:
-    result, extensions_runner = base_execute(
-        schema=schema,
-        query=query,
-        extensions=extensions,
-        root_value=root_value,
-        context_value=context_value,
-        variable_values=variable_values,
-        additional_middlewares=additional_middlewares,
-        operation_name=operation_name,
-    )
-
-    if isawaitable(result):
-        ensure_future(cast(Awaitable[GraphQLExecutionResult], result)).cancel()
-        raise RuntimeError("GraphQL execution failed to complete synchronously.")
-
-    result = cast(GraphQLExecutionResult, result)
-
-    return ExecutionResult(
-        data=result.data,
-        errors=result.errors,
-        extensions=extensions_runner.get_extensions_results(),
-    )
-
-
-def base_execute(
-    schema: GraphQLSchema,
-    query: str,
-    extensions: Sequence[Type[Extension]],
-    root_value: Any = None,
-    context_value: Any = None,
-    variable_values: Dict[str, Any] = None,
-    additional_middlewares: List[Any] = None,
-    operation_name: str = None,
-) -> Tuple[AwaitableOrValue[GraphQLExecutionResult], ExtensionsRunner]:
     execution_context = ExecutionContext(
         query=query,
         context=context_value,
@@ -111,30 +124,36 @@ def base_execute(
         schema_validation_errors = validate_schema(schema)
 
         if schema_validation_errors:
-            return (
-                GraphQLExecutionResult(data=None, errors=schema_validation_errors),
-                extensions_runner,
+            return ExecutionResult(
+                data=None,
+                errors=schema_validation_errors,
+                extensions=extensions_runner.get_extensions_results(),
             )
 
         try:
             with extensions_runner.parsing():
                 document = parse(query)
         except GraphQLError as error:
-            return GraphQLExecutionResult(data=None, errors=[error]), extensions_runner
+            return ExecutionResult(
+                data=None,
+                errors=[error],
+                extensions=extensions_runner.get_extensions_results(),
+            )
 
         except Exception as error:  # pragma: no cover
             error = GraphQLError(str(error), original_error=error)
 
-            return GraphQLExecutionResult(data=None, errors=[error]), extensions_runner
+            return ExecutionResult(
+                data=None,
+                errors=[error],
+                extensions=extensions_runner.get_extensions_results(),
+            )
 
         with extensions_runner.validation():
             validation_errors = validate(schema, document)
 
         if validation_errors:
-            return (
-                GraphQLExecutionResult(data=None, errors=validation_errors),
-                extensions_runner,
-            )
+            return ExecutionResult(data=None, errors=validation_errors)
 
         result = original_execute(
             schema,
@@ -146,4 +165,14 @@ def base_execute(
             context_value=context_value,
         )
 
-    return result, extensions_runner
+        if isawaitable(result):
+            ensure_future(cast(Awaitable[GraphQLExecutionResult], result)).cancel()
+            raise RuntimeError("GraphQL execution failed to complete synchronously.")
+
+    result = cast(GraphQLExecutionResult, result)
+
+    return ExecutionResult(
+        data=result.data,
+        errors=result.errors,
+        extensions=extensions_runner.get_extensions_results(),
+    )

--- a/tests/schema/test_excution_errors.py
+++ b/tests/schema/test_excution_errors.py
@@ -1,3 +1,5 @@
+import pytest
+
 import strawberry
 from strawberry.extensions import Extension
 
@@ -39,6 +41,68 @@ def test_runs_parsing():
     """
 
     result = schema.execute_sync(query)
+
+    assert len(result.errors) == 1
+    assert result.errors[0].message == "Syntax Error: Expected Name, found <EOF>."
+
+
+@pytest.mark.asyncio
+@pytest.mark.filterwarnings("ignore:.* was never awaited:RuntimeWarning")
+async def test_errors_when_running_async_in_sync_mode():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        async def name(self) -> str:
+            return "Patrick"
+
+    schema = strawberry.Schema(query=Query)
+
+    query = """
+        query {
+            name
+        }
+    """
+
+    with pytest.raises(RuntimeError) as e:
+        schema.execute_sync(query)
+
+    assert e.value.args[0] == "GraphQL execution failed to complete synchronously."
+
+
+@pytest.mark.asyncio
+async def test_runs_schema_validation_async():
+    @strawberry.type
+    class Query:
+        ...
+
+    schema = strawberry.Schema(query=Query)
+
+    query = """
+        query {
+            example
+        }
+    """
+
+    result = await schema.execute(query)
+
+    assert len(result.errors) == 1
+    assert result.errors[0].message == "Type Query must define one or more fields."
+
+
+@pytest.mark.asyncio
+async def test_runs_parsing_async():
+    @strawberry.type
+    class Query:
+        example: str
+
+    schema = strawberry.Schema(query=Query)
+
+    query = """
+        query {
+            example
+    """
+
+    result = await schema.execute(query)
 
     assert len(result.errors) == 1
     assert result.errors[0].message == "Syntax Error: Expected Name, found <EOF>."


### PR DESCRIPTION
Had to duplicate the code because I needed to run the await inside `runner.request`. Also simplified the runner and removed the broken run_on_all_extension decorator