### PR TITLE
Add support for specifying private fields through a strawberry.type variable

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: minor
+
+Add support for specifying private fields through a variable on strawberry.type

--- a/docs/types/private-fields.md
+++ b/docs/types/private-fields.md
@@ -1,0 +1,44 @@
+---
+title: Private Fields
+---
+
+## Using Private type hint
+
+Fields can be hidden from the schema by using the Private type hint, like so:
+
+```python+schema
+import strawberry
+
+@strawberry.type
+class Post:
+    uid: strawberry.Private[str]
+    title: str
+    description: str
+---
+
+type Post {
+  title: String!
+  description: String!
+}
+```
+
+## Using private_fields variable
+
+Fields may also be hidden from the schema by passing a private_fields variable to
+strawberry.type, like so:
+
+```python+schema
+import strawberry
+
+@strawberry.type(private_fields=["uid"])
+class Post:
+    uid: str
+    title: str
+    description: str
+---
+
+type Post {
+  title: String!
+  description: String!
+}
+```

--- a/strawberry/type.py
+++ b/strawberry/type.py
@@ -104,10 +104,9 @@ def _process_type(
     wrapped = _wrap_dataclass(cls)
 
     interfaces = _get_interfaces(wrapped)
+    fields = _get_fields(cls)
     if private_fields:
-        fields = [i for i in _get_fields(cls) if i.origin_name not in private_fields]
-    else:
-        fields = _get_fields(cls)
+        fields = [i for i in fields if i.origin_name not in private_fields]
 
     wrapped._type_definition = TypeDefinition(
         name=name,

--- a/strawberry/type.py
+++ b/strawberry/type.py
@@ -97,13 +97,17 @@ def _process_type(
     is_interface: bool = False,
     description: Optional[str] = None,
     federation: Optional[FederationTypeParams] = None,
+    private_fields: Optional[List[str]] = None,
 ):
     name = name or to_camel_case(cls.__name__)
 
     wrapped = _wrap_dataclass(cls)
 
     interfaces = _get_interfaces(wrapped)
-    fields = _get_fields(cls)
+    if private_fields:
+        fields = [i for i in _get_fields(cls) if i.origin_name not in private_fields]
+    else:
+        fields = _get_fields(cls)
 
     wrapped._type_definition = TypeDefinition(
         name=name,
@@ -137,6 +141,7 @@ def type(
     is_interface: bool = False,
     description: str = None,
     federation: Optional[FederationTypeParams] = None,
+    private_fields: Optional[List[str]] = None,
 ):
     """Annotates a class as a GraphQL type.
 
@@ -155,6 +160,7 @@ def type(
             is_interface=is_interface,
             description=description,
             federation=federation,
+            private_fields=private_fields,
         )
 
     if cls is None:

--- a/tests/schema/test_private_field.py
+++ b/tests/schema/test_private_field.py
@@ -23,6 +23,25 @@ def test_private_field():
     assert instance.age == 22
 
 
+def test_private_field_set_through_type_decorator():
+    @strawberry.type(private_fields=["age"])
+    class Query:
+        name: str
+        age: int
+
+    definition = Query._type_definition
+
+    assert definition.name == "Query"
+    assert len(definition.fields) == 1
+
+    assert definition.fields[0].name == "name"
+    assert definition.fields[0].type == str
+
+    instance = Query(name="Luke", age=22)
+    assert instance.name == "Luke"
+    assert instance.age == 22
+
+
 def test_private_field_with_strawberry_field_error():
     with pytest.raises(PrivateStrawberryFieldError) as error:
 

--- a/tests/schema/test_private_field.py
+++ b/tests/schema/test_private_field.py
@@ -37,6 +37,9 @@ def test_private_field_set_through_type_decorator():
     assert definition.fields[0].name == "name"
     assert definition.fields[0].type == str
 
+    for field in definition.fields:
+        assert field.name != "age"
+
     instance = Query(name="Luke", age=22)
     assert instance.name == "Luke"
     assert instance.age == 22


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
`strawberry.Private` is great for specifying private fields, however, does not play well with IDE's: https://github.com/strawberry-graphql/strawberry/issues/702

This PR adds supports for specifying which fields on a type should be made private, through a `private_fields` variable on `strawberry.type` decorator

Example:
```py
import strawberry

@strawberry.type(private_fields=["uid"])
class Post:
    uid: str
    title: str
    description: str
```

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/strawberry-graphql/strawberry/issues/702

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
