### PR TITLE
Annotated arguments

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,9 +7,9 @@ from typing import Annotated
 
 @strawberry.type
 class Query:
-	@strawberry.field
-	def user_by_id(id: Annotated[str, strawberry.argument(description="The ID of the user")]) -> User:
-		...
+    @strawberry.field
+    def user_by_id(id: Annotated[str, strawberry.argument(description="The ID of the user")]) -> User:
+        ...
 ```
 
 which results in the following schema:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,26 @@
+Release type: minor
+
+Add support for adding a description to field arguments using the [`Annotated`](https://docs.python.org/3/library/typing.html#typing.Annotated) type:
+
+```python
+from typing import Annotated
+
+@strawberry.type
+class Query:
+	@strawberry.field
+	def user_by_id(id: Annotated[str, strawberry.argument(description="The ID of the user")]) -> User:
+		...
+```
+
+which results in the following schema:
+
+```graphql
+type Query {
+  userById(
+    """The ID of the user"""
+    id: String
+  ): User!
+}
+```
+
+**Note:** if you are not using Python v3.9 or greater you will need to import `Annotated` from `typing_extensions`

--- a/strawberry/__init__.py
+++ b/strawberry/__init__.py
@@ -2,6 +2,7 @@ __version__ = "0.1.0"
 
 
 from . import federation  # noqa
+from .arguments import argument  # noqa
 from .custom_scalar import scalar  # noqa
 from .directive import directive  # noqa
 from .enum import enum  # noqa

--- a/strawberry/arguments.py
+++ b/strawberry/arguments.py
@@ -43,12 +43,15 @@ def get_arguments_from_annotations(
         )
 
         if get_origin(annotation) is Annotated:
-            argument_definition.type = get_args(annotation)[0]
+            annotated_args = get_args(annotation)
+
+            # The first argument to Annotated is always the underlying type
+            argument_definition.type = annotated_args[0]
 
             argument_metadata = None
-            # Find any instances of StrawberryArgument in the Annotated metadata
+            # Find any instances of StrawberryArgument in the other Annotated args,
             # raising an exception if there are multiple StrawberryArguments
-            for arg in get_args(annotation)[1:]:
+            for arg in annotated_args[1:]:
                 if isinstance(arg, StrawberryArgument):
                     if argument_metadata is not None:
                         raise MultipleStrawberryArgumentsError(

--- a/strawberry/arguments.py
+++ b/strawberry/arguments.py
@@ -1,12 +1,13 @@
 import enum
 import inspect
-from typing import Any, Callable, Dict, List, Mapping, Type, cast, Optional
-from typing_extensions import Annotated, get_origin, get_args
+from typing import Any, Callable, Dict, List, Mapping, Optional, Type, cast
+
+from typing_extensions import Annotated, get_args, get_origin
 
 from .exceptions import (
     MissingArgumentsAnnotationsError,
-    UnsupportedTypeError,
     MultipleStrawberryArgumentsError,
+    UnsupportedTypeError,
 )
 from .scalars import is_scalar
 from .types.type_resolver import resolve_type
@@ -141,7 +142,8 @@ def convert_argument(value: Any, argument_definition: ArgumentDefinition) -> Any
 
 
 def convert_arguments(
-    value: Dict[str, Any], arguments: List[ArgumentDefinition],
+    value: Dict[str, Any],
+    arguments: List[ArgumentDefinition],
 ) -> Dict[str, Any]:
     """Converts a nested dictionary to a dictionary of actual types.
 

--- a/strawberry/exceptions.py
+++ b/strawberry/exceptions.py
@@ -110,3 +110,13 @@ class PrivateStrawberryFieldError(Exception):
         )
 
         super().__init__(message)
+
+
+class MultipleStrawberryArgumentsError(Exception):
+    def __init__(self, field_name: str, argument_name: str):
+        message = (
+            f"Annotation for argument `{argument_name}` on field "
+            f"`{field_name}` cannot have multiple `strawberry.argument`s"
+        )
+
+        super().__init__(message)

--- a/strawberry/schema/types/arguments.py
+++ b/strawberry/schema/types/arguments.py
@@ -20,7 +20,11 @@ def convert_argument(
     # TODO: we could overload the function to tell mypy that it returns input types too
     argument_type = cast(GraphQLInputType, get_graphql_type(argument, type_map))
 
-    return GraphQLArgument(argument_type, default_value=default_value)
+    return GraphQLArgument(
+        argument_type,
+        default_value=default_value,
+        description=argument.description,
+    )
 
 
 def convert_arguments(

--- a/tests/schema/test_arguments.py
+++ b/tests/schema/test_arguments.py
@@ -1,0 +1,28 @@
+from textwrap import dedent
+
+import strawberry
+from typing_extensions import Annotated
+
+
+def test_argument_descriptions():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def hello(  # type: ignore
+            name: Annotated[
+                str, strawberry.argument(description="Your name")  # noqa: F722
+            ] = "Patrick"
+        ) -> str:
+            return f"Hi {name}"
+
+    schema = strawberry.Schema(query=Query)
+
+    assert str(schema) == dedent(
+        '''\
+        type Query {
+          hello(
+            """Your name"""
+            name: String! = "Patrick"
+          ): String!
+        }'''
+    )

--- a/tests/schema/test_arguments.py
+++ b/tests/schema/test_arguments.py
@@ -1,7 +1,8 @@
 from textwrap import dedent
 
-import strawberry
 from typing_extensions import Annotated
+
+import strawberry
 
 
 def test_argument_descriptions():

--- a/tests/types/test_arguments.py
+++ b/tests/types/test_arguments.py
@@ -2,9 +2,10 @@ from typing import List, Optional
 
 import pytest
 
+from typing_extensions import Annotated
+
 import strawberry
 from strawberry.exceptions import MultipleStrawberryArgumentsError
-from typing_extensions import Annotated
 
 
 def test_basic_arguments():

--- a/tests/types/test_arguments.py
+++ b/tests/types/test_arguments.py
@@ -1,3 +1,4 @@
+import sys
 from typing import List, Optional
 
 import pytest
@@ -327,3 +328,35 @@ def test_annotated_with_other_information():
     assert argument.type == str
     assert argument.is_optional is False
     assert argument.description is None
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 9),
+    reason="Annotated type was added in python 3.9",
+)
+def test_annotated_python_39():
+    from typing import Annotated
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def name(  # type: ignore
+            argument: Annotated[
+                str,
+                strawberry.argument(description="This is a description"),  # noqa: F722
+            ]
+        ) -> str:
+            return "Name"
+
+    definition = Query._type_definition
+
+    assert definition.name == "Query"
+
+    assert len(definition.fields[0].arguments) == 1
+
+    argument = definition.fields[0].arguments[0]
+
+    assert argument.name == "argument"
+    assert argument.type == str
+    assert argument.is_optional is False
+    assert argument.description == "This is a description"

--- a/tests/types/test_arguments.py
+++ b/tests/types/test_arguments.py
@@ -303,3 +303,26 @@ def test_multiple_annotated_arguments_exception():
         "on field `name` cannot have multiple "
         "`strawberry.argument`s"
     )
+
+
+def test_annotated_with_other_information():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def name(  # type: ignore
+            argument: Annotated[str, "Some other info"]  # noqa: F722
+        ) -> str:
+            return "Name"
+
+    definition = Query._type_definition
+
+    assert definition.name == "Query"
+
+    assert len(definition.fields[0].arguments) == 1
+
+    argument = definition.fields[0].arguments[0]
+
+    assert argument.name == "argument"
+    assert argument.type == str
+    assert argument.is_optional is False
+    assert argument.description is None

--- a/tests/types/test_arguments.py
+++ b/tests/types/test_arguments.py
@@ -258,6 +258,33 @@ def test_annotated_optional_arguments_on_resolver():
     assert argument.description == "This is a description"
 
 
+def test_annotated_argument_with_default_value():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def name(  # type: ignore
+            argument: Annotated[
+                str,
+                strawberry.argument(description="This is a description"),  # noqa: F722
+            ] = "Patrick"
+        ) -> str:
+            return "Name"
+
+    definition = Query._type_definition
+
+    assert definition.name == "Query"
+
+    assert len(definition.fields[0].arguments) == 1
+
+    argument = definition.fields[0].arguments[0]
+
+    assert argument.name == "argument"
+    assert argument.type == str
+    assert argument.is_optional is False
+    assert argument.description == "This is a description"
+    assert argument.default_value == "Patrick"
+
+
 def test_multiple_annotated_arguments_exception():
     with pytest.raises(MultipleStrawberryArgumentsError) as error:
 


### PR DESCRIPTION
## Description

Add support for adding a description to field arguments using the [`Annotated`](https://docs.python.org/3/library/typing.html#typing.Annotated) type:

```python
from typing import Annotated

@strawberry.type
class Query:
	@strawberry.field
	def user_by_id(id: Annotated[str, strawberry.argument(description="The ID of the user")]) -> User:
		...
```

which results in the following schema:

```graphql
type Query {
  userById(
    """The ID of the user"""
    id: String
  ): User!
}
```

**Note:** if you are not using Python v3.9 or greater you will need to import `Annotated` from `typing_extensions`

**Another note:** pyflakes currently has a bug where it doesn't recognise the `Annotated` syntax

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #509

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
