### PR TITLE
Add sanic file upload support

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,18 @@
+Release type: minor
+
+This release adds file upload support to the [Sanic](https://sanicframework.org)
+integration. No additional configuration is required to enable file upload support.
+
+The following example shows how a file upload based mutation could look like:
+
+```python
+import strawberry
+from strawberry.file_uploads import Upload
+
+
+@strawberry.type
+class Mutation:
+    @strawberry.mutation
+    def read_text(self, text_file: Upload) -> str:
+        return text_file.read().decode()
+```

--- a/strawberry/sanic/utils.py
+++ b/strawberry/sanic/utils.py
@@ -27,7 +27,7 @@ def convert_request_to_files_dict(request: Request) -> dict:
         if len(file_list) == 1:
             # Turn single item file lists into a single file object
             files_dict[field_name] = BytesIO(file_list[0].body)
-        else:
+        else:  # pragma: no cover
             # TODO: Test this branch once file list uploads are supported (see #766).
             # https://github.com/strawberry-graphql/strawberry/issues/766
 

--- a/strawberry/sanic/utils.py
+++ b/strawberry/sanic/utils.py
@@ -28,6 +28,9 @@ def convert_request_to_files_dict(request: Request) -> dict:
             # Turn single item file lists into a single file object
             files_dict[field_name] = BytesIO(file_list[0].body)
         else:
+            # TODO: Test this branch once file list uploads are supported (see #766).
+            # https://github.com/strawberry-graphql/strawberry/issues/766
+
             # Preserve actual file lists for file list upload support
             file_object_list = [BytesIO(file_item.body) for file_item in file_list]
             files_dict[field_name] = file_object_list

--- a/strawberry/sanic/utils.py
+++ b/strawberry/sanic/utils.py
@@ -1,0 +1,35 @@
+from io import BytesIO
+from typing import Dict, List, Union
+
+from sanic.request import Request
+
+
+def convert_request_to_files_dict(request: Request) -> dict:
+    """
+    request.files has the following format, even if only a single file is uploaded:
+
+    {
+        'textFile': [
+            sanic.request.File(
+                type='text/plain',
+                body=b'strawberry',
+                name='textFile.txt'
+            )
+        ]
+    }
+
+    Note that the dictionary entries are lists.
+    """
+    request_files: dict = request.files
+    files_dict: Dict[str, Union[BytesIO, List[BytesIO]]] = {}
+
+    for field_name, file_list in request_files.items():
+        if len(file_list) == 1:
+            # Turn single item file lists into a single file object
+            files_dict[field_name] = BytesIO(file_list[0].body)
+        else:
+            # Preserve actual file lists for file list upload support
+            file_object_list = [BytesIO(file_item.body) for file_item in file_list]
+            files_dict[field_name] = file_object_list
+
+    return files_dict

--- a/strawberry/sanic/views.py
+++ b/strawberry/sanic/views.py
@@ -104,7 +104,10 @@ class GraphQLView(HTTPMethodView):
             files = convert_request_to_files_dict(request)
             operations = json.loads(request.form.get("operations", "{}"))
             files_map = json.loads(request.form.get("map", "{}"))
-            return replace_placeholders_with_files(operations, files_map, files)
+            try:
+                return replace_placeholders_with_files(operations, files_map, files)
+            except KeyError:
+                abort(400, "File(s) missing in form data")
         return request.json
 
     def should_display_graphiql(self, request):

--- a/strawberry/sanic/views.py
+++ b/strawberry/sanic/views.py
@@ -89,10 +89,11 @@ class GraphQLView(HTTPMethodView):
 
         try:
             query = data["query"]
-            variables = data.get("variables")
-            operation_name = data.get("operationName")
         except KeyError:
             raise ServerError("No GraphQL query found in the request", status_code=400)
+
+        variables = data.get("variables")
+        operation_name = data.get("operationName")
 
         return ExecutionContext(
             query=query, variables=variables, operation_name=operation_name

--- a/strawberry/sanic/views.py
+++ b/strawberry/sanic/views.py
@@ -1,16 +1,18 @@
 import json
 from typing import Any
 
-from sanic.exceptions import abort
+from sanic.exceptions import ServerError, abort
 from sanic.request import Request
 from sanic.response import HTTPResponse, html
 from sanic.views import HTTPMethodView
+from strawberry.file_uploads.data import replace_placeholders_with_files
 from strawberry.http import GraphQLHTTPResponse, process_result
-from strawberry.types import ExecutionResult
+from strawberry.types import ExecutionContext, ExecutionResult
 
 from ..schema import BaseSchema
 from .context import StrawberrySanicContext
 from .graphiql import render_graphiql_page
+from .utils import convert_request_to_files_dict
 
 
 class GraphQLView(HTTPMethodView):
@@ -62,28 +64,47 @@ class GraphQLView(HTTPMethodView):
             template = render_graphiql_page()
             return self.render_template(template=template)
 
-        data = request.json
-        try:
-            query = data["query"]
-        except KeyError:
-            return HTTPResponse("No valid query was provided for the request", 400)
-
-        variables = data.get("variables")
-        operation_name = data.get("operationName")
+        operation_context = self.get_execution_context(request)
         context = await self.get_context(request)
+        root_value = self.get_root_value()
 
         result = await self.schema.execute(
-            query,
-            variable_values=variables,
+            query=operation_context.query,
+            variable_values=operation_context.variables,
             context_value=context,
-            operation_name=operation_name,
-            root_value=self.get_root_value(),
+            root_value=root_value,
+            operation_name=operation_context.operation_name,
         )
         response_data = self.process_result(result)
 
         return HTTPResponse(
             json.dumps(response_data), status=200, content_type="application/json"
         )
+
+    def get_execution_context(self, request: Request) -> ExecutionContext:
+        try:
+            data = self.parse_body(request)
+        except json.JSONDecodeError:
+            raise ServerError("Unable to parse request body as JSON", status_code=400)
+
+        try:
+            query = data["query"]
+            variables = data.get("variables")
+            operation_name = data.get("operationName")
+        except KeyError:
+            raise ServerError("No GraphQL query found in the request", status_code=400)
+
+        return ExecutionContext(
+            query=query, variables=variables, operation_name=operation_name
+        )
+
+    def parse_body(self, request: Request) -> dict:
+        if request.content_type.startswith("multipart/form-data"):
+            files = convert_request_to_files_dict(request)
+            operations = json.loads(request.form.get("operations", "{}"))
+            files_map = json.loads(request.form.get("map", "{}"))
+            return replace_placeholders_with_files(operations, files_map, files)
+        return request.json
 
     def should_display_graphiql(self, request):
         if not self.graphiql:

--- a/tests/sanic/app.py
+++ b/tests/sanic/app.py
@@ -1,0 +1,32 @@
+from random import random
+
+import strawberry
+from sanic import Sanic
+from strawberry.file_uploads import Upload
+from strawberry.sanic.views import GraphQLView as BaseGraphQLView
+
+
+def create_app(**kwargs):
+    @strawberry.type
+    class Query:
+        hello: str = "strawberry"
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        def read_text(self, text_file: Upload) -> str:
+            return text_file.read().decode()
+
+    schema = strawberry.Schema(query=Query, mutation=Mutation)
+
+    class GraphQLView(BaseGraphQLView):
+        def get_root_value(self):
+            return Query()
+
+    app = Sanic("test-app-" + str(random()))
+
+    app.add_route(
+        GraphQLView.as_view(schema=schema, graphiql=kwargs.get("graphiql", True)),
+        "/graphql",
+    )
+    return app

--- a/tests/sanic/app.py
+++ b/tests/sanic/app.py
@@ -23,7 +23,7 @@ def create_app(**kwargs):
         def get_root_value(self):
             return Query()
 
-    app = Sanic("test-app-" + str(random()))
+    app = Sanic(f"test-app-{random()}")
 
     app.add_route(
         GraphQLView.as_view(schema=schema, graphiql=kwargs.get("graphiql", True)),

--- a/tests/sanic/conftest.py
+++ b/tests/sanic/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+from .app import create_app
+
+
+@pytest.fixture
+def sanic_client():
+    yield create_app()

--- a/tests/sanic/test_upload.py
+++ b/tests/sanic/test_upload.py
@@ -1,0 +1,33 @@
+def test_single_file_upload(sanic_client):
+    post_data = (
+        "------sanic\r\n"
+        'Content-Disposition: form-data; name="operations"\r\n'
+        "\r\n"
+        "{"
+        '"query": "mutation($textFile: Upload!){readText(textFile: $textFile)}",'
+        '"variables": {"textFile": null}'
+        "}\r\n"
+        "------sanic\r\n"
+        'Content-Disposition: form-data; name="map"\r\n'
+        "\r\n"
+        '{"textFile": ["variables.textFile"]}\r\n'
+        "------sanic\r\n"
+        'Content-Disposition: form-data; name="textFile"; filename="textFile.txt"\r\n'
+        "Content-Type: text/plain\r\n"
+        "\r\n"
+        "strawberry\r\n"
+        "------sanic--"
+    )
+
+    request, response = sanic_client.test_client.post(
+        "/graphql",
+        data=post_data,
+        headers={"content-type": "multipart/form-data; boundary=----sanic"},
+    )
+
+    assert response.status_code == 200
+
+    data = response.json
+
+    assert not data.get("errors")
+    assert data["data"]["readText"] == "strawberry"

--- a/tests/sanic/test_upload.py
+++ b/tests/sanic/test_upload.py
@@ -1,33 +1,132 @@
+OPERATIONS_FIELD = (
+    "------sanic\r\n"
+    'Content-Disposition: form-data; name="operations"\r\n'
+    "\r\n"
+    "{"
+    '"query": "mutation($textFile: Upload!){readText(textFile: $textFile)}",'
+    '"variables": {"textFile": null}'
+    "}\r\n"
+)
+
+MAP_FIELD = (
+    "------sanic\r\n"
+    'Content-Disposition: form-data; name="map"\r\n'
+    "\r\n"
+    '{"textFile": ["variables.textFile"]}\r\n'
+)
+
+TEXT_FILE_FIELD = (
+    "------sanic\r\n"
+    'Content-Disposition: form-data; name="textFile"; filename="textFile.txt"\r\n'
+    "Content-Type: text/plain\r\n"
+    "\r\n"
+    "strawberry\r\n"
+)
+
+END = "------sanic--"
+
+
 def test_single_file_upload(sanic_client):
-    post_data = (
+    data = OPERATIONS_FIELD + MAP_FIELD + TEXT_FILE_FIELD + END
+    headers = {"content-type": "multipart/form-data; boundary=----sanic"}
+
+    request, response = sanic_client.test_client.post(
+        "/graphql",
+        data=data,
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    assert not response.json.get("errors")
+    assert response.json["data"]["readText"] == "strawberry"
+
+
+def test_extra_form_data_fields_are_ignored(sanic_client):
+    extra_field = (
+        "------sanic\r\n"
+        'Content-Disposition: form-data; name="extra_field"\r\n'
+        "\r\n"
+        "{}\r\n"
+    )
+
+    data = OPERATIONS_FIELD + MAP_FIELD + TEXT_FILE_FIELD + extra_field + END
+    headers = {"content-type": "multipart/form-data; boundary=----sanic"}
+
+    request, response = sanic_client.test_client.post(
+        "/graphql",
+        data=data,
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    assert not response.json.get("errors")
+
+
+def test_sending_invalid_form_data(sanic_client):
+    headers = {"content-type": "multipart/form-data; boundary=----fake"}
+    request, response = sanic_client.test_client.post(
+        "/graphql",
+        headers=headers,
+    )
+
+    assert response.status_code == 400
+    assert "No GraphQL query found in the request" in response.text
+
+
+def test_malformed_query(sanic_client):
+    operations_field = (
         "------sanic\r\n"
         'Content-Disposition: form-data; name="operations"\r\n'
         "\r\n"
         "{"
-        '"query": "mutation($textFile: Upload!){readText(textFile: $textFile)}",'
+        '"NOT_QUERY": "",'
         '"variables": {"textFile": null}'
         "}\r\n"
-        "------sanic\r\n"
-        'Content-Disposition: form-data; name="map"\r\n'
-        "\r\n"
-        '{"textFile": ["variables.textFile"]}\r\n'
-        "------sanic\r\n"
-        'Content-Disposition: form-data; name="textFile"; filename="textFile.txt"\r\n'
-        "Content-Type: text/plain\r\n"
-        "\r\n"
-        "strawberry\r\n"
-        "------sanic--"
     )
+
+    data = operations_field + MAP_FIELD + TEXT_FILE_FIELD + END
+    headers = {"content-type": "multipart/form-data; boundary=----sanic"}
 
     request, response = sanic_client.test_client.post(
         "/graphql",
-        data=post_data,
-        headers={"content-type": "multipart/form-data; boundary=----sanic"},
+        data=data,
+        headers=headers,
     )
 
-    assert response.status_code == 200
+    assert response.status_code == 400
+    assert "No GraphQL query found in the request" in response.text
 
-    data = response.json
 
-    assert not data.get("errors")
-    assert data["data"]["readText"] == "strawberry"
+def test_sending_invalid_json_body(sanic_client):
+    operations_field = (
+        "------sanic\r\n"
+        'Content-Disposition: form-data; name="operations"\r\n'
+        "\r\n"
+        "}\r\n"
+    )
+
+    data = operations_field + MAP_FIELD + TEXT_FILE_FIELD + END
+    headers = {"content-type": "multipart/form-data; boundary=----sanic"}
+
+    request, response = sanic_client.test_client.post(
+        "/graphql",
+        data=data,
+        headers=headers,
+    )
+
+    assert response.status_code == 400
+    assert "Unable to parse request body as JSON" in response.text
+
+
+def test_upload_with_missing_file(sanic_client):
+    data = OPERATIONS_FIELD + MAP_FIELD + END
+    headers = {"content-type": "multipart/form-data; boundary=----sanic"}
+
+    request, response = sanic_client.test_client.post(
+        "/graphql",
+        data=data,
+        headers=headers,
+    )
+
+    assert response.status_code == 400
+    assert "File(s) missing in form data" in response.text

--- a/tests/sanic/test_view.py
+++ b/tests/sanic/test_view.py
@@ -1,36 +1,9 @@
-from random import random
-
-import pytest
-
 import strawberry
 from sanic import Sanic
 from strawberry.sanic.views import GraphQLView as BaseGraphQLView
 from strawberry.types import ExecutionResult, Info
 
-
-def create_app(**kwargs):
-    @strawberry.type
-    class Query:
-        hello: str = "strawberry"
-
-    schema = strawberry.Schema(query=Query)
-
-    class GraphQLView(BaseGraphQLView):
-        def get_root_value(self):
-            return Query()
-
-    app = Sanic("test-app-" + str(random()))
-
-    app.add_route(
-        GraphQLView.as_view(schema=schema, graphiql=kwargs.get("graphiql", True)),
-        "/graphql",
-    )
-    return app
-
-
-@pytest.fixture
-def sanic_client():
-    yield create_app()
+from .app import create_app
 
 
 def test_graphql_query(sanic_client):


### PR DESCRIPTION
This PR adds file upload support to Sanic.

## Description

After reading #327 I added file upload support to Sanic. Like with the other integrations this is single file upload support (#766).

Note that the sanic test client does not appear to have an abstraction for form data. Thats why the tests payload is "raw".

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Closes #327 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
