### PR TITLE
Fix __eq__ and __repr__ when using resolver fields

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,19 @@
+Release type: patch
+
+This relases fixes an issue with the generated `__eq__` and `__repr__` methods when defining
+fields with resolvers.
+
+This now works properly:
+
+```python
+@strawberry.type
+class Query:
+    a: int
+
+    @strawberry.field
+    def name(self) -> str:
+        return "A"
+
+assert Query(1) == Query(1)
+assert Query(1) != Query(2)
+```

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -42,13 +42,16 @@ class StrawberryField(dataclasses.Field):
     ):
         federation = federation or FederationFieldParams()
 
+        # basic fields are fields with no provided resolver
+        is_basic_field = not base_resolver
+
         super().__init__(  # type: ignore
             default=dataclasses.MISSING,
             default_factory=dataclasses.MISSING,
             init=base_resolver is None,
-            repr=True,
+            repr=is_basic_field,
+            compare=is_basic_field,
             hash=None,
-            compare=True,
             metadata=None,
         )
 
@@ -90,6 +93,9 @@ class StrawberryField(dataclasses.Field):
 
         self.base_resolver = resolver
         self.type = resolver.type
+
+        self.repr = False
+        self.compare = False
 
         return self
 

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -48,7 +48,7 @@ class StrawberryField(dataclasses.Field):
         super().__init__(  # type: ignore
             default=dataclasses.MISSING,
             default_factory=dataclasses.MISSING,
-            init=base_resolver is None,
+            init=is_basic_field,
             repr=is_basic_field,
             compare=is_basic_field,
             hash=None,
@@ -94,9 +94,6 @@ class StrawberryField(dataclasses.Field):
         self.base_resolver = resolver
         self.type = resolver.type
 
-        self.repr = False
-        self.compare = False
-
         return self
 
     @property
@@ -133,8 +130,9 @@ class StrawberryField(dataclasses.Field):
         self._base_resolver = resolver
         self.origin = resolver.wrapped_func
 
-        # Don't add field to __init__ or __repr__ once it has a resolver
+        # Don't add field to __init__, __repr__ and __eq__ once it has a resolver
         self.init = False
+        self.compare = False
         self.repr = False
 
         # TODO: See test_resolvers.test_raises_error_when_argument_annotation_missing

--- a/tests/types/test_resolvers.py
+++ b/tests/types/test_resolvers.py
@@ -152,3 +152,40 @@ def test_can_reuse_resolver():
     assert definition.fields[1].python_name == "name_2"
     assert definition.fields[1].type == str
     assert definition.fields[1].base_resolver.wrapped_func == get_name
+
+
+def test_eq_resolvers():
+    def get_name(self) -> str:
+        return "Name"
+
+    @strawberry.type
+    class Query:
+        a: int
+        name: str = strawberry.field(resolver=get_name)
+        name_2: str = strawberry.field(resolver=get_name)
+
+    assert Query(1) == Query(1)
+    assert Query(1) != Query(2)
+
+
+def test_eq_fields():
+    @strawberry.type
+    class Query:
+        a: int
+        name: str = strawberry.field(name="name")
+
+    assert Query(1, "name") == Query(1, "name")
+    assert Query(1, "name") != Query(1, "not a name")
+
+
+def test_with_resolver_fields():
+    @strawberry.type
+    class Query:
+        a: int
+
+        @strawberry.field
+        def name(self) -> str:
+            return "A"
+
+    assert Query(1) == Query(1)
+    assert Query(1) != Query(2)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Eq and repr where broken previously. We don't want to include fields with resolvers for eq and repr
as they are basically functions and doesn't make sense to compare functions :)

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

