### PR TITLE
Add docs for resolvers and expose Info type

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 
 ## Installation ( Quick Start )
 
-The quick start method provides a server and CLI to get going quickly.
-Install with:
+The quick start method provides a server and CLI to get going quickly. Install
+with:
 
 ```shell
 pip install strawberry-graphql[debug-server]
@@ -34,7 +34,7 @@ class User:
 @strawberry.type
 class Query:
     @strawberry.field
-    def user(self, info) -> User:
+    def user(self) -> User:
         return User(name="Patrick", age=100)
 
 
@@ -96,7 +96,8 @@ urlpatterns = [
 ## WebSockets
 
 To support graphql Subscriptions over WebSockets you need to provide a WebSocket
-enabled server. The debug server can be made to support WebSockets with these commands:
+enabled server. The debug server can be made to support WebSockets with these
+commands:
 
 ```shell
 pip install strawberry-graphql[debug-server]

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Expose execution info under `strawberry.types.Info`

--- a/docs/concepts/async.md
+++ b/docs/concepts/async.md
@@ -16,7 +16,7 @@ import asyncio
 import strawberry
 
 
-async def resolve_hello(root, info) -> str:
+async def resolve_hello(root) -> str:
     await asyncio.sleep(1)
 
     return "Hello world"

--- a/docs/features/dataloaders.md
+++ b/docs/features/dataloaders.md
@@ -24,8 +24,8 @@ class User:
     id: strawberry.ID
 ```
 
-we need to define a function that returns a list of users based on a list of keys
-passed:
+we need to define a function that returns a list of users based on a list of
+keys passed:
 
 ```python
 from typing import List
@@ -34,8 +34,8 @@ async def load_users(keys: List[int]) -> List[User]:
     return [User(id=key) for key in keys]
 ```
 
-Normally this function would interact with a database or 3rd party API, but for our
-example we don't need that.
+Normally this function would interact with a database or 3rd party API, but for
+our example we don't need that.
 
 Now that we have a loader function, we can define a DataLoader and use it:
 
@@ -47,8 +47,9 @@ loader = DataLoader(load_fn=load_users)
 user = await loader.load(1)
 ```
 
-This will result in a call to `load_user` with keys equal to `[1]`. Where this becomes
-really powerful is when you make multiple requests, like in this example:
+This will result in a call to `load_user` with keys equal to `[1]`. Where this
+becomes really powerful is when you make multiple requests, like in this
+example:
 
 ```python
 import asyncio
@@ -129,13 +130,17 @@ Even if this query is fetching two users, it still results in one call to
 
 As you have seen in the code above, the dataloader is instantiated outside the
 resolver, since we need to share it between multiple resolvers or even between
-multiple resolver calls. However this is a not a recommended pattern when using your schema inside a server because the dataloader will so cache results for as long as the server is running.
+multiple resolver calls. However this is a not a recommended pattern when using
+your schema inside a server because the dataloader will so cache results for as
+long as the server is running.
 
-Instead a common pattern is to create the dataloader when creating the GraphQL context so that it only caches results with a single request.
-Let's see an example of this using our ASGI view:
+Instead a common pattern is to create the dataloader when creating the GraphQL
+context so that it only caches results with a single request. Let's see an
+example of this using our ASGI view:
 
 ```python
 import strawberry
+from strawberry.types import Info
 from strawberry.asgi import GraphQL
 from strawberry.dataloder import DataLoader
 
@@ -162,6 +167,6 @@ class MyGraphQL(GraphQL):
 @strawberry.type
 class Query:
     @strawberry.field
-    async def get_user(self, info, id: strawberry.ID) -> User:
+    async def get_user(self, info: Info, id: strawberry.ID) -> User:
         return await info.context["user_loader"].load(id)
 ```

--- a/docs/features/extensions.md
+++ b/docs/features/extensions.md
@@ -59,10 +59,11 @@ this method _must_ call `_next` with all the arguments, as they will be needed
 by the resolvers:
 
 ```python
+from strawberry.types import Info
 from strawberry.extensions import Extension
 
 class MyExtension(Extension):
-    def resolve(self, _next, root, info, *args, **kwargs):
+    def resolve(self, _next, root, info: Info, *args, **kwargs):
         return _next(root, info, *args, **kwargs)
 ```
 

--- a/docs/integrations/asgi.md
+++ b/docs/integrations/asgi.md
@@ -4,8 +4,8 @@ title: ASGI
 
 # ASGI
 
-Strawberry comes with a basic ASGI integration. It provides an app that you
-can use to serve your GraphQL schema:
+Strawberry comes with a basic ASGI integration. It provides an app that you can
+use to serve your GraphQL schema:
 
 ```python
 from strawberry.asgi import GraphQL
@@ -46,7 +46,7 @@ class MyGraphQL(GraphQL):
 @strawberry.type
 class Query:
     @strawberry.field
-    def example(self, info) -> str:
+    def example(self, info: Info) -> str:
         return str(info.context["example"])
 ```
 
@@ -104,5 +104,5 @@ class MyGraphQL(GraphQL):
         return data
 ```
 
-In this case we are doing the default processing of the result, but it can
-be tweaked based on your needs.
+In this case we are doing the default processing of the result, but it can be
+tweaked based on your needs.

--- a/docs/integrations/django.md
+++ b/docs/integrations/django.md
@@ -53,7 +53,7 @@ class MyGraphQLView(GraphQLView):
 @strawberry.type
 class Query:
     @strawberry.field
-    def example(self, info) -> str:
+    def example(self, info: Info) -> str:
         return str(info.context["example"])
 ```
 
@@ -165,7 +165,7 @@ class MyGraphQLView(AsyncGraphQLView):
 @strawberry.type
 class Query:
     @strawberry.field
-    def example(self, info) -> str:
+    def example(self, info: Info) -> str:
         return str(info.context["example"])
 ```
 

--- a/docs/integrations/flask.md
+++ b/docs/integrations/flask.md
@@ -51,7 +51,7 @@ class MyGraphQLView(GraphQLView):
 @strawberry.type
 class Query:
     @strawberry.field
-    def example(self, info) -> str:
+    def example(self, info: Info) -> str:
         return str(info.context["example"])
 ```
 
@@ -109,5 +109,5 @@ class MyGraphQLView(GraphQLView):
         return data
 ```
 
-In this case we are doing the default processing of the result, but it can
-be tweaked based on your needs.
+In this case we are doing the default processing of the result, but it can be
+tweaked based on your needs.

--- a/docs/types/enums.md
+++ b/docs/types/enums.md
@@ -46,7 +46,7 @@ Let's see how we can use Enums in our schema.
 @strawberry.type
 class Query:
     @strawberry.field
-    def best_flavour(self, info) -> IceCreamFlavour:
+    def best_flavour(self) -> IceCreamFlavour:
         return IceCreamFlavour.STRAWBERRY
 ```
 
@@ -78,8 +78,8 @@ Here is result of executed query:
 }
 ```
 
-We can also use enums when defining object types (using `strawberry.type`).
-Here is an example of an object that has a field using an Enum:
+We can also use enums when defining object types (using `strawberry.type`). Here
+is an example of an object that has a field using an Enum:
 
 ```python
 @strawberry.type
@@ -90,7 +90,7 @@ class Cone:
 @strawberry.type
 class Query:
     @strawberry.field
-    def cone(self, info) -> Cone:
+    def cone(self) -> Cone:
         return Cone(flavour=IceCreamFlavour.STRAWBERRY, num_scoops=4)
 ```
 

--- a/docs/types/resolvers.md
+++ b/docs/types/resolvers.md
@@ -30,15 +30,14 @@ type Query {
 }
 ```
 
-we have defined a `User` type and a `Query` type. To define how the data is
-returned from our server, we use `resolvers` and we attached them to fields.
+We have defined a `User` type and a `Query` type. Next, to define how the data
+is returned from our server, we will attach resolvers to our fields.
 
 ## Let's define a resolver
 
 Let's create a resolver and attach it to the `lastUser` field. A resolver is a
-python function that returns data. In Strawberry there are two ways of defining
-resolvers, the first one is to create a function and then pass it to the field
-definition, like this:
+Python function that returns data. In Strawberry there are two ways of defining
+resolvers; the first is to pass a function to the field definition, like this:
 
 ```python
 def get_last_user() -> Optional[User]:
@@ -49,7 +48,7 @@ class Query:
     last_user: Optional[User] = strawberry.field(resolver=get_last_user)
 ```
 
-When executing this following query Strawberry knows that it needs to call the
+Now when Strawberry executes the following query, it will call the
 `get_last_user` function to fetch the data for the `lastUser` field:
 
 ```graphql+response
@@ -87,15 +86,15 @@ very small resolvers.
 
 > _NOTE:_ the _self_ argument is a bit special here, when executing a GraphQL
 > query, in case of resolvers defined with a decorator, the _self_ argument
-> corresponds to the _root_ value that field, in this example the _root_ value
-> is the value `Query` type, which is usually `None`, you can change the _root_
-> value when calling the `execute` method on a `Schema`. More on root values
-> below
+> corresponds to the _root_ value that field. In this example the _root_ value
+> is the value `Query` type, which is usually `None`. You can change the _root_
+> value when calling the `execute` method on a `Schema`. More on _root_ values
+> below.
 
 ## Defining arguments
 
 Fields can also have arguments; in Strawberry the arguments for a field are
-defined on the resolver, as you would normally do in a python function. Let's
+defined on the resolver, as you would normally do in a Python function. Let's
 define a field on a Query that returns a user by ID:
 
 ```python+schema
@@ -127,9 +126,9 @@ type Query {
 ## Accessing parent's data
 
 It is quite common to want to be able to access the data from the parent in a
-resolver, for example let's say that we want to defined a `fullName` field on
-our user. We can defined a new field with a resolver that combines the first
-name and last name:
+resolver. For example let's say that we want to define a `fullName` field on
+our `User`. We can define a new field with a resolver that combines its first
+and last names:
 
 ```python+schema
 import strawberry
@@ -152,9 +151,9 @@ type User {
 ```
 
 In the case of a decorated resolver you can use the _self_ parameter as you
-would do in a normal python class[^1].
+would do in a method on a normal Python class[^1].
 
-For resolvers defined as normal python functions you can use the special `root`
+For resolvers defined as normal Python functions, you can use the special `root`
 parameter, when defined, Strawberry will pass to it the value of the parent:
 
 ```python
@@ -173,7 +172,7 @@ class User:
 ## Accessing execution information
 
 Sometimes it is useful to access the information for the current execution
-context, to do so you can provide the `info` parameter to resolvers, like this:
+context. To do so you can provide the `info` parameter to resolvers, like this:
 
 ```python
 import strawberry

--- a/docs/types/resolvers.md
+++ b/docs/types/resolvers.md
@@ -4,4 +4,170 @@ title: Resolvers
 
 # Resolvers
 
-Documentation coming soon
+When defining a GraphQL schema, you usually start with the definition of the
+structure of the API, for example, let's take a look at this schema:
+
+```python+schema
+from typing import Optional
+
+import strawberry
+
+@strawberry.type
+class User:
+    name: str
+
+
+@strawberry.type
+class Query:
+    last_user: Optional[User]
+---
+type User {
+    name: String!
+}
+
+type Query {
+    lastUser: User
+}
+```
+
+we have defined a `User` type and a `Query` type. To define how the data is
+returned from our server, we use `resolvers` and we attached them to fields.
+
+## Let's define a resolver
+
+Let's create a resolver and attach it to the `lastUser` field. A resolver is a
+python function that returns data. In Strawberry there are two ways of defining
+resolvers, the first one is to create a function and then pass it to the field
+definition, like this:
+
+```python
+def get_last_user() -> Optional[User]:
+    return User(name="Marco")
+
+@strawberry.type
+class Query:
+    last_user: Optional[User] = strawberry.field(resolver=get_last_user)
+```
+
+When executing this following query Strawberry knows that it needs to call the
+`get_last_user` function to fetch the data for the `lastUser` field:
+
+```graphql+response
+{
+  lastUser {
+    name
+  }
+}
+---
+{
+  "data": {
+    "lastUser": {
+      "name": "Marco"
+    }
+  }
+}
+```
+
+## Defining resolvers as methods
+
+The other way to define a resolver is to use `strawberry.field` as a decorator,
+like here:
+
+```python
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def last_user(self) -> Optional[User]:
+        return User(name="Marco")
+```
+
+this is useful when you want to colocate resolvers and types or when you have
+very small resolvers.
+
+> _NOTE:_ the _self_ argument is a bit special here, when executing a GraphQL
+> query, in case of resolvers defined with a decorator, the _self_ argument
+> corresponds to the _root_ value that field, in this example the _root_ value
+> is the value `Query` type, which is usually `None`, you can change the _root_
+> value when calling the `execute` method on a `Schema`. More on root values
+> below
+
+## Defining arguments
+
+Fields can also have arguments; in Strawberry the arguments for a field are
+defined on the resolver, as you would normally do in a python function. Let's
+define a field on a Query that returns a user by ID:
+
+```python+schema
+from typing import Optional
+
+import strawberry
+
+
+@strawberry.type
+class User:
+    name: str
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def user(self, id: strawberry.ID) -> Optional[User]:
+        return User(name="Marco")
+---
+type User {
+    name: String!
+}
+
+type Query {
+    user(id: ID!): User
+}
+```
+
+## Accessing parent's data
+
+It is quite common to want to be able to access the data from the parent in a
+resolver, for example let's say that we want to defined a `fullName` field on
+our user. We can defined a new field with a resolver that combines the first
+name and last name:
+
+```python+schema
+import strawberry
+
+
+@strawberry.type
+class User:
+    first_name: str
+    last_name: str
+
+    @strawberry.field
+    def full_name(self) -> str:
+        return f"{self.first_name} {self.last_name}"
+---
+type User {
+    firstName: String!
+    lastName: String!
+    fullName: String!
+}
+```
+
+In the case of a decorated resolver you can use the _self_ parameter as you
+would do in a normal python class[^1]
+
+For resolvers defined as normal python functions you can use the special `root`
+parameter, when defined, Strawberry will pass to it the value of the parent:
+
+```python
+import strawberry
+
+def full_name(root: User) -> str:
+    return f"{root.first_name} {root.last_name}"
+
+@strawberry.type
+class User:
+    first_name: str
+    last_name: str
+    full_name: str = strawberry.field(resolver=full_name)
+```
+
+[^1]: TODO: write a page on gotchas around the self parameter

--- a/docs/types/resolvers.md
+++ b/docs/types/resolvers.md
@@ -170,4 +170,9 @@ class User:
     full_name: str = strawberry.field(resolver=full_name)
 ```
 
+## Accessing execution information
+
+Sometimes it is useful to access the information for the current execution
+context, to do so you can provide the `info` parameter to resolvers, like this:
+
 [^1]: TODO: write a page on gotchas around the self parameter

--- a/docs/types/resolvers.md
+++ b/docs/types/resolvers.md
@@ -175,4 +175,31 @@ class User:
 Sometimes it is useful to access the information for the current execution
 context, to do so you can provide the `info` parameter to resolvers, like this:
 
+```python
+import strawberry
+from strawberry.types import info
+
+def full_name(root: User, info: Info) -> str:
+    return f"{root.first_name} {root.last_name} {info.field_name}"
+
+@strawberry.type
+class User:
+    first_name: str
+    last_name: str
+    full_name: str = strawberry.field(resolver=full_name)
+```
+
+### API
+
+`Info[ContextType, RootValueType]`
+
+| Parameter name  | Type                       | Description                                                           |
+| --------------- | -------------------------- | --------------------------------------------------------------------- |
+| field_name      | `str`                      | The name of the current field                                         |
+| context         | `ContextType`              | The value of the context                                              |
+| root_value      | `RootValueType`            | The value for the root type                                           |
+| variable_values | `Optional[Dict[str, Any]]` | The variables for this operation                                      |
+| operation       | `OperationDefinitionNode`  | The ast for the current operation (public API might change in future) |
+| path            | `Path`                     | The path for the current field                                        |
+
 [^1]: TODO: write a page on gotchas around the self parameter

--- a/docs/types/resolvers.md
+++ b/docs/types/resolvers.md
@@ -152,7 +152,7 @@ type User {
 ```
 
 In the case of a decorated resolver you can use the _self_ parameter as you
-would do in a normal python class[^1]
+would do in a normal python class[^1].
 
 For resolvers defined as normal python functions you can use the special `root`
 parameter, when defined, Strawberry will pass to it the value of the parent:
@@ -202,4 +202,7 @@ class User:
 | operation       | `OperationDefinitionNode`  | The ast for the current operation (public API might change in future) |
 | path            | `Path`                     | The path for the current field                                        |
 
-[^1]: TODO: write a page on gotchas around the self parameter
+[^1]:
+    see
+    [this discussion](https://github.com/strawberry-graphql/strawberry/discussions/515)
+    for more context around the self parameter.

--- a/docs/types/resolvers.md
+++ b/docs/types/resolvers.md
@@ -5,7 +5,7 @@ title: Resolvers
 # Resolvers
 
 When defining a GraphQL schema, you usually start with the definition of the
-structure of the API, for example, let's take a look at this schema:
+schema for your API, for example, let's take a look at this schema:
 
 ```python+schema
 import strawberry
@@ -120,12 +120,12 @@ type Query {
 }
 ```
 
-## Accessing parent's data
+## Accessing field's parent's data
 
-It is quite common to want to be able to access the data from the parent in a
-resolver. For example let's say that we want to define a `fullName` field on our
-`User`. We can define a new field with a resolver that combines its first and
-last names:
+It is quite common to want to be able to access the data from the field's parent
+in a resolver. For example let's say that we want to define a `fullName` field
+on our `User`. We can define a new field with a resolver that combines its first
+and last names:
 
 ```python+schema
 import strawberry
@@ -188,7 +188,9 @@ class User:
 
 ### API
 
-`Info[ContextType, RootValueType]`
+Info objects contain information for the current execution context:
+
+`class Info(Generic[ContextType, RootValueType])`
 
 | Parameter name  | Type                      | Description                                                           |
 | --------------- | ------------------------- | --------------------------------------------------------------------- |

--- a/docs/types/resolvers.md
+++ b/docs/types/resolvers.md
@@ -8,8 +8,6 @@ When defining a GraphQL schema, you usually start with the definition of the
 structure of the API, for example, let's take a look at this schema:
 
 ```python+schema
-from typing import Optional
-
 import strawberry
 
 @strawberry.type
@@ -19,14 +17,14 @@ class User:
 
 @strawberry.type
 class Query:
-    last_user: Optional[User]
+    last_user: User
 ---
 type User {
     name: String!
 }
 
 type Query {
-    lastUser: User
+    lastUser: User!
 }
 ```
 
@@ -40,12 +38,12 @@ Python function that returns data. In Strawberry there are two ways of defining
 resolvers; the first is to pass a function to the field definition, like this:
 
 ```python
-def get_last_user() -> Optional[User]:
+def get_last_user() -> User:
     return User(name="Marco")
 
 @strawberry.type
 class Query:
-    last_user: Optional[User] = strawberry.field(resolver=get_last_user)
+    last_user: User = strawberry.field(resolver=get_last_user)
 ```
 
 Now when Strawberry executes the following query, it will call the
@@ -77,7 +75,7 @@ like here:
 @strawberry.type
 class Query:
     @strawberry.field
-    def last_user(self) -> Optional[User]:
+    def last_user(self) -> User:
         return User(name="Marco")
 ```
 
@@ -98,8 +96,6 @@ defined on the resolver, as you would normally do in a Python function. Let's
 define a field on a Query that returns a user by ID:
 
 ```python+schema
-from typing import Optional
-
 import strawberry
 
 
@@ -111,7 +107,8 @@ class User:
 @strawberry.type
 class Query:
     @strawberry.field
-    def user(self, id: strawberry.ID) -> Optional[User]:
+    def user(self, id: strawberry.ID) -> User:
+        # here you'd use the `id` to get the user from the database
         return User(name="Marco")
 ---
 type User {
@@ -119,16 +116,16 @@ type User {
 }
 
 type Query {
-    user(id: ID!): User
+    user(id: ID!): User!
 }
 ```
 
 ## Accessing parent's data
 
 It is quite common to want to be able to access the data from the parent in a
-resolver. For example let's say that we want to define a `fullName` field on
-our `User`. We can define a new field with a resolver that combines its first
-and last names:
+resolver. For example let's say that we want to define a `fullName` field on our
+`User`. We can define a new field with a resolver that combines its first and
+last names:
 
 ```python+schema
 import strawberry
@@ -154,7 +151,8 @@ In the case of a decorated resolver you can use the _self_ parameter as you
 would do in a method on a normal Python class[^1].
 
 For resolvers defined as normal Python functions, you can use the special `root`
-parameter, when defined, Strawberry will pass to it the value of the parent:
+parameter, when added to arguments of the function, Strawberry will pass to it
+the value of the parent:
 
 ```python
 import strawberry
@@ -192,14 +190,14 @@ class User:
 
 `Info[ContextType, RootValueType]`
 
-| Parameter name  | Type                       | Description                                                           |
-| --------------- | -------------------------- | --------------------------------------------------------------------- |
-| field_name      | `str`                      | The name of the current field                                         |
-| context         | `ContextType`              | The value of the context                                              |
-| root_value      | `RootValueType`            | The value for the root type                                           |
-| variable_values | `Optional[Dict[str, Any]]` | The variables for this operation                                      |
-| operation       | `OperationDefinitionNode`  | The ast for the current operation (public API might change in future) |
-| path            | `Path`                     | The path for the current field                                        |
+| Parameter name  | Type                      | Description                                                           |
+| --------------- | ------------------------- | --------------------------------------------------------------------- |
+| field_name      | `str`                     | The name of the current field                                         |
+| context         | `ContextType`             | The value of the context                                              |
+| root_value      | `RootValueType`           | The value for the root type                                           |
+| variable_values | `Dict[str, Any]`          | The variables for this operation                                      |
+| operation       | `OperationDefinitionNode` | The ast for the current operation (public API might change in future) |
+| path            | `Path`                    | The path for the current field                                        |
 
 [^1]:
     see

--- a/strawberry/extensions/__init__.py
+++ b/strawberry/extensions/__init__.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict
 
-from strawberry.types import ExecutionContext
+from strawberry.types import ExecutionContext, Info
 
 
 class Extension:
@@ -22,7 +22,7 @@ class Extension:
     def on_parsing_end(self):
         ...
 
-    def resolve(self, _next, root, info, *args, **kwargs):
+    def resolve(self, _next, root, info: Info, *args, **kwargs):
         return _next(root, info, *args, **kwargs)
 
     def get_results(self) -> Dict[str, Any]:

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -78,7 +78,7 @@ def field(
     >>>     field_abc: str = strawberry.field(description="ABC")
 
     >>>     @strawberry.field(description="ABC")
-    >>>     def field_with_resolver(self, info) -> str:
+    >>>     def field_with_resolver(self) -> str:
     >>>         return "abc"
 
     it can be used both as decorator and as a normal function.

--- a/strawberry/middleware.py
+++ b/strawberry/middleware.py
@@ -3,6 +3,8 @@ from typing import Any, Dict, List
 
 from typing_extensions import Protocol
 
+from strawberry.types.info import Info
+
 from .directive import DirectiveDefinition
 
 
@@ -11,7 +13,7 @@ SPECIFIED_DIRECTIVES = {"include", "skip"}
 
 class Middleware(Protocol):
     @abstractmethod
-    def resolve(self, next_, root, info, **kwargs):
+    def resolve(self, next_, root, info: Info, **kwargs) -> None:
         raise NotImplementedError
 
 
@@ -22,7 +24,8 @@ class DirectivesMiddleware:
             for directive in directives
         }
 
-    def resolve(self, next_, root, info, **kwargs):
+    # TODO: we might need the graphql info here
+    def resolve(self, next_, root, info, **kwargs) -> Any:
         result = next_(root, info, **kwargs)
 
         for directive in info.field_nodes[0].directives:

--- a/strawberry/permission.py
+++ b/strawberry/permission.py
@@ -1,9 +1,14 @@
+from typing import Any
+
+from strawberry.types.info import Info
+
+
 class BasePermission:
     """
     Base class for creating permissions
     """
 
-    def has_permission(self, source, info, **kwargs):
+    def has_permission(self, source: Any, info: Info, **kwargs) -> bool:
         raise NotImplementedError(
             "Permission classes should override has_permission method"
         )

--- a/strawberry/resolvers.py
+++ b/strawberry/resolvers.py
@@ -80,7 +80,9 @@ def get_result_for_field(
 
 
 def get_resolver(field: FieldDefinition) -> Callable:
-    # TODO: convert info to our info
+    # TODO: make sure that info is of type Info, currently it
+    # is the value returned by graphql-core
+    # https://github.com/strawberry-graphql/strawberry/issues/709
     def _check_permissions(source, info: Info, **kwargs):
         """
         Checks if the permission should be accepted and

--- a/strawberry/resolvers.py
+++ b/strawberry/resolvers.py
@@ -2,6 +2,8 @@ import enum
 from inspect import iscoroutine
 from typing import Any, Awaitable, Callable, Dict, List, Tuple, Union, cast
 
+from strawberry.types.info import Info
+
 from .arguments import convert_arguments
 from .field import FieldDefinition
 from .types.fields.resolver import StrawberryResolver
@@ -78,7 +80,8 @@ def get_result_for_field(
 
 
 def get_resolver(field: FieldDefinition) -> Callable:
-    def _check_permissions(source, info, **kwargs):
+    # TODO: convert info to our info
+    def _check_permissions(source, info: Info, **kwargs):
         """
         Checks if the permission should be accepted and
         raises an exception if not
@@ -90,7 +93,7 @@ def get_resolver(field: FieldDefinition) -> Callable:
                 message = getattr(permission, "message", None)
                 raise PermissionError(message)
 
-    async def _resolver_async(source, info, **kwargs):
+    async def _resolver_async(source, info: Info, **kwargs):
         _check_permissions(source, info, **kwargs)
 
         result = get_result_for_field(field, kwargs=kwargs, info=info, source=source)

--- a/strawberry/types/__init__.py
+++ b/strawberry/types/__init__.py
@@ -1,4 +1,5 @@
 from .execution import ExecutionContext, ExecutionResult
+from .info import Info
 
 
-__all__ = ["ExecutionContext", "ExecutionResult"]
+__all__ = ["ExecutionContext", "ExecutionResult", "Info"]

--- a/strawberry/types/info.py
+++ b/strawberry/types/info.py
@@ -1,0 +1,20 @@
+import dataclasses
+from typing import Generic, TypeVar
+
+from graphql import OperationDefinitionNode
+from graphql.pyutils.path import Path
+
+
+ContextType = TypeVar("ContextType")
+RootValueType = TypeVar("RootValueType")
+
+
+@dataclasses.dataclass
+class Info(Generic[ContextType, RootValueType]):
+    field_name: str
+    context: ContextType
+    root_value: RootValueType
+    # TODO: create an abstraction on these fields
+    operation: OperationDefinitionNode
+    path: Path
+    # TODO: parent_type, return_type as strawberry types

--- a/strawberry/types/info.py
+++ b/strawberry/types/info.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import Generic, TypeVar
+from typing import Any, Dict, Generic, TypeVar
 
 from graphql import OperationDefinitionNode
 from graphql.pyutils.path import Path
@@ -14,6 +14,7 @@ class Info(Generic[ContextType, RootValueType]):
     field_name: str
     context: ContextType
     root_value: RootValueType
+    variable_values: Dict[str, Any]
     # TODO: create an abstraction on these fields
     operation: OperationDefinitionNode
     path: Path

--- a/tests/asgi/conftest.py
+++ b/tests/asgi/conftest.py
@@ -9,23 +9,24 @@ from starlette.testclient import TestClient
 import strawberry
 from strawberry.asgi import GraphQL as BaseGraphQL
 from strawberry.permission import BasePermission
+from strawberry.types import Info
 
 
 class AlwaysFailPermission(BasePermission):
     message = "You are not authorized"
 
-    def has_permission(self, source, info):
+    def has_permission(self, source: typing.Any, info: Info, **kwargs) -> bool:
         return False
 
 
 @strawberry.type
 class Query:
     @strawberry.field
-    def hello(self, info, name: typing.Optional[str] = None) -> str:
+    def hello(self, name: typing.Optional[str] = None) -> str:
         return f"Hello {name or 'world'}"
 
     @strawberry.field(permission_classes=[AlwaysFailPermission])
-    def always_fail(self, info) -> Optional[str]:
+    def always_fail(self) -> Optional[str]:
         return "Hey"
 
     @strawberry.field
@@ -36,13 +37,13 @@ class Query:
 @strawberry.type
 class Subscription:
     @strawberry.subscription
-    async def example(self, info) -> typing.AsyncGenerator[str, None]:
+    async def example(self) -> typing.AsyncGenerator[str, None]:
         await asyncio.sleep(1.5)
 
         yield "Hi"
 
     @strawberry.subscription
-    async def example_error(self, info) -> typing.AsyncGenerator[str, None]:
+    async def example_error(self) -> typing.AsyncGenerator[str, None]:
         raise ValueError("This is an example")
 
         yield "Hi"

--- a/tests/asgi/test_async.py
+++ b/tests/asgi/test_async.py
@@ -13,7 +13,7 @@ def async_schema():
     @strawberry.type
     class Query:
         @strawberry.field
-        async def hello(self, info, name: typing.Optional[str] = None) -> str:
+        async def hello(self, name: typing.Optional[str] = None) -> str:
             return f"Hello {name or 'world'}"
 
     return strawberry.Schema(Query)

--- a/tests/asgi/test_query.py
+++ b/tests/asgi/test_query.py
@@ -2,7 +2,7 @@ from starlette.testclient import TestClient
 
 import strawberry
 from strawberry.asgi import GraphQL as BaseGraphQL
-from strawberry.types import ExecutionResult
+from strawberry.types import ExecutionResult, Info
 
 
 def test_simple_query(schema, test_client):
@@ -71,7 +71,7 @@ def test_custom_context():
     @strawberry.type
     class Query:
         @strawberry.field
-        def custom_context_value(self, info) -> str:
+        def custom_context_value(self, info: Info) -> str:
             return info.context["custom_context_value"]
 
     schema = strawberry.Schema(query=Query)
@@ -92,7 +92,7 @@ def test_custom_process_result():
     @strawberry.type
     class Query:
         @strawberry.field
-        def abc(self, info) -> str:
+        def abc(self) -> str:
             return "ABC"
 
     schema = strawberry.Schema(query=Query)

--- a/tests/benchmarks/test_execute.py
+++ b/tests/benchmarks/test_execute.py
@@ -45,7 +45,7 @@ def test_execute(benchmark, items):
     @strawberry.type
     class Query:
         @strawberry.field
-        def patrons(self, info) -> List[Patron]:
+        def patrons(self) -> List[Patron]:
             return [
                 Patron(
                     id=i,

--- a/tests/cli/helpers/sample_schema.py
+++ b/tests/cli/helpers/sample_schema.py
@@ -10,7 +10,7 @@ class User:
 @strawberry.type
 class Query:
     @strawberry.field
-    def user(self, info) -> User:
+    def user(self) -> User:
         return User(name="Patrick", age=100)
 
 

--- a/tests/django/test_async_view.py
+++ b/tests/django/test_async_view.py
@@ -28,11 +28,11 @@ class Query:
     hello: str = "strawberry"
 
     @strawberry.field
-    async def hello_async(self, info) -> str:
+    async def hello_async(self) -> str:
         return "async strawberry"
 
     @strawberry.field
-    async def example_async(self, info) -> str:
+    async def example_async(self) -> str:
         def _get_name():
             return Example.objects.first().name
 

--- a/tests/django/test_views.py
+++ b/tests/django/test_views.py
@@ -1,5 +1,5 @@
 import json
-from typing import Optional
+from typing import Any, Optional
 
 import pytest
 
@@ -10,7 +10,7 @@ from django.test.client import RequestFactory
 import strawberry
 from strawberry.django.views import GraphQLView as BaseGraphQLView
 from strawberry.permission import BasePermission
-from strawberry.types import ExecutionResult
+from strawberry.types import ExecutionResult, Info
 
 from .app.models import Example
 
@@ -18,7 +18,7 @@ from .app.models import Example
 class AlwaysFailPermission(BasePermission):
     message = "You are not authorized"
 
-    def has_permission(self, source, info):
+    def has_permission(self, source: Any, info: Info, **kwargs) -> bool:
         return False
 
 
@@ -27,11 +27,11 @@ class Query:
     hello: str = "strawberry"
 
     @strawberry.field(permission_classes=[AlwaysFailPermission])
-    def always_fail(self, info) -> Optional[str]:
+    def always_fail(self) -> Optional[str]:
         return "Hey"
 
     @strawberry.field
-    def example(self, info) -> str:
+    def example(self) -> str:
         return Example.objects.first().name
 
 
@@ -154,7 +154,7 @@ def test_custom_context():
     @strawberry.type
     class Query:
         @strawberry.field
-        def custom_context_value(self, info) -> str:
+        def custom_context_value(self, info: Info) -> str:
             return info.context["custom_value"]
 
     schema = strawberry.Schema(query=Query)
@@ -181,7 +181,7 @@ def test_custom_process_result():
     @strawberry.type
     class Query:
         @strawberry.field
-        def abc(self, info) -> str:
+        def abc(self) -> str:
             return "ABC"
 
     schema = strawberry.Schema(query=Query)

--- a/tests/federation/test_entities.py
+++ b/tests/federation/test_entities.py
@@ -15,7 +15,7 @@ def test_fetch_entities():
     @strawberry.federation.type(extend=True)
     class Query:
         @strawberry.field
-        def top_products(self, info, first: int) -> typing.List[Product]:
+        def top_products(self, first: int) -> typing.List[Product]:
             return []
 
     schema = strawberry.federation.Schema(query=Query)

--- a/tests/federation/test_printer.py
+++ b/tests/federation/test_printer.py
@@ -27,7 +27,7 @@ def test_entities_type_when_no_type_has_keys():
     @strawberry.federation.type
     class Query:
         @strawberry.field
-        def top_products(self, info, first: int) -> List[Product]:
+        def top_products(self, first: int) -> List[Product]:
             return []
 
     schema = strawberry.federation.Schema(query=Query)

--- a/tests/federation/test_schema.py
+++ b/tests/federation/test_schema.py
@@ -15,7 +15,7 @@ def test_entities_type_when_no_type_has_keys():
     @strawberry.federation.type(extend=True)
     class Query:
         @strawberry.field
-        def top_products(self, info, first: int) -> List[Product]:
+        def top_products(self, first: int) -> List[Product]:
             return []
 
     schema = strawberry.federation.Schema(query=Query)
@@ -49,7 +49,7 @@ def test_entities_type():
     @strawberry.federation.type(extend=True)
     class Query:
         @strawberry.field
-        def top_products(self, info, first: int) -> List[Product]:
+        def top_products(self, first: int) -> List[Product]:
             return []
 
     schema = strawberry.federation.Schema(query=Query)
@@ -82,7 +82,7 @@ def test_additional_scalars():
     @strawberry.federation.type(extend=True)
     class Query:
         @strawberry.field
-        def top_products(self, info, first: int) -> List[Example]:
+        def top_products(self, first: int) -> List[Example]:
             return []
 
     schema = strawberry.federation.Schema(query=Query)
@@ -110,7 +110,7 @@ def test_service():
     @strawberry.federation.type(extend=True)
     class Query:
         @strawberry.field
-        def top_products(self, info, first: int) -> List[Product]:
+        def top_products(self, first: int) -> List[Product]:
             return []
 
     schema = strawberry.federation.Schema(query=Query)
@@ -161,7 +161,7 @@ def test_using_generics():
     @strawberry.federation.type(extend=True)
     class Query:
         @strawberry.field
-        def top_products(self, info, first: int) -> ListOfProducts[Product]:
+        def top_products(self, first: int) -> ListOfProducts[Product]:
             return ListOfProducts([])
 
     schema = strawberry.federation.Schema(query=Query)

--- a/tests/flask/test_view.py
+++ b/tests/flask/test_view.py
@@ -5,7 +5,7 @@ import pytest
 import strawberry
 from flask import Flask, request
 from strawberry.flask.views import GraphQLView as BaseGraphQLView
-from strawberry.types import ExecutionResult
+from strawberry.types import ExecutionResult, Info
 
 
 def create_app(**kwargs):
@@ -82,7 +82,7 @@ def test_custom_context():
     @strawberry.type
     class Query:
         @strawberry.field
-        def custom_context_value(self, info) -> str:
+        def custom_context_value(self, info: Info) -> str:
             return info.context["custom_value"]
 
     schema = strawberry.Schema(query=Query)
@@ -113,7 +113,7 @@ def test_custom_process_result():
     @strawberry.type
     class Query:
         @strawberry.field
-        def abc(self, info) -> str:
+        def abc(self) -> str:
             return "ABC"
 
     schema = strawberry.Schema(query=Query)

--- a/tests/mypy/test_fields.yml
+++ b/tests/mypy/test_fields.yml
@@ -14,6 +14,7 @@
 - case: test_all_field_usage
   main: |
     import strawberry
+    from strawberry.types import Info
 
     def some_resolver() -> str:
         return ""
@@ -26,7 +27,7 @@
         d: str = strawberry.field(resolver=some_resolver)
 
         @strawberry.field(description="ABC")
-        def e(self, info) -> str:
+        def e(self, info: Info) -> str:
             return ""
 
         @strawberry.field(name="f")
@@ -40,12 +41,12 @@
     reveal_type(Example.e)
     reveal_type(Example.f_resolver)
   out: |
-    main:21: note: Revealed type is 'builtins.str'
     main:22: note: Revealed type is 'builtins.str'
     main:23: note: Revealed type is 'builtins.str'
     main:24: note: Revealed type is 'builtins.str'
-    main:25: note: Revealed type is 'Any'
+    main:25: note: Revealed type is 'builtins.str'
     main:26: note: Revealed type is 'Any'
+    main:27: note: Revealed type is 'Any'
 
 - case: test_private_field
   main: |

--- a/tests/schema/extensions/test_apollo.py
+++ b/tests/schema/extensions/test_apollo.py
@@ -24,7 +24,7 @@ def test_tracing_sync(mocker):
     @strawberry.type
     class Query:
         @strawberry.field
-        def person(self, info) -> Person:
+        def person(self) -> Person:
             return Person()
 
     schema = strawberry.Schema(query=Query, extensions=[ApolloTracingExtensionSync])
@@ -79,11 +79,11 @@ async def test_tracing_async(mocker):
     @strawberry.type
     class Query:
         @strawberry.field
-        def example(self, info) -> str:
+        def example(self) -> str:
             return "Hi"
 
         @strawberry.field
-        async def person(self, info) -> Person:
+        async def person(self) -> Person:
             return Person()
 
     schema = strawberry.Schema(query=Query, extensions=[ApolloTracingExtension])
@@ -146,7 +146,7 @@ def test_should_not_trace_introspection_sync_queries(mocker):
     @strawberry.type
     class Query:
         @strawberry.field
-        def person(self, info) -> Person:
+        def person(self) -> Person:
             return Person()
 
     schema = strawberry.Schema(query=Query, extensions=[ApolloTracingExtensionSync])
@@ -181,7 +181,7 @@ async def test_should_not_trace_introspection_async_queries(mocker):
     @strawberry.type
     class Query:
         @strawberry.field
-        async def person(self, info) -> Person:
+        async def person(self) -> Person:
             return Person()
 
     schema = strawberry.Schema(query=Query, extensions=[ApolloTracingExtension])

--- a/tests/schema/extensions/test_extensions.py
+++ b/tests/schema/extensions/test_extensions.py
@@ -17,7 +17,7 @@ def test_base_extension():
     @strawberry.type
     class Query:
         @strawberry.field
-        def person(self, info) -> Person:
+        def person(self) -> Person:
             return Person()
 
     schema = strawberry.Schema(query=Query, extensions=[Extension])
@@ -45,7 +45,7 @@ def test_extension():
     @strawberry.type
     class Query:
         @strawberry.field
-        def person(self, info) -> Person:
+        def person(self) -> Person:
             return Person()
 
     schema = strawberry.Schema(query=Query, extensions=[MyExtension])
@@ -76,7 +76,7 @@ async def test_extension_async():
     @strawberry.type
     class Query:
         @strawberry.field
-        async def person(self, info) -> Person:
+        async def person(self) -> Person:
             return Person()
 
     schema = strawberry.Schema(query=Query, extensions=[MyExtension])

--- a/tests/schema/extensions/test_opentelemetry.py
+++ b/tests/schema/extensions/test_opentelemetry.py
@@ -22,7 +22,7 @@ class Person:
 @strawberry.type
 class Query:
     @strawberry.field
-    async def person(self, info) -> Person:
+    async def person(self) -> Person:
         return Person()
 
 
@@ -35,7 +35,7 @@ async def test_opentelemetry_uses_global_tracer(global_tracer_mock):
     @strawberry.type
     class Query:
         @strawberry.field
-        async def person(self, info) -> Person:
+        async def person(self) -> Person:
             return Person()
 
     schema = strawberry.Schema(query=Query, extensions=[OpenTelemetryExtension])
@@ -62,7 +62,7 @@ async def test_opentelemetry_Sync_uses_global_tracer(global_tracer_mock):
     @strawberry.type
     class Query:
         @strawberry.field
-        async def person(self, info) -> Person:
+        async def person(self) -> Person:
             return Person()
 
     schema = strawberry.Schema(query=Query, extensions=[OpenTelemetryExtensionSync])

--- a/tests/schema/test_basic.py
+++ b/tests/schema/test_basic.py
@@ -60,7 +60,7 @@ def test_does_camel_case_conversion():
     @strawberry.type
     class Query:
         @strawberry.field
-        def hello_world(self, info, query_param: str) -> str:
+        def hello_world(self, query_param: str) -> str:
             return query_param
 
     schema = strawberry.Schema(query=Query)
@@ -83,11 +83,11 @@ def test_can_rename_fields():
     @strawberry.type
     class Query:
         @strawberry.field
-        def hello(self, info) -> Hello:
+        def hello(self) -> Hello:
             return Hello("hi")
 
         @strawberry.field(name="example1")
-        def example(self, info, query_param: str) -> str:
+        def example(self, query_param: str) -> str:
             return query_param
 
     schema = strawberry.Schema(query=Query)
@@ -137,11 +137,11 @@ def test_field_description():
         a: str = strawberry.field(description="Example")
 
         @strawberry.field
-        def b(self, info, id: int) -> str:
+        def b(self, id: int) -> str:
             return "I'm a resolver"
 
         @strawberry.field(description="Example C")
-        def c(self, info, id: int) -> str:
+        def c(self, id: int) -> str:
             return "I'm a resolver"
 
     schema = strawberry.Schema(query=Query)
@@ -172,11 +172,11 @@ def test_field_deprecated_reason():
         a: str = strawberry.field(deprecation_reason="Deprecated A")
 
         @strawberry.field
-        def b(self, info, id: int) -> str:
+        def b(self, id: int) -> str:
             return "I'm a resolver"
 
         @strawberry.field(deprecation_reason="Deprecated B")
-        def c(self, info, id: int) -> str:
+        def c(self, id: int) -> str:
             return "I'm a resolver"
 
     schema = strawberry.Schema(query=Query)
@@ -281,7 +281,7 @@ def test_parent_class_fields_are_inherited():
         cheese: str = "swiss"
 
         @strawberry.field
-        def friend(self, info) -> str:
+        def friend(self) -> str:
             return "food"
 
     @strawberry.type
@@ -289,13 +289,13 @@ def test_parent_class_fields_are_inherited():
         cake: str = "made_in_switzerland"
 
         @strawberry.field
-        def hello_this_is(self, info) -> str:
+        def hello_this_is(self) -> str:
             return "patrick"
 
     @strawberry.type
     class Query:
         @strawberry.field
-        def example(self, info) -> Schema:
+        def example(self) -> Schema:
             return Schema()
 
     schema = strawberry.Schema(query=Query)
@@ -327,7 +327,7 @@ def test_can_return_compatible_type():
     @strawberry.type
     class Query:
         @strawberry.field
-        def assortment(self, info) -> Cheese:
+        def assortment(self) -> Cheese:
             return Example(name="Asiago")  # type: ignore
 
     schema = strawberry.Schema(query=Query)
@@ -353,7 +353,7 @@ def test_init_var():
     @strawberry.type
     class Query:
         @strawberry.field
-        def category(self, info) -> Category:
+        def category(self) -> Category:
             return Category(name="example", id="123")
 
     schema = strawberry.Schema(query=Query)
@@ -374,7 +374,7 @@ def test_nested_types():
     @strawberry.type
     class Query:
         @strawberry.field
-        def user(self, info) -> User:
+        def user(self) -> User:
             return User(name="Patrick")
 
     schema = strawberry.Schema(query=Query)

--- a/tests/schema/test_custom_scalar.py
+++ b/tests/schema/test_custom_scalar.py
@@ -27,7 +27,7 @@ def test_custom_scalar_serialization():
     @strawberry.type
     class Query:
         @strawberry.field
-        def custom_scalar_field(self, info) -> Base64Encoded:
+        def custom_scalar_field(self) -> Base64Encoded:
             return Base64Encoded(b"decoded value")
 
     schema = strawberry.Schema(Query)
@@ -42,7 +42,7 @@ def test_custom_scalar_deserialization():
     @strawberry.type
     class Query:
         @strawberry.field
-        def decode_base64(self, info, encoded: Base64Encoded) -> str:
+        def decode_base64(self, encoded: Base64Encoded) -> str:
             return bytes(encoded).decode("ascii")
 
     schema = strawberry.Schema(Query)
@@ -61,7 +61,7 @@ def test_custom_scalar_decorated_class():
     @strawberry.type
     class Query:
         @strawberry.field
-        def answer(self, info) -> Always42:
+        def answer(self) -> Always42:
             return Always42()
 
     schema = strawberry.Schema(Query)
@@ -76,7 +76,7 @@ def test_custom_scalar_default_serialization():
     @strawberry.type
     class Query:
         @strawberry.field
-        def my_str(self, info, arg: MyStr) -> MyStr:
+        def my_str(self, arg: MyStr) -> MyStr:
             return MyStr(str(arg) + "Suffix")
 
     schema = strawberry.Schema(Query)

--- a/tests/schema/test_directives.py
+++ b/tests/schema/test_directives.py
@@ -16,7 +16,7 @@ def test_supports_default_directives():
     @strawberry.type
     class Query:
         @strawberry.field
-        def person(self, info) -> Person:
+        def person(self) -> Person:
             return Person()
 
     query = """query ($includePoints: Boolean!){
@@ -79,7 +79,7 @@ def test_runs_directives():
     @strawberry.type
     class Query:
         @strawberry.field
-        def person(self, info) -> Person:
+        def person(self) -> Person:
             return Person()
 
     @strawberry.directive(
@@ -123,7 +123,7 @@ def test_runs_directives_with_list_params():
     @strawberry.type
     class Query:
         @strawberry.field
-        def person(self, info) -> Person:
+        def person(self) -> Person:
             return Person()
 
     @strawberry.directive(locations=[DirectiveLocation.FIELD])

--- a/tests/schema/test_enum.py
+++ b/tests/schema/test_enum.py
@@ -17,7 +17,7 @@ def test_enum_resolver():
     @strawberry.type
     class Query:
         @strawberry.field
-        def best_flavour(self, info) -> IceCreamFlavour:
+        def best_flavour(self) -> IceCreamFlavour:
             return IceCreamFlavour.STRAWBERRY
 
     schema = strawberry.Schema(query=Query)
@@ -36,7 +36,7 @@ def test_enum_resolver():
     @strawberry.type
     class Query:
         @strawberry.field
-        def cone(self, info) -> Cone:
+        def cone(self) -> Cone:
             return Cone(flavour=IceCreamFlavour.STRAWBERRY)
 
     schema = strawberry.Schema(query=Query)
@@ -59,7 +59,7 @@ def test_enum_arguments():
     @strawberry.type
     class Query:
         @strawberry.field
-        def flavour_available(self, info, flavour: IceCreamFlavour) -> bool:
+        def flavour_available(self, flavour: IceCreamFlavour) -> bool:
             return flavour == IceCreamFlavour.STRAWBERRY
 
     @strawberry.input
@@ -69,7 +69,7 @@ def test_enum_arguments():
     @strawberry.type
     class Mutation:
         @strawberry.mutation
-        def eat_cone(self, info, input: ConeInput) -> bool:
+        def eat_cone(self, input: ConeInput) -> bool:
             return input.flavour == IceCreamFlavour.STRAWBERRY
 
     schema = strawberry.Schema(query=Query, mutation=Mutation)
@@ -113,7 +113,7 @@ def test_enum_falsy_values():
     @strawberry.type
     class Query:
         @strawberry.field
-        def print_flavour(self, info, input: Input) -> str:
+        def print_flavour(self, input: Input) -> str:
             return f"{input.flavour.value}"
 
     schema = strawberry.Schema(query=Query)
@@ -142,7 +142,7 @@ def test_enum_in_list():
     @strawberry.type
     class Query:
         @strawberry.field
-        def best_flavours(self, info) -> List[IceCreamFlavour]:
+        def best_flavours(self) -> List[IceCreamFlavour]:
             return [IceCreamFlavour.STRAWBERRY, IceCreamFlavour.PISTACHIO]
 
     schema = strawberry.Schema(query=Query)
@@ -166,7 +166,7 @@ def test_enum_in_optional_list():
     @strawberry.type
     class Query:
         @strawberry.field
-        def best_flavours(self, info) -> Optional[List[IceCreamFlavour]]:
+        def best_flavours(self) -> Optional[List[IceCreamFlavour]]:
             return None
 
     schema = strawberry.Schema(query=Query)
@@ -190,7 +190,7 @@ async def test_enum_resolver_async():
     @strawberry.type
     class Query:
         @strawberry.field
-        async def best_flavour(self, info) -> IceCreamFlavour:
+        async def best_flavour(self) -> IceCreamFlavour:
             return IceCreamFlavour.STRAWBERRY
 
     schema = strawberry.Schema(query=Query)
@@ -215,7 +215,7 @@ async def test_enum_in_list_async():
     @strawberry.type
     class Query:
         @strawberry.field
-        async def best_flavours(self, info) -> List[IceCreamFlavour]:
+        async def best_flavours(self) -> List[IceCreamFlavour]:
             return [IceCreamFlavour.STRAWBERRY, IceCreamFlavour.PISTACHIO]
 
     schema = strawberry.Schema(query=Query)

--- a/tests/schema/test_generics.py
+++ b/tests/schema/test_generics.py
@@ -14,7 +14,7 @@ def test_supports_generic_simple_type():
     @strawberry.type
     class Query:
         @strawberry.field
-        def int_edge(self, info) -> Edge[int]:
+        def int_edge(self) -> Edge[int]:
             return Edge(cursor=strawberry.ID("1"), node_field=1)
 
     schema = strawberry.Schema(query=Query)
@@ -50,7 +50,7 @@ def test_supports_generic():
     @strawberry.type
     class Query:
         @strawberry.field
-        def person_edge(self, info) -> Edge[Person]:
+        def person_edge(self) -> Edge[Person]:
             return Edge(cursor=strawberry.ID("1"), node=Person(name="Example"))
 
     schema = strawberry.Schema(query=Query)
@@ -89,7 +89,7 @@ def test_supports_multiple_generic():
     @strawberry.type
     class Query:
         @strawberry.field
-        def multiple(self, info) -> Multiple[int, str]:
+        def multiple(self) -> Multiple[int, str]:
             return Multiple(a=123, b="123")
 
     schema = strawberry.Schema(query=Query)
@@ -128,7 +128,7 @@ def test_support_nested_generics():
     @strawberry.type
     class Query:
         @strawberry.field
-        def users(self, info) -> Connection[User]:
+        def users(self) -> Connection[User]:
             return Connection(edge=Edge(node=User("Patrick")))
 
     schema = strawberry.Schema(query=Query)
@@ -170,7 +170,7 @@ def test_supports_optional():
     @strawberry.type
     class Query:
         @strawberry.field
-        def user(self, info) -> Edge[User]:
+        def user(self) -> Edge[User]:
             return Edge()
 
     schema = strawberry.Schema(query=Query)
@@ -204,7 +204,7 @@ def test_supports_lists():
     @strawberry.type
     class Query:
         @strawberry.field
-        def user(self, info) -> Edge[User]:
+        def user(self) -> Edge[User]:
             return Edge(nodes=[])
 
     schema = strawberry.Schema(query=Query)
@@ -238,7 +238,7 @@ def test_supports_lists_of_optionals():
     @strawberry.type
     class Query:
         @strawberry.field
-        def user(self, info) -> Edge[User]:
+        def user(self) -> Edge[User]:
             return Edge(nodes=[None])
 
     schema = strawberry.Schema(query=Query)
@@ -280,7 +280,7 @@ def test_can_extend_generics():
     @strawberry.type
     class Query:
         @strawberry.field
-        def users(self, info) -> ConnectionWithMeta[User]:
+        def users(self) -> ConnectionWithMeta[User]:
             return ConnectionWithMeta(meta="123", edges=[Edge(node=User("Patrick"))])
 
     schema = strawberry.Schema(query=Query)
@@ -325,7 +325,7 @@ def test_supports_generic_in_unions():
     @strawberry.type
     class Query:
         @strawberry.field
-        def example(self, info) -> typing.Union[Fallback, Edge[int]]:
+        def example(self) -> typing.Union[Fallback, Edge[int]]:
             return Edge(cursor=strawberry.ID("1"), node=1)
 
     schema = strawberry.Schema(query=Query)
@@ -365,7 +365,7 @@ def test_supports_generic_in_unions_multiple_vars():
     @strawberry.type
     class Query:
         @strawberry.field
-        def example(self, info) -> typing.Union[Fallback, Edge[int, str]]:
+        def example(self) -> typing.Union[Fallback, Edge[int, str]]:
             return Edge(node="string", info=1)
 
     schema = strawberry.Schema(query=Query)
@@ -411,7 +411,7 @@ def test_supports_generic_in_unions_with_nesting():
     @strawberry.type
     class Query:
         @strawberry.field
-        def users(self, info) -> typing.Union[Connection[User], Fallback]:
+        def users(self) -> typing.Union[Connection[User], Fallback]:
             return Connection(edge=Edge(node=User("Patrick")))
 
     schema = strawberry.Schema(query=Query)
@@ -452,7 +452,7 @@ def test_supports_multiple_generics_in_union():
     @strawberry.type
     class Query:
         @strawberry.field
-        def example(self, info) -> typing.List[typing.Union[Edge[int], Edge[str]]]:
+        def example(self) -> typing.List[typing.Union[Edge[int], Edge[str]]]:
             return [
                 Edge(cursor=strawberry.ID("1"), node=1),
                 Edge(cursor=strawberry.ID("2"), node="string"),
@@ -502,7 +502,7 @@ def test_generated_names():
     @strawberry.type
     class Query:
         @strawberry.field
-        def person_edge(self, info) -> EdgeWithCursor[SpecialPerson]:
+        def person_edge(self) -> EdgeWithCursor[SpecialPerson]:
             return EdgeWithCursor(
                 cursor=strawberry.ID("1"), node=SpecialPerson(name="Example")
             )
@@ -545,7 +545,7 @@ def test_supports_lists_within_unions():
     @strawberry.type
     class Query:
         @strawberry.field
-        def user(self, info) -> typing.Union[User, Edge[User]]:
+        def user(self) -> typing.Union[User, Edge[User]]:
             return Edge(nodes=[User("P")])
 
     schema = strawberry.Schema(query=Query)
@@ -582,7 +582,7 @@ def test_supports_lists_within_unions_empty_list():
     @strawberry.type
     class Query:
         @strawberry.field
-        def user(self, info) -> typing.Union[User, Edge[User]]:
+        def user(self) -> typing.Union[User, Edge[User]]:
             return Edge(nodes=[])
 
     schema = strawberry.Schema(query=Query)
@@ -619,7 +619,7 @@ def test_raises_error_when_unable_to_find_type():
     @strawberry.type
     class Query:
         @strawberry.field
-        def user(self, info) -> typing.Union[User, Edge[User]]:
+        def user(self) -> typing.Union[User, Edge[User]]:
             return Edge(nodes=["bad example"])  # type: ignore
 
     schema = strawberry.Schema(query=Query)

--- a/tests/schema/test_info.py
+++ b/tests/schema/test_info.py
@@ -1,0 +1,51 @@
+import strawberry
+from strawberry.types import Info
+
+
+def test_info_has_the_correct_shape():
+    my_context = "123"
+    root_value = "ABC"
+
+    @strawberry.type
+    class Result:
+        field_name: str
+        operation: str
+        path: str
+        context_equal: bool
+        root_equal: bool
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def hello(self, info: Info[str, str]) -> Result:
+            return Result(
+                path="".join([str(p) for p in info.path.as_list()]),
+                operation=str(info.operation),
+                field_name=info.field_name,
+                context_equal=info.context == my_context,
+                root_equal=info.root_value == root_value,
+            )
+
+    schema = strawberry.Schema(query=Query)
+
+    query = """{
+        hello {
+            fieldName
+            contextEqual
+            operation
+            path
+            rootEqual
+        }
+    }"""
+
+    result = schema.execute_sync(query, context_value=my_context, root_value=root_value)
+
+    assert not result.errors
+    assert result.data["hello"] == {
+        # TODO: abstract this (in future)
+        "operation": "OperationDefinitionNode at 0:141",
+        "fieldName": "hello",
+        "path": "hello",
+        "contextEqual": True,
+        "rootEqual": True,
+    }

--- a/tests/schema/test_info.py
+++ b/tests/schema/test_info.py
@@ -11,6 +11,7 @@ def test_info_has_the_correct_shape():
         field_name: str
         operation: str
         path: str
+        variable_values: str
         context_equal: bool
         root_equal: bool
 
@@ -22,6 +23,7 @@ def test_info_has_the_correct_shape():
                 path="".join([str(p) for p in info.path.as_list()]),
                 operation=str(info.operation),
                 field_name=info.field_name,
+                variable_values=str(info.variable_values),
                 context_equal=info.context == my_context,
                 root_equal=info.root_value == root_value,
             )
@@ -35,6 +37,7 @@ def test_info_has_the_correct_shape():
             operation
             path
             rootEqual
+            variableValues
         }
     }"""
 
@@ -43,9 +46,10 @@ def test_info_has_the_correct_shape():
     assert not result.errors
     assert result.data["hello"] == {
         # TODO: abstract this (in future)
-        "operation": "OperationDefinitionNode at 0:141",
+        "operation": "OperationDefinitionNode at 0:168",
         "fieldName": "hello",
         "path": "hello",
         "contextEqual": True,
         "rootEqual": True,
+        "variableValues": "{}",
     }

--- a/tests/schema/test_interface.py
+++ b/tests/schema/test_interface.py
@@ -19,7 +19,7 @@ def test_query_interface():
     @strawberry.type
     class Root:
         @strawberry.field
-        def assortment(self, info) -> List[Cheese]:
+        def assortment(self) -> List[Cheese]:
             return [
                 Italian(name="Asiago", province="Friuli"),
                 Swiss(name="Tomme", canton="Vaud"),

--- a/tests/schema/test_mutation.py
+++ b/tests/schema/test_mutation.py
@@ -13,7 +13,7 @@ def test_mutation():
     @strawberry.type
     class Mutation:
         @strawberry.mutation
-        def say(self, info) -> str:
+        def say(self) -> str:
             return "Hello!"
 
     schema = strawberry.Schema(query=Query, mutation=Mutation)
@@ -39,7 +39,7 @@ def test_mutation_with_input_type():
     @strawberry.type
     class Mutation:
         @strawberry.mutation
-        def say(self, info, input: SayInput) -> str:
+        def say(self, input: SayInput) -> str:
             return f"Hello {input.name} of {input.age} years old!"
 
     schema = strawberry.Schema(query=Query, mutation=Mutation)
@@ -65,14 +65,14 @@ def test_unset_types():
     @strawberry.type
     class Mutation:
         @strawberry.mutation
-        def say(self, info, name: typing.Optional[str] = UNSET) -> str:  # type: ignore
+        def say(self, name: typing.Optional[str] = UNSET) -> str:  # type: ignore
             if is_unset(name):
                 return "Name is unset"
 
             return f"Hello {name}!"
 
         @strawberry.mutation
-        def say_age(self, info, input: InputExample) -> str:
+        def say_age(self, input: InputExample) -> str:
             age = "unset" if is_unset(input.age) else input.age
 
             return f"Hello {input.name} of age {age}!"
@@ -101,9 +101,7 @@ def test_unset_types_name_with_underscore():
     @strawberry.type
     class Mutation:
         @strawberry.mutation
-        def say(
-            self, info, first_name: typing.Optional[str] = UNSET  # type: ignore
-        ) -> str:
+        def say(self, first_name: typing.Optional[str] = UNSET) -> str:  # type: ignore
             if is_unset(first_name):
                 return "Name is unset"
 
@@ -113,7 +111,7 @@ def test_unset_types_name_with_underscore():
             return f"Hello {first_name}!"
 
         @strawberry.mutation
-        def say_age(self, info, input: InputExample) -> str:
+        def say_age(self, input: InputExample) -> str:
             age = "unset" if is_unset(input.age) else input.age
             age = "empty" if age == "" else age
 
@@ -149,9 +147,7 @@ def test_unset_types_stringify_empty():
     @strawberry.type
     class Mutation:
         @strawberry.mutation
-        def say(
-            self, info, first_name: typing.Optional[str] = UNSET  # type: ignore
-        ) -> str:
+        def say(self, first_name: typing.Optional[str] = UNSET) -> str:  # type: ignore
             return f"Hello {first_name}!"
 
     schema = strawberry.Schema(query=Query, mutation=Mutation)
@@ -187,7 +183,7 @@ def test_converting_to_dict_with_unset():
     @strawberry.type
     class Mutation:
         @strawberry.mutation
-        def say(self, info, input: Input) -> str:
+        def say(self, input: Input) -> str:
             data = dataclasses.asdict(input)
 
             if is_unset(data["name"]):

--- a/tests/schema/test_permission.py
+++ b/tests/schema/test_permission.py
@@ -4,6 +4,7 @@ import pytest
 
 import strawberry
 from strawberry.permission import BasePermission
+from strawberry.types import Info
 
 
 def test_raises_graphql_error_when_permission_method_is_missing():
@@ -13,7 +14,7 @@ def test_raises_graphql_error_when_permission_method_is_missing():
     @strawberry.type
     class Query:
         @strawberry.field(permission_classes=[IsAuthenticated])
-        def user(self, info) -> str:
+        def user(self) -> str:
             return "patrick"
 
     schema = strawberry.Schema(query=Query)
@@ -31,13 +32,13 @@ def test_raises_graphql_error_when_permission_is_denied():
     class IsAuthenticated(BasePermission):
         message = "User is not authenticated"
 
-        def has_permission(self, source, info):
+        def has_permission(self, source: typing.Any, info: Info, **kwargs) -> bool:
             return False
 
     @strawberry.type
     class Query:
         @strawberry.field(permission_classes=[IsAuthenticated])
-        def user(self, info) -> str:
+        def user(self) -> str:
             return "patrick"
 
     schema = strawberry.Schema(query=Query)
@@ -53,7 +54,7 @@ async def test_raises_permission_error_for_subscription():
     class IsAdmin(BasePermission):
         message = "You are not authorized"
 
-        def has_permission(self, source, info):
+        def has_permission(self, source: typing.Any, info: Info, **kwargs) -> bool:
             return False
 
     @strawberry.type
@@ -79,7 +80,7 @@ def test_can_use_source_when_testing_permission():
     class CanSeeEmail(BasePermission):
         message = "Cannot see email for this user"
 
-        def has_permission(self, source, info):
+        def has_permission(self, source: typing.Any, info: Info, **kwargs) -> bool:
             return source.name.lower() == "patrick"
 
     @strawberry.type
@@ -87,13 +88,13 @@ def test_can_use_source_when_testing_permission():
         name: str
 
         @strawberry.field(permission_classes=[CanSeeEmail])
-        def email(self, info) -> str:
+        def email(self) -> str:
             return "patrick.arminio@gmail.com"
 
     @strawberry.type
     class Query:
         @strawberry.field
-        def user(self, info, name: str) -> User:
+        def user(self, name: str) -> User:
             return User(name=name)
 
     schema = strawberry.Schema(query=Query)
@@ -113,21 +114,21 @@ def test_can_use_args_when_testing_permission():
     class CanSeeEmail(BasePermission):
         message = "Cannot see email for this user"
 
-        def has_permission(self, source, info, secure):
-            return secure
+        def has_permission(self, source: typing.Any, info: Info, **kwargs) -> bool:
+            return kwargs.get("secure", False)
 
     @strawberry.type
     class User:
         name: str
 
         @strawberry.field(permission_classes=[CanSeeEmail])
-        def email(self, info, secure: bool) -> str:
+        def email(self, secure: bool) -> str:
             return "patrick.arminio@gmail.com"
 
     @strawberry.type
     class Query:
         @strawberry.field
-        def user(self, info, name: str) -> User:
+        def user(self, name: str) -> User:
             return User(name=name)
 
     schema = strawberry.Schema(query=Query)
@@ -147,7 +148,7 @@ def test_can_use_on_simple_fields():
     class CanSeeEmail(BasePermission):
         message = "Cannot see email for this user"
 
-        def has_permission(self, source, info):
+        def has_permission(self, source: typing.Any, info: Info, **kwargs) -> bool:
             return source.name.lower() == "patrick"
 
     @strawberry.type
@@ -158,7 +159,7 @@ def test_can_use_on_simple_fields():
     @strawberry.type
     class Query:
         @strawberry.field
-        def user(self, info, name: str) -> User:
+        def user(self, name: str) -> User:
             return User(name=name, email="patrick.arminio@gmail.com")
 
     schema = strawberry.Schema(query=Query)

--- a/tests/schema/test_resolvers.py
+++ b/tests/schema/test_resolvers.py
@@ -11,7 +11,7 @@ def test_resolver():
     @strawberry.type
     class Query:
         @strawberry.field
-        def hello(self, info) -> str:
+        def hello(self) -> str:
             return "I'm a resolver"
 
     schema = strawberry.Schema(query=Query)
@@ -26,16 +26,16 @@ def test_resolver():
 
 @pytest.mark.asyncio
 async def test_resolver_function():
-    def function_resolver(root, info) -> str:
+    def function_resolver(root) -> str:
         return "I'm a function resolver"
 
-    async def async_resolver(root, info) -> str:
+    async def async_resolver(root) -> str:
         return "I'm an async resolver"
 
-    def resolve_name(root, info) -> str:
+    def resolve_name(root) -> str:
         return root.name
 
-    def resolve_say_hello(root, info, name: str) -> str:
+    def resolve_say_hello(root, name: str) -> str:
         return f"Hello {name}"
 
     @strawberry.type
@@ -66,10 +66,10 @@ async def test_resolver_function():
 
 
 def test_resolvers_on_types():
-    def function_resolver(root, info) -> str:
+    def function_resolver(root) -> str:
         return "I'm a function resolver"
 
-    def function_resolver_with_params(root, info, x: str) -> str:
+    def function_resolver_with_params(root, x: str) -> str:
         return f"I'm {x}"
 
     @strawberry.type
@@ -82,7 +82,7 @@ def test_resolvers_on_types():
     @strawberry.type
     class Query:
         @strawberry.field
-        def example(self, info) -> Example:
+        def example(self) -> Example:
             return Example()
 
     schema = strawberry.Schema(query=Query)
@@ -301,7 +301,7 @@ async def test_async_list_resolver():
     @strawberry.type
     class Query:
         @strawberry.field
-        async def best_flavours(self, info) -> List[str]:
+        async def best_flavours(self) -> List[str]:
             return ["strawberry", "pistachio"]
 
     schema = strawberry.Schema(query=Query)

--- a/tests/schema/test_subscription.py
+++ b/tests/schema/test_subscription.py
@@ -14,7 +14,7 @@ async def test_subscription():
     @strawberry.type
     class Subscription:
         @strawberry.subscription
-        async def example(self, info) -> typing.AsyncGenerator[str, None]:
+        async def example(self) -> typing.AsyncGenerator[str, None]:
             yield "Hi"
 
     schema = strawberry.Schema(query=Query, subscription=Subscription)
@@ -37,7 +37,7 @@ async def test_subscription_with_arguments():
     @strawberry.type
     class Subscription:
         @strawberry.subscription
-        async def example(self, info, name: str) -> typing.AsyncGenerator[str, None]:
+        async def example(self, name: str) -> typing.AsyncGenerator[str, None]:
             yield f"Hi {name}"
 
     schema = strawberry.Schema(query=Query, subscription=Subscription)

--- a/tests/schema/test_union.py
+++ b/tests/schema/test_union.py
@@ -79,7 +79,7 @@ def test_union_as_mutation_return():
     @strawberry.type
     class Mutation:
         @strawberry.mutation
-        def hello(self, info) -> Union[A, B]:
+        def hello(self) -> Union[A, B]:
             return B(y=5)
 
     schema = strawberry.Schema(query=A, mutation=Mutation)
@@ -122,7 +122,7 @@ def test_types_not_included_in_the_union_are_rejected():
     @strawberry.type
     class Mutation:
         @strawberry.mutation
-        def hello(self, info) -> Union[A, B]:
+        def hello(self) -> Union[A, B]:
             return Outside(c=5)  # type:ignore
 
     schema = strawberry.Schema(query=A, mutation=Mutation, types=[Outside])

--- a/tests/schema/types/test_datetime.py
+++ b/tests/schema/types/test_datetime.py
@@ -23,7 +23,7 @@ def test_serialization(typing, instance, serialized):
     @strawberry.type
     class Query:
         @strawberry.field
-        def serialize(self, info) -> typing:
+        def serialize(self) -> typing:
             return instance
 
     schema = strawberry.Schema(Query)
@@ -59,7 +59,7 @@ def test_deserialization(typing, name, instance, serialized):
         deserialized = None
 
         @strawberry.field
-        def deserialize(self, info, arg: typing) -> bool:
+        def deserialize(self, arg: typing) -> bool:
             Query.deserialized = arg
             return True
 
@@ -92,7 +92,7 @@ def test_deserialization_with_parse_literal(typing, instance, serialized):
         deserialized = None
 
         @strawberry.field
-        def deserialize(self, info, arg: typing) -> bool:
+        def deserialize(self, arg: typing) -> bool:
             Query.deserialized = arg
             return True
 

--- a/tests/test_cyclic/type_a.py
+++ b/tests/test_cyclic/type_a.py
@@ -16,7 +16,7 @@ class TypeA:
     ] = None
 
     @strawberry.field()
-    def type_b(self, info) -> strawberry.LazyType["TypeB", "tests.test_cyclic.type_b"]:
+    def type_b(self) -> strawberry.LazyType["TypeB", "tests.test_cyclic.type_b"]:
         from .type_b import TypeB
 
         return TypeB()

--- a/tests/test_cyclic/type_b.py
+++ b/tests/test_cyclic/type_b.py
@@ -12,7 +12,7 @@ if typing.TYPE_CHECKING:
 @strawberry.type
 class TypeB:
     @strawberry.field()
-    def type_a(self, info) -> strawberry.LazyType["TypeA", "tests.test_cyclic.type_a"]:
+    def type_a(self) -> strawberry.LazyType["TypeA", "tests.test_cyclic.type_a"]:
         from .type_a import TypeA
 
         return TypeA()

--- a/tests/types/test_enums.py
+++ b/tests/types/test_enums.py
@@ -61,7 +61,7 @@ def test_can_use_enum_as_arguments():
     @strawberry.type
     class Query:
         @strawberry.field
-        def flavour_available(self, info, flavour: IceCreamFlavour) -> bool:
+        def flavour_available(self, flavour: IceCreamFlavour) -> bool:
             return flavour == IceCreamFlavour.STRAWBERRY
 
     field = Query._type_definition.fields[0]

--- a/tests/types/test_permissions.py
+++ b/tests/types/test_permissions.py
@@ -1,12 +1,15 @@
+from typing import Any
+
 import strawberry
 from strawberry.permission import BasePermission
+from strawberry.types import Info
 
 
 def test_permission_classes_basic_fields():
     class IsAuthenticated(BasePermission):
         message = "User is not authenticated"
 
-        def has_permission(self, source, info):
+        def has_permission(self, source: Any, info: Info, **kwargs) -> bool:
             return False
 
     @strawberry.type
@@ -26,13 +29,13 @@ def test_permission_classes():
     class IsAuthenticated(BasePermission):
         message = "User is not authenticated"
 
-        def has_permission(self, source, info):
+        def has_permission(self, source: Any, info: Info, **kwargs) -> bool:
             return False
 
     @strawberry.type
     class Query:
         @strawberry.field(permission_classes=[IsAuthenticated])
-        def user(self, info) -> str:
+        def user(self) -> str:
             return "patrick"
 
     definition = Query._type_definition

--- a/tests/types/test_resolvers.py
+++ b/tests/types/test_resolvers.py
@@ -51,7 +51,7 @@ def test_raises_error_when_return_annotation_missing():
         @strawberry.type
         class Query:
             @strawberry.field
-            def hello(self, info):
+            def hello(self):
                 return "I'm a resolver"
 
     assert e.value.args == (
@@ -78,7 +78,7 @@ def test_raises_error_when_argument_annotation_missing():
     with pytest.raises(MissingArgumentsAnnotationsError) as e:
 
         @strawberry.field
-        def hello(self, info, query) -> str:
+        def hello(self, query) -> str:
             return "I'm a resolver"
 
     assert e.value.args == (
@@ -89,7 +89,7 @@ def test_raises_error_when_argument_annotation_missing():
     with pytest.raises(MissingArgumentsAnnotationsError) as e:
 
         @strawberry.field
-        def hello2(self, info, query, limit) -> str:
+        def hello2(self, query, limit) -> str:
             return "I'm a resolver"
 
     assert e.value.args == (


### PR DESCRIPTION
This PR adds docs for resolvers and also creates a public `Info` type for the `info` parameter.

Currently it is a subset of the graphql-core so I didn't create a function that converts the original to our version, let me know what you think about that :)

Sorry for the big diff, I went and removed info where it wasn't needed. And added the type where needed :)

Closes #680 