### PR TITLE
Add support for default values and factories in pydantic

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,3 @@
 Release type: patch
 
-This release improves Pydantic support to to support default values and factories.
+This release improves Pydantic support to support default values and factories.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+This release improves Pydantic support to to support default values and factories.

--- a/tests/experimental/pydantic/test_basic.py
+++ b/tests/experimental/pydantic/test_basic.py
@@ -174,8 +174,8 @@ def test_type_with_fields_coming_from_strawberry_and_pydantic():
 
 @pytest.mark.xfail(
     reason=(
-        "passing default values when extending types from pydantic "
-        "is not currently supported"
+        "passing default values when extending types from pydantic is not"
+        "supported. https://github.com/strawberry-graphql/strawberry/issues/829"
     )
 )
 def test_type_with_fields_coming_from_strawberry_and_pydantic_with_default():

--- a/tests/experimental/pydantic/test_basic.py
+++ b/tests/experimental/pydantic/test_basic.py
@@ -172,6 +172,40 @@ def test_type_with_fields_coming_from_strawberry_and_pydantic():
     assert definition.fields[2].is_optional is False
 
 
+@pytest.mark.xfail(
+    reason=(
+        "passing default values when extending types from pydantic "
+        "is not currently supported"
+    )
+)
+def test_type_with_fields_coming_from_strawberry_and_pydantic_with_default():
+    class User(pydantic.BaseModel):
+        age: int
+        password: Optional[str]
+
+    @strawberry.experimental.pydantic.type(User, fields=["age", "password"])
+    class UserType:
+        name: str = "Michael"
+
+    definition: TypeDefinition = UserType._type_definition
+
+    assert definition.name == "UserType"
+    assert len(definition.fields) == 3
+
+    assert definition.fields[0].graphql_name == "age"
+    assert definition.fields[0].type is int
+    assert definition.fields[0].is_optional is False
+
+    assert definition.fields[1].graphql_name == "password"
+    assert definition.fields[1].type is str
+    assert definition.fields[1].is_optional is True
+
+    assert definition.fields[2].graphql_name == "name"
+    assert definition.fields[2].type is str
+    assert definition.fields[2].is_optional is False
+    assert definition.fields[2].default_value == "Michael"
+
+
 def test_type_with_nested_fields_coming_from_strawberry_and_pydantic():
     @strawberry.type
     class Name:

--- a/tests/experimental/pydantic/test_conversion.py
+++ b/tests/experimental/pydantic/test_conversion.py
@@ -326,7 +326,7 @@ def test_can_covert_pydantic_type_to_strawberry_with_missing_index_data_in_neste
     ]
 
 
-def test_can_covert_input_types_to_pydantic():
+def test_can_convert_input_types_to_pydantic():
     class User(pydantic.BaseModel):
         age: int
         password: Optional[str]
@@ -336,6 +336,22 @@ def test_can_covert_input_types_to_pydantic():
         pass
 
     data = UserInput(1, None)
+    user = data.to_pydantic()
+
+    assert user.age == 1
+    assert user.password is None
+
+
+def test_can_convert_input_types_to_pydantic_default_values():
+    class User(pydantic.BaseModel):
+        age: int
+        password: Optional[str] = None
+
+    @strawberry.experimental.pydantic.input(User, fields=["age", "password"])
+    class UserInput:
+        pass
+
+    data = UserInput(1)
     user = data.to_pydantic()
 
     assert user.age == 1


### PR DESCRIPTION
## Description

Our dataclass generation code wasn't copying the default values and factories (as this was a relatively new feature), this PR updates the code to support that.

We will still need to add support for default values when extending generated types, but
we can do that in another PR :)

I've marked this PR as bugfix, as this is something that should have been already supported :)

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation


