### PR TITLE
Add missing LICENSE file for the mypy plugin

### DIFF
--- a/strawberry/ext/LICENSE
+++ b/strawberry/ext/LICENSE
@@ -1,0 +1,27 @@
+Strawberry has a copy of the Mypy dataclasses plugin.
+
+Mypy (and mypyc) are licensed under the terms of the MIT license, reproduced below.
+
+= = = = =
+
+The MIT License
+
+Copyright (c) 2015-2019 Jukka Lehtosalo and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/strawberry/ext/mypy_plugin.py
+++ b/strawberry/ext/mypy_plugin.py
@@ -219,6 +219,8 @@ def _collect_field_args(expr: Expression) -> Tuple[bool, Dict[str, Expression]]:
 # Custom dataclass transfomer that knows about strawberry.field, we cannot
 # extend the mypy one as it might be compiled by mypyc and we'd get this error
 # >>> TypeError: interpreted classes cannot inherit from compiled
+# Original copy from
+# https://github.com/python/mypy/blob/849a7f73/mypy/plugins/dataclasses.py
 
 SELF_TVAR_NAME = "_DT"  # type: Final
 


### PR DESCRIPTION
Adds a missing license since we copied the data classes plugin from mypy