### PR TITLE
UUID type

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+Release type: minor
+
+Register UUID's as a custom scalar type instead of the ID type.
+
+⚠️ This is a potential breaking change because inputs of type UUID are now parsed as instances of uuid.UUID instead of strings as they were before.

--- a/strawberry/custom_scalar.py
+++ b/strawberry/custom_scalar.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import Callable, Dict, Optional, Type
 
+from .exceptions import ScalarAlreadyRegisteredError
 from .utils.str_converters import to_camel_case
 
 
@@ -41,6 +42,9 @@ def _process_scalar(
 ):
 
     name = name or to_camel_case(cls.__name__)
+
+    if cls in SCALAR_REGISTRY:
+        raise ScalarAlreadyRegisteredError(name)
 
     wrapper = ScalarWrapper(cls)
     wrapper._scalar_definition = ScalarDefinition(

--- a/strawberry/exceptions.py
+++ b/strawberry/exceptions.py
@@ -120,3 +120,10 @@ class MultipleStrawberryArgumentsError(Exception):
         )
 
         super().__init__(message)
+
+
+class ScalarAlreadyRegisteredError(Exception):
+    def __init__(self, scalar_name: str):
+        message = (f"Scalar `{scalar_name}` has already been registered")
+
+        super().__init__(message)

--- a/strawberry/exceptions.py
+++ b/strawberry/exceptions.py
@@ -124,6 +124,6 @@ class MultipleStrawberryArgumentsError(Exception):
 
 class ScalarAlreadyRegisteredError(Exception):
     def __init__(self, scalar_name: str):
-        message = (f"Scalar `{scalar_name}` has already been registered")
+        message = f"Scalar `{scalar_name}` has already been registered"
 
         super().__init__(message)

--- a/strawberry/schema/types/base_scalars.py
+++ b/strawberry/schema/types/base_scalars.py
@@ -42,5 +42,8 @@ Decimal = scalar(
 )
 
 UUID = scalar(
-    uuid.UUID, name="UUID", serialize=str, parse_value=uuid.UUID,
+    uuid.UUID,
+    name="UUID",
+    serialize=str,
+    parse_value=uuid.UUID,
 )

--- a/strawberry/schema/types/base_scalars.py
+++ b/strawberry/schema/types/base_scalars.py
@@ -1,5 +1,6 @@
 import datetime
 import decimal
+import uuid
 from operator import methodcaller
 
 import dateutil.parser
@@ -38,4 +39,8 @@ Decimal = scalar(
     description="Decimal (fixed-point)",
     serialize=str,
     parse_value=decimal.Decimal,
+)
+
+UUID = scalar(
+    uuid.UUID, name="UUID", description="UUID", serialize=str, parse_value=uuid.UUID,
 )

--- a/strawberry/schema/types/base_scalars.py
+++ b/strawberry/schema/types/base_scalars.py
@@ -42,5 +42,5 @@ Decimal = scalar(
 )
 
 UUID = scalar(
-    uuid.UUID, name="UUID", description="UUID", serialize=str, parse_value=uuid.UUID,
+    uuid.UUID, name="UUID", serialize=str, parse_value=uuid.UUID,
 )

--- a/strawberry/schema/types/scalar.py
+++ b/strawberry/schema/types/scalar.py
@@ -1,7 +1,6 @@
 import datetime
 import decimal
 from typing import Dict, Type, cast
-from uuid import UUID
 
 from graphql import (
     GraphQLBoolean,
@@ -16,7 +15,7 @@ from strawberry.custom_scalar import SCALAR_REGISTRY, ScalarDefinition
 from strawberry.file_uploads.scalars import Upload
 from strawberry.scalars import ID
 
-from .base_scalars import Date, DateTime, Decimal, Time
+from .base_scalars import UUID, Date, DateTime, Decimal, Time
 from .types import ConcreteType, TypeMap
 
 
@@ -36,7 +35,7 @@ DEFAULT_SCALAR_REGISTRY: Dict[Type, GraphQLScalarType] = {
     float: GraphQLFloat,
     bool: GraphQLBoolean,
     ID: GraphQLID,
-    UUID: GraphQLID,
+    UUID: _make_scalar_type(UUID._scalar_definition),
     Upload: _make_scalar_type(Upload._scalar_definition),
     datetime.date: _make_scalar_type(Date._scalar_definition),
     datetime.datetime: _make_scalar_type(DateTime._scalar_definition),

--- a/tests/schema/test_scalars.py
+++ b/tests/schema/test_scalars.py
@@ -11,13 +11,14 @@ def test_uuid_field_string_value():
 
     schema = strawberry.Schema(query=Query)
 
-    assert str(schema) == dedent('''\
+    assert str(schema) == dedent('''
       type Query {
         uniqueId: UUID!
       }
 
       """UUID"""
-      scalar UUID''')
+      scalar UUID
+    ''').strip()
 
     result = schema.execute_sync("query { uniqueId }", root_value=Query(
         unique_id="e350746c-33b6-4469-86b0-5f16e1e12232",
@@ -35,13 +36,14 @@ def test_uuid_field_uuid_value():
 
     schema = strawberry.Schema(query=Query)
 
-    assert str(schema) == dedent('''\
+    assert str(schema) == dedent('''
       type Query {
         uniqueId: UUID!
       }
 
       """UUID"""
-      scalar UUID''')
+      scalar UUID
+    ''').strip()
 
     result = schema.execute_sync("query { uniqueId }", root_value=Query(
         unique_id=UUID("e350746c-33b6-4469-86b0-5f16e1e12232"),

--- a/tests/schema/test_scalars.py
+++ b/tests/schema/test_scalars.py
@@ -1,0 +1,78 @@
+from textwrap import dedent
+from uuid import UUID
+
+import strawberry
+
+
+def test_uuid_field_string_value():
+    @strawberry.type
+    class Query:
+        unique_id: UUID
+
+    schema = strawberry.Schema(query=Query)
+
+    assert str(schema) == dedent('''\
+      type Query {
+        uniqueId: UUID!
+      }
+
+      """UUID"""
+      scalar UUID''')
+
+    result = schema.execute_sync("query { uniqueId }", root_value=Query(
+        unique_id="e350746c-33b6-4469-86b0-5f16e1e12232",
+    ))
+    assert not result.errors
+    assert result.data == {
+        "uniqueId": "e350746c-33b6-4469-86b0-5f16e1e12232",
+    }
+
+
+def test_uuid_field_uuid_value():
+    @strawberry.type
+    class Query:
+        unique_id: UUID
+
+    schema = strawberry.Schema(query=Query)
+
+    assert str(schema) == dedent('''\
+      type Query {
+        uniqueId: UUID!
+      }
+
+      """UUID"""
+      scalar UUID''')
+
+    result = schema.execute_sync("query { uniqueId }", root_value=Query(
+        unique_id=UUID("e350746c-33b6-4469-86b0-5f16e1e12232"),
+    ))
+    assert not result.errors
+    assert result.data == {
+        "uniqueId": "e350746c-33b6-4469-86b0-5f16e1e12232",
+    }
+
+
+def test_uuid_input():
+    @strawberry.type
+    class Query:
+        ok: bool
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        def uuid_input(self, input_id: UUID) -> str:
+            assert isinstance(input_id, UUID)
+            return str(input_id)
+
+    schema = strawberry.Schema(query=Query, mutation=Mutation)
+
+    result = schema.execute_sync("""
+        mutation {
+            uuidInput(inputId: "e350746c-33b6-4469-86b0-5f16e1e12232")
+        }
+    """)
+
+    assert not result.errors
+    assert result.data == {
+        "uuidInput": "e350746c-33b6-4469-86b0-5f16e1e12232",
+    }

--- a/tests/schema/test_scalars.py
+++ b/tests/schema/test_scalars.py
@@ -16,7 +16,6 @@ def test_uuid_field_string_value():
         uniqueId: UUID!
       }
 
-      """UUID"""
       scalar UUID
     ''').strip()
 
@@ -41,7 +40,6 @@ def test_uuid_field_uuid_value():
         uniqueId: UUID!
       }
 
-      """UUID"""
       scalar UUID
     ''').strip()
 

--- a/tests/schema/test_scalars.py
+++ b/tests/schema/test_scalars.py
@@ -11,17 +11,25 @@ def test_uuid_field_string_value():
 
     schema = strawberry.Schema(query=Query)
 
-    assert str(schema) == dedent('''
+    assert (
+        str(schema)
+        == dedent(
+            """
       type Query {
         uniqueId: UUID!
       }
 
       scalar UUID
-    ''').strip()
+    """
+        ).strip()
+    )
 
-    result = schema.execute_sync("query { uniqueId }", root_value=Query(
-        unique_id="e350746c-33b6-4469-86b0-5f16e1e12232",
-    ))
+    result = schema.execute_sync(
+        "query { uniqueId }",
+        root_value=Query(
+            unique_id="e350746c-33b6-4469-86b0-5f16e1e12232",
+        ),
+    )
     assert not result.errors
     assert result.data == {
         "uniqueId": "e350746c-33b6-4469-86b0-5f16e1e12232",
@@ -35,17 +43,25 @@ def test_uuid_field_uuid_value():
 
     schema = strawberry.Schema(query=Query)
 
-    assert str(schema) == dedent('''
+    assert (
+        str(schema)
+        == dedent(
+            """
       type Query {
         uniqueId: UUID!
       }
 
       scalar UUID
-    ''').strip()
+    """
+        ).strip()
+    )
 
-    result = schema.execute_sync("query { uniqueId }", root_value=Query(
-        unique_id=UUID("e350746c-33b6-4469-86b0-5f16e1e12232"),
-    ))
+    result = schema.execute_sync(
+        "query { uniqueId }",
+        root_value=Query(
+            unique_id=UUID("e350746c-33b6-4469-86b0-5f16e1e12232"),
+        ),
+    )
     assert not result.errors
     assert result.data == {
         "uniqueId": "e350746c-33b6-4469-86b0-5f16e1e12232",
@@ -66,11 +82,13 @@ def test_uuid_input():
 
     schema = strawberry.Schema(query=Query, mutation=Mutation)
 
-    result = schema.execute_sync("""
+    result = schema.execute_sync(
+        """
         mutation {
             uuidInput(inputId: "e350746c-33b6-4469-86b0-5f16e1e12232")
         }
-    """)
+    """
+    )
 
     assert not result.errors
     assert result.data == {

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -27,7 +27,6 @@ def test_simple_required_types():
       uid: UUID!
     }
 
-    """UUID"""
     scalar UUID
     '''
 
@@ -82,7 +81,6 @@ def test_input_simple_required_types():
       search(input: MyInput!): String!
     }
 
-    """UUID"""
     scalar UUID
     '''
 

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -17,16 +17,19 @@ def test_simple_required_types():
         id: strawberry.ID
         uid: UUID
 
-    expected_type = """
+    expected_type = '''
     type Query {
       s: String!
       i: Int!
       b: Boolean!
       f: Float!
       id: ID!
-      uid: ID!
+      uid: UUID!
     }
-    """
+
+    """UUID"""
+    scalar UUID
+    '''
 
     schema = strawberry.Schema(query=Query)
 
@@ -65,20 +68,23 @@ def test_input_simple_required_types():
         def search(self, input: MyInput) -> str:
             return input.s
 
-    expected_type = """
+    expected_type = '''
     input MyInput {
       s: String!
       i: Int!
       b: Boolean!
       f: Float!
       id: ID!
-      uid: ID!
+      uid: UUID!
     }
 
     type Query {
       search(input: MyInput!): String!
     }
-    """
+
+    """UUID"""
+    scalar UUID
+    '''
 
     schema = strawberry.Schema(query=Query)
 

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -17,7 +17,7 @@ def test_simple_required_types():
         id: strawberry.ID
         uid: UUID
 
-    expected_type = '''
+    expected_type = """
     type Query {
       s: String!
       i: Int!
@@ -28,7 +28,7 @@ def test_simple_required_types():
     }
 
     scalar UUID
-    '''
+    """
 
     schema = strawberry.Schema(query=Query)
 
@@ -67,7 +67,7 @@ def test_input_simple_required_types():
         def search(self, input: MyInput) -> str:
             return input.s
 
-    expected_type = '''
+    expected_type = """
     input MyInput {
       s: String!
       i: Int!
@@ -82,7 +82,7 @@ def test_input_simple_required_types():
     }
 
     scalar UUID
-    '''
+    """
 
     schema = strawberry.Schema(query=Query)
 


### PR DESCRIPTION
## Description

Register UUID's as a custom scalar type instead of the `ID` type. 

⚠️ This is a potential breaking change because inputs of type `UUID` are now parsed as instances of `uuid.UUID` instead of strings as they were before.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
