### PR TITLE
Fix bug with using arguments with generics

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Fix bug when using arguments inside a type that uses typing.Generics

--- a/strawberry/types/generics.py
+++ b/strawberry/types/generics.py
@@ -1,12 +1,11 @@
 import builtins
-import dataclasses
 from typing import Dict, Iterable, Tuple, Type, Union, cast
 
 from strawberry.union import StrawberryUnion, union
 from strawberry.utils.str_converters import capitalize_first
 from strawberry.utils.typing import is_type_var, is_union
 
-from .types import FederationFieldParams, FieldDefinition, TypeDefinition
+from .types import FieldDefinition, TypeDefinition
 
 
 def get_name_from_types(types: Iterable[Union[Type, StrawberryUnion]]):
@@ -74,7 +73,7 @@ def copy_type_with(
             name = get_name_from_types(params_to_type.values()) + definition.name
 
             for field in definition.fields:
-                kwargs = dataclasses.asdict(field)
+                kwargs = field.__dict__.copy()
 
                 if field.is_list:
                     child = cast(FieldDefinition, field.child)
@@ -96,9 +95,6 @@ def copy_type_with(
                     kwargs["type"] = copy_type_with(
                         field_type, params_to_type=params_to_type
                     )
-
-                federation_args = kwargs.pop("federation")
-                kwargs["federation"] = FederationFieldParams(**federation_args)
 
                 fields.append(FieldDefinition(**kwargs))
 

--- a/tests/types/test_generic.py
+++ b/tests/types/test_generic.py
@@ -671,3 +671,33 @@ def test_generic_with_arguments():
     assert type_definition.fields[0].arguments[0].name == "ids"
     assert type_definition.fields[0].arguments[0].is_list
     assert type_definition.fields[0].arguments[0].child.type == int
+
+
+def test_federation():
+    @strawberry.federation.type(keys=["id"])
+    class Edge(Generic[T]):
+        id: strawberry.ID
+        node_field: T
+
+    definition = Edge._type_definition
+
+    Copy = copy_type_with(Edge, str)
+
+    definition = Copy._type_definition
+
+    assert definition.name == "StrEdge"
+    assert definition.is_generic is False
+    assert definition.type_params == {}
+
+    assert len(definition.fields) == 2
+
+    assert definition.fields[0].name == "id"
+    assert definition.fields[0].type == strawberry.ID
+    assert definition.fields[0].is_optional is False
+
+    assert definition.fields[1].name == "nodeField"
+    assert definition.fields[1].type == str
+    assert definition.fields[1].is_optional is False
+
+    assert definition.federation.keys == ["id"]
+    assert definition.federation.extend is False

--- a/tests/types/test_generic.py
+++ b/tests/types/test_generic.py
@@ -635,3 +635,39 @@ def test_using_generics_with_interfaces():
     assert definition.fields[0].type._type_definition.is_generic is False
     assert definition.fields[0].type._type_definition.fields[0].name == "node"
     assert definition.fields[0].type._type_definition.fields[0].type == WithName
+
+
+def test_generic_with_arguments():
+    T = TypeVar("T")
+
+    @strawberry.type
+    class Collection(Generic[T]):
+        @strawberry.field
+        def by_id(self, ids: List[int]) -> List[T]:
+            return []
+
+    @strawberry.type
+    class Post:
+        name: str
+
+    @strawberry.type
+    class Query:
+        user: Collection[Post]
+
+    definition = Query._type_definition
+
+    assert definition.name == "Query"
+    assert len(definition.fields) == 1
+
+    assert definition.fields[0].name == "user"
+
+    type_definition = definition.fields[0].type._type_definition
+
+    assert type_definition.name == "PostCollection"
+    assert type_definition.is_generic is False
+    assert type_definition.fields[0].name == "byId"
+    assert type_definition.fields[0].is_list
+    assert type_definition.fields[0].child.type == Post
+    assert type_definition.fields[0].arguments[0].name == "ids"
+    assert type_definition.fields[0].arguments[0].is_list
+    assert type_definition.fields[0].arguments[0].child.type == int


### PR DESCRIPTION
## Description

Currently generics work by copying the fields using the `dataclasses.asdict` method. However this method recursively converts all the fields of the dataclass into dictionaries. This results in a TypeError when constructing the schema where the code assumes the `arguments` attribute is an instance of `ArgumentDefinition` but it's now a dictionary.

This code fixes the error by replacing the use of `asdict` with `__dict__` so that it only converts one level deep.

Additionally this means that the workaround where the `FederationFieldParams` type is constructed again can be removed.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #757 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
