### PR TITLE
WIP: field data processors and validators

### DIFF
--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -209,7 +209,10 @@ class StrawberryField(dataclasses.Field):
 
         if self.base_resolver:
             args, kwargs = self._get_arguments(kwargs, source=source, info=info)
-            validators.validate_arguments(kwargs, info)
+
+            error = validators.validate_arguments(kwargs, info)
+            if error:
+                return error
 
             return self.base_resolver(*args, **kwargs)
 

--- a/strawberry/validators.py
+++ b/strawberry/validators.py
@@ -1,0 +1,26 @@
+from typing import Any, Dict
+
+from strawberry.field import StrawberryField
+from strawberry.types.info import Info
+
+
+def validate_arguments(kwargs: Dict[str, Any], info: Info):
+    for instance in kwargs.values():
+        validate_fields(instance, info)
+
+
+def validate_fields(instance: Any, info: Info):
+    if not hasattr(instance, "_type_definition"):
+        return
+    for field in instance._type_definition.fields:
+        if not field.validators:
+            continue
+        value = getattr(instance, field.name)
+        value = validate_field(field, value, info)
+        setattr(instance, field.name, value)
+
+
+def validate_field(field: StrawberryField, value: Any, info: Info) -> Any:
+    for validator in field.validators:
+        value = validator(value=value, info=info)
+    return value

--- a/strawberry/validators.py
+++ b/strawberry/validators.py
@@ -1,22 +1,47 @@
-from typing import Any, Dict
+import dataclasses
+from typing import Any, Dict, List
 
+from strawberry.arguments import UNSET
 from strawberry.field import StrawberryField
 from strawberry.types.info import Info
 
 
+class StrawberryErrorType(BaseException):
+    pass
+
+
+def analyze_errors(errors):
+    err = None
+    for error in errors:
+        if err is None:
+            err = error
+            continue
+        for field in dataclasses.fields(error):
+            value = getattr(error, field.name, UNSET)
+            if value is not UNSET:
+                setattr(err, field.name, value)
+    return err
+
+
 def validate_arguments(kwargs: Dict[str, Any], info: Info):
+    errors: List[Any] = []
     for instance in kwargs.values():
-        validate_fields(instance, info)
+        validate_fields(instance, info, errors)
+    return analyze_errors(errors)
 
 
-def validate_fields(instance: Any, info: Info):
+def validate_fields(instance: Any, info: Info, errors: List[Any]):
     if not hasattr(instance, "_type_definition"):
         return
     for field in instance._type_definition.fields:
         if not field.validators:
             continue
         value = getattr(instance, field.name)
-        value = validate_field(field, value, info)
+        try:
+            value = validate_field(field, value, info)
+        except StrawberryErrorType as e:
+            errors.append(e)
+            continue
         setattr(instance, field.name, value)
 
 

--- a/strawberry/validators.py
+++ b/strawberry/validators.py
@@ -40,7 +40,9 @@ def validate_fields(instance: Any, info: Info, errors: List[Any]):
         try:
             value = validate_field(field, value, info)
         except StrawberryErrorType as e:
-            errors.append(e)
+            value = e
+        if isinstance(value, StrawberryErrorType):
+            errors.append(value)
             continue
         setattr(instance, field.name, value)
 

--- a/tests/types/test_validator_errors.py
+++ b/tests/types/test_validator_errors.py
@@ -1,0 +1,87 @@
+from typing import Union
+
+import strawberry
+from strawberry.arguments import UNSET
+from strawberry.validators import StrawberryErrorType
+
+
+def validate_email(value, info):
+    if "@" not in value:
+        raise ErrorType(email="Invalid email")
+    return value.strip()
+
+
+def validate_postcode(value, info):
+    postcode = int(value)
+    if postcode < 1 or postcode > 99999:
+        raise ErrorType(postcode="Invalid post code")
+    return f"{postcode:05d}"
+
+
+@strawberry.type
+class SuccessType:
+    message: str
+
+
+@strawberry.type
+class ErrorType(StrawberryErrorType):
+    message: str = "Check input fields"
+    email: str = UNSET
+    postcode: str = UNSET
+
+
+@strawberry.input
+class InputType:
+    email: str = strawberry.field(validators=[validate_email])
+    postcode: str = strawberry.field(validators=[validate_postcode])
+
+
+@strawberry.type
+class Query:
+    dummy: str
+
+
+@strawberry.type
+class Mutation:
+    @strawberry.mutation
+    def save_data(self, data: InputType) -> Union[SuccessType, ErrorType]:
+        return SuccessType(message="Data saved")
+
+
+schema = strawberry.Schema(query=Query, mutation=Mutation)
+query = """
+mutation($data: InputType!) {
+    saveData(data: $data) {
+        ... on SuccessType {
+            message
+        }
+        ... on ErrorType {
+            message
+            email
+            postcode
+        }
+    }
+}
+"""
+
+
+def test_success():
+    result = schema.execute_sync(
+        query, variable_values={"data": {"email": "a@a.aa", "postcode": "1234"}}
+    )
+    assert not result.errors
+    assert result.data["saveData"] == {
+        "message": "Data saved",
+    }
+
+
+def test_error():
+    result = schema.execute_sync(
+        query, variable_values={"data": {"email": "asd", "postcode": "-1"}}
+    )
+    assert not result.errors == "Check input fields"
+    assert result.data["saveData"] == {
+        "message": "Check input fields",
+        "email": "Invalid email",
+        "postcode": "Invalid post code",
+    }

--- a/tests/types/test_validator_errors.py
+++ b/tests/types/test_validator_errors.py
@@ -5,9 +5,9 @@ from strawberry.arguments import UNSET
 from strawberry.validators import StrawberryErrorType
 
 
-def validate_email(value, info):
+def validate_email(value, info) -> Union[str, "ErrorType"]:
     if "@" not in value:
-        raise ErrorType(email="Invalid email")
+        return ErrorType(email="Invalid email")
     return value.strip()
 
 

--- a/tests/types/test_validators.py
+++ b/tests/types/test_validators.py
@@ -1,0 +1,70 @@
+import strawberry
+
+
+def upper_validator(value, info):
+    return value.upper()
+
+
+def test_validator():
+    @strawberry.type
+    class Type:
+        string: str = strawberry.field(validators=[upper_validator])
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def type() -> Type:
+            return Type("hello")
+
+    schema = strawberry.Schema(Query)
+
+    result = schema.execute_sync("{ type { string } }")
+
+    assert not result.errors
+    assert result.data["type"]["string"] == "HELLO"
+
+
+def test_validator_decorator():
+    @strawberry.type
+    class Type:
+        string: str = strawberry.field()
+
+        @string.validator
+        def validator(value, info):
+            return value.title()
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def type() -> Type:
+            return Type("hello")
+
+    schema = strawberry.Schema(Query)
+
+    result = schema.execute_sync("{ type { string } }")
+
+    assert not result.errors
+    assert result.data["type"]["string"] == "Hello"
+
+
+def test_input_validation():
+    @strawberry.input
+    class Input:
+        string: str = strawberry.field(validators=[upper_validator])
+
+    @strawberry.type
+    class Query:
+        s: str
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        def mutation(self, input: Input) -> str:
+            return input.string
+
+    schema = strawberry.Schema(query=Query, mutation=Mutation)
+
+    result = schema.execute_sync('mutation { mutation(input: { string: "hello" }) }')
+
+    assert not result.errors
+    assert result.data["mutation"] == "HELLO"

--- a/tests/types/test_validators.py
+++ b/tests/types/test_validators.py
@@ -2,6 +2,8 @@ import strawberry
 
 
 def upper_validator(value, info):
+    if info.context and info.context in value:
+        raise ValueError("Invalid value")
     return value.upper()
 
 
@@ -22,6 +24,11 @@ def test_validator():
 
     assert not result.errors
     assert result.data["type"]["string"] == "HELLO"
+
+    # error case
+    result = schema.execute_sync("{ type { string } }", context_value="hello")
+
+    assert result.errors[0].message == "Invalid value"
 
 
 def test_validator_decorator():
@@ -68,3 +75,10 @@ def test_input_validation():
 
     assert not result.errors
     assert result.data["mutation"] == "HELLO"
+
+    # error case
+    result = schema.execute_sync(
+        'mutation { mutation(input: { string: "hello" }) }', context_value="hello"
+    )
+
+    assert result.errors[0].message == "Invalid value"


### PR DESCRIPTION
The purpose of this pull request is to demonstrate the functionality of validators. This new feature has been proposed and discussed in #788.

## Description

New `validators` list is added to `StrawberryField` structure which contains list of callable validators. User defined validator function takes value as an parameter and returns validated value. Validator function is called after resolver functions with output types and before resolver with input types. See discussion in #788.

Both output and input types are supported.

```python
def permission_validator(value, info):
    if not info.context.request.user.has_permission():
        raise Exception('Permission denied')
    return value

@strawberry.type
class User:
    # option 1, define validator as a field parameter
    name: str = strawberry.field(validators=[permission_validator])
    age: int = strawberry.field()

    # option 2, define validator with field decorator    
    @age.validator
    def age(value, info):
        if not info.context.request.user.has_permission():
            raise Exception('Permission denied')
        return value
```

## Types of Changes

- [x] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #788

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
