### PR TITLE
Update pyproject.toml

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+This releases fixes a wrong dependency issue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ hupper = "^1.5"
 pygments = "^2.3"
 uvicorn = {version = ">=0.11.6,<0.14.0", optional = true}
 django = {version = ">=2,<4", optional = true}
-graphql-core = {version = "^3.0.0"}
+graphql-core = {version = "^3.1.0"}
 asgiref = {version = "^3.2", optional = true}
 flask = {version = "^1.1", optional = true}
 typing_extensions = "^3.7.4"


### PR DESCRIPTION
## Description

Since version 3.1.0, `graphql.utilities.schema_printer` has been renamed `graphql.utilities.print_schema` causing import errors

## Types of Changes

- [ ] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #626

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
