### PR TITLE
Combine sync and async resolvers into single function

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+release type: patch
+
+This releases changes how we define resolvers internally, now we have one single resolver for async and sync code.

--- a/strawberry/resolvers.py
+++ b/strawberry/resolvers.py
@@ -95,31 +95,22 @@ def get_resolver(field: FieldDefinition) -> Callable:
                 message = getattr(permission, "message", None)
                 raise PermissionError(message)
 
-    async def _resolver_async(source, info: Info, **kwargs):
+    def _resolver(source, info: Info, **kwargs):
         _check_permissions(source, info, **kwargs)
 
         result = get_result_for_field(field, kwargs=kwargs, info=info, source=source)
 
         if iscoroutine(result):  # pragma: no cover
-            result = await result
+
+            async def await_result(result):
+                result = await result
+                result = convert_enums_to_values(field, result)
+                return result
+
+            return await_result(result)
 
         result = convert_enums_to_values(field, result)
-
         return result
 
-    def _resolver(source, info, **kwargs):
-        _check_permissions(source, info, **kwargs)
-
-        result = get_result_for_field(field, kwargs=kwargs, info=info, source=source)
-        result = convert_enums_to_values(field, result)
-
-        return result
-
-    _resolver_async._is_default = not field.base_resolver  # type: ignore
     _resolver._is_default = not field.base_resolver  # type: ignore
-
-    return (
-        _resolver_async
-        if field.base_resolver and field.base_resolver.is_async
-        else _resolver
-    )
+    return _resolver


### PR DESCRIPTION
After this the resolver can be sync or async function and type is
detected at runtime and not at schema conversion time as before.

This is internal change and not affecting to API.

GraphQL library uses the same logic here: https://github.com/graphql-python/graphql-core/blob/main/src/graphql/execution/execute.py#L640