### PR TITLE
Fix generic input types so that they can be used as type of arguments

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,17 @@
 release type: patch
 
-This release fixes generic input type convertsion so that generic type can be used as type of arguments.
+This release fixes support for generic types so that now we can also use generics for input types:
+
+```python
+T = typing.TypeVar("T")
+
+@strawberry.input
+class Input(typing.Generic[T]):
+    field: T
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def field(self, input: Input[str]) -> str:
+        return input.field
+```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+release type: patch
+
+This release fixes generic input type convertsion so that generic type can be used as type of arguments.

--- a/strawberry/types/generics.py
+++ b/strawberry/types/generics.py
@@ -132,7 +132,7 @@ def copy_type_with(
 
             copied_type = builtins.type(
                 name,
-                (),
+                (base.__origin__,) if hasattr(base, "__origin__") else (),
                 {"_type_definition": type_definition},
             )
 

--- a/tests/schema/test_generics.py
+++ b/tests/schema/test_generics.py
@@ -740,3 +740,28 @@ def test_generic_extending_with_type_var():
     """
 
     assert str(schema) == textwrap.dedent(expected_schema).strip()
+
+
+def test_supports_generic_input_type():
+    T = typing.TypeVar("T")
+
+    @strawberry.input
+    class Input(typing.Generic[T]):
+        field: T
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def field(self, input: Input[str]) -> str:
+            return input.field
+
+    schema = strawberry.Schema(query=Query)
+
+    query = """{
+        field(input: { field: "data" })
+    }"""
+
+    result = schema.execute_sync(query)
+
+    assert not result.errors
+    assert result.data == {"field": "data"}


### PR DESCRIPTION
Currently following schema raises exception `TypeError: StrInput() takes no arguments`.

```python
T = typing.TypeVar("T")

@strawberry.input
class Input(typing.Generic[T]):
    field: T

@strawberry.type
class Query:
    @strawberry.field
    def field(self, input: Input[str]) -> str:
        return input.field
```

This pull request fixes generic input types so that they can be used as type of arguments.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
