### PR TITLE
Make field typing more specific

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -24,6 +24,7 @@ exclude_lines =
     if 0:
     if __name__ == .__main__.:
 
+    @overload
 
 
 omit =

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,4 +56,4 @@ jobs:
       - run: pip install poetry
       - name: Install dependencies
         run: poetry install
-      - run: poetry run mypy --ignore-missing-imports .
+      - run: poetry run mypy --ignore-missing-imports --config-file mypy.ini .

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Improve typing for `field` and `StrawberryField`.

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,5 @@
 [mypy]
 plugins = ./strawberry/ext/mypy_plugin.py
 implicit_reexport = False
-disallow_untyped_decorators = True
+; Disabled because of this bug: https://github.com/python/mypy/issues/9689
+; disallow_untyped_decorators = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,3 +1,4 @@
 [mypy]
 plugins = ./strawberry/ext/mypy_plugin.py
 implicit_reexport = False
+disallow_untyped_decorators = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ known_first_party = ["strawberry"]
 sections = ["FUTURE", "STDLIB", "PYTEST", "THIRDPARTY", "DJANGO", "GRAPHQL", "FIRSTPARTY", "LOCALFOLDER"]
 
 [tool.pytest.ini_options]
-addopts = "-xs --emoji --mypy-ini-file=tests/mypy/config.cfg --benchmark-disable"
+addopts = "-xs --emoji --mypy-ini-file=tests/mypy/mypy.ini --benchmark-disable"
 DJANGO_SETTINGS_MODULE = "tests.django.django_settings"
 testpaths = ["tests/"]
 [build-system]

--- a/tests/mypy/mypy.ini
+++ b/tests/mypy/mypy.ini
@@ -5,7 +5,8 @@ ignore_errors = False
 ignore_missing_imports = True
 strict_optional = True
 implicit_reexport = False
-disallow_untyped_decorators = True
+; Disabled because of this bug: https://github.com/python/mypy/issues/9689
+; disallow_untyped_decorators = True
 
 [mypy-graphql.*]
 ignore_errors = True

--- a/tests/mypy/mypy.ini
+++ b/tests/mypy/mypy.ini
@@ -4,6 +4,8 @@ check_untyped_defs = True
 ignore_errors = False
 ignore_missing_imports = True
 strict_optional = True
+implicit_reexport = False
+disallow_untyped_decorators = True
 
 [mypy-graphql.*]
 ignore_errors = True

--- a/tests/mypy/test_fields.yml
+++ b/tests/mypy/test_fields.yml
@@ -11,6 +11,42 @@
   out: |
     main:8: error: Unexpected keyword argument "n" for "User"
 
+- case: test_all_field_usage
+  main: |
+    import strawberry
+
+    def some_resolver() -> str:
+        return ""
+
+    @strawberry.type
+    class Example:
+        a: str
+        b: str = strawberry.field(name="b")
+        c: str = strawberry.field(name="c", resolver=some_resolver)
+        d: str = strawberry.field(resolver=some_resolver)
+
+        @strawberry.field(description="ABC")
+        def e(self, info) -> str:
+            return ""
+
+        @strawberry.field(name="f")
+        def f_resolver(self, info) -> str:
+            return ""
+
+    reveal_type(Example.a)
+    reveal_type(Example.b)
+    reveal_type(Example.c)
+    reveal_type(Example.d)
+    reveal_type(Example.e)
+    reveal_type(Example.f_resolver)
+  out: |
+    main:21: note: Revealed type is 'builtins.str'
+    main:22: note: Revealed type is 'builtins.str'
+    main:23: note: Revealed type is 'builtins.str'
+    main:24: note: Revealed type is 'builtins.str'
+    main:25: note: Revealed type is 'Any'
+    main:26: note: Revealed type is 'Any'
+
 - case: test_private_field
   main: |
     import strawberry


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

Improves `field` typing using overloading and `StrawberryField` typing using generics.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

`field` could not be used as a decorator in strict codebases as there was no way for MyPy to know whether or not it was going to return a decorator or `Any`.

https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-disallow-untyped-decorators

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

