### PR TITLE
Add support for strawberry.field in mypy

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+This release improves mypy support for strawberry.field

--- a/strawberry/ext/mypy_plugin.py
+++ b/strawberry/ext/mypy_plugin.py
@@ -15,6 +15,7 @@ from mypy.plugin import (
     AnalyzeTypeContext,
     ClassDefContext,
     DynamicClassDefContext,
+    FunctionContext,
     Plugin,
     SemanticAnalyzerPluginInterface,
 )
@@ -37,6 +38,13 @@ def lazy_type_analyze_callback(ctx: AnalyzeTypeContext) -> Type:
     type_ = ctx.api.analyze_type(type_name)
 
     return type_
+
+
+def strawberry_field_hook(ctx: FunctionContext) -> Type:
+    # TODO: check when used as decorator, check type of the caller
+    # TODO: check type of resolver if any
+
+    return AnyType(TypeOfAny.special_form)
 
 
 def private_type_analyze_callback(ctx: AnalyzeTypeContext) -> Type:
@@ -175,6 +183,14 @@ class StrawberryPlugin(Plugin):
 
         if "strawberry.enum" in fullname:
             return enum_hook
+
+        return None
+
+    def get_function_hook(
+        self, fullname: str
+    ) -> Optional[Callable[[FunctionContext], Type]]:
+        if fullname == "strawberry.field.field":
+            return strawberry_field_hook
 
         return None
 

--- a/tests/mypy/test_fields.yml
+++ b/tests/mypy/test_fields.yml
@@ -4,7 +4,7 @@
 
     @strawberry.type
     class User:
-        name: str = strawberry.field(description='Example')  # type: ignore
+        name: str = strawberry.field(description='Example')
 
     User(name="Patrick")
     User(n="Patrick")
@@ -21,9 +21,9 @@
     @strawberry.type
     class Example:
         a: str
-        b: str = strawberry.field(name="b")  # type: ignore
-        c: str = strawberry.field(name="c", resolver=some_resolver)  # type: ignore
-        d: str = strawberry.field(resolver=some_resolver)  # type: ignore
+        b: str = strawberry.field(name="b")
+        c: str = strawberry.field(name="c", resolver=some_resolver)
+        d: str = strawberry.field(resolver=some_resolver)
 
         @strawberry.field(description="ABC")
         def e(self, info) -> str:
@@ -44,8 +44,8 @@
     main:22: note: Revealed type is 'builtins.str'
     main:23: note: Revealed type is 'builtins.str'
     main:24: note: Revealed type is 'builtins.str'
-    main:25: note: Revealed type is 'strawberry.field.StrawberryField'
-    main:26: note: Revealed type is 'strawberry.field.StrawberryField'
+    main:25: note: Revealed type is 'Any'
+    main:26: note: Revealed type is 'Any'
 
 - case: test_private_field
   main: |


### PR DESCRIPTION
This is a very lazy way of doing this, but we can improve the plugin later :)

Ideally we should differentiate when strawberry.field is used as decorator and we should check that the resolver type matches the field definition, but this is proving hard to do, so for now I'll just return any.