### PR TITLE
Improve how we generate types from Pydantic

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+Release type: patch
+
+This release fixes the pydantic integration where you couldn't
+convert objects to pydantic instance when they didn't have a
+default value.

--- a/strawberry/experimental/pydantic/type.py
+++ b/strawberry/experimental/pydantic/type.py
@@ -5,14 +5,13 @@ from typing import Any, Dict, List, Optional, Type
 from pydantic import BaseModel
 from pydantic.fields import ModelField
 
-import strawberry
 from strawberry.experimental.pydantic.conversion import (
     convert_pydantic_model_to_strawberry_class,
 )
 from strawberry.experimental.pydantic.fields import get_basic_type
+from strawberry.field import StrawberryField
 from strawberry.type import _process_type
 from strawberry.types.types import FederationTypeParams
-from strawberry.utils.str_converters import to_camel_case
 
 from .exceptions import MissingFieldsListError, UnregisteredTypeException
 
@@ -62,8 +61,10 @@ def type(
             (
                 name,
                 get_type_for_field(field),
-                dataclasses.field(
-                    default=strawberry.field(name=to_camel_case(field.alias))
+                StrawberryField(
+                    python_name=field.name,
+                    graphql_name=field.alias if field.has_alias else None,
+                    type_=get_type_for_field(field),
                 ),
             )
             for name, field in model_fields.items()
@@ -76,9 +77,7 @@ def type(
                 (
                     name,
                     type_,
-                    dataclasses.field(
-                        default=strawberry.field(name=to_camel_case(name))
-                    ),
+                    StrawberryField(python_name=name, graphql_name=None, type_=type_),
                 )
                 for name, type_ in cls_annotations.items()
             )

--- a/strawberry/type.py
+++ b/strawberry/type.py
@@ -98,12 +98,10 @@ def _process_type(
 ):
     name = name or to_camel_case(cls.__name__)
 
-    wrapped = _wrap_dataclass(cls)
-
-    interfaces = _get_interfaces(wrapped)
+    interfaces = _get_interfaces(cls)
     fields = _get_fields(cls)
 
-    wrapped._type_definition = TypeDefinition(
+    cls._type_definition = TypeDefinition(
         name=name,
         is_input=is_input,
         is_interface=is_interface,
@@ -124,7 +122,7 @@ def _process_type(
         if field.base_resolver and field.python_name:
             setattr(cls, field.python_name, field.base_resolver.wrapped_func)
 
-    return wrapped
+    return cls
 
 
 def type(
@@ -146,8 +144,10 @@ def type(
     """
 
     def wrap(cls):
+        wrapped = _wrap_dataclass(cls)
+
         return _process_type(
-            cls,
+            wrapped,
             name=name,
             is_input=is_input,
             is_interface=is_interface,

--- a/tests/experimental/pydantic/test_basic.py
+++ b/tests/experimental/pydantic/test_basic.py
@@ -204,7 +204,7 @@ def test_type_with_nested_fields_coming_from_strawberry_and_pydantic():
     assert definition.fields[2].is_optional is False
 
 
-def test_type_with_alised_pydantic_field():
+def test_type_with_aliased_pydantic_field():
     class UserModel(pydantic.BaseModel):
         age_: int = pydantic.Field(..., alias="age")
         password: Optional[str]

--- a/tests/experimental/pydantic/test_conversion.py
+++ b/tests/experimental/pydantic/test_conversion.py
@@ -324,3 +324,19 @@ def test_can_covert_pydantic_type_to_strawberry_with_missing_index_data_in_neste
         # This was None in the UserModel
         Work(name="Alternative", year=3030),
     ]
+
+
+def test_can_covert_input_types_to_pydantic():
+    class User(pydantic.BaseModel):
+        age: int
+        password: Optional[str]
+
+    @strawberry.experimental.pydantic.input(User, fields=["age", "password"])
+    class UserInput:
+        pass
+
+    data = UserInput(1, None)
+    user = data.to_pydantic()
+
+    assert user.age == 1
+    assert user.password is None


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This PR improves how we generate types from Pydantic, it starts by using the StrawberryField (h/t @BryceBeagle) and then changes where we call @dataclass when using the decorator, we do this because @dataclass replaces StrawberryField with dataclasses.Field which breaks things unfortunately.
This is fine to do since we already create a dataclass when creating a type from Pydantic :)

I also tried to add a check with `dataclasses.isdataclass` but that was breaking interfaces and inheritance :(

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation
