### PR TITLE
Pass `execution_context_class` to schema

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Pass `execution_context_class` to Schema creation

--- a/strawberry/schema/execute.py
+++ b/strawberry/schema/execute.py
@@ -1,8 +1,9 @@
 from asyncio import ensure_future
 from inspect import isawaitable
-from typing import Any, Awaitable, Dict, List, Sequence, Type, cast
+from typing import Any, Awaitable, Dict, List, Optional, Sequence, Type, cast
 
 from graphql import (
+    ExecutionContext as GraphQLExecutionContext,
     ExecutionResult as GraphQLExecutionResult,
     GraphQLError,
     GraphQLSchema,
@@ -25,6 +26,7 @@ async def execute(
     variable_values: Dict[str, Any] = None,
     additional_middlewares: List[Any] = None,
     operation_name: str = None,
+    execution_context_class: Optional[Type[GraphQLExecutionContext]] = None,
 ) -> ExecutionResult:
     execution_context = ExecutionContext(
         query=query,
@@ -77,6 +79,7 @@ async def execute(
             variable_values=variable_values,
             operation_name=operation_name,
             context_value=context_value,
+            execution_context_class=execution_context_class,
         )
 
         if isawaitable(result):
@@ -100,6 +103,7 @@ def execute_sync(
     variable_values: Dict[str, Any] = None,
     additional_middlewares: List[Any] = None,
     operation_name: str = None,
+    execution_context_class: Optional[Type[GraphQLExecutionContext]] = None,
 ) -> ExecutionResult:
     execution_context = ExecutionContext(
         query=query,
@@ -151,6 +155,7 @@ def execute_sync(
             variable_values=variable_values,
             operation_name=operation_name,
             context_value=context_value,
+            execution_context_class=execution_context_class,
         )
 
         if isawaitable(result):

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -1,6 +1,12 @@
 from typing import Any, Dict, List, Optional, Sequence, Type, Union
 
-from graphql import GraphQLSchema, get_introspection_query, parse, validate_schema
+from graphql import (
+    ExecutionContext as GraphQLExecutionContext,
+    GraphQLSchema,
+    get_introspection_query,
+    parse,
+    validate_schema,
+)
 from graphql.subscription import subscribe
 from graphql.type.directives import specified_directives
 
@@ -27,9 +33,11 @@ class Schema:
         directives=(),
         types=(),
         extensions: Sequence[Type[Extension]] = (),
+        execution_context_class: Optional[Type[GraphQLExecutionContext]] = None,
     ):
         self.extensions = extensions
         self.type_map: Dict[str, ConcreteType] = {}
+        self.execution_context_class = execution_context_class
 
         query_type = get_object_type(query, self.type_map)
         mutation_type = get_object_type(mutation, self.type_map) if mutation else None
@@ -87,6 +95,7 @@ class Schema:
             operation_name=operation_name,
             additional_middlewares=self.middleware,
             extensions=self.extensions,
+            execution_context_class=self.execution_context_class,
         )
 
         return ExecutionResult(
@@ -112,6 +121,7 @@ class Schema:
             operation_name=operation_name,
             additional_middlewares=self.middleware,
             extensions=self.extensions,
+            execution_context_class=self.execution_context_class,
         )
 
         return ExecutionResult(

--- a/tests/schema/test_schema_generation.py
+++ b/tests/schema/test_schema_generation.py
@@ -1,6 +1,10 @@
+from typing import Any, Dict, Optional, cast
+
 import pytest
 
 from graphql import (
+    ExecutionContext as GraphQLExecutionContext,
+    ExecutionResult,
     GraphQLField,
     GraphQLNonNull,
     GraphQLObjectType,
@@ -8,6 +12,7 @@ from graphql import (
     GraphQLString,
     print_schema as graphql_core_print_schema,
 )
+from graphql.pyutils import AwaitableOrValue
 
 import strawberry
 
@@ -57,3 +62,37 @@ def test_schema_fails_on_an_invalid_schema():
 
     with pytest.raises(ValueError, match="Invalid Schema. Errors.*"):
         strawberry.Schema(query=Query)
+
+
+def test_custom_execution_context():
+    class CustomExecutionContext(GraphQLExecutionContext):
+        def build_response(
+            self, data: AwaitableOrValue[Optional[Dict[str, Any]]]
+        ) -> AwaitableOrValue[ExecutionResult]:
+            result = cast(ExecutionResult, super().build_response(data))
+
+            if not result.data:
+                return result
+
+            # Add some extra data to the response
+            result.data.update(
+                {
+                    "extra": "data",
+                }
+            )
+            return result
+
+    @strawberry.type
+    class Query:
+        hello: str = "World"
+
+    schema = strawberry.Schema(
+        query=Query, execution_context_class=CustomExecutionContext
+    )
+
+    result = schema.execute_sync("{ hello }", root_value=Query())
+
+    assert result.data == {
+        "hello": "World",
+        "extra": "data",
+    }


### PR DESCRIPTION
## Description

This PR allows passing a custom GraphQL-core execution context class to the Schema creation. I've split this out from the #614 PR so that it can be reviewed on it's own.

I don't think we have any documentation on the Schema class currently so I'm not sure where to add any. Any ideas @patrick91 ?

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
