### PR TITLE
[sanic] Enable async get_context

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Change `get_context` to be async for sanic integration

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,3 @@
-Release type: patch
+Release type: minor
 
 Change `get_context` to be async for sanic integration

--- a/docs/integrations/sanic.md
+++ b/docs/integrations/sanic.md
@@ -32,7 +32,7 @@ The `GraphQLView` accepts two options at the moment:
 
 The base `GraphQLView` class can be extended by overriding the following methods:
 
-- `get_context(self) -> Any`
+- `async get_context(self) -> Any`
 - `get_root_value(self) -> Any`
 - `process_result(self, result: ExecutionResult) -> GraphQLHTTPResponse`
 
@@ -44,7 +44,7 @@ dictionary with the request.
 
 ```python
 class MyGraphQLView(GraphQLView):
-    def get_context(self, request) -> Any:
+    async def get_context(self, request) -> Any:
         return {"example": 1}
 
 

--- a/strawberry/sanic/views.py
+++ b/strawberry/sanic/views.py
@@ -40,7 +40,7 @@ class GraphQLView(HTTPMethodView):
     def get_root_value(self):
         return None
 
-    def get_context(self, request: Request) -> Any:
+    async def get_context(self, request: Request) -> Any:
         return StrawberrySanicContext(request)
 
     def render_template(self, template=None):
@@ -70,7 +70,7 @@ class GraphQLView(HTTPMethodView):
 
         variables = data.get("variables")
         operation_name = data.get("operationName")
-        context = self.get_context(request)
+        context = await self.get_context(request)
 
         result = await self.schema.execute(
             query,

--- a/tests/sanic/test_view.py
+++ b/tests/sanic/test_view.py
@@ -64,7 +64,7 @@ def test_graphiql_disabled_view():
 
 def test_custom_context():
     class CustomGraphQLView(BaseGraphQLView):
-        def get_context(self, request):
+        async def get_context(self, request):
             return {"request": request, "custom_value": "Hi!"}
 
     @strawberry.type


### PR DESCRIPTION
## Description

Allows `get_context` function in `GraphQLView` to be async.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
