### PR TITLE
Bug fix: allow .get in context request as well as [] notation

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Enable using .get for django context as well as for the square brackets notation.

--- a/strawberry/django/context.py
+++ b/strawberry/django/context.py
@@ -8,4 +8,10 @@ class StrawberryDjangoContext:
     request: HttpRequest
 
     def __getitem__(self, key):
+        # __getitem__ override needed to avoid issues for who's
+        # using info.context["request"]
+        return super().__getattribute__(key)
+
+    def get(self, key):
+        """Enable .get notation for accessing the request"""
         return super().__getattribute__(key)

--- a/tests/django/test_views.py
+++ b/tests/django/test_views.py
@@ -43,6 +43,13 @@ class GetRequestValueWithDotNotationQuery:
 
 
 @strawberry.type
+class GetRequestValueUsingGetQuery:
+    @strawberry.field
+    def get_request_value(self, info: Info) -> str:
+        return info.context.get("request")
+
+
+@strawberry.type
 class GetRequestValueQuery:
     @strawberry.field
     def get_request_value(self, info: Info) -> str:
@@ -156,7 +163,12 @@ def test_returns_errors_and_data():
 
 
 @pytest.mark.parametrize(
-    "query", (GetRequestValueWithDotNotationQuery, GetRequestValueQuery)
+    "query",
+    (
+        GetRequestValueWithDotNotationQuery,
+        GetRequestValueUsingGetQuery,
+        GetRequestValueQuery,
+    ),
 )
 def test_strawberry_django_context(query):
     factory = RequestFactory()


### PR DESCRIPTION
## Description

This PR fixes issues for who is using `.get` notation for accessing the `django.context.request`

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
