### PR TITLE
Bugfix: Async lists

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+This release fixes a bug when returning list in async resolvers

--- a/strawberry/resolvers.py
+++ b/strawberry/resolvers.py
@@ -63,6 +63,11 @@ def get_arguments(
 def get_result_for_field(
     field: FieldDefinition, kwargs: Dict[str, Any], source: Any, info: Any
 ) -> Union[Awaitable[Any], Any]:
+    """
+    Calls the resolver defined for `field`. If field doesn't have a
+    resolver defined we default to using getattr on `source`.
+    """
+
     actual_resolver = field.base_resolver
 
     if actual_resolver:

--- a/strawberry/resolvers.py
+++ b/strawberry/resolvers.py
@@ -48,7 +48,7 @@ def get_arguments(
 
     args = []
 
-    if "self" in function_args:
+    if function_args and function_args[0] == "self":
         args.append(source)
 
     if "root" in function_args:

--- a/tests/schema/test_enum.py
+++ b/tests/schema/test_enum.py
@@ -2,6 +2,8 @@ import typing
 from enum import Enum
 from typing import List, Optional
 
+import pytest
+
 import strawberry
 
 
@@ -175,3 +177,52 @@ def test_enum_in_optional_list():
 
     assert not result.errors
     assert result.data["bestFlavours"] is None
+
+
+@pytest.mark.asyncio
+async def test_enum_resolver_async():
+    @strawberry.enum
+    class IceCreamFlavour(Enum):
+        VANILLA = "vanilla"
+        STRAWBERRY = "strawberry"
+        CHOCOLATE = "chocolate"
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        async def best_flavour(self, info) -> IceCreamFlavour:
+            return IceCreamFlavour.STRAWBERRY
+
+    schema = strawberry.Schema(query=Query)
+
+    query = "{ bestFlavour }"
+
+    result = await schema.execute(query)
+
+    assert not result.errors
+    assert result.data["bestFlavour"] == "STRAWBERRY"
+
+
+@pytest.mark.asyncio
+async def test_enum_in_list_async():
+    @strawberry.enum
+    class IceCreamFlavour(Enum):
+        VANILLA = "vanilla"
+        STRAWBERRY = "strawberry"
+        CHOCOLATE = "chocolate"
+        PISTACHIO = "pistachio"
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        async def best_flavours(self, info) -> List[IceCreamFlavour]:
+            return [IceCreamFlavour.STRAWBERRY, IceCreamFlavour.PISTACHIO]
+
+    schema = strawberry.Schema(query=Query)
+
+    query = "{ bestFlavours }"
+
+    result = await schema.execute(query)
+
+    assert not result.errors
+    assert result.data["bestFlavours"] == ["STRAWBERRY", "PISTACHIO"]

--- a/tests/schema/test_resolvers.py
+++ b/tests/schema/test_resolvers.py
@@ -294,3 +294,21 @@ def test_extending_type():
 
     assert not result.errors
     assert result.data == {"name": "Name", "name2": "Name 2"}
+
+
+@pytest.mark.asyncio
+async def test_async_list_resolver():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        async def best_flavours(self, info) -> List[str]:
+            return ["strawberry", "pistachio"]
+
+    schema = strawberry.Schema(query=Query)
+
+    query = "{ bestFlavours }"
+
+    result = await schema.execute(query, root_value=Query())
+
+    assert not result.errors
+    assert result.data["bestFlavours"] == ["strawberry", "pistachio"]


### PR DESCRIPTION
## Description

The changes introduced to enable resolvers to return a list of enums has broken support for returning lists from async resolvers. Specifically this line: https://github.com/strawberry-graphql/strawberry/blob/0ed51802b9ce3e7abe0282953384e8155a575cfa/strawberry/resolvers.py#L28 
fails with the error `'coroutine' object is not iterable`. I've added some regression tests to show the issue but I'm not sure how to solve it. Any ideas @patrick91 @BryceBeagle ?

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
