### PR TITLE
Fix issue when using union as type param for generics

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,23 @@
+Release type: patch
+
+This release fixes an issue when usign unions inside generic types, this is now
+supported:
+
+
+```python
+@strawberry.type
+class Dog:
+    name: str
+
+@strawberry.type
+class Cat:
+    name: str
+
+@strawberry.type
+class Connection(Generic[T]):
+    nodes: List[T]
+
+@strawberry.type
+class Query:
+    connection: Connection[Union[Dog, Cat]]
+```

--- a/strawberry/types/generics.py
+++ b/strawberry/types/generics.py
@@ -1,34 +1,56 @@
 import builtins
 import dataclasses
-from typing import Dict, Iterable, Tuple, Type, cast
+from typing import Dict, Iterable, Tuple, Type, Union, cast
 
 from strawberry.union import StrawberryUnion, union
 from strawberry.utils.str_converters import capitalize_first
-from strawberry.utils.typing import is_type_var
+from strawberry.utils.typing import is_type_var, is_union
 
 from .types import FederationFieldParams, FieldDefinition, TypeDefinition
 
 
-def get_name_from_types(types: Iterable[Type]):
-    return "".join([capitalize_first(type.__name__) for type in types])
+def get_name_from_types(types: Iterable[Union[Type, StrawberryUnion]]):
+    names = []
+
+    for type_ in types:
+        if isinstance(type_, StrawberryUnion):
+            return type_.name
+        else:
+            name = capitalize_first(type_.__name__)
+
+        names.append(name)
+
+    return "".join(names)
+
+
+def copy_union_with(
+    types: Tuple[Type, ...],
+    params_to_type: Dict[Type, Union[Type, StrawberryUnion]] = None,
+    description=None,
+) -> StrawberryUnion:
+    types = cast(
+        Tuple[Type, ...],
+        tuple(copy_type_with(t, params_to_type=params_to_type) for t in types),
+    )
+
+    return union(
+        name=get_name_from_types(types),
+        types=types,
+        description=description,
+    )
 
 
 def copy_type_with(
-    base: Type, *types: Type, params_to_type: Dict[Type, Type] = None
+    base: Type,
+    *types: Type,
+    params_to_type: Dict[Type, Union[Type, StrawberryUnion]] = None
 ) -> Type:
     if params_to_type is None:
         params_to_type = {}
 
     if isinstance(base, StrawberryUnion):
-        types = cast(
-            Tuple[Type, ...],
-            tuple(copy_type_with(t, params_to_type=params_to_type) for t in base.types),
-        )
-
-        return union(
-            name=get_name_from_types(types),
-            types=types,
-            description=base.description,
+        return copy_union_with(
+            base.types, params_to_type=params_to_type, description=base.description
         )
 
     if hasattr(base, "_type_definition"):
@@ -38,7 +60,14 @@ def copy_type_with(
             fields = []
 
             type_params = definition.type_params.values()
-            params_to_type.update(dict(zip(type_params, types)))
+
+            for param, type_ in zip(type_params, types):
+                if is_union(type_):
+                    params_to_type[param] = copy_union_with(
+                        type_.__args__, params_to_type=params_to_type
+                    )
+                else:
+                    params_to_type[param] = type_
 
             name = get_name_from_types(params_to_type.values()) + definition.name
 
@@ -98,6 +127,9 @@ def copy_type_with(
             return copied_type
 
     if is_type_var(base):
-        return params_to_type[base]
+        # TODO: we ignore the type issue here as we'll improve how types
+        # are represented internally (using StrawberryTypes) so we can improve
+        # typings later
+        return params_to_type[base]  # type: ignore
 
     return base

--- a/tests/types/test_generic.py
+++ b/tests/types/test_generic.py
@@ -586,3 +586,28 @@ def test_anonymous_union_inside_generics():
     assert isinstance(union_definition, StrawberryUnion)
     assert union_definition.types[0]._type_definition.name == "Dog"
     assert union_definition.types[1]._type_definition.name == "Cat"
+
+
+def test_using_generics_with_interfaces():
+    @strawberry.type
+    class Edge(Generic[T]):
+        node: T
+
+    @strawberry.interface
+    class WithName:
+        name: str
+
+    @strawberry.type
+    class Query:
+        user: Edge[WithName]
+
+    definition = Query._type_definition
+
+    assert definition.name == "Query"
+    assert len(definition.fields) == 1
+
+    assert definition.fields[0].name == "user"
+    assert definition.fields[0].type._type_definition.name == "WithNameEdge"
+    assert definition.fields[0].type._type_definition.is_generic is False
+    assert definition.fields[0].type._type_definition.fields[0].name == "node"
+    assert definition.fields[0].type._type_definition.fields[0].type == WithName


### PR DESCRIPTION
Thanks @jordangarside for the bug report! 

This PR fixes an issue with using unions inside generic types, this is now
supported:

```python
@strawberry.type
class Dog:
    name: str

@strawberry.type
class Cat:
    name: str

@strawberry.type
class Connection(Generic[T]):
    nodes: List[T]

@strawberry.type
class Query:
    connection: Connection[Union[Dog, Cat]]
```

While previously it was failing trying to get the name of the Union

