### PR TITLE
docs(docs): add Query to mutation docs

### DIFF
--- a/docs/01_general/03_mutations.md
+++ b/docs/01_general/03_mutations.md
@@ -15,6 +15,14 @@ implement a mutation that is supposed to send an email:
 ```python
 import strawberry
 
+# Reader, you can safely ignore Query in this example, it is required by
+# strawberry.Schema so it is included here for completeness
+@strawberry.type
+class Query:
+    @strawberry.field
+    def hello() -> str:
+        return "world"
+
 @strawberry.type
 class Mutation:
     @strawberry.mutation
@@ -23,7 +31,7 @@ class Mutation:
 
         return True
 
-schema = strawberry.Schema(mutation=Mutation)
+schema = strawberry.Schema(query=Query, mutation=Mutation)
 ```
 
 Like queries, mutations are defined in a class that is then passed to the Schema


### PR DESCRIPTION
In #607 it was pointed out that `strawberry.Schema` requires a `query` argument. I used the mutation docs as my basis and they didn't explicitly define Query; it sort of makes sense because it muddies the example but at the same time they should be copypasta friendly. To that end, I added what I hope is a friendly comment (happy to reword!) to bring attention to the fact the Mutation is the important aspect of the docs not the Query.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
