### PR TITLE
Use `.python_name` instead of `.name` within StrawberryField

### DIFF
--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -54,7 +54,7 @@ class StrawberryField(dataclasses.Field):
 
         self._graphql_name = graphql_name
         if python_name is not None:
-            self.name = python_name
+            self.python_name = python_name
         if type_ is not None:
             # TODO: Clean up the typing around StrawberryField.type
             self.type = typing.cast(type, type_)
@@ -113,6 +113,10 @@ class StrawberryField(dataclasses.Field):
     @property
     def python_name(self) -> str:
         return self.name
+
+    @python_name.setter
+    def python_name(self, name: str) -> None:
+        self.name = name
 
     @property
     def base_resolver(self) -> Optional[StrawberryResolver]:

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -104,8 +104,8 @@ class StrawberryField(dataclasses.Field):
     def graphql_name(self) -> Optional[str]:
         if self._graphql_name:
             return to_camel_case(self._graphql_name)
-        if self.name:
-            return to_camel_case(self.name)
+        if self.python_name:
+            return to_camel_case(self.python_name)
         if self.base_resolver:
             return to_camel_case(self.base_resolver.name)
         return None


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Minor internal change for consistency: `StrawberryField.graphql_name` was accessing `StrawberryField.name` instead of `StrawberryField.python_name`. Nothing should be using `.name` at the moment except the base `dataclass.Field` class. 

No immediate release should be necessary. No objections, @botberry!

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

n/a

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
