### PR TITLE
Fix inconsistent subscription generator clean up when the client disconnects

### DIFF
--- a/strawberry/asgi/__init__.py
+++ b/strawberry/asgi/__init__.py
@@ -1,12 +1,13 @@
 import asyncio
 import json
 import typing
-from websockets.exceptions import ConnectionClosedError
+
 from starlette import status
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse, PlainTextResponse, Response
 from starlette.types import Receive, Scope, Send
 from starlette.websockets import WebSocket, WebSocketDisconnect, WebSocketState
+from websockets.exceptions import ConnectionClosedError
 
 from graphql import ExecutionResult as GraphQLExecutionResult, GraphQLError
 from graphql.error import format_error as format_graphql_error
@@ -184,6 +185,14 @@ class GraphQL:
                     ]
 
                 await self._send_message(websocket, GQL_DATA, payload, operation_id)
+        except asyncio.CancelledError:
+            # CancelError will be received when the client disconnects
+            # and the `handle_async_results` task gets cancelled
+
+            # Suppress the error and prevent sending any message, since the
+            # client was disconnected now
+            return
+
         except Exception as error:
             if not isinstance(error, GraphQLError):
                 error = GraphQLError(str(error), original_error=error)
@@ -194,10 +203,6 @@ class GraphQL:
                 {"data": None, "errors": [format_graphql_error(error)]},
                 operation_id,
             )
-        except asyncio.CancelledError:
-            # CancelError will be received when the client disconnects and the handle_async_results task being cancelled
-            # Suppress the error and prevent contining to the sending completion message stage
-            return
 
         if (
             websocket.client_state != WebSocketState.DISCONNECTED

--- a/strawberry/asgi/__init__.py
+++ b/strawberry/asgi/__init__.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 import typing
-
+from websockets.exceptions import ConnectionClosedError
 from starlette import status
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse, PlainTextResponse, Response
@@ -194,12 +194,19 @@ class GraphQL:
                 {"data": None, "errors": [format_graphql_error(error)]},
                 operation_id,
             )
+        except asyncio.CancelledError:
+            # CancelError will be received when the client disconnects and the handle_async_results task being cancelled
+            # Suppress the error and prevent contining to the sending completion message stage
+            return
 
         if (
             websocket.client_state != WebSocketState.DISCONNECTED
             and websocket.application_state != WebSocketState.DISCONNECTED
         ):
-            await self._send_message(websocket, GQL_COMPLETE, None, operation_id)
+            try:
+                await self._send_message(websocket, GQL_COMPLETE, None, operation_id)
+            except ConnectionClosedError:
+                pass
 
     async def _send_message(
         self,


### PR DESCRIPTION
## Description

1. catch the `asyncio.CancelledError` raised when the client disconnects. Otherwise, the task will exit and leave un-retrieved exception error.
2. The checks on L202 seems unable to catch the disconnected state and insist to send the completion to the disconnected socket, leading to an error printed in the console. I wonder whether we could completely remove the `if` check and just use the try-except?
3. Unit-test pending

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR
#889 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
