### PR TITLE
Improve typings for strawberry.enum

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Improves typing when decorating an enum with kwargs like description and name. Adds more mypy tests.

--- a/strawberry/enum.py
+++ b/strawberry/enum.py
@@ -1,6 +1,6 @@
 import dataclasses
 from enum import EnumMeta
-from typing import Any, List, Optional
+from typing import Any, Callable, List, Optional, Union
 
 from .exceptions import NotAnEnum
 
@@ -18,7 +18,9 @@ class EnumDefinition:
     description: Optional[str]
 
 
-def _process_enum(cls, name=None, description=None):
+def _process_enum(
+    cls: EnumMeta, name: Optional[str] = None, description: Optional[str] = None
+) -> EnumMeta:
     if not isinstance(cls, EnumMeta):
         raise NotAnEnum()
 
@@ -38,14 +40,16 @@ def _process_enum(cls, name=None, description=None):
     return cls
 
 
-def enum(_cls=None, *, name=None, description=None):
+def enum(
+    _cls: EnumMeta = None, *, name=None, description=None
+) -> Union[EnumMeta, Callable[[EnumMeta], EnumMeta]]:
     """Registers the enum in the GraphQL type system.
 
     If name is passed, the name of the GraphQL type will be
     the value passed of name instead of the Enum class name.
     """
 
-    def wrap(cls):
+    def wrap(cls: EnumMeta) -> EnumMeta:
         return _process_enum(cls, name, description)
 
     if not _cls:

--- a/tests/mypy/test_enum.yml
+++ b/tests/mypy/test_enum.yml
@@ -43,3 +43,41 @@
   out: |
     main:19: note: Revealed type is 'Any'
     main:20: note: Revealed type is 'Any'
+
+- case: test_enum_with_decorator
+  main: |
+    from enum import Enum
+
+    import strawberry
+
+    @strawberry.enum
+    class IceCreamFlavour(Enum):
+        VANILLA = "vanilla"
+        STRAWBERRY = "strawberry"
+        CHOCOLATE = "chocolate"
+
+    a: IceCreamFlavour
+    reveal_type(IceCreamFlavour)
+    reveal_type(a)
+  out: |
+    main:12: note: Revealed type is 'def (value: builtins.object) -> main.IceCreamFlavour*'
+    main:13: note: Revealed type is 'main.IceCreamFlavour'
+
+- case: test_enum_with_decorator_and_name
+  main: |
+    from enum import Enum
+
+    import strawberry
+
+    @strawberry.enum(name="IceCreamFlavour")
+    class Flavour(Enum):
+        VANILLA = "vanilla"
+        STRAWBERRY = "strawberry"
+        CHOCOLATE = "chocolate"
+
+    a: Flavour
+    reveal_type(Flavour)
+    reveal_type(a)
+  out: |
+    main:12: note: Revealed type is 'def (value: builtins.object) -> main.Flavour*'
+    main:13: note: Revealed type is 'main.Flavour'


### PR DESCRIPTION
## Description

Adds typing for decorating Enum classes with `kwargs`.
Ex: 
`@strawberry.enum(name="...")` 

## Types of Changes
- Type annotations
- Tests for mypy
## Issues Fixed or Closed by This PR

*

## Checklist

- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
