### PR TITLE
Fix typo in Schema-Basics Docs

### DIFF
--- a/docs/01_general/01_schema-basics.md
+++ b/docs/01_general/01_schema-basics.md
@@ -223,7 +223,7 @@ structure:
 ```json
 {
   "data": {
-    "getBooks": [
+    "books": [
       { "title": "Jurassic Park", "author": { "name": "Michael Crichton" } }
     ]
   }


### PR DESCRIPTION
This pull request is in regards to Issue #604.

![image](https://user-images.githubusercontent.com/40510797/100537738-cd7e3300-31df-11eb-9e27-264840ff01c0.png)

Closes #604 