### PR TITLE
Fix content type in django view

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+This release fixes a regression with the django sending the wrong content type.

--- a/strawberry/django/views.py
+++ b/strawberry/django/views.py
@@ -24,8 +24,11 @@ from ..schema import BaseSchema
 from .context import StrawberryDjangoContext
 
 
-class TemporalHttpResponse(HttpResponse):
+class TemporalHttpResponse(JsonResponse):
     status_code = None
+
+    def __init__(self) -> None:
+        super().__init__({})
 
 
 class BaseView(View):

--- a/tests/django/test_views.py
+++ b/tests/django/test_views.py
@@ -119,6 +119,7 @@ def test_graphql_query():
     response = GraphQLView.as_view(schema=schema)(request)
     data = json.loads(response.content.decode())
 
+    assert response["content-type"] == "application/json"
     assert data["data"]["hello"] == "strawberry"
 
 


### PR DESCRIPTION
This fixes the content type for the django view, as mentioned here 
https://github.com/strawberry-graphql/strawberry/pull/773
I introduced a regression that made the view return content type as HTML
