### PR TITLE
Fix order of type evaluation

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+This release fixes an issue with forward types

--- a/strawberry/types/type_resolver.py
+++ b/strawberry/types/type_resolver.py
@@ -60,14 +60,15 @@ def resolve_type(field_definition: Union[FieldDefinition, ArgumentDefinition]) -
     type = cast(Type, field_definition.type)
     origin_name = cast(str, field_definition.origin_name)
 
-    if isinstance(type, LazyType):
-        field_definition.type = type.resolve_type()
-
     if isinstance(type, str):
         module = sys.modules[field_definition.origin.__module__].__dict__
 
         type = eval(type, module)
         field_definition.type = type
+
+    if isinstance(type, LazyType):
+        field_definition.type = type.resolve_type()
+        type = cast(Type, field_definition.type)
 
     if is_forward_ref(type):
         # if the type is a forward reference we try to resolve the type by


### PR DESCRIPTION
This is a bit hard to explain or even reproduce, the gist is that
I am converting a big schema to strawberry and there's a lot of 
circular dependencies, so I have to use lazy types and forward refs.

In one case, not sure why, the LazyType annotation came back as a
string and since we where evaluating the LazyType before doing
the eval, things went wrong.

This PR changes the order and fixes that :)
