### PR TITLE
Add optional response to ASGI app context

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+Release type: patch
+
+This release updates `get_context` in the asgi integration to also
+receive a temporal response object that can be used to set headers
+and cookies.

--- a/docs/integrations/asgi.md
+++ b/docs/integrations/asgi.md
@@ -27,7 +27,7 @@ The `GraphQL` app accepts two options at the moment:
 
 We allow to extend the base `GraphQL` app, by overriding the following methods:
 
-- `async get_context(self, request: Union[Request, WebSocket]) -> Any`
+- `async get_context(self, request: Union[Request, WebSocket], response: typing.Optional[Response] = None) -> Any`
 - `async get_root_value(self, request: Request) -> Any`
 - `async process_result(self, request: Request, result: ExecutionResult) -> GraphQLHTTPResponse`
 
@@ -35,11 +35,11 @@ We allow to extend the base `GraphQL` app, by overriding the following methods:
 
 `get_context` allows to provide a custom context object that can be used in your
 resolver. You can return anything here, by default we return a dictionary with
-the request.
+the request and the response.
 
-```python
+```python3
 class MyGraphQL(GraphQL):
-    async def get_context(self, request: Union[Request, WebSocket]) -> Any:
+    async def get_context(self, request: Union[Request, WebSocket], response: Optional[Response]) -> Any:
         return {"example": 1}
 
 
@@ -55,6 +55,23 @@ called "example".
 
 Then we use the context in a resolver, the resolver will return "1" in this
 case.
+
+### Setting response headers
+
+It is possible to use `get_context` to set response headers. A common use case might be cookie-based user authentication,
+where your login mutation resolver needs to respond with e.g. `Set-Cookie: token=secret-token`.
+
+This is possible by updating the response dict contained inside of the `Info` object.
+
+```python3
+@strawberry.type
+class Mutation:
+    @strawberry.field
+    def login(self, info: Info) -> bool:
+        token = do_login()
+        info.context["response"].set_cookie(key="token", value=token)
+        return True
+```
 
 ## get_root_value
 

--- a/docs/integrations/asgi.md
+++ b/docs/integrations/asgi.md
@@ -27,7 +27,7 @@ The `GraphQL` app accepts two options at the moment:
 
 We allow to extend the base `GraphQL` app, by overriding the following methods:
 
-- `async get_context(self, request: Union[Request, WebSocket], response: typing.Optional[Response] = None) -> Any`
+- `async get_context(self, request: Union[Request, WebSocket], response: Optional[Response] = None) -> Any`
 - `async get_root_value(self, request: Request) -> Any`
 - `async process_result(self, request: Request, result: ExecutionResult) -> GraphQLHTTPResponse`
 
@@ -61,7 +61,7 @@ case.
 It is possible to use `get_context` to set response headers. A common use case might be cookie-based user authentication,
 where your login mutation resolver needs to set a cookie on the response.
 
-This is possible by updating the response dict contained inside of the `Info` object.
+This is possible by updating the response object contained inside the context of the `Info` object.
 
 ```python
 @strawberry.type

--- a/docs/integrations/asgi.md
+++ b/docs/integrations/asgi.md
@@ -59,7 +59,7 @@ case.
 ### Setting response headers
 
 It is possible to use `get_context` to set response headers. A common use case might be cookie-based user authentication,
-where your login mutation resolver needs to respond with e.g. `Set-Cookie: token=secret-token`.
+where your login mutation resolver needs to set a cookie on the response.
 
 This is possible by updating the response dict contained inside of the `Info` object.
 

--- a/docs/integrations/asgi.md
+++ b/docs/integrations/asgi.md
@@ -37,7 +37,7 @@ We allow to extend the base `GraphQL` app, by overriding the following methods:
 resolver. You can return anything here, by default we return a dictionary with
 the request and the response.
 
-```python3
+```python
 class MyGraphQL(GraphQL):
     async def get_context(self, request: Union[Request, WebSocket], response: Optional[Response]) -> Any:
         return {"example": 1}
@@ -63,7 +63,7 @@ where your login mutation resolver needs to set a cookie on the response.
 
 This is possible by updating the response dict contained inside of the `Info` object.
 
-```python3
+```python
 @strawberry.type
 class Mutation:
     @strawberry.mutation

--- a/docs/integrations/asgi.md
+++ b/docs/integrations/asgi.md
@@ -66,7 +66,7 @@ This is possible by updating the response dict contained inside of the `Info` ob
 ```python3
 @strawberry.type
 class Mutation:
-    @strawberry.field
+    @strawberry.mutation
     def login(self, info: Info) -> bool:
         token = do_login()
         info.context["response"].set_cookie(key="token", value=token)

--- a/strawberry/asgi/__init__.py
+++ b/strawberry/asgi/__init__.py
@@ -4,6 +4,7 @@ import typing
 from starlette.requests import Request
 from starlette.types import Receive, Scope, Send
 from starlette.websockets import WebSocket, WebSocketDisconnect, WebSocketState
+from starlette.responses import Response
 
 from graphql import GraphQLError
 from graphql.error import format_error as format_graphql_error
@@ -54,9 +55,9 @@ class GraphQL:
         return None
 
     async def get_context(
-        self, request: typing.Union[Request, WebSocket]
+        self, request: typing.Union[Request, WebSocket], response: typing.Optional[Response] = None
     ) -> typing.Optional[typing.Any]:
-        return {"request": request}
+        return {"request": request, "response": response}
 
     async def handle_keep_alive(self, websocket):
         if (
@@ -191,7 +192,16 @@ class GraphQL:
     async def handle_http(self, scope: Scope, receive: Receive, send: Send):
         request = Request(scope=scope, receive=receive)
         root_value = await self.get_root_value(request)
-        context = await self.get_context(request)
+
+        sub_response = Response(
+            content=None,
+            status_code=None,
+            headers=None,
+            media_type=None,
+            background=None,
+        )
+
+        context = await self.get_context(request=request, response=sub_response)
 
         response = await get_http_response(
             request=request,
@@ -201,6 +211,11 @@ class GraphQL:
             root_value=root_value,
             context=context,
         )
+
+        response.headers.raw.extend(sub_response.headers.raw)
+
+        if sub_response.status_code:
+            response.status_code = sub_response.status_code
 
         await response(scope, receive, send)
 

--- a/strawberry/asgi/__init__.py
+++ b/strawberry/asgi/__init__.py
@@ -2,9 +2,9 @@ import asyncio
 import typing
 
 from starlette.requests import Request
+from starlette.responses import Response
 from starlette.types import Receive, Scope, Send
 from starlette.websockets import WebSocket, WebSocketDisconnect, WebSocketState
-from starlette.responses import Response
 
 from graphql import GraphQLError
 from graphql.error import format_error as format_graphql_error
@@ -55,7 +55,9 @@ class GraphQL:
         return None
 
     async def get_context(
-        self, request: typing.Union[Request, WebSocket], response: typing.Optional[Response] = None
+        self,
+        request: typing.Union[Request, WebSocket],
+        response: typing.Optional[Response] = None,
     ) -> typing.Optional[typing.Any]:
         return {"request": request, "response": response}
 
@@ -195,7 +197,7 @@ class GraphQL:
 
         sub_response = Response(
             content=None,
-            status_code=None,
+            status_code=None,  # type: ignore
             headers=None,
             media_type=None,
             background=None,

--- a/tests/asgi/test_query.py
+++ b/tests/asgi/test_query.py
@@ -66,9 +66,8 @@ def test_context_response():
         @strawberry.field
         def something(self, info: Info) -> str:
             r = info.context["response"]
-            r.raw_headers.append((b'x-bar', b'bar'))
-            print(r.raw_headers)
-            return 'foo'
+            r.raw_headers.append((b"x-bar", b"bar"))
+            return "foo"
 
     schema = strawberry.Schema(query=Query)
     app = BaseGraphQL(schema)
@@ -78,7 +77,26 @@ def test_context_response():
 
     assert response.status_code == 200
     assert response.json() == {"data": {"something": "foo"}}
-    assert response.headers.get('x-bar') == 'bar'
+    assert response.headers.get("x-bar") == "bar"
+
+
+def test_can_set_custom_status_code():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def something(self, info: Info) -> str:
+            r = info.context["response"]
+            r.status_code = 418
+            return "foo"
+
+    schema = strawberry.Schema(query=Query)
+    app = BaseGraphQL(schema)
+
+    test_client = TestClient(app)
+    response = test_client.post("/", json={"query": "{ something }"})
+
+    assert response.status_code == 418
+    assert response.json() == {"data": {"something": "foo"}}
 
 
 def test_custom_context():

--- a/tests/asgi/test_query.py
+++ b/tests/asgi/test_query.py
@@ -60,6 +60,27 @@ def test_root_value(schema, test_client):
     assert response.json() == {"data": {"rootName": "Query"}}
 
 
+def test_context_response():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def something(self, info: Info) -> str:
+            r = info.context["response"]
+            r.raw_headers.append((b'x-bar', b'bar'))
+            print(r.raw_headers)
+            return 'foo'
+
+    schema = strawberry.Schema(query=Query)
+    app = BaseGraphQL(schema)
+
+    test_client = TestClient(app)
+    response = test_client.post("/", json={"query": "{ something }"})
+
+    assert response.status_code == 200
+    assert response.json() == {"data": {"something": "foo"}}
+    assert response.headers.get('x-bar') == 'bar'
+
+
 def test_custom_context():
     class CustomGraphQL(BaseGraphQL):
         async def get_context(self, request, response):

--- a/tests/asgi/test_query.py
+++ b/tests/asgi/test_query.py
@@ -62,7 +62,7 @@ def test_root_value(schema, test_client):
 
 def test_custom_context():
     class CustomGraphQL(BaseGraphQL):
-        async def get_context(self, request):
+        async def get_context(self, request, response):
             return {
                 "request": request,
                 "custom_context_value": "Hi!",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Resolves https://github.com/strawberry-graphql/strawberry/issues/748.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

HTTP requests to the strawberry GraphQL ASGI application server can now pre-set HTTP _response_ headers, useful for setting HTTP response headers e.g. `Set-Cookie: my-login-cookie-token-thing`, so that auth-related operations can be handled via GraphQL mutations.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
