### PR TITLE
Fix bug where types argument is positional for strawberry.union

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,7 @@
+Release type: patch
+
+Fix mypy plugin to handle bug where the `types` argument to `strawberry.union` is passed in as a keyword argument instead of a position one.
+
+```python
+MyUnion = strawberry.union(types=(TypeA, TypeB), name="MyUnion")
+```

--- a/strawberry/ext/mypy_plugin.py
+++ b/strawberry/ext/mypy_plugin.py
@@ -71,7 +71,12 @@ def _get_type_for_expr(expr: Expression, api: SemanticAnalyzerPluginInterface):
 
 
 def union_hook(ctx: DynamicClassDefContext) -> None:
-    types = ctx.call.args[1]
+    try:
+        # Check if types is passed as a keyword argument
+        types = ctx.call.args[ctx.call.arg_names.index("types")]
+    except ValueError:
+        # Fall back to assuming position arguments
+        types = ctx.call.args[1]
 
     if isinstance(types, TupleExpr):
         try:

--- a/tests/mypy/test_union.yml
+++ b/tests/mypy/test_union.yml
@@ -49,3 +49,30 @@
   out: |
     main:16: note: Revealed type is 'builtins.object'
     main:19: note: Revealed type is 'Union[main.Error, main.Edge[builtins.str]]'
+
+- case: test_union_kwargs
+  main: |
+    import typing
+
+    import strawberry
+
+    @strawberry.type
+    class User:
+        name: str
+
+    @strawberry.type
+    class Error:
+        message: str
+
+    Response = strawberry.union(types=(User, Error), name="Response")
+
+    a: Response
+    reveal_type(Response)
+    reveal_type(a)
+
+    a = User('abc')
+    reveal_type(a)
+  out: |
+    main:16: note: Revealed type is 'builtins.object'
+    main:17: note: Revealed type is 'Union[main.User, main.Error]'
+    main:20: note: Revealed type is 'main.User'


### PR DESCRIPTION
## Description

Fix mypy plugin to handle bug where the `types` argument to `strawberry.union` is passed in as a keyword argument instead of a position one.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
