### PR TITLE
Clean up StrawberryField and StrawberryArgument interface

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+Release type: patch
+
+* Remove usages of `undefined` in favour of `UNSET`
+* Change the signature of `StrawberryField` to make it easier to instantiate
+directly. Also change `default_value` argument to `default`
+* Rename `default_value` to `default` in `StrawberryArgument`

--- a/strawberry/arguments.py
+++ b/strawberry/arguments.py
@@ -13,6 +13,21 @@ from .union import StrawberryUnion
 from .utils.str_converters import to_camel_case
 
 
+class _Unset:
+    def __str__(self):
+        return ""
+
+    def __bool__(self):
+        return False
+
+
+UNSET: Any = _Unset()
+
+
+def is_unset(value: Any) -> bool:
+    return type(value) is _Unset
+
+
 class StrawberryArgumentAnnotation:
     description: Optional[str]
 
@@ -35,7 +50,7 @@ class StrawberryArgument:
         is_list: bool = False,
         is_union: bool = False,
         description: Optional[str] = None,
-        default_value: Any = undefined,
+        default: Any = UNSET,
     ) -> None:
         self.python_name = python_name
         self._graphql_name = graphql_name
@@ -48,7 +63,7 @@ class StrawberryArgument:
         self.is_list = is_list
         self.is_union = is_union
         self.description = description
-        self.default_value = default_value
+        self.default = default
 
     @property
     def graphql_name(self) -> Optional[str]:
@@ -63,7 +78,7 @@ class StrawberryArgument:
         cls,
         python_name: str,
         annotation: Type[Annotated],  # type: ignore
-        default_value: Any,
+        default: Any,
         origin: Any,
     ) -> StrawberryArgument:
         annotated_args = get_args(annotation)
@@ -94,7 +109,7 @@ class StrawberryArgument:
             python_name=python_name,
             # TODO: fetch from StrawberryArgumentAnnotation
             graphql_name=None,
-            default_value=default_value,
+            default=default,
         )
 
 
@@ -110,7 +125,7 @@ def get_arguments_from_annotations(
     for name, annotation in annotations.items():
         default_value = parameters[name].default
         default_value = (
-            undefined
+            UNSET
             if default_value is inspect.Parameter.empty or is_unset(default_value)
             else default_value
         )
@@ -119,7 +134,7 @@ def get_arguments_from_annotations(
             argument = StrawberryArgument.from_annotated(
                 python_name=name,
                 annotation=annotation,
-                default_value=default_value,
+                default=default_value,
                 origin=origin,
             )
         else:
@@ -127,7 +142,7 @@ def get_arguments_from_annotations(
                 type_=annotation,
                 python_name=name,
                 graphql_name=None,
-                default_value=default_value,
+                default=default_value,
                 description=None,
                 origin=origin,
             )
@@ -137,21 +152,6 @@ def get_arguments_from_annotations(
         arguments.append(argument)
 
     return arguments
-
-
-class _Unset:
-    def __str__(self):
-        return ""
-
-    def __bool__(self):
-        return False
-
-
-UNSET: Any = _Unset()
-
-
-def is_unset(value: Any) -> bool:
-    return type(value) is _Unset
 
 
 def convert_argument(value: Any, argument: StrawberryArgument) -> Any:

--- a/strawberry/arguments.py
+++ b/strawberry/arguments.py
@@ -50,7 +50,7 @@ class StrawberryArgument:
         is_list: bool = False,
         is_union: bool = False,
         description: Optional[str] = None,
-        default: Any = UNSET,
+        default: object = UNSET,
     ) -> None:
         self.python_name = python_name
         self._graphql_name = graphql_name
@@ -78,7 +78,7 @@ class StrawberryArgument:
         cls,
         python_name: str,
         annotation: Type[Annotated],  # type: ignore
-        default: Any,
+        default: object,
         origin: Any,
     ) -> StrawberryArgument:
         annotated_args = get_args(annotation)
@@ -123,18 +123,18 @@ def get_arguments_from_annotations(
     arguments = []
 
     for name, annotation in annotations.items():
-        default_value = parameters[name].default
-        default_value = (
+        default = parameters[name].default
+        default = (
             UNSET
-            if default_value is inspect.Parameter.empty or is_unset(default_value)
-            else default_value
+            if default is inspect.Parameter.empty or is_unset(default)
+            else default
         )
 
         if get_origin(annotation) is Annotated:
             argument = StrawberryArgument.from_annotated(
                 python_name=name,
                 annotation=annotation,
-                default=default_value,
+                default=default,
                 origin=origin,
             )
         else:
@@ -142,7 +142,7 @@ def get_arguments_from_annotations(
                 type_=annotation,
                 python_name=name,
                 graphql_name=None,
-                default=default_value,
+                default=default,
                 description=None,
                 origin=origin,
             )

--- a/strawberry/experimental/pydantic/type.py
+++ b/strawberry/experimental/pydantic/type.py
@@ -65,7 +65,7 @@ def type(
                 StrawberryField(
                     python_name=field.name,
                     graphql_name=field.alias if field.has_alias else None,
-                    default_value=field.default if not field.required else UNSET,
+                    default=field.default if not field.required else UNSET,
                     default_factory=(
                         field.default_factory if field.default_factory else UNSET
                     ),
@@ -94,7 +94,7 @@ def type(
                         # adding fields at the beginning won't work as we will also
                         # support default values on them (so the problem will be just
                         # shifted around)
-                        default_value=None,
+                        default=None,
                     ),
                 )
                 for name, type_ in cls_annotations.items()

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -38,7 +38,7 @@ class StrawberryField(dataclasses.Field):
         description: Optional[str] = None,
         base_resolver: Optional[StrawberryResolver] = None,
         permission_classes: List[Type[BasePermission]] = (),  # type: ignore
-        default: Any = UNSET,
+        default: object = UNSET,
         default_factory: Union[Callable, object] = UNSET,
         deprecation_reason: Optional[str] = None,
     ):
@@ -48,9 +48,9 @@ class StrawberryField(dataclasses.Field):
         is_basic_field = not base_resolver
 
         super().__init__(  # type: ignore
-            default=(default if default != UNSET else dataclasses.MISSING),
+            default=(default if default is not UNSET else dataclasses.MISSING),
             default_factory=(
-                default_factory if default_factory != UNSET else dataclasses.MISSING
+                default_factory if default_factory is not UNSET else dataclasses.MISSING
             ),
             init=is_basic_field,
             repr=is_basic_field,

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -24,9 +24,9 @@ _RESOLVER_TYPE = Union[StrawberryResolver, Callable]
 class StrawberryField(dataclasses.Field):
     def __init__(
         self,
-        python_name: Optional[str],
-        graphql_name: Optional[str],
-        type_: Optional[Union[Type, StrawberryUnion]],
+        python_name: Optional[str] = None,
+        graphql_name: Optional[str] = None,
+        type_: Optional[Union[Type, StrawberryUnion]] = None,
         origin: Optional[Union[Type, Callable]] = None,
         child: Optional["StrawberryField"] = None,
         is_subscription: bool = False,

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -38,7 +38,7 @@ class StrawberryField(dataclasses.Field):
         description: Optional[str] = None,
         base_resolver: Optional[StrawberryResolver] = None,
         permission_classes: List[Type[BasePermission]] = (),  # type: ignore
-        default_value: Any = UNSET,
+        default: Any = UNSET,
         default_factory: Union[Callable, object] = UNSET,
         deprecation_reason: Optional[str] = None,
     ):
@@ -48,7 +48,7 @@ class StrawberryField(dataclasses.Field):
         is_basic_field = not base_resolver
 
         super().__init__(  # type: ignore
-            default=(default_value if default_value != UNSET else dataclasses.MISSING),
+            default=(default if default != UNSET else dataclasses.MISSING),
             default_factory=(
                 default_factory if default_factory != UNSET else dataclasses.MISSING
             ),
@@ -73,7 +73,11 @@ class StrawberryField(dataclasses.Field):
         if base_resolver is not None:
             self.base_resolver = base_resolver
 
-        self.default_value = default_value
+        # Note: StrawberryField.default is the same as
+        # StrawberryField.default_value except that `.default` uses
+        # `dataclasses.MISSING` to represent an "undefined" value and
+        # `.default_value` uses `UNSET`
+        self.default_value = default
 
         self.child = child
         self.is_child_optional = is_child_optional
@@ -329,7 +333,7 @@ def field(
         permission_classes=permission_classes or [],
         federation=federation or FederationFieldParams(),
         deprecation_reason=deprecation_reason,
-        default_value=default,
+        default=default,
         default_factory=default_factory,
     )
 

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -97,9 +97,7 @@ class GraphQLCoreConverter:
         raise TypeError(f"Unexpected type '{type_}'")
 
     def from_argument(self, argument: StrawberryArgument) -> GraphQLArgument:
-        default_value = (
-            Undefined if argument.default_value is undefined else argument.default_value
-        )
+        default_value = Undefined if argument.default is UNSET else argument.default
 
         argument_type = self.get_graphql_type_argument(argument)
         argument_type = cast(GraphQLInputType, argument_type)

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -174,6 +174,7 @@ class GraphQLCoreConverter:
         )
 
     def from_input_field(self, field: StrawberryField) -> GraphQLInputField:
+        default_value: object
         if field.default_value in [undefined, UNSET]:
             default_value = Undefined
         else:

--- a/strawberry/types/generics.py
+++ b/strawberry/types/generics.py
@@ -83,7 +83,7 @@ def copy_type_with(
                     graphql_name=field.graphql_name,
                     origin=field.origin,
                     type_=field.type,
-                    default_value=field.default_value,
+                    default=field.default_value,
                     base_resolver=field.base_resolver,
                     child=field.child,
                     is_child_optional=field.is_child_optional,

--- a/strawberry/types/type_resolver.py
+++ b/strawberry/types/type_resolver.py
@@ -422,7 +422,7 @@ def _get_fields(cls: Type) -> List[StrawberryField]:
                 graphql_name=to_camel_case(field.name),
                 type_=field_type,
                 origin=cls,
-                default_value=getattr(cls, field.name, UNSET),
+                default=getattr(cls, field.name, UNSET),
             )
 
         field_name = field.graphql_name

--- a/tests/experimental/pydantic/test_basic.py
+++ b/tests/experimental/pydantic/test_basic.py
@@ -203,7 +203,7 @@ def test_type_with_fields_coming_from_strawberry_and_pydantic_with_default():
     assert definition.fields[2].graphql_name == "name"
     assert definition.fields[2].type is str
     assert definition.fields[2].is_optional is False
-    assert definition.fields[2].default_value == "Michael"
+    assert definition.fields[2].default == "Michael"
 
 
 def test_type_with_nested_fields_coming_from_strawberry_and_pydantic():

--- a/tests/types/test_arguments.py
+++ b/tests/types/test_arguments.py
@@ -6,8 +6,8 @@ import pytest
 from typing_extensions import Annotated
 
 import strawberry
+from strawberry.arguments import UNSET
 from strawberry.exceptions import MultipleStrawberryArgumentsError
-from strawberry.types.types import undefined
 
 
 def test_basic_arguments():
@@ -229,7 +229,7 @@ def test_argument_with_default_value_none():
     assert argument.type == str
     assert argument.is_optional is True
     assert argument.description is None
-    assert argument.default_value is None
+    assert argument.default is None
 
 
 def test_argument_with_default_value_undefined():
@@ -251,7 +251,7 @@ def test_argument_with_default_value_undefined():
     assert argument.type == str
     assert argument.is_optional is True
     assert argument.description is None
-    assert argument.default_value == undefined
+    assert argument.default is UNSET
 
 
 def test_annotated_argument_on_resolver():
@@ -330,7 +330,7 @@ def test_annotated_argument_with_default_value():
     assert argument.type == str
     assert argument.is_optional is False
     assert argument.description == "This is a description"
-    assert argument.default_value == "Patrick"
+    assert argument.default == "Patrick"
 
 
 def test_multiple_annotated_arguments_exception():


### PR DESCRIPTION
## Description

* Change the signature of StrawberryField to make it easier to instantiate directly (defaulting arguments to None)
* Rename `default_value` to `default` in StrawberryField
* Rename `default_value` to `default` in StrawberryArgument
* Remove usages of `undefined` in favour of `UNSET` (note: I haven't actually removed `undefined` but I think we can do that now)

These changes are pretty minor but they are the ground work for allowing custom fields. I was just going to do all the changes necessary but #906 changes some of the code I was going to touch so I'll write up my proposal for it first before doing the code changes.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
