### PR TITLE
Add support for scalars in MyPY

### DIFF
--- a/strawberry/schema/types/scalar.py
+++ b/strawberry/schema/types/scalar.py
@@ -35,12 +35,12 @@ DEFAULT_SCALAR_REGISTRY: Dict[Type, GraphQLScalarType] = {
     float: GraphQLFloat,
     bool: GraphQLBoolean,
     ID: GraphQLID,
-    UUID: _make_scalar_type(UUID._scalar_definition),
-    Upload: _make_scalar_type(Upload._scalar_definition),
-    datetime.date: _make_scalar_type(Date._scalar_definition),
-    datetime.datetime: _make_scalar_type(DateTime._scalar_definition),
-    datetime.time: _make_scalar_type(Time._scalar_definition),
-    decimal.Decimal: _make_scalar_type(Decimal._scalar_definition),
+    UUID: _make_scalar_type(UUID._scalar_definition),  # type: ignore
+    Upload: _make_scalar_type(Upload._scalar_definition),  # type: ignore
+    datetime.date: _make_scalar_type(Date._scalar_definition),  # type: ignore
+    datetime.datetime: _make_scalar_type(DateTime._scalar_definition),  # type: ignore
+    datetime.time: _make_scalar_type(Time._scalar_definition),  # type: ignore
+    decimal.Decimal: _make_scalar_type(Decimal._scalar_definition),  # type: ignore
 }
 
 

--- a/tests/mypy/test_scalar.yml
+++ b/tests/mypy/test_scalar.yml
@@ -1,0 +1,30 @@
+- case: test_scalar
+  main: |
+    import strawberry
+    from typing import NewType
+
+    PostTitle = strawberry.scalar(NewType("PostTitle", str), description="...")
+
+    @strawberry.type
+    class Post:
+        title: PostTitle
+
+    reveal_type(Post("123").title)
+  out: |
+    main:10: note: Revealed type is 'builtins.str'
+
+- case: test_scalar_new_type
+  main: |
+    import strawberry
+    from typing import NewType
+
+    Title = NewType("Title", str)
+    PostTitle = strawberry.scalar(Title, description="...")
+
+    @strawberry.type
+    class Post:
+        title: PostTitle
+
+    reveal_type(Post(Title("123")).title)
+  out: |
+    main:11: note: Revealed type is 'main.Title'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This is not finished yet, it already improves MyPy support for scalars, but I think it not ideal.

This:
```python
PostTitle = strawberry.scalar(NewType("PostTitle", str), description="...")

@strawberry.type
class Post:
	title: PostTitle

reveal_type(Post("123").title)
```

Should say `PostTitle` instead of `builtins.str`, but I'm unsure how to make it so, 
will try again :)

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Closes #767

