### PR TITLE
Use field definition to check if we are returning a list or not

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+This release improves how we handle enum values when returing lists of enums.


### PR DESCRIPTION
The previous check I've done would crash when returning string types that weren't real strings (like proxy strings in django).

This check should be much better :)