### PR TITLE
Add support for union in mypy plugin

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
         additional_dependencies: ["flake8-eradicate==0.4.0"]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.770
+    rev: v0.782
     hooks:
       - id: mypy
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+This releases adds support for strawberry.union inside mypy.

--- a/strawberry/ext/mypy_plugin.py
+++ b/strawberry/ext/mypy_plugin.py
@@ -1,6 +1,6 @@
 from typing import Callable, Optional
 
-from mypy.nodes import GDEF, Block, ClassDef, SymbolTableNode
+from mypy.nodes import GDEF, SymbolTableNode, TypeAlias
 from mypy.plugin import (
     AnalyzeTypeContext,
     ClassDefContext,
@@ -8,7 +8,7 @@ from mypy.plugin import (
     Plugin,
 )
 from mypy.plugins import dataclasses
-from mypy.types import Type
+from mypy.types import Type, UnionType
 
 
 def lazy_type_analyze_callback(ctx: AnalyzeTypeContext) -> Type:
@@ -26,22 +26,28 @@ def private_type_analyze_callback(ctx: AnalyzeTypeContext) -> Type:
 
 
 def union_hook(ctx: DynamicClassDefContext) -> None:
-    # TODO: use these types to construct a propert return type (now it is Any)
-    # >>> types = ctx.call.args[1]
-    # >>> type_ = UnionType(tuple(ctx.api.named_type(x.name) for x in types.items))
+    types = ctx.call.args[1]
+    type_ = UnionType(
+        tuple(ctx.api.named_type(x.name) for x in types.items)  # type: ignore
+    )
 
-    class_def = ClassDef(ctx.name, Block([]))
-    class_def.fullname = ctx.api.qualified_name(ctx.name)
-    info = ctx.api.make_empty_type_info(class_def)  # type: ignore
+    type_alias = TypeAlias(
+        type_,
+        fullname=ctx.api.qualified_name(ctx.name),
+        line=ctx.call.line,
+        column=ctx.call.column,
+    )
 
-    ctx.api.add_symbol_table_node(ctx.name, SymbolTableNode(GDEF, info))
+    ctx.api.add_symbol_table_node(
+        ctx.name, SymbolTableNode(GDEF, type_alias, plugin_generated=True)
+    )
 
 
 class StrawberryPlugin(Plugin):
     def get_dynamic_class_hook(
         self, fullname: str
     ) -> Optional[Callable[[DynamicClassDefContext], None]]:
-        if "strawberry" in fullname:
+        if "strawberry" in fullname and "union" in fullname:
             print(fullname)
 
         if "strawberry.union.union" in fullname:

--- a/strawberry/ext/mypy_plugin.py
+++ b/strawberry/ext/mypy_plugin.py
@@ -1,6 +1,12 @@
 from typing import Callable, Optional
 
-from mypy.plugin import AnalyzeTypeContext, ClassDefContext, Plugin
+from mypy.nodes import GDEF, Block, ClassDef, SymbolTableNode
+from mypy.plugin import (
+    AnalyzeTypeContext,
+    ClassDefContext,
+    DynamicClassDefContext,
+    Plugin,
+)
 from mypy.plugins import dataclasses
 from mypy.types import Type
 
@@ -19,7 +25,27 @@ def private_type_analyze_callback(ctx: AnalyzeTypeContext) -> Type:
     return type_
 
 
+def union_hook(ctx: DynamicClassDefContext) -> None:
+    # TODO: use these types to construct a propert return type (now it is Any)
+    # >>> types = ctx.call.args[1]
+    # >>> type_ = UnionType(tuple(ctx.api.named_type(x.name) for x in types.items))
+
+    class_def = ClassDef(ctx.name, Block([]))
+    class_def.fullname = ctx.api.qualified_name(ctx.name)
+    info = ctx.api.make_empty_type_info(class_def)  # type: ignore
+
+    ctx.api.add_symbol_table_node(ctx.name, SymbolTableNode(GDEF, info))
+
+
 class StrawberryPlugin(Plugin):
+    def get_dynamic_class_hook(
+        self, fullname: str
+    ) -> Optional[Callable[[DynamicClassDefContext], None]]:
+        if "strawberry.union.union" in fullname:
+            return union_hook
+
+        return None
+
     def get_type_analyze_hook(self, fullname: str):
         if fullname == "strawberry.lazy_type.LazyType":
             return lazy_type_analyze_callback

--- a/strawberry/ext/mypy_plugin.py
+++ b/strawberry/ext/mypy_plugin.py
@@ -47,10 +47,9 @@ class StrawberryPlugin(Plugin):
     def get_dynamic_class_hook(
         self, fullname: str
     ) -> Optional[Callable[[DynamicClassDefContext], None]]:
-        if "strawberry" in fullname and "union" in fullname:
-            print(fullname)
-
-        if "strawberry.union.union" in fullname:
+        # TODO: investigate why we need this instead of `strawberry.union.union` on CI
+        # we have the same issue in the other hooks
+        if "strawberry.union" in fullname:
             return union_hook
 
         return None

--- a/strawberry/ext/mypy_plugin.py
+++ b/strawberry/ext/mypy_plugin.py
@@ -1,11 +1,20 @@
 from typing import Callable, Optional
 
-from mypy.nodes import GDEF, SymbolTableNode, TypeAlias
+from mypy.nodes import (
+    GDEF,
+    Expression,
+    IndexExpr,
+    NameExpr,
+    SymbolTableNode,
+    TupleExpr,
+    TypeAlias,
+)
 from mypy.plugin import (
     AnalyzeTypeContext,
     ClassDefContext,
     DynamicClassDefContext,
     Plugin,
+    SemanticAnalyzerPluginInterface,
 )
 from mypy.plugins import dataclasses
 from mypy.types import Type, UnionType
@@ -25,22 +34,35 @@ def private_type_analyze_callback(ctx: AnalyzeTypeContext) -> Type:
     return type_
 
 
+def _get_type_for_expr(expr: Expression, api: SemanticAnalyzerPluginInterface):
+    if isinstance(expr, NameExpr):
+        return api.named_type(expr.name)
+
+    if isinstance(expr, IndexExpr):
+        type_ = _get_type_for_expr(expr.base, api)
+        type_.args = [_get_type_for_expr(expr.index, api)]
+
+        return type_
+
+    raise ValueError(f"Unsupported expression f{type(expr)}")
+
+
 def union_hook(ctx: DynamicClassDefContext) -> None:
     types = ctx.call.args[1]
-    type_ = UnionType(
-        tuple(ctx.api.named_type(x.name) for x in types.items)  # type: ignore
-    )
 
-    type_alias = TypeAlias(
-        type_,
-        fullname=ctx.api.qualified_name(ctx.name),
-        line=ctx.call.line,
-        column=ctx.call.column,
-    )
+    if isinstance(types, TupleExpr):
+        type_ = UnionType(tuple(_get_type_for_expr(x, ctx.api) for x in types.items))
 
-    ctx.api.add_symbol_table_node(
-        ctx.name, SymbolTableNode(GDEF, type_alias, plugin_generated=True)
-    )
+        type_alias = TypeAlias(
+            type_,
+            fullname=ctx.api.qualified_name(ctx.name),
+            line=ctx.call.line,
+            column=ctx.call.column,
+        )
+
+        ctx.api.add_symbol_table_node(
+            ctx.name, SymbolTableNode(GDEF, type_alias, plugin_generated=True)
+        )
 
 
 class StrawberryPlugin(Plugin):

--- a/strawberry/ext/mypy_plugin.py
+++ b/strawberry/ext/mypy_plugin.py
@@ -41,6 +41,9 @@ class StrawberryPlugin(Plugin):
     def get_dynamic_class_hook(
         self, fullname: str
     ) -> Optional[Callable[[DynamicClassDefContext], None]]:
+        if "strawberry" in fullname:
+            print(fullname)
+
         if "strawberry.union.union" in fullname:
             return union_hook
 

--- a/strawberry/ext/mypy_plugin.py
+++ b/strawberry/ext/mypy_plugin.py
@@ -61,7 +61,7 @@ def union_hook(ctx: DynamicClassDefContext) -> None:
         )
 
         ctx.api.add_symbol_table_node(
-            ctx.name, SymbolTableNode(GDEF, type_alias, plugin_generated=True)
+            ctx.name, SymbolTableNode(GDEF, type_alias, plugin_generated=False)
         )
 
 

--- a/tests/mypy/test_decorators.yml
+++ b/tests/mypy/test_decorators.yml
@@ -36,36 +36,3 @@
     NameInterface(n="Patrick")
   out: |
     main:8: error: Unexpected keyword argument "n" for "NameInterface"
-
-- case: test_field
-  main: |
-    import strawberry
-
-    @strawberry.type
-    class User:
-        name: str = strawberry.field(description='Example')
-
-    User(name="Patrick")
-    User(n="Patrick")
-  out: |
-    main:8: error: Unexpected keyword argument "n" for "User"
-
-- case: test_private_field
-  main: |
-    import strawberry
-
-    @strawberry.type
-    class User:
-        age: strawberry.Private[int]
-
-        @strawberry.field
-        def age_in_months(self) -> int:
-            return self.age * 12
-
-        @strawberry.field
-        def wrong_type(self) -> int:
-            reveal_type(self.age)
-            return self.age.trim()
-  out: |
-    main:13: note: Revealed type is 'builtins.int'
-    main:14: error: "int" has no attribute "trim"

--- a/tests/mypy/test_fields.yml
+++ b/tests/mypy/test_fields.yml
@@ -1,0 +1,32 @@
+- case: test_field
+  main: |
+    import strawberry
+
+    @strawberry.type
+    class User:
+        name: str = strawberry.field(description='Example')
+
+    User(name="Patrick")
+    User(n="Patrick")
+  out: |
+    main:8: error: Unexpected keyword argument "n" for "User"
+
+- case: test_private_field
+  main: |
+    import strawberry
+
+    @strawberry.type
+    class User:
+        age: strawberry.Private[int]
+
+        @strawberry.field
+        def age_in_months(self) -> int:
+            return self.age * 12
+
+        @strawberry.field
+        def wrong_type(self) -> int:
+            reveal_type(self.age)
+            return self.age.trim()
+  out: |
+    main:13: note: Revealed type is 'builtins.int'
+    main:14: error: "int" has no attribute "trim"

--- a/tests/mypy/test_union.yml
+++ b/tests/mypy/test_union.yml
@@ -1,0 +1,22 @@
+- case: test_type
+  main: |
+    import typing
+
+    import strawberry
+
+    @strawberry.type
+    class User:
+        name: str
+
+    @strawberry.type
+    class Error:
+        message: str
+
+    Response = strawberry.union("Response", (User, Error))
+
+    a: Response
+    reveal_type(Response)
+    reveal_type(a)
+  out: |
+    main:16: note: Revealed type is 'Any'
+    main:17: note: Revealed type is 'main.Response'

--- a/tests/mypy/test_union.yml
+++ b/tests/mypy/test_union.yml
@@ -19,6 +19,8 @@
     reveal_type(a)
 
     a = User('abc')
+    reveal_type(a)
   out: |
-    main:16: note: Revealed type is 'Any'
-    main:17: note: Revealed type is 'main.Response'
+    main:16: note: Revealed type is 'builtins.object'
+    main:17: note: Revealed type is 'Union[main.User, main.Error]'
+    main:20: note: Revealed type is 'main.User'

--- a/tests/mypy/test_union.yml
+++ b/tests/mypy/test_union.yml
@@ -17,6 +17,8 @@
     a: Response
     reveal_type(Response)
     reveal_type(a)
+
+    a = User('abc')
   out: |
     main:16: note: Revealed type is 'Any'
     main:17: note: Revealed type is 'main.Response'

--- a/tests/mypy/test_union.yml
+++ b/tests/mypy/test_union.yml
@@ -1,4 +1,4 @@
-- case: test_type
+- case: test_union
   main: |
     import typing
 
@@ -24,3 +24,28 @@
     main:16: note: Revealed type is 'builtins.object'
     main:17: note: Revealed type is 'Union[main.User, main.Error]'
     main:20: note: Revealed type is 'main.User'
+
+- case: test_union_generics
+  main: |
+    from typing import Generic, TypeVar
+
+    import strawberry
+
+    T = TypeVar("T")
+
+    @strawberry.type
+    class Error:
+        message: str
+
+    @strawberry.type
+    class Edge(Generic[T]):
+        node: T
+
+    Result = strawberry.union("Result", (Error, Edge[str]))
+    reveal_type(Result)
+
+    a: Result
+    reveal_type(a)
+  out: |
+    main:16: note: Revealed type is 'builtins.object'
+    main:19: note: Revealed type is 'Union[main.Error, main.Edge[builtins.str]]'


### PR DESCRIPTION
This PR improves the mypy plugin to work with `strawberry.union`, this code should not raise any error:

```python
import strawberry


@strawberry.type
class User:
    name: str


@strawberry.type
class Error:
    message: str


Response = strawberry.union("Response", (User, Error))

a: Response
reveal_type(Response)


a = User('abc')
```

currently it does, but we are getting there :)

Closes #485 