### PR TITLE
Add support for a default and default_factory with strawberry.field

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,10 @@
+Release type: minor
+
+Add support for `default` and `default_factory` arguments in `strawberry.field`
+
+```python
+@strawberry.type
+class Droid:
+    name: str = strawberry.field(default="R2D2")
+    aka: List[str] = strawberry.field(default_factory=["Artoo"])
+```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,5 +6,5 @@ Add support for `default` and `default_factory` arguments in `strawberry.field`
 @strawberry.type
 class Droid:
     name: str = strawberry.field(default="R2D2")
-    aka: List[str] = strawberry.field(default_factory=["Artoo"])
+    aka: List[str] = strawberry.field(default_factory=lambda: ["Artoo"])
 ```

--- a/strawberry/exceptions.py
+++ b/strawberry/exceptions.py
@@ -153,3 +153,13 @@ class FieldWithResolverAndDefaultValueError(Exception):
         )
 
         super().__init__(message)
+
+
+class FieldWithResolverAndDefaultFactoryError(Exception):
+    def __init__(self, field_name: str, type_name: str):
+        message = (
+            f'Field "{field_name}" on type "{type_name}" cannot define a '
+            "default_factory and a resolver."
+        )
+
+        super().__init__(message)

--- a/strawberry/exceptions.py
+++ b/strawberry/exceptions.py
@@ -143,3 +143,13 @@ class WrongNumberOfResultsReturned(Exception):
         )
 
         super().__init__(message)
+
+
+class FieldWithResolverAndDefaultValueError(Exception):
+    def __init__(self, field_name: str, type_name: str):
+        message = (
+            f'Field "{field_name}" on type "{type_name}" cannot define a default '
+            "value and a resolver."
+        )
+
+        super().__init__(message)

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -47,7 +47,9 @@ class StrawberryField(dataclasses.Field):
         is_basic_field = not base_resolver
 
         super().__init__(  # type: ignore
-            default=dataclasses.MISSING,
+            default=(
+                default_value if default_value != undefined else dataclasses.MISSING
+            ),
             default_factory=dataclasses.MISSING,
             init=is_basic_field,
             repr=is_basic_field,
@@ -281,6 +283,7 @@ def field(
     permission_classes: Optional[List[Type[BasePermission]]] = None,
     federation: Optional[FederationFieldParams] = None,
     deprecation_reason: Optional[str] = None,
+    default: Any = undefined,
 ) -> StrawberryField:
     """Annotates a method or property as a GraphQL field.
 
@@ -306,6 +309,7 @@ def field(
         permission_classes=permission_classes or [],
         federation=federation or FederationFieldParams(),
         deprecation_reason=deprecation_reason,
+        default_value=default,
     )
 
     if resolver:

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -48,9 +48,7 @@ class StrawberryField(dataclasses.Field):
         is_basic_field = not base_resolver
 
         super().__init__(  # type: ignore
-            default=(
-                default_value if default_value != UNSET else dataclasses.MISSING
-            ),
+            default=(default_value if default_value != UNSET else dataclasses.MISSING),
             default_factory=(
                 default_factory if default_factory != UNSET else dataclasses.MISSING
             ),

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -6,14 +6,14 @@ from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple, Type, 
 
 from graphql import GraphQLResolveInfo
 
-from strawberry.arguments import convert_arguments
+from strawberry.arguments import UNSET, convert_arguments
 from strawberry.types.info import Info
 from strawberry.utils.typing import get_parameters, has_type_var, is_type_var
 
 from .arguments import StrawberryArgument
 from .permission import BasePermission
 from .types.fields.resolver import StrawberryResolver
-from .types.types import FederationFieldParams, undefined
+from .types.types import FederationFieldParams
 from .union import StrawberryUnion
 from .utils.str_converters import to_camel_case
 
@@ -38,8 +38,8 @@ class StrawberryField(dataclasses.Field):
         description: Optional[str] = None,
         base_resolver: Optional[StrawberryResolver] = None,
         permission_classes: List[Type[BasePermission]] = (),  # type: ignore
-        default_value: Any = undefined,
-        default_factory: Union[Callable, object] = undefined,
+        default_value: Any = UNSET,
+        default_factory: Union[Callable, object] = UNSET,
         deprecation_reason: Optional[str] = None,
     ):
         federation = federation or FederationFieldParams()
@@ -49,10 +49,10 @@ class StrawberryField(dataclasses.Field):
 
         super().__init__(  # type: ignore
             default=(
-                default_value if default_value != undefined else dataclasses.MISSING
+                default_value if default_value != UNSET else dataclasses.MISSING
             ),
             default_factory=(
-                default_factory if default_factory != undefined else dataclasses.MISSING
+                default_factory if default_factory != UNSET else dataclasses.MISSING
             ),
             init=is_basic_field,
             repr=is_basic_field,
@@ -286,8 +286,8 @@ def field(
     permission_classes: Optional[List[Type[BasePermission]]] = None,
     federation: Optional[FederationFieldParams] = None,
     deprecation_reason: Optional[str] = None,
-    default: Any = undefined,
-    default_factory: Union[Callable, object] = undefined,
+    default: Any = UNSET,
+    default_factory: Union[Callable, object] = UNSET,
 ) -> StrawberryField:
     """Annotates a method or property as a GraphQL field.
 

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -39,6 +39,7 @@ class StrawberryField(dataclasses.Field):
         base_resolver: Optional[StrawberryResolver] = None,
         permission_classes: List[Type[BasePermission]] = (),  # type: ignore
         default_value: Any = undefined,
+        default_factory: Union[Callable, object] = undefined,
         deprecation_reason: Optional[str] = None,
     ):
         federation = federation or FederationFieldParams()
@@ -50,7 +51,9 @@ class StrawberryField(dataclasses.Field):
             default=(
                 default_value if default_value != undefined else dataclasses.MISSING
             ),
-            default_factory=dataclasses.MISSING,
+            default_factory=(
+                default_factory if default_factory != undefined else dataclasses.MISSING
+            ),
             init=is_basic_field,
             repr=is_basic_field,
             compare=is_basic_field,
@@ -284,6 +287,7 @@ def field(
     federation: Optional[FederationFieldParams] = None,
     deprecation_reason: Optional[str] = None,
     default: Any = undefined,
+    default_factory: Union[Callable, object] = undefined,
 ) -> StrawberryField:
     """Annotates a method or property as a GraphQL field.
 
@@ -310,6 +314,7 @@ def field(
         federation=federation or FederationFieldParams(),
         deprecation_reason=deprecation_reason,
         default_value=default,
+        default_factory=default_factory,
     )
 
     if resolver:

--- a/strawberry/types/type_resolver.py
+++ b/strawberry/types/type_resolver.py
@@ -4,9 +4,10 @@ import typing
 from typing import Dict, List, Type, cast
 
 from strawberry.exceptions import (
+    FieldWithResolverAndDefaultFactoryError,
+    FieldWithResolverAndDefaultValueError,
     MissingTypesForGenericError,
     PrivateStrawberryFieldError,
-    FieldWithResolverAndDefaultValueError,
 )
 from strawberry.field import StrawberryField
 from strawberry.lazy_type import LazyType
@@ -385,6 +386,17 @@ def _get_fields(cls: Type) -> List[StrawberryField]:
             # Check that default is not set if a resolver is defined
             if field.default != dataclasses.MISSING and field.base_resolver is not None:
                 raise FieldWithResolverAndDefaultValueError(
+                    field.python_name, cls.__name__
+                )
+
+            # Check that default_factory is not set if a resolver is defined
+            # Note: using getattr because of this issue:
+            # https://github.com/python/mypy/issues/6910
+            if (
+                getattr(field, "default_factory") != dataclasses.MISSING  # noqa
+                and field.base_resolver is not None
+            ):
+                raise FieldWithResolverAndDefaultFactoryError(
                     field.python_name, cls.__name__
                 )
 

--- a/strawberry/types/type_resolver.py
+++ b/strawberry/types/type_resolver.py
@@ -27,11 +27,8 @@ from strawberry.utils.typing import (
     is_union,
 )
 
-from ..arguments import StrawberryArgument
+from ..arguments import UNSET, StrawberryArgument
 from .generics import copy_type_with, get_name_from_types
-
-# TODO: why do we have undefined?
-from .types import undefined
 
 
 def _resolve_generic_type(type: Type, field_name: str) -> Type:
@@ -425,7 +422,7 @@ def _get_fields(cls: Type) -> List[StrawberryField]:
                 graphql_name=to_camel_case(field.name),
                 type_=field_type,
                 origin=cls,
-                default_value=getattr(cls, field.name, undefined),
+                default_value=getattr(cls, field.name, UNSET),
             )
 
         field_name = field.graphql_name

--- a/strawberry/types/type_resolver.py
+++ b/strawberry/types/type_resolver.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Type, cast
 from strawberry.exceptions import (
     MissingTypesForGenericError,
     PrivateStrawberryFieldError,
+    FieldWithResolverAndDefaultValueError,
 )
 from strawberry.field import StrawberryField
 from strawberry.lazy_type import LazyType
@@ -380,6 +381,12 @@ def _get_fields(cls: Type) -> List[StrawberryField]:
             # Check that the field type is not Private
             if isinstance(field.type, Private):
                 raise PrivateStrawberryFieldError(field.python_name, cls.__name__)
+
+            # Check that default is not set if a resolver is defined
+            if field.default != dataclasses.MISSING and field.base_resolver is not None:
+                raise FieldWithResolverAndDefaultValueError(
+                    field.python_name, cls.__name__
+                )
 
             # we make sure that the origin is either the field's resolver when
             # called as:

--- a/tests/schema/test_basic.py
+++ b/tests/schema/test_basic.py
@@ -7,7 +7,10 @@ from typing import Optional
 import pytest
 
 import strawberry
-from strawberry.exceptions import FieldWithResolverAndDefaultValueError
+from strawberry.exceptions import (
+    FieldWithResolverAndDefaultFactoryError,
+    FieldWithResolverAndDefaultValueError,
+)
 
 
 def test_raises_exception_with_unsupported_types():
@@ -480,3 +483,13 @@ def test_field_with_separate_resolver_default():
         @strawberry.type
         class Query:
             c: str = strawberry.field(default="Example C", resolver=test_resolver)
+
+
+def test_field_with_resolver_default_factory():
+    with pytest.raises(FieldWithResolverAndDefaultFactoryError):
+
+        @strawberry.type
+        class Query:
+            @strawberry.field(default_factory=lambda: "Example C")
+            def c(self) -> str:
+                return "I'm a resolver"

--- a/tests/types/test_basic.py
+++ b/tests/types/test_basic.py
@@ -77,3 +77,12 @@ def test_graphql_name_unchanged():
     definition = Query._type_definition
 
     assert definition.fields[0].graphql_name == "some_name"
+
+
+def test_field_with_default():
+    @strawberry.type
+    class Query:
+        the_field: int = strawberry.field(default=3)
+
+    instance = Query()
+    assert instance.the_field == 3

--- a/tests/types/test_basic.py
+++ b/tests/types/test_basic.py
@@ -86,3 +86,12 @@ def test_field_with_default():
 
     instance = Query()
     assert instance.the_field == 3
+
+
+def test_field_with_default_factory():
+    @strawberry.type
+    class Query:
+        the_field: int = strawberry.field(default_factory=lambda: 3)
+
+    instance = Query()
+    assert instance.the_field == 3


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Add `default` and `default_factory` arguments to `strawberry.field` to bring it inline with `dataclasses.field`.

Note: I haven't added the `metadata` attribute because I'm not sure there is a compelling reason to add it.

# Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Closes #569

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
