### PR TITLE
Allow interfaces to implement interfaces #553

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,4 @@
-Release type: bugfix
+Release type: patch
 
 Allow interfaces to implement other interfaces.
 This may be useful if you are using the relay pattern

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,43 @@
+Release type: bugfix
+
+Allow interfaces to implement other interfaces.
+This may be useful if you are using the relay pattern
+or if you want to model base interfaces that can be extended.
+
+Example:
+```python
+import strawberry
+
+
+@strawberry.interface
+class Error:
+    message: str
+
+@strawberry.interface
+class FieldError(Error):
+    message: str
+    field: str
+
+@strawberry.type
+class PasswordTooShort(FieldError):
+    message: str
+    field: str
+    fix: str
+```
+Produces the following SDL:
+```graphql
+interface Error {
+  message: String!
+}
+
+interface FieldError implements Error {
+  message: String!
+  field: String!
+}
+
+type PasswordTooShort implements FieldError & Error {
+  message: String!
+  field: String!
+  fix: String!
+}
+```

--- a/strawberry/schema/types/object_type.py
+++ b/strawberry/schema/types/object_type.py
@@ -14,7 +14,7 @@ def _get_object_type_for_type_definition(
 ) -> GraphQLType:
 
     if type_definition.name not in type_map:
-        TypeClass: Type = GraphQLObjectType
+        TypeClass: Type = GraphQLInterfaceType
 
         kwargs = {}
 
@@ -28,10 +28,17 @@ def _get_object_type_for_type_definition(
                 _get_object_type_for_type_definition(interface, type_map)
                 for interface in type_definition.interfaces
             ]
-            # this tells GraphQL core what the returned object's actual type is
-            kwargs["is_type_of"] = lambda obj, _: isinstance(  # type: ignore
-                obj, type_definition.origin
-            )
+
+            # After https://github.com/graphql/graphql-spec/pull/373/files
+            # Now interfaces can also implement interfaces.
+            # But `GraphQLInterfaceType` constructor doesn't accept
+            # `is_type_of` argument.
+            # So we check first, and only add it for `GraphQLInterfaceType`
+            if TypeClass == GraphQLObjectType:
+                # this tells GraphQL core what the returned object's actual type is
+                kwargs["is_type_of"] = lambda obj, _: isinstance(  # type: ignore
+                    obj, type_definition.origin
+                )
 
         assert not type_definition.is_generic
 

--- a/strawberry/schema/types/object_type.py
+++ b/strawberry/schema/types/object_type.py
@@ -33,8 +33,8 @@ def _get_object_type_for_type_definition(
             # Now interfaces can also implement interfaces.
             # But `GraphQLInterfaceType` constructor doesn't accept
             # `is_type_of` argument.
-            # So we check first, and only add it for `GraphQLInterfaceType`
-            if TypeClass == GraphQLObjectType:
+            # So we check first, and we avoid adding it for `GraphQLInterfaceType`s
+            if not type_definition.is_interface:
                 # this tells GraphQL core what the returned object's actual type is
                 kwargs["is_type_of"] = lambda obj, _: isinstance(  # type: ignore
                     obj, type_definition.origin

--- a/strawberry/schema/types/object_type.py
+++ b/strawberry/schema/types/object_type.py
@@ -14,7 +14,7 @@ def _get_object_type_for_type_definition(
 ) -> GraphQLType:
 
     if type_definition.name not in type_map:
-        TypeClass: Type = GraphQLInterfaceType
+        TypeClass: Type = GraphQLObjectType
 
         kwargs = {}
 

--- a/strawberry/type.py
+++ b/strawberry/type.py
@@ -21,6 +21,9 @@ def _get_interfaces(cls: Type) -> List[TypeDefinition]:
         if type_definition and type_definition.is_interface:
             interfaces.append(type_definition)
 
+        for inherited_interface in _get_interfaces(base):
+            interfaces.append(inherited_interface)
+
     return interfaces
 
 

--- a/tests/schema/test_interface.py
+++ b/tests/schema/test_interface.py
@@ -42,3 +42,53 @@ def test_query_interface():
         {"name": "Asiago", "province": "Friuli"},
         {"canton": "Vaud", "name": "Tomme"},
     ]
+
+
+def test_interfaces_can_implement_other_interfaces():
+    @strawberry.interface
+    class Error:
+        message: str
+
+    @strawberry.interface
+    class FieldError(Error):
+        message: str
+        field: str
+
+    @strawberry.type
+    class PasswordTooShort(FieldError, Error):  # Bug? FieldError should be enough, Error is redundant
+        message: str
+        field: str
+        fix: str
+
+    @strawberry.type
+    class Query:
+
+        @strawberry.field
+        def always_error(self) -> Error:
+            return PasswordTooShort(
+                message='Password Too Short', field='Password', fix='Choose more characters'
+            )
+
+    schema = strawberry.Schema(Query, types=[PasswordTooShort])
+    query = """{
+        alwaysError {
+            ... on Error {
+                message
+            }
+            ... on FieldError {
+                field
+            }
+            ... on PasswordTooShort {
+                fix
+            }
+        }
+    }"""
+
+    result = schema.execute_sync(query)
+
+    assert not result.errors
+    assert result.data["alwaysError"] == {
+        'message': 'Password Too Short',
+        'field': 'Password',
+        'fix': 'Choose more characters',
+    }

--- a/tests/schema/test_interface.py
+++ b/tests/schema/test_interface.py
@@ -62,11 +62,12 @@ def test_interfaces_can_implement_other_interfaces():
 
     @strawberry.type
     class Query:
-
         @strawberry.field
         def always_error(self) -> Error:
             return PasswordTooShort(
-                message='Password Too Short', field='Password', fix='Choose more characters'
+                message="Password Too Short",
+                field="Password",
+                fix="Choose more characters",
             )
 
     schema = strawberry.Schema(Query, types=[PasswordTooShort])
@@ -88,7 +89,7 @@ def test_interfaces_can_implement_other_interfaces():
 
     assert not result.errors
     assert result.data["alwaysError"] == {
-        'message': 'Password Too Short',
-        'field': 'Password',
-        'fix': 'Choose more characters',
+        "message": "Password Too Short",
+        "field": "Password",
+        "fix": "Choose more characters",
     }

--- a/tests/schema/test_interface.py
+++ b/tests/schema/test_interface.py
@@ -55,7 +55,7 @@ def test_interfaces_can_implement_other_interfaces():
         field: str
 
     @strawberry.type
-    class PasswordTooShort(FieldError, Error):  # Bug? FieldError should be enough, Error is redundant
+    class PasswordTooShort(FieldError):
         message: str
         field: str
         fix: str

--- a/tests/types/test_interfaces.py
+++ b/tests/types/test_interfaces.py
@@ -104,4 +104,4 @@ def test_interfaces_can_implement_other_interfaces():
 
     definition = Person._type_definition
     assert definition.is_interface is False
-    assert definition.interfaces == [UserNodeInterface._type_definition]  # Should Node be here too?
+    assert definition.interfaces == [UserNodeInterface._type_definition, Node._type_definition]

--- a/tests/types/test_interfaces.py
+++ b/tests/types/test_interfaces.py
@@ -1,4 +1,5 @@
 import strawberry
+import textwrap
 
 
 def test_defining_interface():
@@ -81,3 +82,26 @@ def test_implementing_interface_twice():
 
     assert definition.is_interface is False
     assert definition.interfaces == [Node._type_definition]
+
+
+def test_interfaces_can_implement_other_interfaces():
+    @strawberry.interface
+    class Node:
+        id: strawberry.ID
+
+    @strawberry.interface
+    class UserNodeInterface(Node):
+        id: strawberry.ID
+        name: str
+
+    @strawberry.type
+    class Person(UserNodeInterface):
+        id: strawberry.ID
+        name: str
+
+    assert UserNodeInterface._type_definition.is_interface is True
+    assert UserNodeInterface._type_definition.interfaces == [Node._type_definition]
+
+    definition = Person._type_definition
+    assert definition.is_interface is False
+    assert definition.interfaces == [UserNodeInterface._type_definition]  # Should Node be here too?

--- a/tests/types/test_interfaces.py
+++ b/tests/types/test_interfaces.py
@@ -1,5 +1,4 @@
 import strawberry
-import textwrap
 
 
 def test_defining_interface():
@@ -104,4 +103,7 @@ def test_interfaces_can_implement_other_interfaces():
 
     definition = Person._type_definition
     assert definition.is_interface is False
-    assert definition.interfaces == [UserNodeInterface._type_definition, Node._type_definition]
+    assert definition.interfaces == [
+        UserNodeInterface._type_definition,
+        Node._type_definition,
+    ]


### PR DESCRIPTION
## Description
After [0c85996](https://github.com/graphql-python/graphql-core/commit/0c85996115738ab92d6d2be8a7245635446a3c59) it's possible in graphql for interfaces to implement interfaces. Before only object types could.

Before adding tests i wanted to validate if this is the correct approach or there's a better approach.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

#553 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Minimal Example to test the fix
Write this into a `filename.py`
```python
import random
import strawberry


@strawberry.type
class Query:

    @strawberry.field
    def hello() -> str:
        return 'World'


@strawberry.interface
class ErrorInterface:
    message: str


@strawberry.interface
class FirstErrorInterface(ErrorInterface):
    code: int = 0


@strawberry.type
class ValueError(FirstErrorInterface):
    message: str


@strawberry.type
class KeyError(FirstErrorInterface):
    message: str


@strawberry.type
class Mutation:

    @strawberry.mutation
    def first(self) -> FirstErrorInterface:
        klass = random.choice([ValueError, KeyError])
        return klass('Wrong!')


schema = strawberry.Schema(Query, Mutation, types=[ValueError, KeyError])
print(str(schema))
```
Without this changes, it should break with
```
[...]
  File "strawberry\schema\types\object_type.py", line 39, in _get_object_type_for_type_definition
    object_type = TypeClass(
TypeError: __init__() got an unexpected keyword argument 'is_type_of'
```

With this changes it should print the schema as follows:
```graphql
interface ErrorInterface {
  message: String!
}

interface FirstErrorInterface implements ErrorInterface {
  message: String!
  code: Int!
}

type KeyError implements FirstErrorInterface {
  message: String!
  code: Int!
}

type Mutation {
  first: FirstErrorInterface!
}

type Query {
  hello: String!
}

type ValueError implements FirstErrorInterface {
  message: String!
  code: Int!
}
```