### PR TITLE
🎨 Use str magic method

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Add `__str__` to `Schema` to allow printing schema sdl with `str(schema)`

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -132,3 +132,5 @@ class Schema:
 
     def as_str(self) -> str:
         return print_schema(self)
+
+    __str__ = as_str

--- a/tests/schema/test_basic.py
+++ b/tests/schema/test_basic.py
@@ -345,7 +345,6 @@ def test_multiple_fields_with_same_type():
 
 
 def test_str_magic_method_prints_schema_sdl():
-
     @strawberry.type
     class Query:
         exampleBool: bool
@@ -361,4 +360,6 @@ def test_str_magic_method_prints_schema_sdl():
     }
     """
     assert str(schema) == textwrap.dedent(expected).strip()
-    assert '<strawberry.schema.schema.Schema object' in repr(schema), "Repr should not be affected"
+    assert "<strawberry.schema.schema.Schema object" in repr(
+        schema
+    ), "Repr should not be affected"

--- a/tests/schema/test_basic.py
+++ b/tests/schema/test_basic.py
@@ -1,3 +1,4 @@
+import textwrap
 import typing
 from dataclasses import InitVar, dataclass
 from enum import Enum
@@ -341,3 +342,23 @@ def test_multiple_fields_with_same_type():
     assert not result.errors
     assert result.data["me"] is None
     assert result.data["you"] is None
+
+
+def test_str_magic_method_prints_schema_sdl():
+
+    @strawberry.type
+    class Query:
+        exampleBool: bool
+        exampleStr: str = "Example"
+        exampleInt: int = 1
+
+    schema = strawberry.Schema(query=Query)
+    expected = """
+    type Query {
+      exampleBool: Boolean!
+      exampleStr: String!
+      exampleInt: Int!
+    }
+    """
+    assert str(schema) == textwrap.dedent(expected).strip()
+    assert '<strawberry.schema.schema.Schema object' in repr(schema), "Repr should not be affected"


### PR DESCRIPTION
Just a cosmetic change, but a believe a useful one nonetheless. 
Being able to do `str(schema)` to print the schema seems more pythonic than `schema.as_str()`.

Perhaps you disagree, in that case you can dismiss the pr and i will take no offense