### PR TITLE
Add cli option to specify src directory

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,11 @@
+Release type: minor
+
+Add --app-dir CLI option to specify where to find the schema module to load when using
+the debug server.
+
+For example if you have a _schema_ module in a _my_app_ package under ./src, then you
+can run the debug server with it using:
+
+```bash
+strawberry server --app-dir src my_app.schema
+```

--- a/strawberry/cli/commands/server.py
+++ b/strawberry/cli/commands/server.py
@@ -19,8 +19,11 @@ from strawberry.asgi import GraphQL
     default=".",
     type=str,
     show_default=True,
-    help="Look for the module in the specified directory, by adding this to the "
-    "PYTHONPATH. Defaults to the current working directory.",
+    help=(
+        "Look for the module in the specified directory, by adding this to the "
+        "PYTHONPATH. Defaults to the current working directory. "
+        "Works the same as `--app-dir` in uvicorn."
+    ),
 )
 def server(module, host, port, app_dir):
     sys.path.insert(0, app_dir)

--- a/strawberry/cli/commands/server.py
+++ b/strawberry/cli/commands/server.py
@@ -1,5 +1,4 @@
 import importlib
-import os
 import sys
 
 import click
@@ -15,8 +14,16 @@ from strawberry.asgi import GraphQL
 @click.argument("module", type=str)
 @click.option("-h", "--host", default="0.0.0.0", type=str)
 @click.option("-p", "--port", default=8000, type=int)
-def server(module, host, port):
-    sys.path.append(os.getcwd())
+@click.option(
+    "--app-dir",
+    default=".",
+    type=str,
+    show_default=True,
+    help="Look for the module in the specified directory, by adding this to the "
+    "PYTHONPATH. Defaults to the current working directory.",
+)
+def server(module, host, port, app_dir):
+    sys.path.insert(0, app_dir)
 
     reloader = hupper.start_reloader("strawberry.cli.run", verbose=False)
 

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -1,0 +1,20 @@
+import pytest
+
+from click.testing import CliRunner
+
+
+@pytest.fixture
+def cli_runner(mocker):
+    # Mock of uvicorn.run
+    uvicorn_run_patch = mocker.patch("uvicorn.run")
+    uvicorn_run_patch.return_value = True
+    # Mock to prevent the reloader from kicking in
+    hupper_reloader_patch = mocker.patch("hupper.start_reloader")
+    hupper_reloader_patch.return_value = MockReloader()
+    return CliRunner()
+
+
+class MockReloader:
+    @staticmethod
+    def watch_files(*args, **kwargs):
+        return True

--- a/tests/cli/test_server.py
+++ b/tests/cli/test_server.py
@@ -1,21 +1,11 @@
 import hupper
 import uvicorn
-from click.testing import CliRunner
 
 from strawberry.cli.commands.server import server as cmd_server
 
 
-def test_cli_cmd_server(mocker):
-
-    # Mock of uvicorn.run
-    uvicorn_run_patch = mocker.patch("uvicorn.run")
-    uvicorn_run_patch.return_value = True
-    # Mock to prevent the reloader from kicking in
-    hupper_reloader_patch = mocker.patch("hupper.start_reloader")
-    hupper_reloader_patch.return_value = MockReloader()
-    runner = CliRunner()
-
-    result = runner.invoke(cmd_server, ["tests.cli.helpers.sample_schema"], "")
+def test_cli_cmd_server(cli_runner):
+    result = cli_runner.invoke(cmd_server, ["tests.cli.helpers.sample_schema"], "")
     assert result.exit_code == 0
 
     # We started the reloader
@@ -25,7 +15,14 @@ def test_cli_cmd_server(mocker):
     assert result.output == "Running strawberry on http://0.0.0.0:8000/ 🍓\n"
 
 
-class MockReloader:
-    @staticmethod
-    def watch_files(*args, **kwargs):
-        return True
+def test_cli_cmd_server_app_dir_option(cli_runner):
+    result = cli_runner.invoke(
+        cmd_server, ["--app-dir=./tests/cli/helpers", "sample_schema"], ""
+    )
+    assert result.exit_code == 0
+
+    # We started the reloader
+    assert hupper.start_reloader.call_count == 1
+    assert uvicorn.run.call_count == 1
+
+    assert result.output == "Running strawberry on http://0.0.0.0:8000/ 🍓\n"


### PR DESCRIPTION
In my project python packages live under the src directory. I want to be able to run the strawberry serve command from the root directory. The uvicorn cli [has a `--app-dir` option](https://github.com/encode/uvicorn/blob/master/uvicorn/main.py#L322) to support this use case. The present change adds the same mechanism to the strawberry CLI, also in the form of an `--app-dir` option.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
