### PR TITLE
WIP: add default resolver for type

### DIFF
--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -72,6 +72,10 @@ class StrawberryField(dataclasses.Field):
         self._base_resolver: Optional[StrawberryResolver] = None
         if base_resolver is not None:
             self.base_resolver = base_resolver
+        elif hasattr(self.type, "_type_definition"):
+            default_resolver = self.type._type_definition.default_resolver
+            if default_resolver is not None:
+                self.base_resolver = StrawberryResolver(default_resolver)
 
         self.default_value = default_value
 

--- a/strawberry/type.py
+++ b/strawberry/type.py
@@ -1,6 +1,6 @@
 import dataclasses
 from functools import partial
-from typing import List, Optional, Type, cast
+from typing import Callable, List, Optional, Type, cast
 
 from strawberry.utils.typing import is_generic
 
@@ -95,6 +95,7 @@ def _process_type(
     is_interface: bool = False,
     description: Optional[str] = None,
     federation: Optional[FederationTypeParams] = None,
+    default_resolver: Optional[Callable] = None,
 ):
     name = name or to_camel_case(cls.__name__)
 
@@ -109,6 +110,7 @@ def _process_type(
         interfaces=interfaces,
         description=description,
         federation=federation or FederationTypeParams(),
+        default_resolver=default_resolver,
         origin=cls,
         _fields=fields,
     )
@@ -133,6 +135,7 @@ def type(
     is_interface: bool = False,
     description: str = None,
     federation: Optional[FederationTypeParams] = None,
+    default_resolver: Optional[Callable] = None,
 ):
     """Annotates a class as a GraphQL type.
 
@@ -153,6 +156,7 @@ def type(
             is_interface=is_interface,
             description=description,
             federation=federation,
+            default_resolver=default_resolver,
         )
 
     if cls is None:

--- a/strawberry/types/types.py
+++ b/strawberry/types/types.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import TYPE_CHECKING, Dict, List, Optional, Type
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Type
 
 
 if TYPE_CHECKING:
@@ -27,6 +27,7 @@ class TypeDefinition:
 
     _fields: List["StrawberryField"]
     _type_params: Dict[str, Type] = dataclasses.field(default_factory=dict, init=False)
+    default_resolver: Optional[Callable] = None
 
     def get_field(self, name: str) -> Optional["StrawberryField"]:
         return next(

--- a/tests/schema/test_resolvers.py
+++ b/tests/schema/test_resolvers.py
@@ -312,3 +312,32 @@ async def test_async_list_resolver():
 
     assert not result.errors
     assert result.data["bestFlavours"] == ["strawberry", "pistachio"]
+
+
+def test_default_resolver():
+    def resolver() -> str:
+        return Greetings(message="hello")
+
+    @strawberry.type(default_resolver=resolver)
+    class Greetings:
+        message: str
+
+    @strawberry.type
+    class Query:
+        greetings1: Greetings
+
+        @strawberry.field
+        def greetings2() -> Greetings:
+            return Greetings(message="hi")
+
+    schema = strawberry.Schema(query=Query)
+
+    query = "{ greetings1 { message } greetings2 { message } }"
+
+    result = schema.execute_sync(query)
+
+    assert not result.errors
+    assert result.data == {
+        "greetings1": {"message": "hello"},
+        "greetings2": {"message": "hi"},
+    }


### PR DESCRIPTION
This pull request adds new `default_resolver` parameter for `strawberry_type`, which is used to resolve the type if `base_resolver` is not given.

See more detailed description and examples are in the ticket #839.