### PR TITLE
Add support for deprecation_reason on field

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: minor
+
+This release adds support to mark a field as deprecated via `deprecation_reason`

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -69,7 +69,8 @@ def field(
     is_subscription: bool = False,
     description: Optional[str] = None,
     permission_classes: Optional[List[Type[BasePermission]]] = None,
-    federation: Optional[FederationFieldParams] = None
+    federation: Optional[FederationFieldParams] = None,
+    deprecation_reason: Optional[str] = None,
 ):
     """Annotates a method or property as a GraphQL field.
 
@@ -97,6 +98,7 @@ def field(
         permission_classes=permission_classes or [],
         arguments=[],  # modified by resolver in __call__
         federation=federation or FederationFieldParams(),
+        deprecation_reason=deprecation_reason,
     )
 
     field_ = StrawberryField(field_definition)

--- a/strawberry/schema/types/fields.py
+++ b/strawberry/schema/types/fields.py
@@ -40,6 +40,8 @@ def get_field(
     else:
         kwargs["args"] = convert_arguments(field.arguments, type_map)
         kwargs["resolve"] = resolver
+
+    if not is_input:
         kwargs["deprecation_reason"] = field.deprecation_reason
 
     return TypeClass(graphql_type, **kwargs)  # type: ignore

--- a/strawberry/schema/types/fields.py
+++ b/strawberry/schema/types/fields.py
@@ -40,5 +40,6 @@ def get_field(
     else:
         kwargs["args"] = convert_arguments(field.arguments, type_map)
         kwargs["resolve"] = resolver
+        kwargs["deprecation_reason"] = field.deprecation_reason
 
     return TypeClass(graphql_type, **kwargs)  # type: ignore

--- a/strawberry/types/types.py
+++ b/strawberry/types/types.py
@@ -92,3 +92,4 @@ class FieldDefinition:
         default_factory=list
     )
     default_value: Any = undefined
+    deprecation_reason: Optional[str] = None

--- a/tests/schema/test_basic.py
+++ b/tests/schema/test_basic.py
@@ -166,6 +166,40 @@ def test_field_description():
     ]
 
 
+def test_field_deprecated_reason():
+    @strawberry.type
+    class Query:
+        a: str = strawberry.field(deprecation_reason="Deprecated A")
+
+        @strawberry.field
+        def b(self, info, id: int) -> str:
+            return "I'm a resolver"
+
+        @strawberry.field(deprecation_reason="Deprecated B")
+        def c(self, info, id: int) -> str:
+            return "I'm a resolver"
+
+    schema = strawberry.Schema(query=Query)
+
+    query = """{
+        __type(name: "Query") {
+            fields(includeDeprecated: true) {
+                name
+                deprecationReason
+            }
+        }
+    }"""
+
+    result = schema.execute_sync(query)
+
+    assert not result.errors
+    assert result.data["__type"]["fields"] == [
+        {"name": "a", "deprecationReason": "Deprecated A"},
+        {"name": "b", "deprecationReason": None},
+        {"name": "c", "deprecationReason": "Deprecated B"},
+    ]
+
+
 def test_enum_description():
     @strawberry.enum(description="We love ice-creams")
     class IceCreamFlavour(Enum):

--- a/tests/schema/test_basic.py
+++ b/tests/schema/test_basic.py
@@ -200,6 +200,36 @@ def test_field_deprecated_reason():
     ]
 
 
+def test_field_deprecated_reason_subscription():
+    @strawberry.type
+    class Query:
+        a: str
+
+    @strawberry.type
+    class Subscription:
+        @strawberry.subscription(deprecation_reason="Deprecated A")
+        def a(self) -> str:
+            return "A"
+
+    schema = strawberry.Schema(query=Query, subscription=Subscription)
+
+    query = """{
+        __type(name: "Subscription") {
+            fields(includeDeprecated: true) {
+                name
+                deprecationReason
+            }
+        }
+    }"""
+
+    result = schema.execute_sync(query)
+
+    assert not result.errors
+    assert result.data["__type"]["fields"] == [
+        {"name": "a", "deprecationReason": "Deprecated A"},
+    ]
+
+
 def test_enum_description():
     @strawberry.enum(description="We love ice-creams")
     class IceCreamFlavour(Enum):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Added deprecation_reason to allow to mark a field as deprecated

New optional string field in `strawberry.field`

<img width="1418" alt="image" src="https://user-images.githubusercontent.com/73083038/97166108-9bab2400-177c-11eb-8850-87ffefbdd34f.png">

Example schema:

```
import typing
import strawberry


@strawberry.type
class User:
    name: str
    age: int = strawberry.field(deprecation_reason="ciao!")

@strawberry.type
class Query:
    @strawberry.field
    def user(self, info) -> User:
        return User(name="Patrick", age=100)


schema = strawberry.Schema(query=Query)

```

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Closes #375

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
