### PR TITLE
Include `field_nodes` in Strawberry info object.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Include `field_nodes` in Strawberry info object.

--- a/strawberry/resolvers.py
+++ b/strawberry/resolvers.py
@@ -126,6 +126,7 @@ def strawberry_info_from_graphql(
 ) -> Info:
     return Info(
         field_name=info.field_name,
+        field_nodes=info.field_nodes,
         context=info.context,
         root_value=info.root_value,
         variable_values=info.variable_values,

--- a/strawberry/types/info.py
+++ b/strawberry/types/info.py
@@ -1,7 +1,8 @@
 import dataclasses
-from typing import Any, Dict, Generic, Optional, Type, TypeVar, Union
+from typing import Any, Dict, Generic, List, Optional, Type, TypeVar, Union
 
 from graphql import OperationDefinitionNode
+from graphql.language import FieldNode
 from graphql.pyutils.path import Path
 
 from strawberry.union import StrawberryUnion
@@ -14,6 +15,7 @@ RootValueType = TypeVar("RootValueType")
 @dataclasses.dataclass
 class Info(Generic[ContextType, RootValueType]):
     field_name: str
+    field_nodes: List[FieldNode]
     context: ContextType
     root_value: RootValueType
     variable_values: Dict[str, Any]

--- a/tests/schema/test_info.py
+++ b/tests/schema/test_info.py
@@ -9,6 +9,7 @@ def test_info_has_the_correct_shape():
     @strawberry.type
     class Result:
         field_name: str
+        field_nodes: str
         operation: str
         path: str
         variable_values: str
@@ -24,6 +25,7 @@ def test_info_has_the_correct_shape():
                 path="".join([str(p) for p in info.path.as_list()]),
                 operation=str(info.operation),
                 field_name=info.field_name,
+                field_nodes=str(info.field_nodes),
                 variable_values=str(info.variable_values),
                 context_equal=info.context == my_context,
                 root_equal=info.root_value == root_value,
@@ -35,6 +37,7 @@ def test_info_has_the_correct_shape():
     query = """{
         hello {
             fieldName
+            fieldNodes
             contextEqual
             operation
             path
@@ -47,9 +50,11 @@ def test_info_has_the_correct_shape():
     result = schema.execute_sync(query, context_value=my_context, root_value=root_value)
 
     assert not result.errors
-    assert result.data["hello"] == {
+    info = result.data["hello"]
+    assert info.pop("operation").startswith("OperationDefinitionNode at")
+    assert info.pop("fieldNodes").startswith("[FieldNode at")
+    assert info == {
         # TODO: abstract this (in future)
-        "operation": "OperationDefinitionNode at 0:191",
         "fieldName": "hello",
         "path": "hello",
         "contextEqual": True,


### PR DESCRIPTION
## Description

The new Info wrapper omitted the `field_nodes`.

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
