### PR TITLE
Expose Strawberry info in resolvers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,10 @@
 name: Backend tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
   unit-tests:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: minor
+
+Expose Strawberry Info object instead of GraphQLResolveInfo in resolvers

--- a/docs/types/resolvers.md
+++ b/docs/types/resolvers.md
@@ -192,14 +192,15 @@ Info objects contain information for the current execution context:
 
 `class Info(Generic[ContextType, RootValueType])`
 
-| Parameter name  | Type                      | Description                                                           |
-| --------------- | ------------------------- | --------------------------------------------------------------------- |
-| field_name      | `str`                     | The name of the current field                                         |
-| context         | `ContextType`             | The value of the context                                              |
-| root_value      | `RootValueType`           | The value for the root type                                           |
-| variable_values | `Dict[str, Any]`          | The variables for this operation                                      |
-| operation       | `OperationDefinitionNode` | The ast for the current operation (public API might change in future) |
-| path            | `Path`                    | The path for the current field                                        |
+| Parameter name  | Type                                     | Description                                                           |
+| --------------- | ---------------------------------------- | --------------------------------------------------------------------- |
+| field_name      | `str`                                    | The name of the current field                                         |
+| context         | `ContextType`                            | The value of the context                                              |
+| root_value      | `RootValueType`                          | The value for the root type                                           |
+| variable_values | `Dict[str, Any]`                         | The variables for this operation                                      |
+| operation       | `OperationDefinitionNode`                | The ast for the current operation (public API might change in future) |
+| path            | `Path`                                   | The path for the current field                                        |
+| return_type     | `Optional[Union[Type, StrawberryUnion]]` | The return type of this operation                                     |
 
 [^1]:
     see

--- a/docs/types/resolvers.md
+++ b/docs/types/resolvers.md
@@ -192,15 +192,14 @@ Info objects contain information for the current execution context:
 
 `class Info(Generic[ContextType, RootValueType])`
 
-| Parameter name  | Type                                     | Description                                                           |
-| --------------- | ---------------------------------------- | --------------------------------------------------------------------- |
-| field_name      | `str`                                    | The name of the current field                                         |
-| context         | `ContextType`                            | The value of the context                                              |
-| root_value      | `RootValueType`                          | The value for the root type                                           |
-| variable_values | `Dict[str, Any]`                         | The variables for this operation                                      |
-| operation       | `OperationDefinitionNode`                | The ast for the current operation (public API might change in future) |
-| path            | `Path`                                   | The path for the current field                                        |
-| return_type     | `Optional[Union[Type, StrawberryUnion]]` | The return type of this operation                                     |
+| Parameter name  | Type                      | Description                                                           |
+| --------------- | ------------------------- | --------------------------------------------------------------------- |
+| field_name      | `str`                     | The name of the current field                                         |
+| context         | `ContextType`             | The value of the context                                              |
+| root_value      | `RootValueType`           | The value for the root type                                           |
+| variable_values | `Dict[str, Any]`          | The variables for this operation                                      |
+| operation       | `OperationDefinitionNode` | The ast for the current operation (public API might change in future) |
+| path            | `Path`                    | The path for the current field                                        |
 
 [^1]:
     see

--- a/strawberry/resolvers.py
+++ b/strawberry/resolvers.py
@@ -2,6 +2,8 @@ import enum
 from inspect import iscoroutine
 from typing import Any, Awaitable, Callable, Dict, List, Tuple, Union, cast
 
+from graphql import GraphQLResolveInfo
+
 from strawberry.types.info import Info
 
 from .arguments import convert_arguments
@@ -95,10 +97,13 @@ def get_resolver(field: FieldDefinition) -> Callable:
                 message = getattr(permission, "message", None)
                 raise PermissionError(message)
 
-    def _resolver(source, info: Info, **kwargs):
-        _check_permissions(source, info, **kwargs)
+    def _resolver(source, info: GraphQLResolveInfo, **kwargs):
+        strawberry_info = strawberry_info_from_graphql(field, info)
+        _check_permissions(source, strawberry_info, **kwargs)
 
-        result = get_result_for_field(field, kwargs=kwargs, info=info, source=source)
+        result = get_result_for_field(
+            field, kwargs=kwargs, info=strawberry_info, source=source
+        )
 
         if iscoroutine(result):  # pragma: no cover
 
@@ -114,3 +119,17 @@ def get_resolver(field: FieldDefinition) -> Callable:
 
     _resolver._is_default = not field.base_resolver  # type: ignore
     return _resolver
+
+
+def strawberry_info_from_graphql(
+    field: FieldDefinition, info: GraphQLResolveInfo
+) -> Info:
+    return Info(
+        field_name=info.field_name,
+        context=info.context,
+        root_value=info.root_value,
+        variable_values=info.variable_values,
+        return_type=field.type,
+        operation=info.operation,
+        path=info.path,
+    )

--- a/strawberry/types/info.py
+++ b/strawberry/types/info.py
@@ -1,8 +1,10 @@
 import dataclasses
-from typing import Any, Dict, Generic, TypeVar
+from typing import Any, Dict, Generic, Optional, Type, TypeVar, Union
 
 from graphql import OperationDefinitionNode
 from graphql.pyutils.path import Path
+
+from strawberry.union import StrawberryUnion
 
 
 ContextType = TypeVar("ContextType")
@@ -15,7 +17,9 @@ class Info(Generic[ContextType, RootValueType]):
     context: ContextType
     root_value: RootValueType
     variable_values: Dict[str, Any]
+    # TODO: update to StrawberryType once it's implemented
+    return_type: Optional[Union[Type, StrawberryUnion]]
     # TODO: create an abstraction on these fields
     operation: OperationDefinitionNode
     path: Path
-    # TODO: parent_type, return_type as strawberry types
+    # TODO: parent_type as strawberry types

--- a/tests/schema/test_info.py
+++ b/tests/schema/test_info.py
@@ -14,6 +14,7 @@ def test_info_has_the_correct_shape():
         variable_values: str
         context_equal: bool
         root_equal: bool
+        return_type: str
 
     @strawberry.type
     class Query:
@@ -26,6 +27,7 @@ def test_info_has_the_correct_shape():
                 variable_values=str(info.variable_values),
                 context_equal=info.context == my_context,
                 root_equal=info.root_value == root_value,
+                return_type=str(info.return_type),
             )
 
     schema = strawberry.Schema(query=Query)
@@ -38,6 +40,7 @@ def test_info_has_the_correct_shape():
             path
             rootEqual
             variableValues
+            returnType
         }
     }"""
 
@@ -46,10 +49,11 @@ def test_info_has_the_correct_shape():
     assert not result.errors
     assert result.data["hello"] == {
         # TODO: abstract this (in future)
-        "operation": "OperationDefinitionNode at 0:168",
+        "operation": "OperationDefinitionNode at 0:191",
         "fieldName": "hello",
         "path": "hello",
         "contextEqual": True,
         "rootEqual": True,
         "variableValues": "{}",
+        "returnType": "<class 'tests.schema.test_info.test_info_has_the_correct_shape.<locals>.Result'>",  # noqa
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Resolvers should receive the Strawberry info instead of the GraphQL Info

This means that the resolver info will receive the strawberry types instead of GraphQL types


## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist


- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
