### PR TITLE
[graphiql] Attach CSRF token w/ requests to server

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Configures GraphiQL to attach CSRF cookies as request headers sent to the GQL server.

--- a/strawberry/static/graphiql.html
+++ b/strawberry/static/graphiql.html
@@ -32,6 +32,7 @@
     <script src="https://cdn.jsdelivr.net/npm/graphiql-with-extensions@0.14.3/graphiqlWithExtensions.min.js"
         integrity="sha384-TqI6gT2PjmSrnEOTvGHLad1U4Vm5VoyzMmcKK0C/PLCWTnwPyXhCJY6NYhC/tp19"
         crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/js-cookie@rc/dist/js.cookie.min.js"></script>
 
     <!-- breaking changes in subscriptions-transport-ws since 0.9.0 -->
     <script src="https://cdn.jsdelivr.net/npm/subscriptions-transport-ws@0.8.3/browser/client.js"></script>
@@ -52,6 +53,11 @@
                 Accept: 'application/json',
                 'Content-Type': 'application/json',
             };
+
+            var csrfToken = Cookies.get('csrftoken');
+            if (csrfToken) {
+              headers['x-csrftoken'] = csrfToken;
+            }
 
             return fetch(fetchURL, {
                 method: 'post',


### PR DESCRIPTION
## Description

We are using Strawberry w/ GraphiQL enabled ("dev" mode IIRC) in our development cluster.

It's a minikube cluster where our goal is to replicate production environment as much as possible.

One such prod consideration is CSRF as we use cookie-based session authentication.

We have configured our backend accordingly to verify CSRF tokens presented from clients; in order to continue to make use of the GraphiQL interface as we are actively developing our GraphQL API/backend, we need to send the CSRF token w/ requests originating from `https://our-domain.com/api/` in the browser (this corresponds to the page that renders our GraphiQL interface).