### PR TITLE
Add execute context that can handle promises

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -522,6 +522,20 @@ toml = "*"
 virtualenv = ">=20.0.8"
 
 [[package]]
+name = "promise"
+version = "2.3"
+description = "Promises/A+ implementation for Python"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+six = "*"
+
+[package.extras]
+test = ["pytest (>=2.7.3)", "pytest-cov", "coveralls", "futures", "pytest-benchmark", "mock"]
+
+[[package]]
 name = "py"
 version = "1.9.0"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
@@ -626,7 +640,7 @@ py = ">=1.8.2"
 toml = "*"
 
 [package.extras]
-checkqa_mypy = ["mypy (==0.780)"]
+checkqa_mypy = ["mypy (0.780)"]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
@@ -673,7 +687,7 @@ coverage = ">=4.4"
 pytest = ">=4.6"
 
 [package.extras]
-testing = ["fields", "hunter", "process-tests (==2.0.2)", "six", "pytest-xdist", "virtualenv"]
+testing = ["fields", "hunter", "process-tests (2.0.2)", "six", "pytest-xdist", "virtualenv"]
 
 [[package]]
 name = "pytest-django"
@@ -797,7 +811,7 @@ urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
 security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)"]
-socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
+socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7)", "win-inet-pton"]
 
 [[package]]
 name = "six"
@@ -874,7 +888,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 [package.extras]
 brotli = ["brotlipy (>=0.6.0)"]
 secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
-socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
 
 [[package]]
 name = "uvicorn"
@@ -941,7 +955,7 @@ python-versions = ">=3.6"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
+testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [extras]
 debug-server = ["uvicorn"]
@@ -953,7 +967,7 @@ pydantic = ["pydantic"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "41714f944320393b54e7f99d26b8414ab4a967ea71a10a59b48be432a8532531"
+content-hash = "973d3ad16c83b74e015cab35037b535581d839092b345052eafab0878d986694"
 
 [metadata.files]
 appdirs = [
@@ -1215,6 +1229,9 @@ pre-commit = [
     {file = "pre_commit-2.9.2-py2.py3-none-any.whl", hash = "sha256:949b13efb7467ae27e2c8f9e83434dacf2682595124d8902554a4e18351e5781"},
     {file = "pre_commit-2.9.2.tar.gz", hash = "sha256:e31c04bc23741194a7c0b983fe512801e151a0638c6001c49f2bd034f8a664a1"},
 ]
+promise = [
+    {file = "promise-2.3.tar.gz", hash = "sha256:dfd18337c523ba4b6a58801c164c1904a9d4d1b1747c7d5dbf45b693a49d93d0"},
+]
 py = [
     {file = "py-1.9.0-py2.py3-none-any.whl", hash = "sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2"},
     {file = "py-1.9.0.tar.gz", hash = "sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342"},
@@ -1328,8 +1345,6 @@ pyyaml = [
     {file = "PyYAML-5.3.1-cp37-cp37m-win_amd64.whl", hash = "sha256:73f099454b799e05e5ab51423c7bcf361c58d3206fa7b0d555426b1f4d9a3eaf"},
     {file = "PyYAML-5.3.1-cp38-cp38-win32.whl", hash = "sha256:06a0d7ba600ce0b2d2fe2e78453a470b5a6e000a985dd4a4e54e436cc36b0e97"},
     {file = "PyYAML-5.3.1-cp38-cp38-win_amd64.whl", hash = "sha256:95f71d2af0ff4227885f7a6605c37fd53d3a106fcab511b8860ecca9fcf400ee"},
-    {file = "PyYAML-5.3.1-cp39-cp39-win32.whl", hash = "sha256:ad9c67312c84def58f3c04504727ca879cb0013b2517c85a9a253f0cb6380c0a"},
-    {file = "PyYAML-5.3.1-cp39-cp39-win_amd64.whl", hash = "sha256:6034f55dab5fea9e53f436aa68fa3ace2634918e8b5994d82f3621c04ff5ed2e"},
     {file = "PyYAML-5.3.1.tar.gz", hash = "sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d"},
 ]
 regex = [
@@ -1407,28 +1422,19 @@ typed-ast = [
     {file = "typed_ast-1.4.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:269151951236b0f9a6f04015a9004084a5ab0d5f19b57de779f908621e7d8b75"},
     {file = "typed_ast-1.4.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:24995c843eb0ad11a4527b026b4dde3da70e1f2d8806c99b7b4a7cf491612652"},
     {file = "typed_ast-1.4.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"},
-    {file = "typed_ast-1.4.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:fcf135e17cc74dbfbc05894ebca928ffeb23d9790b3167a674921db19082401f"},
     {file = "typed_ast-1.4.1-cp36-cp36m-win32.whl", hash = "sha256:4e3e5da80ccbebfff202a67bf900d081906c358ccc3d5e3c8aea42fdfdfd51c1"},
     {file = "typed_ast-1.4.1-cp36-cp36m-win_amd64.whl", hash = "sha256:249862707802d40f7f29f6e1aad8d84b5aa9e44552d2cc17384b209f091276aa"},
     {file = "typed_ast-1.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8ce678dbaf790dbdb3eba24056d5364fb45944f33553dd5869b7580cdbb83614"},
     {file = "typed_ast-1.4.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:c9e348e02e4d2b4a8b2eedb48210430658df6951fa484e59de33ff773fbd4b41"},
     {file = "typed_ast-1.4.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:bcd3b13b56ea479b3650b82cabd6b5343a625b0ced5429e4ccad28a8973f301b"},
-    {file = "typed_ast-1.4.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:f208eb7aff048f6bea9586e61af041ddf7f9ade7caed625742af423f6bae3298"},
     {file = "typed_ast-1.4.1-cp37-cp37m-win32.whl", hash = "sha256:d5d33e9e7af3b34a40dc05f498939f0ebf187f07c385fd58d591c533ad8562fe"},
     {file = "typed_ast-1.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:0666aa36131496aed8f7be0410ff974562ab7eeac11ef351def9ea6fa28f6355"},
     {file = "typed_ast-1.4.1-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:d205b1b46085271b4e15f670058ce182bd1199e56b317bf2ec004b6a44f911f6"},
     {file = "typed_ast-1.4.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:6daac9731f172c2a22ade6ed0c00197ee7cc1221aa84cfdf9c31defeb059a907"},
     {file = "typed_ast-1.4.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:498b0f36cc7054c1fead3d7fc59d2150f4d5c6c56ba7fb150c013fbc683a8d2d"},
-    {file = "typed_ast-1.4.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:7e4c9d7658aaa1fc80018593abdf8598bf91325af6af5cce4ce7c73bc45ea53d"},
     {file = "typed_ast-1.4.1-cp38-cp38-win32.whl", hash = "sha256:715ff2f2df46121071622063fc7543d9b1fd19ebfc4f5c8895af64a77a8c852c"},
     {file = "typed_ast-1.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4"},
     {file = "typed_ast-1.4.1-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:d43943ef777f9a1c42bf4e552ba23ac77a6351de620aa9acf64ad54933ad4d34"},
-    {file = "typed_ast-1.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:92c325624e304ebf0e025d1224b77dd4e6393f18aab8d829b5b7e04afe9b7a2c"},
-    {file = "typed_ast-1.4.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:d648b8e3bf2fe648745c8ffcee3db3ff903d0817a01a12dd6a6ea7a8f4889072"},
-    {file = "typed_ast-1.4.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:fac11badff8313e23717f3dada86a15389d0708275bddf766cca67a84ead3e91"},
-    {file = "typed_ast-1.4.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:0d8110d78a5736e16e26213114a38ca35cb15b6515d535413b090bd50951556d"},
-    {file = "typed_ast-1.4.1-cp39-cp39-win32.whl", hash = "sha256:b52ccf7cfe4ce2a1064b18594381bccf4179c2ecf7f513134ec2f993dd4ab395"},
-    {file = "typed_ast-1.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:3742b32cf1c6ef124d57f95be609c473d7ec4c14d0090e5a5e05a15269fb4d0c"},
     {file = "typed_ast-1.4.1.tar.gz", hash = "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b"},
 ]
 typing-extensions = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ flake8-black = "^0.2.1"
 django = {version = ">=2,<4", optional = false}
 pydantic = {version = "^1.6.1", optional = false}
 uvicorn = ">=0.11.6,<0.13.0"
+promise = "^2.3"
 
 [tool.poetry.extras]
 debug-server = ["uvicorn"]

--- a/strawberry/schema/execute.py
+++ b/strawberry/schema/execute.py
@@ -1,10 +1,11 @@
 from asyncio import ensure_future
 from inspect import isawaitable
-from typing import Any, Awaitable, Dict, List, Sequence, Type, cast
+from typing import Any, Awaitable, Dict, List, Optional, Sequence, Type, cast
 
-from promise import is_thenable, Promise
+from promise import Promise, is_thenable
 
 from graphql import (
+    ExecutionContext as GraphQLExecutionContext,
     ExecutionResult as GraphQLExecutionResult,
     GraphQLError,
     GraphQLSchema,
@@ -17,8 +18,6 @@ from graphql.validation import validate
 from strawberry.extensions import Extension
 from strawberry.extensions.runner import ExtensionsRunner
 from strawberry.types import ExecutionContext, ExecutionResult
-
-from .execute_context import ExecutionContextWithPromise
 
 
 async def execute(
@@ -111,6 +110,7 @@ def execute_sync(
     variable_values: Dict[str, Any] = None,
     additional_middlewares: List[Any] = None,
     operation_name: str = None,
+    execution_context_class: Optional[Type[GraphQLExecutionContext]] = None,
 ) -> ExecutionResult:
     execution_context = ExecutionContext(
         query=query,
@@ -165,7 +165,7 @@ def execute_sync(
                 variable_values=variable_values,
                 operation_name=operation_name,
                 context_value=context_value,
-                execution_context_class=ExecutionContextWithPromise,
+                execution_context_class=execution_context_class,
                 is_awaitable=is_awaitable,
             )
 

--- a/strawberry/schema/execute_context.py
+++ b/strawberry/schema/execute_context.py
@@ -1,0 +1,127 @@
+from typing import Any, Dict, List, Optional, Union
+
+from promise import Promise, is_thenable, promise_for_dict
+
+from graphql import (
+    ExecutionContext,
+    GraphQLError,
+    GraphQLField,
+    GraphQLFieldResolver,
+    GraphQLObjectType,
+    GraphQLOutputType,
+    GraphQLResolveInfo,
+)
+from graphql.execution.values import get_argument_values
+from graphql.language import FieldNode
+from graphql.pyutils import AwaitableOrValue, Path, Undefined
+
+
+class ExecutionContextWithPromise(ExecutionContext):
+    def build_response(self, data):
+        if is_thenable(data):
+            original_build_response = super().build_response
+
+            def on_rejected(error):
+                self.errors.append(error)
+                return None
+
+            def on_resolve(data):
+                return original_build_response(data)
+
+            promise = data.catch(on_rejected).then(on_resolve)
+            return promise
+        return super().build_response(data)
+
+    def resolve_field_value_or_error(
+        self,
+        field_def: GraphQLField,
+        field_nodes: List[FieldNode],
+        resolve_fn: GraphQLFieldResolver,
+        source: Any,
+        info: GraphQLResolveInfo,
+    ) -> Union[Exception, Any]:
+        """Resolve field to a value or an error.
+
+        Isolates the "ReturnOrAbrupt" behavior to not de-opt the resolve_field()
+        method. Returns the result of resolveFn or the abrupt-return Error object.
+
+        For internal use only.
+        """
+        try:
+            # Build a dictionary of arguments from the field.arguments AST, using the
+            # variables scope to fulfill any variable references.
+            args = get_argument_values(field_def, field_nodes[0], self.variable_values)
+
+            # Note that contrary to the JavaScript implementation, we pass the context
+            # value as part of the resolve info.
+            result = resolve_fn(source, info, **args)
+            if is_thenable(result):
+                return result
+
+            return result
+        except GraphQLError as error:
+            return error
+        except Exception as error:
+            return GraphQLError(str(error), original_error=error)
+
+    def complete_value_catching_error(
+        self,
+        return_type: GraphQLOutputType,
+        field_nodes: List[FieldNode],
+        info: GraphQLResolveInfo,
+        path: Path,
+        result: Any,
+    ) -> AwaitableOrValue[Any]:
+        """Complete a value while catching an error.
+        This is a small wrapper around completeValue which detects and logs errors in
+        the execution context.
+        """
+        completed: AwaitableOrValue[Any]
+        try:
+            if is_thenable(result):
+
+                def handle_error(error):
+                    self.handle_field_error(error, field_nodes, path, return_type)
+
+                completed = Promise.resolve(result).then(
+                    lambda resolved: self.complete_value(
+                        return_type, field_nodes, info, path, resolved
+                    ),
+                    handle_error,
+                )
+            else:
+                completed = self.complete_value(
+                    return_type, field_nodes, info, path, result
+                )
+            return completed
+        except Exception as error:
+            self.handle_field_error(error, field_nodes, path, return_type)
+            return None
+
+    def execute_fields(
+        self,
+        parent_type: GraphQLObjectType,
+        source_value: Any,
+        path: Optional[Path],
+        fields: Dict[str, List[FieldNode]],
+    ):
+        """Execute the given fields concurrently.
+
+        Implements the "Evaluating selection sets" section of the spec for "read" mode.
+        """
+        contains_promise = False
+        results = {}
+        for response_name, field_nodes in fields.items():
+            field_path = Path(path, response_name)
+            result = self.resolve_field(
+                parent_type, source_value, field_nodes, field_path
+            )
+            if result is not Undefined:
+                results[response_name] = result
+                if is_thenable(result):
+                    contains_promise = True
+
+        if contains_promise:
+            return promise_for_dict(results)
+
+        return results

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -1,6 +1,12 @@
 from typing import Any, Dict, List, Optional, Sequence, Type, Union
 
-from graphql import GraphQLSchema, get_introspection_query, parse, validate_schema
+from graphql import (
+    ExecutionContext,
+    GraphQLSchema,
+    get_introspection_query,
+    parse,
+    validate_schema,
+)
 from graphql.subscription import subscribe
 from graphql.type.directives import specified_directives
 
@@ -90,9 +96,7 @@ class Schema:
         )
 
         return ExecutionResult(
-            data=result.data,
-            errors=result.errors,
-            extensions=result.extensions,
+            data=result.data, errors=result.errors, extensions=result.extensions,
         )
 
     def execute_sync(
@@ -102,6 +106,7 @@ class Schema:
         context_value: Optional[Any] = None,
         root_value: Optional[Any] = None,
         operation_name: Optional[str] = None,
+        execution_context_class: Optional[Type[ExecutionContext]] = None,
     ) -> ExecutionResult:
         result = execute_sync(
             self._schema,
@@ -112,12 +117,11 @@ class Schema:
             operation_name=operation_name,
             additional_middlewares=self.middleware,
             extensions=self.extensions,
+            execution_context_class=execution_context_class,
         )
 
         return ExecutionResult(
-            data=result.data,
-            errors=result.errors,
-            extensions=result.extensions,
+            data=result.data, errors=result.errors, extensions=result.extensions,
         )
 
     async def subscribe(

--- a/tests/schema/test_sync_dataloader.py
+++ b/tests/schema/test_sync_dataloader.py
@@ -1,0 +1,33 @@
+from promise import Promise
+from promise.dataloader import DataLoader
+
+import strawberry
+
+
+def test_batches_correct():
+    load_calls = []
+
+    class TestDataLoader(DataLoader):
+        def batch_load_fn(self, keys):
+            load_calls.append(keys)
+            return Promise.resolve(keys)
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def get_id(self, info, id: str) -> str:
+            return info.context["dataloader"].load(id)
+
+    schema = strawberry.Schema(query=Query)
+    result = schema.execute_sync(
+        """
+        query {
+            id1: getId(id: "1")
+            id2: getId(id: "2")
+        }
+    """,
+        context_value={"dataloader": TestDataLoader()},
+    )
+    assert not result.errors
+    assert result.data == {"id1": "1", "id2": "2"}
+    assert load_calls == [["1", "2"]]

--- a/tests/schema/test_sync_dataloader.py
+++ b/tests/schema/test_sync_dataloader.py
@@ -2,6 +2,7 @@ from promise import Promise
 from promise.dataloader import DataLoader
 
 import strawberry
+from strawberry.schema.execute_context import ExecutionContextWithPromise
 
 
 def test_batches_correct():
@@ -27,6 +28,7 @@ def test_batches_correct():
         }
     """,
         context_value={"dataloader": TestDataLoader()},
+        execution_context_class=ExecutionContextWithPromise,
     )
     assert not result.errors
     assert result.data == {"id1": "1", "id2": "2"}


### PR DESCRIPTION
## Description

POC for a custom graphql-core `ExecutionContext` class that handles Promises (from https://github.com/syrusakbary/promise) so that you can use a sync dataloader. Couple of notes:

* This is a just a rough exploration of a potential solution. It needs a lot more testing and I've probably missed some things.
* There is no easy way to extend some of the `ExecutionContext` methods so I had to duplicate them and add custom logic (I also got rid of the code paths that handle async code). This will make maintenance a bit of a pain if those code paths change
* Regardless of whether we end up going down this route I think expanding the `execute` and `execute_sync` methods to allow passing of the `execution_context_class` would be beneficial

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
