### PR TITLE
Pythonic wrapper for graphql core `FieldNode`.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Translate graphql-core `FieldNode` into a strawberry type on the `info` object.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,7 @@
 Release type: patch
 
-Translate graphql-core `FieldNode` into a strawberry type on the `info` object.
+This releases adds `selected_fields` on the `info` objects and it 
+allows to introspect the fields that have been selected in a GraphQL
+operation.
+
+This can become useful to run optimisation based on the queried fields.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
 Release type: patch
 
-This releases adds `selected_fields` on the `info` objects and it 
+This releases adds `selected_fields` on the `info` objects and it
 allows to introspect the fields that have been selected in a GraphQL
 operation.
 

--- a/docs/types/resolvers.md
+++ b/docs/types/resolvers.md
@@ -192,14 +192,15 @@ Info objects contain information for the current execution context:
 
 `class Info(Generic[ContextType, RootValueType])`
 
-| Parameter name  | Type                      | Description                                                           |
-| --------------- | ------------------------- | --------------------------------------------------------------------- |
-| field_name      | `str`                     | The name of the current field                                         |
-| context         | `ContextType`             | The value of the context                                              |
-| root_value      | `RootValueType`           | The value for the root type                                           |
-| variable_values | `Dict[str, Any]`          | The variables for this operation                                      |
-| operation       | `OperationDefinitionNode` | The ast for the current operation (public API might change in future) |
-| path            | `Path`                    | The path for the current field                                        |
+| Parameter name  | Type                      | Description                                                                             |
+| --------------- | ------------------------- | --------------------------------------------------------------------------------------- |
+| field_name      | `str`                     | The name of the current field                                                           |
+| context         | `ContextType`             | The value of the context                                                                |
+| root_value      | `RootValueType`           | The value for the root type                                                             |
+| variable_values | `Dict[str, Any]`          | The variables for this operation                                                        |
+| operation       | `OperationDefinitionNode` | The ast for the current operation (public API might change in future)                   |
+| path            | `Path`                    | The path for the current field                                                          |
+| selected_fields | `List[SelectedField]`     | Additional information related to the current field (public API might change in future) |
 
 [^1]:
     see

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -42,6 +42,7 @@ from strawberry.scalars import is_scalar
 from strawberry.schema.config import StrawberryConfig
 from strawberry.type import StrawberryList, StrawberryOptional, StrawberryType
 from strawberry.types.info import Info
+from strawberry.types.nodes import SelectedField
 from strawberry.types.types import TypeDefinition
 from strawberry.union import StrawberryUnion
 
@@ -339,7 +340,8 @@ class GraphQLCoreConverter:
         def _strawberry_info_from_graphql(info: GraphQLResolveInfo) -> Info:
             return Info(
                 field_name=info.field_name,
-                field_nodes=info.field_nodes,
+                field_nodes=info.field_nodes,  # deprecated
+                selected_fields=list(map(SelectedField, info.field_nodes)),
                 context=info.context,
                 root_value=info.root_value,
                 variable_values=info.variable_values,

--- a/strawberry/types/info.py
+++ b/strawberry/types/info.py
@@ -7,6 +7,8 @@ from graphql.pyutils.path import Path
 
 from strawberry.type import StrawberryType
 
+from .nodes import SelectedField
+
 
 ContextType = TypeVar("ContextType")
 RootValueType = TypeVar("RootValueType")
@@ -15,7 +17,8 @@ RootValueType = TypeVar("RootValueType")
 @dataclasses.dataclass
 class Info(Generic[ContextType, RootValueType]):
     field_name: str
-    field_nodes: List[FieldNode]
+    field_nodes: List[FieldNode]  # deprecated
+    selected_fields: List[SelectedField]
     context: ContextType
     root_value: RootValueType
     variable_values: Dict[str, Any]

--- a/strawberry/types/nodes.py
+++ b/strawberry/types/nodes.py
@@ -1,0 +1,106 @@
+"""
+Abstraction layer for graphql-core field nodes.
+
+Call `SelectedField` on a graphql `FieldNode`, such as in `info.field_nodes`.
+
+If a node has only one useful value, it's value is inlined.
+
+If a list of nodes have unique names, it's transformed into a mapping.
+Note Python dicts maintain ordering (for all supported versions).
+"""
+
+import dataclasses
+from typing import Any, Dict, Iterable, List, NewType, Optional, Union
+
+from graphql.language import (  # type: ignore
+    ArgumentNode,
+    DirectiveNode,
+    FieldNode,
+    FragmentSpreadNode,
+    InlineFragmentNode,
+    Node,
+    ValueNode,
+)
+
+
+Arguments = NewType("Arguments", Dict[str, Any])
+Directives = NewType("Directives", Dict[str, Arguments])
+Selection = Union["SelectedField", "FragmentSpread", "InlineFragment"]
+
+
+def value(node: ValueNode) -> Any:
+    """Return useful value from any node."""
+    if hasattr(node, "fields"):
+        return {
+            field.name.value: value(field.value)
+            for field in node.fields  # type: ignore
+        }
+    if hasattr(node, "values"):
+        return list(map(value, node.values))  # type: ignore
+    if hasattr(node, "name"):
+        return node.name.value  # type: ignore
+    return getattr(node, "value", None)
+
+
+def arguments(nodes: Iterable[ArgumentNode]) -> Arguments:
+    """Return mapping of arguments."""
+    return {node.name.value: value(node.value) for node in nodes}  # type: ignore
+
+
+def directives(nodes: Iterable[DirectiveNode]) -> Directives:
+    """Return mapping of directives."""
+    return {node.name.value: arguments(node.arguments) for node in nodes}  # type: ignore
+
+
+def selection(node: Node) -> Selection:
+    """Return typed `Selection` based on node type."""
+    if hasattr(node, "alias"):
+        return SelectedField(node)  # type: ignore
+    if hasattr(node, "selection_set"):
+        return InlineFragment(node)  # type: ignore
+    return FragmentSpread(node)  # type: ignore
+
+
+@dataclasses.dataclass
+class FragmentSpread:
+    """Wrapper for a FragmentSpreadNode."""
+
+    name: str
+    directives: Directives
+
+    def __init__(self, node: FragmentSpreadNode):
+        self.name = node.name.value
+        self.directives = directives(node.directives)
+
+
+@dataclasses.dataclass
+class InlineFragment:
+    """Wrapper for a InlineFragmentNode."""
+
+    type_condition: str
+    selections: List[Selection]
+    directives: Directives
+
+    def __init__(self, node: InlineFragmentNode):
+        self.type_condition = node.type_condition.name.value
+        self.selections = list(
+            map(selection, getattr(node.selection_set, "selections", []))
+        )
+        self.directives = directives(node.directives)
+
+
+@dataclasses.dataclass
+class SelectedField(FragmentSpread):
+    """Wrapper for a FieldNode."""
+
+    alias: Optional[str]
+    arguments: Arguments
+    selections: List[Selection]
+
+    def __init__(self, node: FieldNode):
+        super().__init__(node)  # type: ignore
+        self.alias = getattr(node.alias, "value", None)
+        self.arguments = arguments(node.arguments)
+        self.selections = list(
+            map(selection, getattr(node.selection_set, "selections", []))
+        )


### PR DESCRIPTION
## Description

Follow-up to #787, and may also be reusable in #862. Instead of directly relying on graphql-core node objects, creates strawberry types to be used on `info.field`.

Uses dataclasses, and creates a flatter more Pythonic representation of the node objects provided by GraphQL-core.

Note `field_nodes` is a list, but appears to always be a list of 1 - namely the field being resolved.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
