### PR TITLE
Gracefully handle user-induced subscription errors.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Gracefully handle user-induced subscription errors.

--- a/tests/asgi/test_subscription.py
+++ b/tests/asgi/test_subscription.py
@@ -11,6 +11,7 @@ from strawberry.asgi.constants import (
     GQL_CONNECTION_KEEP_ALIVE,
     GQL_CONNECTION_TERMINATE,
     GQL_DATA,
+    GQL_ERROR,
     GQL_START,
     GQL_STOP,
 )
@@ -122,6 +123,68 @@ def test_subscription_errors(test_client):
         response = ws.receive_json()
         assert response["type"] == GQL_COMPLETE
         assert response["id"] == "demo"
+
+        ws.send_json({"type": GQL_CONNECTION_TERMINATE})
+
+        # make sure the websocket is disconnected now
+        with pytest.raises(starlette.websockets.WebSocketDisconnect):
+            ws.receive_json()
+
+
+def test_subscription_field_error(test_client):
+    with test_client.websocket_connect("/", "graphql-ws") as ws:
+        ws.send_json({"type": GQL_CONNECTION_INIT})
+        ws.send_json(
+            {
+                "type": GQL_START,
+                "id": "invalid-field",
+                "payload": {"query": "subscription { notASubscriptionField }"},
+            }
+        )
+
+        response = ws.receive_json()
+        assert response["type"] == GQL_CONNECTION_ACK
+
+        response = ws.receive_json()
+        assert response["type"] == GQL_ERROR
+        assert response["id"] == "invalid-field"
+        assert response["payload"] == {
+            "locations": [{"line": 1, "column": 16}],
+            "path": None,
+            "message": (
+                "The subscription field 'notASubscriptionField' is not defined."
+            ),
+        }
+
+        ws.send_json({"type": GQL_CONNECTION_TERMINATE})
+
+        # make sure the websocket is disconnected now
+        with pytest.raises(starlette.websockets.WebSocketDisconnect):
+            ws.receive_json()
+
+
+def test_subscription_syntax_error(test_client):
+    with test_client.websocket_connect("/", "graphql-ws") as ws:
+        ws.send_json({"type": GQL_CONNECTION_INIT})
+        ws.send_json(
+            {
+                "type": GQL_START,
+                "id": "syntax-error",
+                "payload": {"query": "subscription { example "},
+            }
+        )
+
+        response = ws.receive_json()
+        assert response["type"] == GQL_CONNECTION_ACK
+
+        response = ws.receive_json()
+        assert response["type"] == GQL_ERROR
+        assert response["id"] == "syntax-error"
+        assert response["payload"] == {
+            "locations": [{"line": 1, "column": 24}],
+            "path": None,
+            "message": "Syntax Error: Expected Name, found <EOF>.",
+        }
 
         ws.send_json({"type": GQL_CONNECTION_TERMINATE})
 


### PR DESCRIPTION
## Description

When submitting subscription queries that had syntax errors or invalid
field references the resulting error would cause an unhandled exception
that resulted in the connection being prematurely terminated (without
notice).

In these situations the errors are now handled and a proper `GQL_ERROR`
is returned to the client with the offending error as the payload.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
