### PR TITLE
Fix issue where `StrawberryField.graphql_name` would always be `camelCased`

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Fix issue where StrawberryField.graphql_name would always be camelCased

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -106,7 +106,7 @@ class StrawberryField(dataclasses.Field):
     @property
     def graphql_name(self) -> Optional[str]:
         if self._graphql_name:
-            return to_camel_case(self._graphql_name)
+            return self._graphql_name
         if self.python_name:
             return to_camel_case(self.python_name)
         if self.base_resolver:

--- a/tests/types/test_basic.py
+++ b/tests/types/test_basic.py
@@ -67,3 +67,13 @@ def test_can_use_types_directly():
     user = User(username="abc")
     assert user.username == "abc"
     assert user.email() == "abc@somesite.com"
+
+
+def test_graphql_name_unchanged():
+    @strawberry.type
+    class Query:
+        the_field: int = strawberry.field(name="some_name")
+
+    definition = Query._type_definition
+
+    assert definition.fields[0].graphql_name == "some_name"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

With the recent `StrawberryField` refactor, we introduced a bug where the name that GraphQL uses would always be camelCased, even if explictly set to some value. This regression has been fixed and a test has been added. 

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

n/a

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
