### PR TITLE
Disable fail fast tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ known_first_party = ["strawberry"]
 sections = ["FUTURE", "STDLIB", "PYTEST", "THIRDPARTY", "DJANGO", "GRAPHQL", "FIRSTPARTY", "LOCALFOLDER"]
 
 [tool.pytest.ini_options]
-addopts = "-xs --emoji --mypy-ini-file=mypy_tests.ini --benchmark-disable"
+addopts = "-s --emoji --mypy-ini-file=mypy_tests.ini --benchmark-disable"
 DJANGO_SETTINGS_MODULE = "tests.django.django_settings"
 testpaths = ["tests/"]
 [build-system]


### PR DESCRIPTION
Fail fast tests don't make a lot of sense on CI, so let's disable them
