### PR TITLE
Use type definition name to generate generic names

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,15 @@
+Release type: patch
+
+Fix Generic name generation to use the custom name specified in Strawberry if available
+
+```python
+@strawberry.type(name="AnotherName")
+class EdgeName:
+    node: str
+
+@strawberry.type
+class Connection(Generic[T]):
+    edge: T
+```
+
+will result in `AnotherNameConnection`, and not `EdgeNameConnection` as before.

--- a/strawberry/types/generics.py
+++ b/strawberry/types/generics.py
@@ -15,6 +15,8 @@ def get_name_from_types(types: Iterable[Union[Type, StrawberryUnion]]):
     for type_ in types:
         if isinstance(type_, StrawberryUnion):
             return type_.name
+        elif hasattr(type_, "_type_definition"):
+            name = capitalize_first(type_._type_definition.name)
         else:
             name = capitalize_first(type_.__name__)
 

--- a/tests/types/test_generic.py
+++ b/tests/types/test_generic.py
@@ -83,6 +83,30 @@ def test_generics_nested():
     assert definition.fields[0].is_optional is False
 
 
+def test_generics_name():
+    @strawberry.type(name="AnotherName")
+    class EdgeName:
+        node: str
+
+    @strawberry.type
+    class Connection(Generic[T]):
+        edge: T
+
+    Copy = copy_type_with(Connection, EdgeName)
+
+    definition = Copy._type_definition
+
+    assert definition.name == "AnotherNameConnection"
+    assert definition.is_generic is False
+    assert definition.type_params == {}
+
+    assert len(definition.fields) == 1
+
+    assert definition.fields[0].name == "edge"
+    assert definition.fields[0].type._type_definition.name == "AnotherName"
+    assert definition.fields[0].is_optional is False
+
+
 def test_generics_nested_in_list():
     @strawberry.type
     class Edge(Generic[T]):


### PR DESCRIPTION
## Description

Strawberry ignores the `name` parameter when creating the names for generic types

E.g

If I do

```
ErrorClass = TypeVar("ErrorClass")


@strawberry.type
class ValidationError(Generic[ErrorClass]):
    errors: ErrorClass

@strawberry.type(name="Login")
class LoginValidationError:
    email: list[str]
    password: list[str]

ValidationError[LoginValidationError]
```

the GraphQL name will be `LoginValidationErrorValidationError` and not `LoginValidationError` like expected

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
