### PR TITLE
Set origin_name to be the field origin name

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,13 @@
+Release type: patch
+
+Fix issue preventing reusing the same resolver for multiple fields, like here:
+
+```python
+def get_name(self) -> str:
+    return "Name"
+
+@strawberry.type
+class Query:
+    name: str = strawberry.field(resolver=get_name)
+    name_2: str = strawberry.field(resolver=get_name)
+```

--- a/strawberry/types/type_resolver.py
+++ b/strawberry/types/type_resolver.py
@@ -298,6 +298,7 @@ def _get_fields(cls: Type) -> List[FieldDefinition]:
             # the correct origin for determining field types when resolving
             # the types.
             field_definition.origin = field_definition.origin or cls
+            field_definition.origin_name = field.name
 
         # Create a FieldDefinition for fields that didn't use strawberry.field
         else:

--- a/tests/types/test_resolvers.py
+++ b/tests/types/test_resolvers.py
@@ -135,3 +135,28 @@ def test_raises_error_when_missing_type():
         'Unable to determine the type of field "missing". Either annotate it '
         "directly, or provide a typed resolver using @strawberry.field."
     )
+
+
+def test_can_reuse_resolver():
+    def get_name(self) -> str:
+        return "Name"
+
+    @strawberry.type
+    class Query:
+        name: str = strawberry.field(resolver=get_name)
+        name_2: str = strawberry.field(resolver=get_name)
+
+    definition = Query._type_definition
+
+    assert definition.name == "Query"
+    assert len(definition.fields) == 2
+
+    assert definition.fields[0].name == "name"
+    assert definition.fields[0].origin_name == "name"
+    assert definition.fields[0].type == str
+    assert definition.fields[0].base_resolver.wrapped_func == get_name
+
+    assert definition.fields[1].name == "name2"
+    assert definition.fields[1].origin_name == "name_2"
+    assert definition.fields[1].type == str
+    assert definition.fields[1].base_resolver.wrapped_func == get_name


### PR DESCRIPTION
We want origin_name to be the name of the field, not the resolver,
otherwise this would prevent us to the reuse a resolver with the
same name in a type.

Fixes use cases like this:

```python
def get_name(self) -> str:
    return "Name"

@strawberry.type
class Query:
    name: str = strawberry.field(resolver=get_name)
    name_2: str = strawberry.field(resolver=get_name)
```
