### PR TITLE
Extend support for parsing datetimes.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+Release type: patch
+
+Extend support for parsing isoformat datetimes,
+adding a dependency on the `dateutil` library.
+For example: "2020-10-12T22:00:00.000Z"
+can now be parsed as a datetime with a UTC timezone.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ flask = {version = "^1.1",optional = true}
 typing_extensions = "^3.7.4"
 opentelemetry-api = {version = "^0.13b0",optional = true}
 opentelemetry-sdk = {version = "^0.13b0",optional = true}
+python-dateutil = "^2.7.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.1"

--- a/strawberry/schema/types/base_scalars.py
+++ b/strawberry/schema/types/base_scalars.py
@@ -1,6 +1,7 @@
 import datetime
 import decimal
 from operator import methodcaller
+import dateutil.parser
 
 from strawberry.custom_scalar import scalar
 
@@ -20,7 +21,7 @@ DateTime = scalar(
     name="DateTime",
     description="Date with time (isoformat)",
     serialize=isoformat,
-    parse_value=datetime.datetime.fromisoformat,
+    parse_value=dateutil.parser.isoparse,
 )
 Time = scalar(
     datetime.time,

--- a/strawberry/schema/types/base_scalars.py
+++ b/strawberry/schema/types/base_scalars.py
@@ -1,6 +1,7 @@
 import datetime
 import decimal
 from operator import methodcaller
+
 import dateutil.parser
 
 from strawberry.custom_scalar import scalar

--- a/tests/schema/types/test_datetime.py
+++ b/tests/schema/types/test_datetime.py
@@ -1,4 +1,5 @@
 import datetime
+import dateutil.tz
 
 import pytest
 
@@ -41,6 +42,12 @@ def test_serialization(typing, instance, serialized):
             "DateTime",
             datetime.datetime(2019, 10, 25, 13, 37),
             "2019-10-25T13:37:00",
+        ),
+        (
+            datetime.datetime,
+            "DateTime",
+            datetime.datetime(2019, 10, 25, 13, 37, tzinfo=dateutil.tz.tzutc()),
+            "2019-10-25T13:37:00Z",
         ),
         (datetime.time, "Time", datetime.time(13, 37), "13:37:00"),
     ],

--- a/tests/schema/types/test_datetime.py
+++ b/tests/schema/types/test_datetime.py
@@ -1,7 +1,8 @@
 import datetime
-import dateutil.tz
 
 import pytest
+
+import dateutil.tz
 
 import strawberry
 


### PR DESCRIPTION
This PR adds support for parsing datetime's with a trailing Z to indicate UTC,
for example: "2020-10-12T22:00:00.000**Z**".

## Description

The client library I'm using (urql) sends datetimes like this,
but Python's `datetime.fromisoformat` cannot parse them
with the [documentation](https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat) suggesting to use the `dateutil` library.

This PR adds that library as a dependency,
specifying any version since the needed function was introduced.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
