### PR TITLE
Make to_camel_case and capitalize_first configurable

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,10 @@
+Release type: patch
+
+This release adds the ability to disable to_camel_case and capitalize_first:
+
+```py
+from strawberry.utils import str_converters
+
+str_converters.auto_camelcase = False
+str_converters.auto_capitalize = False
+```

--- a/strawberry/utils/str_converters.py
+++ b/strawberry/utils/str_converters.py
@@ -1,6 +1,12 @@
+auto_camel_case = True
+auto_capitalize = True
+
+
 # Adapted from this response in Stackoverflow
 # http://stackoverflow.com/a/19053800/1072990
 def to_camel_case(snake_str: str) -> str:
+    if auto_camel_case is False:
+        return snake_str
     components = snake_str.split("_")
     # We capitalize the first letter of each component except the first one
     # with the 'capitalize' method and join them together.
@@ -8,4 +14,6 @@ def to_camel_case(snake_str: str) -> str:
 
 
 def capitalize_first(name: str) -> str:
+    if auto_capitalize is False:
+        return name
     return name[0].upper() + name[1:]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

Adds `auto_camelcase` and `auto_capitalize` bools inside of `str_converters` that can be modified to stop camelCasing or Capitalizing.

```py
from strawberry.utils import str_converters

str_converters.auto_camelcase = False
```

I wasn't sure of a better way to do this, as these utilities are used in various functions that can be run at any time before a schema is generated.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/strawberry-graphql/strawberry/issues/542

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

There wasn't any test on these methods already and I don't think this functionality is very complicated at the moment.
Also not sure about adding to the docs since it might not be the long-term API that is wanted here.