### PR TITLE
Fix TypeError: list object expected in mypy plugin

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+This releases fixes another issue with the mypy plugin

--- a/strawberry/ext/mypy_plugin.py
+++ b/strawberry/ext/mypy_plugin.py
@@ -56,7 +56,7 @@ def _get_type_for_expr(expr: Expression, api: SemanticAnalyzerPluginInterface):
 
     if isinstance(expr, IndexExpr):
         type_ = _get_type_for_expr(expr.base, api)
-        type_.args = (_get_type_for_expr(expr.index, api),)
+        type_.args = [_get_type_for_expr(expr.index, api)]
 
         return type_
 


### PR DESCRIPTION
Found another small issue

```
Running . mypy...
./admin_api/feature_switch/resolvers.py:30: error: INTERNAL ERROR -- Please try using mypy master on Github:
https://mypy.rtfd.io/en/latest/common_issues.html#using-a-development-mypy-build
Please report a bug at https://github.com/python/mypy/issues
version: 0.782
Traceback (most recent call last):
  File "mypy/semanal.py", line 4691, in accept
  File "mypy/nodes.py", line 1062, in accept
  File "mypy/semanal.py", line 1943, in visit_assignment_stmt
  File "mypy/semanal.py", line 2194, in apply_dynamic_class_hook
  File "/Users/patrick/Documents/github/streetteam/root/ambassador_api/.virtualenv/lib/python3.7/site-packages/strawberry/ext/mypy_plugin.py", line 72, in union_hook
    tuple(_get_type_for_expr(x, ctx.api) for x in types.items)
  File "/Users/patrick/Documents/github/streetteam/root/ambassador_api/.virtualenv/lib/python3.7/site-packages/strawberry/ext/mypy_plugin.py", line 72, in <genexpr>
    tuple(_get_type_for_expr(x, ctx.api) for x in types.items)
  File "/Users/patrick/Documents/github/streetteam/root/ambassador_api/.virtualenv/lib/python3.7/site-packages/strawberry/ext/mypy_plugin.py", line 59, in _get_type_for_expr
    type_.args = (_get_type_for_expr(expr.index, api),)
TypeError: list object expected; got tuple[mypy.types.Instance]
./admin_api/feature_switch/resolvers.py:30: : note: use --pdb to drop into pdb
```