### PR TITLE
Fix how we check if a type is generic

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,25 @@
+Release type: patch
+
+This release fixes a bug that prevented from extending a generic type when
+passing a type, like here:
+
+```python
+T = typing.TypeVar("T")
+
+@strawberry.interface
+class Node(typing.Generic[T]):
+    id: strawberry.ID
+
+    def _resolve(self) -> typing.Optional[T]:
+        return None
+
+@strawberry.type
+class Book(Node[str]):
+    name: str
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def books(self) -> typing.List[Book]:
+        return list()
+```

--- a/strawberry/utils/typing.py
+++ b/strawberry/utils/typing.py
@@ -80,7 +80,7 @@ def is_generic(annotation: Type) -> bool:
             typing.ClassVar,
             AsyncGenerator,
         )
-    )
+    ) and get_parameters(annotation)
 
 
 def is_type_var(annotation: Type) -> bool:

--- a/tests/schema/test_generics.py
+++ b/tests/schema/test_generics.py
@@ -700,3 +700,43 @@ def test_generic_with_arguments():
     """
 
     assert str(schema) == textwrap.dedent(expected_schema).strip()
+
+
+def test_generic_extending_with_type_var():
+    T = typing.TypeVar("T")
+
+    @strawberry.interface
+    class Node(typing.Generic[T]):
+        id: strawberry.ID
+
+        def _resolve(self) -> typing.Optional[T]:
+            return None
+
+    @strawberry.type
+    class Book(Node[str]):
+        name: str
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def books(self) -> typing.List[Book]:
+            return list()
+
+    schema = strawberry.Schema(query=Query)
+
+    expected_schema = """
+    type Book implements Node {
+      id: ID!
+      name: String!
+    }
+
+    interface Node {
+      id: ID!
+    }
+
+    type Query {
+      books: [Book!]!
+    }
+    """
+
+    assert str(schema) == textwrap.dedent(expected_schema).strip()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This PR fixes how we check if a type is generic, which was preventing us from being able to subclass a generic type while passing a type to it.

```python
T = typing.TypeVar("T")

@strawberry.interface
class Node(typing.Generic[T]):
    id: strawberry.ID

    def _resolve(self) -> typing.Optional[T]:
        return None

@strawberry.type
class Book(Node[str]):
    name: str

@strawberry.type
class Query:
    @strawberry.field
    def books(self) -> typing.List[Book]:
        return list()
```

**NOTE**: we should probably also fix this use case:

```python
T = typing.TypeVar("T")

@strawberry.interface
class Node(typing.Generic[T]):
    id: strawberry.ID
    name: T

@strawberry.type
class Book(Node[str]):
    ...
```

which is still unsupported, but I can be done in another PR

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
