### PR TITLE
[ Django ] Raise exception when JSON parsing fails within the parse_body method

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Raise exception when un-serializable payload is provided to the Django view.

--- a/strawberry/django/views.py
+++ b/strawberry/django/views.py
@@ -57,7 +57,10 @@ class BaseView(View):
         return "text/html" in request.META.get("HTTP_ACCEPT", "")
 
     def get_execution_context(self, request: HttpRequest) -> ExecutionContext:
-        data = self.parse_body(request)
+        try:
+            data = self.parse_body(request)
+        except json.decoder.JSONDecodeError:
+            raise SuspiciousOperation("Unable to parse request body as JSON")
 
         try:
             query = data["query"]

--- a/tests/django/test_async_view.py
+++ b/tests/django/test_async_view.py
@@ -94,7 +94,7 @@ async def test_fails_when_not_sending_query():
     with pytest.raises(SuspiciousOperation) as e:
         await AsyncGraphQLView.as_view(schema=schema)(request)
 
-        assert e.value.args == ("No GraphQL query found in the request",)
+    assert e.value.args == ("No GraphQL query found in the request",)
 
 
 async def test_fails_when_request_body_has_invalid_json():

--- a/tests/django/test_async_view.py
+++ b/tests/django/test_async_view.py
@@ -97,6 +97,19 @@ async def test_fails_when_not_sending_query():
         assert e.value.args == ("No GraphQL query found in the request",)
 
 
+async def test_fails_when_request_body_has_invalid_json():
+    factory = RequestFactory()
+
+    request = factory.post(
+        "/graphql/", "definitely-not-json-string", content_type="application/json"
+    )
+
+    with pytest.raises(SuspiciousOperation) as e:
+        await AsyncGraphQLView.as_view(schema=schema, graphiql=False)(request)
+
+    assert e.value.args == ("Unable to parse request body as JSON",)
+
+
 @pytest.mark.django_db
 async def test_async_graphql_query_model():
     prepare_db = sync_to_async(

--- a/tests/django/test_views.py
+++ b/tests/django/test_views.py
@@ -96,7 +96,7 @@ def test_fails_when_not_sending_query():
     with pytest.raises(SuspiciousOperation) as e:
         GraphQLView.as_view(schema=schema, graphiql=False)(request)
 
-        assert e.value.args == ("No GraphQL query found in the request",)
+    assert e.value.args == ("No GraphQL query found in the request",)
 
 
 def test_fails_when_request_body_has_invalid_json():

--- a/tests/django/test_views.py
+++ b/tests/django/test_views.py
@@ -99,6 +99,19 @@ def test_fails_when_not_sending_query():
         assert e.value.args == ("No GraphQL query found in the request",)
 
 
+def test_fails_when_request_body_has_invalid_json():
+    factory = RequestFactory()
+
+    request = factory.post(
+        "/graphql/", "definitely-not-json-string", content_type="application/json"
+    )
+
+    with pytest.raises(SuspiciousOperation) as e:
+        GraphQLView.as_view(schema=schema, graphiql=False)(request)
+
+    assert e.value.args == ("Unable to parse request body as JSON",)
+
+
 def test_graphiql_disabled_view():
     factory = RequestFactory()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Raising exception when invalid, non parsable JSON provided to the Django integration.

Added a catch block for the parse_body method, catching the parsing exceptions and raised:
```python
SuspiciousOperation("Unable to parse request body as JSON")
```

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #756 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [X] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
