### PR TITLE
types/info: Add fragments field to Info

### DIFF
--- a/docs/types/resolvers.md
+++ b/docs/types/resolvers.md
@@ -192,14 +192,15 @@ Info objects contain information for the current execution context:
 
 `class Info(Generic[ContextType, RootValueType])`
 
-| Parameter name  | Type                      | Description                                                           |
-| --------------- | ------------------------- | --------------------------------------------------------------------- |
-| field_name      | `str`                     | The name of the current field                                         |
-| context         | `ContextType`             | The value of the context                                              |
-| root_value      | `RootValueType`           | The value for the root type                                           |
-| variable_values | `Dict[str, Any]`          | The variables for this operation                                      |
-| operation       | `OperationDefinitionNode` | The ast for the current operation (public API might change in future) |
-| path            | `Path`                    | The path for the current field                                        |
+| Parameter name  | Type                                | Description                                                           |
+| --------------- | ----------------------------------- | --------------------------------------------------------------------- |
+| field_name      | `str`                               | The name of the current field                                         |
+| context         | `ContextType`                       | The value of the context                                              |
+| root_value      | `RootValueType`                     | The value for the root type                                           |
+| variable_values | `Dict[str, Any]`                    | The variables for this operation                                      |
+| operation       | `OperationDefinitionNode`           | The ast for the current operation (public API might change in future) |
+| path            | `Path`                              | The path for the current field                                        |
+| fragments       | `Dict[str, FragmentDefinitionNode]` | The resolved fragments within the document                            |
 
 [^1]:
     see

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -253,6 +253,7 @@ class StrawberryField(dataclasses.Field):
                 return_type=self._get_return_type(),
                 operation=info.operation,
                 path=info.path,
+                fragments=info.fragments,
             )
 
         def _resolver(source, info: GraphQLResolveInfo, **kwargs):

--- a/strawberry/types/info.py
+++ b/strawberry/types/info.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, Generic, List, Optional, Type, TypeVar, Union
 
 from graphql import OperationDefinitionNode
 from graphql.language import FieldNode
+from graphql.language.ast import FragmentDefinitionNode
 from graphql.pyutils.path import Path
 
 from strawberry.union import StrawberryUnion
@@ -25,3 +26,4 @@ class Info(Generic[ContextType, RootValueType]):
     operation: OperationDefinitionNode
     path: Path
     # TODO: parent_type as strawberry types
+    fragments: Dict[str, FragmentDefinitionNode]

--- a/tests/schema/test_info.py
+++ b/tests/schema/test_info.py
@@ -20,6 +20,7 @@ def test_info_has_the_correct_shape():
         context_equal: bool
         root_equal: bool
         return_type: str
+        fragments: str
 
     @strawberry.type
     class Query:
@@ -34,6 +35,7 @@ def test_info_has_the_correct_shape():
                 context_equal=info.context == my_context,
                 root_equal=info.root_value == root_value,
                 return_type=str(info.return_type),
+                fragments=str({k: str(v) for k, v in info.fragments.items()}),
             )
 
     schema = strawberry.Schema(query=Query)
@@ -48,6 +50,7 @@ def test_info_has_the_correct_shape():
             rootEqual
             variableValues
             returnType
+            fragments
         }
     }"""
 
@@ -65,6 +68,7 @@ def test_info_has_the_correct_shape():
         "rootEqual": True,
         "variableValues": "{}",
         "returnType": "<class 'tests.schema.test_info.test_info_has_the_correct_shape.<locals>.Result'>",  # noqa
+        "fragments": "{}",
     }
 
 


### PR DESCRIPTION
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
My project currently uses fragments in order to break up data, though I was unable to find a way to look up those fragment definitions from within my resolvers. This patch adds the vanilla `.fragments` field to the custom Info field provided by Strawberry in order to allow for full document parsing from within the resolver. Please feel free to let me know if there's some other way I can achieve this in case I missed it. I also only added minimal tests since the functionality itself just exposes a vanilla python-graphql field, though I can add more detailed tests if desired.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
