### PR TITLE
Edit wrong example of source code in Doc

### DIFF
--- a/docs/01_general/03_mutations.md
+++ b/docs/01_general/03_mutations.md
@@ -15,7 +15,7 @@ implement a mutation that is supposed to send an email:
 ```python
 import strawberry
 
-
+@strawberry.type
 class Mutation:
     @strawberry.mutation
     def send_email(self, email: str) -> bool:


### PR DESCRIPTION
When `@strawberry.type` is not writed on `class Mutation`, then It isn't work.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

I tried Mutation as follow example source code in Doc, there was a error in example source code.
I saw unit test in ![here](https://github.com/strawberry-graphql/strawberry/blob/master/tests/schema/test_mutation.py) and change it right way.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
