### PR TITLE
Enable using strawberry.enum as a function with MyPy

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,17 @@
+Release type: patch
+
+This release adds support for using strawberry.enum as a function with MyPy,
+this is now valid typed code:
+
+```python
+from enum import Enum
+
+import strawberry
+
+class IceCreamFlavour(Enum):
+    VANILLA = "vanilla"
+    STRAWBERRY = "strawberry"
+    CHOCOLATE = "chocolate"
+
+Flavour = strawberry.enum(IceCreamFlavour)
+```

--- a/strawberry/ext/mypy_plugin.py
+++ b/strawberry/ext/mypy_plugin.py
@@ -65,6 +65,21 @@ def union_hook(ctx: DynamicClassDefContext) -> None:
         )
 
 
+def enum_hook(ctx: DynamicClassDefContext) -> None:
+    enum_type = _get_type_for_expr(ctx.call.args[0], ctx.api)
+
+    type_alias = TypeAlias(
+        enum_type,
+        fullname=ctx.api.qualified_name(ctx.name),
+        line=ctx.call.line,
+        column=ctx.call.column,
+    )
+
+    ctx.api.add_symbol_table_node(
+        ctx.name, SymbolTableNode(GDEF, type_alias, plugin_generated=False)
+    )
+
+
 class StrawberryPlugin(Plugin):
     def get_dynamic_class_hook(
         self, fullname: str
@@ -73,6 +88,9 @@ class StrawberryPlugin(Plugin):
         # we have the same issue in the other hooks
         if "strawberry.union" in fullname:
             return union_hook
+
+        if "strawberry.enum" in fullname:
+            return enum_hook
 
         return None
 

--- a/tests/mypy/test_enum.yml
+++ b/tests/mypy/test_enum.yml
@@ -1,0 +1,19 @@
+- case: test_union
+  main: |
+    from enum import Enum
+
+    import strawberry
+
+    class IceCreamFlavour(Enum):
+        VANILLA = "vanilla"
+        STRAWBERRY = "strawberry"
+        CHOCOLATE = "chocolate"
+
+    Flavour = strawberry.enum(IceCreamFlavour)
+
+    a: Flavour
+    reveal_type(Flavour)
+    reveal_type(a)
+  out: |
+    main:13: note: Revealed type is 'def (value: builtins.object) -> main.IceCreamFlavour'
+    main:14: note: Revealed type is 'main.IceCreamFlavour'


### PR DESCRIPTION
Bad title I know, but this PR improves the mypy plugin with supporting more usecases for strawberry.enum, this is now valid typed code:

```python
from enum import Enum

import strawberry

class IceCreamFlavour(Enum):
    VANILLA = "vanilla"
    STRAWBERRY = "strawberry"
    CHOCOLATE = "chocolate"

Flavour = strawberry.enum(IceCreamFlavour)

a: Flavour
```

as previous it wasn't