### PR TITLE
Fix `from_pydantic' with falsy values

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Fix converting pydantic objects to strawberry types using `from_pydantic` when having a falsy value like 0 or ''.

--- a/strawberry/experimental/pydantic/conversion.py
+++ b/strawberry/experimental/pydantic/conversion.py
@@ -7,7 +7,7 @@ from strawberry.scalars import is_scalar
 def _convert_from_pydantic_to_strawberry_field(
     field: StrawberryField, data_from_model=None, extra=None
 ):
-    data = data_from_model or extra
+    data = data_from_model if data_from_model is not None else extra
 
     if field.is_list:
         assert field.child is not None

--- a/tests/experimental/pydantic/test_conversion.py
+++ b/tests/experimental/pydantic/test_conversion.py
@@ -52,6 +52,22 @@ def test_can_covert_alias_pydantic_field_to_strawberry():
     assert user.password == "abc"
 
 
+def test_can_covert_falsy_values_to_strawberry():
+    class UserModel(pydantic.BaseModel):
+        age: int
+        password: str
+
+    @strawberry.experimental.pydantic.type(UserModel, fields=["age", "password"])
+    class User:
+        pass
+
+    origin_user = UserModel(age=0, password="")
+    user = User.from_pydantic(origin_user)
+
+    assert user.age == 0
+    assert user.password == ""
+
+
 def test_can_covert_pydantic_type_with_nested_data_to_strawberry():
     class WorkModel(pydantic.BaseModel):
         name: str


### PR DESCRIPTION
## Description
I discovered that when converting objects with falsy values like 0 or '' they are changed to None.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Closes #859

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
