### PR TITLE
Set default value to null when it's set to None

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Set default value to null in the schema when it's set to None

--- a/strawberry/arguments.py
+++ b/strawberry/arguments.py
@@ -31,7 +31,7 @@ def get_arguments_from_annotations(
         default_value = parameters[name].default
         default_value = (
             undefined
-            if default_value in (inspect._empty, None)  # type: ignore
+            if default_value == inspect._empty  # type: ignore
             else default_value
         )
 

--- a/tests/schema/test_arguments.py
+++ b/tests/schema/test_arguments.py
@@ -1,4 +1,5 @@
 from textwrap import dedent
+from typing import Optional
 
 from typing_extensions import Annotated
 
@@ -25,5 +26,22 @@ def test_argument_descriptions():
             """Your name"""
             name: String! = "Patrick"
           ): String!
+        }'''
+    )
+
+
+def test_argument_with_default_value_none():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def hello(self, name: Optional[str] = None) -> str:
+            return f"Hi {name}"
+
+    schema = strawberry.Schema(query=Query)
+
+    assert str(schema) == dedent(
+        '''\
+        type Query {
+          hello(name: String = null): String!
         }'''
     )

--- a/tests/schema/test_arguments.py
+++ b/tests/schema/test_arguments.py
@@ -40,8 +40,8 @@ def test_argument_with_default_value_none():
     schema = strawberry.Schema(query=Query)
 
     assert str(schema) == dedent(
-        '''\
+        """\
         type Query {
           hello(name: String = null): String!
-        }'''
+        }"""
     )

--- a/tests/types/test_arguments.py
+++ b/tests/types/test_arguments.py
@@ -7,6 +7,7 @@ from typing_extensions import Annotated
 
 import strawberry
 from strawberry.exceptions import MultipleStrawberryArgumentsError
+from strawberry.types.types import undefined
 
 
 def test_basic_arguments():
@@ -206,6 +207,50 @@ def test_arguments_when_extending_multiple_types():
     assert definition.fields[1].arguments[0].name == "id"
     assert definition.fields[1].arguments[0].type == strawberry.ID
     assert definition.fields[1].arguments[0].is_optional is False
+
+
+def test_argument_with_default_value_none():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def name(self, argument: Optional[str] = None) -> str:
+            return "Name"
+
+    definition = Query._type_definition
+
+    assert definition.name == "Query"
+
+    assert len(definition.fields[0].arguments) == 1
+
+    argument = definition.fields[0].arguments[0]
+
+    assert argument.name == "argument"
+    assert argument.type == str
+    assert argument.is_optional is True
+    assert argument.description is None
+    assert argument.default_value is None
+
+
+def test_argument_with_default_value_undefined():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def name(self, argument: Optional[str]) -> str:
+            return "Name"
+
+    definition = Query._type_definition
+
+    assert definition.name == "Query"
+
+    assert len(definition.fields[0].arguments) == 1
+
+    argument = definition.fields[0].arguments[0]
+
+    assert argument.name == "argument"
+    assert argument.type == str
+    assert argument.is_optional is True
+    assert argument.description is None
+    assert argument.default_value == undefined
 
 
 def test_annotated_argument_on_resolver():

--- a/tests/utils/test_arguments_converter.py
+++ b/tests/utils/test_arguments_converter.py
@@ -240,3 +240,24 @@ def test_uses_default_for_optional_types_when_nothing_is_passed():
     arguments = [ArgumentDefinition(name="input", origin_name="input", type=Input)]
 
     assert convert_arguments(args, arguments) == {"input": Input(UNSET, None)}
+
+
+def test_when_optional():
+    @strawberry.input
+    class Number:
+        value: int
+
+    @strawberry.input
+    class Input:
+        numbers: Optional[Number] = UNSET
+        numbers_second: Optional[Number] = UNSET
+
+    args = {}
+
+    arguments = [
+        ArgumentDefinition(
+            name="input", origin_name="input", type=Input, is_optional=True
+        )
+    ]
+
+    assert convert_arguments(args, arguments) == {}


### PR DESCRIPTION
## Description

Currently if an argument has a default value set to `None` it won't show up in the schema as `null`. This PR fixes that.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
