### PR TITLE
Resolve pytest deprecation warning

### DIFF
--- a/tests/flask/test_view.py
+++ b/tests/flask/test_view.py
@@ -29,7 +29,7 @@ def create_app(**kwargs):
     return app
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def flask_client():
     app = create_app()
 


### PR DESCRIPTION
tests/flask/test_view.py:33
/home/ulgens/Dropbox/workspace/gql/strawberry/tests/flask/test_view.py:33:
PytestDeprecationWarning: @pytest.yield_fixture is deprecated.
  Use @pytest.fixture instead; they are the same

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
