### PR TITLE
Fix MyPy crash when casting in enum decorator

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Fixes mypy failing when casting in enum decorator

--- a/strawberry/ext/mypy_plugin.py
+++ b/strawberry/ext/mypy_plugin.py
@@ -9,6 +9,7 @@ from mypy.nodes import (
     Argument,
     AssignmentStmt,
     CallExpr,
+    CastExpr,
     Context,
     Expression,
     IndexExpr,
@@ -112,6 +113,15 @@ def _get_type_for_expr(expr: Expression, api: SemanticAnalyzerPluginInterface):
             return _get_named_type(expr.fullname, api)
         else:
             raise InvalidNodeTypeException(expr)
+
+    if isinstance(expr, CallExpr):
+        if expr.analyzed:
+            return _get_type_for_expr(expr.analyzed, api)
+        else:
+            raise InvalidNodeTypeException(expr)
+
+    if isinstance(expr, CastExpr):
+        return expr.type
 
     raise ValueError(f"Unsupported expression {type(expr)}")
 

--- a/tests/mypy/test_enum.yml
+++ b/tests/mypy/test_enum.yml
@@ -44,6 +44,27 @@
     main:19: note: Revealed type is 'Any'
     main:20: note: Revealed type is 'Any'
 
+- case: test_enum_from_cast
+  main: |
+    from enum import Enum
+    from typing import Type, cast
+
+    import strawberry
+
+    class IceCreamFlavour(Enum):
+        VANILLA = "vanilla"
+        STRAWBERRY = "strawberry"
+        CHOCOLATE = "chocolate"
+
+    Flavour = strawberry.enum(cast(Type[Enum], IceCreamFlavour))
+
+    a: Flavour
+    reveal_type(Flavour)
+    reveal_type(a)
+  out: |
+    main:14: note: Revealed type is 'builtins.object'
+    main:15: note: Revealed type is 'Type[enum.Enum]'
+
 - case: test_enum_with_decorator
   main: |
     from enum import Enum


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

We're using strawberry's `enum` type with Django's new `TextChoices` enumeration type. This works well except that, as we're not using `django-stubs`, we have to cast our `TextChoices` to satisfy mypy. This causes strawberry's mypy plugin to crash.

Currently we're using the following workaround:

```python
_Vehicle = cast(Type[Enum], DBVehicle)
Vehicle = strawberry.enum(_Vehicle)
```

This PR updates the plugin to allow casting like so:

```python
Vehicle = strawberry.enum(cast(Type[Enum], DBVehicle))
```

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
