### PR TITLE
Add support for unions in get_optional_annotation 

### DIFF
--- a/strawberry/utils/typing.py
+++ b/strawberry/utils/typing.py
@@ -42,7 +42,14 @@ def is_optional(annotation: Type) -> bool:
 
 def get_optional_annotation(annotation: Type) -> Type:
     types = annotation.__args__
-    non_none_types = [x for x in types if x != None.__class__]  # noqa:E711
+
+    non_none_types = tuple(x for x in types if x != None.__class__)  # noqa:E711
+
+    # if we have multiple non none types we want to return a copy of this
+    # type (normally a Union type).
+
+    if len(non_none_types) > 1:
+        return annotation.copy_with(non_none_types)
 
     return non_none_types[0]
 

--- a/tests/utils/test_typing.py
+++ b/tests/utils/test_typing.py
@@ -1,0 +1,15 @@
+from typing import Optional, Union
+
+from strawberry.utils.typing import get_optional_annotation
+
+
+def test_get_optional_annotation():
+
+    # Pair Union
+    assert get_optional_annotation(Optional[Union[str, bool]]) == Union[str, bool]
+
+    # More than pair Union
+    assert (
+        get_optional_annotation(Optional[Union[str, int, bool]])
+        == Union[str, int, bool]
+    )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Modified `utils/typing.py::get_optional_annotation` when passed a union as demonstrated in issue #602.
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

`get_optional_annotation` when passed `Optional[Union[str, int]]` will now return Union[str, int]

<!--- Describe your changes in detail here. -->
## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR
Closes #602 


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
