### PR TITLE
Disable implicit reexport

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+This release disable implicit re-export of modules. This fixes Strawberry for you if you were using `implicit_reexport = False` in your MyPy config.

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,2 +1,3 @@
 [mypy]
 plugins = ./strawberry/ext/mypy_plugin.py
+implicit_reexport = False

--- a/strawberry/__init__.py
+++ b/strawberry/__init__.py
@@ -1,17 +1,39 @@
 __version__ = "0.1.0"
 
 
-from . import federation  # noqa
-from .arguments import argument  # noqa
-from .custom_scalar import scalar  # noqa
-from .directive import directive  # noqa
-from .enum import enum  # noqa
-from .field import field  # noqa
-from .lazy_type import LazyType  # noqa
-from .mutation import mutation, subscription  # noqa
-from .permission import BasePermission  # noqa
-from .private import Private  # noqa
-from .scalars import ID  # noqa
-from .schema import Schema  # noqa
-from .type import input, interface, type  # noqa
-from .union import union  # noqa
+from . import federation
+from .arguments import argument
+from .custom_scalar import scalar
+from .directive import directive
+from .enum import enum
+from .field import field
+from .lazy_type import LazyType
+from .mutation import mutation, subscription
+from .permission import BasePermission
+from .private import Private
+from .scalars import ID
+from .schema import Schema
+from .type import input, interface, type
+from .union import union
+
+
+__all__ = [
+    "BasePermission",
+    "ID",
+    "LazyType",
+    "Private",
+    "Schema",
+    "__version__",
+    "argument",
+    "directive",
+    "enum",
+    "federation",
+    "field",
+    "input",
+    "interface",
+    "mutation",
+    "scalar",
+    "subscription",
+    "type",
+    "union",
+]

--- a/strawberry/__init__.py
+++ b/strawberry/__init__.py
@@ -1,6 +1,3 @@
-__version__ = "0.1.0"
-
-
 from . import federation
 from .arguments import argument
 from .custom_scalar import scalar
@@ -23,7 +20,6 @@ __all__ = [
     "LazyType",
     "Private",
     "Schema",
-    "__version__",
     "argument",
     "directive",
     "enum",

--- a/strawberry/arguments.py
+++ b/strawberry/arguments.py
@@ -170,3 +170,17 @@ def convert_arguments(
 
 def argument(description: Optional[str] = None) -> StrawberryArgument:
     return StrawberryArgument(description=description)
+
+
+__all__ = [
+    "ArgumentDefinition",
+    "StrawberryArgument",
+    "UNSET",
+    "argument",
+    "convert_argument",
+    "convert_arguments",
+    "get_arguments_from_annotations",
+    "get_arguments_from_resolver",
+    "is_unset",
+    "undefined",
+]

--- a/strawberry/directive.py
+++ b/strawberry/directive.py
@@ -28,3 +28,6 @@ def directive(*, locations: List[DirectiveLocation], description=None, name=None
         return f
 
     return _wrap
+
+
+__all__ = ["DirectiveLocation", "DirectiveDefinition", "directive"]

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -106,3 +106,6 @@ def field(
     if resolver:
         return field_(resolver)
     return field_
+
+
+__all__ = ["FederationFieldParams", "FieldDefinition", "StrawberryField", "field"]

--- a/strawberry/file_uploads/__init__.py
+++ b/strawberry/file_uploads/__init__.py
@@ -1,1 +1,4 @@
-from .scalars import Upload  # noqa
+from .scalars import Upload
+
+
+__all__ = ["Upload"]

--- a/strawberry/schema/__init__.py
+++ b/strawberry/schema/__init__.py
@@ -1,2 +1,5 @@
-from .base import BaseSchema, ExecutionResult  # noqa
-from .schema import Schema  # noqa
+from .base import BaseSchema as BaseSchema, ExecutionResult as ExecutionResult
+from .schema import Schema as Schema
+
+
+__all__ = ["BaseSchema", "ExecutionResult", "Schema"]

--- a/strawberry/schema/types/__init__.py
+++ b/strawberry/schema/types/__init__.py
@@ -1,3 +1,6 @@
-from .directives import get_directive_type  # noqa
-from .object_type import get_object_type  # noqa
-from .types import ConcreteType  # noqa
+from .directives import get_directive_type as get_directive_type
+from .object_type import get_object_type as get_object_type
+from .types import ConcreteType as ConcreteType
+
+
+__all__ = ["ConcreteType", "get_directive_type", "get_object_type"]

--- a/strawberry/schema/types/types.py
+++ b/strawberry/schema/types/types.py
@@ -1,7 +1,7 @@
 import dataclasses
 from typing import Dict, Union
 
-from graphql import GraphQLField, GraphQLInputField, GraphQLType  # noqa
+from graphql import GraphQLField, GraphQLInputField, GraphQLType
 
 from strawberry.custom_scalar import ScalarDefinition
 from strawberry.enum import EnumDefinition
@@ -19,3 +19,6 @@ class ConcreteType:
 
 
 TypeMap = Dict[str, ConcreteType]
+
+
+__all__ = ["ConcreteType", "Field", "GraphQLType", "TypeMap"]

--- a/strawberry/type.py
+++ b/strawberry/type.py
@@ -121,3 +121,12 @@ def type(
 
 input = partial(type, is_input=True)
 interface = partial(type, is_interface=True)
+
+
+__all__ = [
+    "FederationTypeParams",
+    "TypeDefinition",
+    "input",
+    "interface",
+    "type",
+]

--- a/strawberry/types/__init__.py
+++ b/strawberry/types/__init__.py
@@ -1,1 +1,4 @@
-from .execution import ExecutionContext, ExecutionResult  # noqa
+from .execution import ExecutionContext, ExecutionResult
+
+
+__all__ = ["ExecutionContext", "ExecutionResult"]

--- a/tests/test_strawberry.py
+++ b/tests/test_strawberry.py
@@ -1,5 +1,0 @@
-from strawberry import __version__
-
-
-def test_version():
-    assert __version__ == "0.1.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

This disables [implicit re-export](https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-no-implicit-reexport) of modules. This is one of the stricter rules in MyPy and if someone is using this project and that flag then they will not be able to import modules off of the top level modules.

```
import strawberry

@strawberry.field
...
```

Would throw an implicit reexport error for a user.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
