### PR TITLE
Enable .(dot) notation in the get_context of the django views.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,4 +193,5 @@ $RECYCLE.BIN/
 # End of https://www.gitignore.io/api/macos,linux,python,windows
 
 .vscode/
+.idea/
 node_modules/

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: minor
+
+Enable dot notation for django context request

--- a/docs/integrations/django.md
+++ b/docs/integrations/django.md
@@ -41,8 +41,17 @@ We allow to extend the base `GraphQLView`, by overriding the following methods:
 ## get_context
 
 `get_context` allows to provide a custom context object that can be used in your
-resolver. You can return anything here, by default we return a dictionary with
-the request.
+resolver. You can return anything here, by default we return a `StrawberryDjangoContext` object.
+
+```python
+@strawberry.type
+class Query:
+    @strawberry.field
+    def user(self, info: Info) -> str:
+        return str(info.context.request.user)
+```
+
+or in case of a custom context:
 
 ```python
 class MyGraphQLView(GraphQLView):

--- a/strawberry/django/context.py
+++ b/strawberry/django/context.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+
+from django.http import HttpRequest
+
+
+@dataclass
+class StrawberryDjangoContext:
+    request: HttpRequest
+
+    def __getitem__(self, key):
+        return super().__getattribute__(key)

--- a/strawberry/django/views.py
+++ b/strawberry/django/views.py
@@ -20,6 +20,7 @@ from strawberry.types import ExecutionResult
 from strawberry.types.execution import ExecutionContext
 
 from ..schema import BaseSchema
+from .context import StrawberryDjangoContext
 
 
 class BaseView(View):
@@ -92,7 +93,7 @@ class GraphQLView(BaseView):
         return None
 
     def get_context(self, request: HttpRequest) -> Any:
-        return {"request": request}
+        return StrawberryDjangoContext(request)
 
     def process_result(
         self, request: HttpRequest, result: ExecutionResult

--- a/tests/django/test_views.py
+++ b/tests/django/test_views.py
@@ -35,6 +35,20 @@ class Query:
         return Example.objects.first().name
 
 
+@strawberry.type
+class GetRequestValueWithDotNotaionQuery:
+    @strawberry.field
+    def get_request_value(self, info: Info) -> str:
+        return info.context.request
+
+
+@strawberry.type
+class GetRequestValueQuery:
+    @strawberry.field
+    def get_request_value(self, info: Info) -> str:
+        return info.context["request"]
+
+
 schema = strawberry.Schema(query=Query)
 
 
@@ -141,13 +155,29 @@ def test_returns_errors_and_data():
     assert data["errors"][0]["message"] == "You are not authorized"
 
 
+@pytest.mark.parametrize(
+    "query", (GetRequestValueWithDotNotaionQuery, GetRequestValueQuery)
+)
+def test_strawberry_django_context(query):
+    factory = RequestFactory()
+
+    schema = strawberry.Schema(query=query)
+
+    query = "{ getRequestValue }"
+    request = factory.post(
+        "/graphql/", {"query": query}, content_type="application/json"
+    )
+
+    response = GraphQLView.as_view(schema=schema)(request)
+    data = json.loads(response.content.decode())
+    assert response.status_code == 200
+    assert data["data"] == {"getRequestValue": "<WSGIRequest: POST '/graphql/'>"}
+
+
 def test_custom_context():
     class CustomGraphQLView(BaseGraphQLView):
         def get_context(self, request):
-            return {
-                "request": request,
-                "custom_value": "Hi!",
-            }
+            return {"request": request, "custom_value": "Hi!"}
 
     factory = RequestFactory()
 

--- a/tests/django/test_views.py
+++ b/tests/django/test_views.py
@@ -36,7 +36,7 @@ class Query:
 
 
 @strawberry.type
-class GetRequestValueWithDotNotaionQuery:
+class GetRequestValueWithDotNotationQuery:
     @strawberry.field
     def get_request_value(self, info: Info) -> str:
         return info.context.request
@@ -156,7 +156,7 @@ def test_returns_errors_and_data():
 
 
 @pytest.mark.parametrize(
-    "query", (GetRequestValueWithDotNotaionQuery, GetRequestValueQuery)
+    "query", (GetRequestValueWithDotNotationQuery, GetRequestValueQuery)
 )
 def test_strawberry_django_context(query):
     factory = RequestFactory()


### PR DESCRIPTION
## Description
Currently the request coming from the `context` object within the `get_context`  in `views.py` in the `django` module, is a dict which can be accessed via standard python syntax. This PR adds the dot notation to the `request` object.
```python3
>>> context = {"request": "hi"}
>>> print(context.request)
hi
>>> print(context["request"]
hi
```
__Note: this works with nested dict too__


## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement/optimization
- [x] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
- [X] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
