### PR TITLE
Fix federation field requires and provides

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,22 @@
+Release type: patch
+
+Fix `@requires(fields: ["email"])` usage on a Federation field
+
+You can use `@requires` to specify which field your resolver needs
+
+```python
+import strawberry
+
+@strawberry.federation.type(keys=["id"], extend=True)
+class Product:
+    id: strawberry.ID = strawberry.federation.field(external=True)
+    code: str = strawberry.federation.field(external=True)
+
+    @classmethod
+    def resolve_reference(cls, id: strawberry.ID, code: str):
+        return cls(id=id, code=code)
+
+    @strawberry.federation.field(requires=["code"])
+    def my_code(self) -> str:
+        return self.code
+```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,8 +1,8 @@
 Release type: patch
 
-Fix `@requires(fields: ["email"])` usage on a Federation field
+Fix `@requires(fields: ["email"])` and `@provides(fields: ["name"])` usage on a Federation field
 
-You can use `@requires` to specify which field your resolver needs
+You can use `@requires` to specify which fields you need to resolve a field
 
 ```python
 import strawberry
@@ -20,3 +20,7 @@ class Product:
     def my_code(self) -> str:
         return self.code
 ```
+
+`@provides` can be used to specify what fields are going to be resolved
+by the service itself without having the Gateway to contact the external service
+to resolve them.

--- a/strawberry/printer.py
+++ b/strawberry/printer.py
@@ -27,7 +27,7 @@ def print_federation_field_directive(field: Optional[StrawberryField]) -> str:
     out = ""
 
     if field.federation.provides:
-        out += f' @provides(fields: "{field.federation.provides}")'
+        out += f' @provides(fields: "{" ".join(field.federation.provides)}")'
 
     if field.federation.requires:
         out += f' @requires(fields: "{" ".join(field.federation.requires)}")'

--- a/strawberry/printer.py
+++ b/strawberry/printer.py
@@ -30,7 +30,7 @@ def print_federation_field_directive(field: Optional[StrawberryField]) -> str:
         out += f' @provides(fields: "{field.federation.provides}")'
 
     if field.federation.requires:
-        out += f' @requires(fields: "{field.federation.requires}")'
+        out += f' @requires(fields: "{" ".join(field.federation.requires)}")'
 
     if field.federation.external:
         out += " @external"

--- a/tests/federation/test_printer.py
+++ b/tests/federation/test_printer.py
@@ -137,3 +137,67 @@ def test_fields_requires_are_printed_correctly():
     assert schema.as_str() == textwrap.dedent(expected).strip()
 
     del Review
+
+
+def test_field_provides_are_printed_correctly():
+    global Review
+
+    @strawberry.federation.type
+    class User:
+        username: str
+
+    @strawberry.federation.type(keys=["upc"], extend=True)
+    class Product:
+        upc: str = strawberry.federation.field(external=True)
+        name: str = strawberry.federation.field(external=True)
+        reviews: List["Review"]
+
+    @strawberry.federation.type
+    class Review:
+        body: str
+        author: User
+        product: Product = strawberry.federation.field(provides=["name"])
+
+    @strawberry.federation.type
+    class Query:
+        @strawberry.field
+        def top_products(self, first: int) -> List[Product]:
+            return []
+
+    schema = strawberry.federation.Schema(query=Query)
+
+    expected = """
+        extend type Product @key(fields: "upc") {
+          upc: String! @external
+          name: String! @external
+          reviews: [Review!]!
+        }
+
+        type Query {
+          _service: _Service!
+          _entities(representations: [_Any!]!): [_Entity]!
+          topProducts(first: Int!): [Product!]!
+        }
+
+        type Review {
+          body: String!
+          author: User!
+          product: Product! @provides(fields: "name")
+        }
+
+        type User {
+          username: String!
+        }
+
+        scalar _Any
+
+        union _Entity = Product
+
+        type _Service {
+          sdl: String!
+        }
+    """
+
+    assert schema.as_str() == textwrap.dedent(expected).strip()
+
+    del Review

--- a/tests/federation/test_printer.py
+++ b/tests/federation/test_printer.py
@@ -66,3 +66,74 @@ def test_entities_type_when_no_type_has_keys():
     assert schema.as_str() == textwrap.dedent(expected).strip()
 
     del Review
+
+
+def test_fields_requires_are_printed_correctly():
+    global Review
+
+    @strawberry.federation.type
+    class User:
+        username: str
+
+    @strawberry.federation.type(keys=["upc"], extend=True)
+    class Product:
+        upc: str = strawberry.federation.field(external=True)
+        field1: str = strawberry.federation.field(external=True)
+        field2: str = strawberry.federation.field(external=True)
+        field3: str = strawberry.federation.field(external=True)
+
+        @strawberry.federation.field(requires=["field1", "field2", "field3"])
+        def reviews(self) -> List["Review"]:
+            return []
+
+    @strawberry.federation.type
+    class Review:
+        body: str
+        author: User
+        product: Product
+
+    @strawberry.federation.type
+    class Query:
+        @strawberry.field
+        def top_products(self, first: int) -> List[Product]:
+            return []
+
+    schema = strawberry.federation.Schema(query=Query)
+
+    expected = """
+        extend type Product @key(fields: "upc") {
+          upc: String! @external
+          field1: String! @external
+          field2: String! @external
+          field3: String! @external
+          reviews: [Review!]! @requires(fields: "field1 field2 field3")
+        }
+
+        type Query {
+          _service: _Service!
+          _entities(representations: [_Any!]!): [_Entity]!
+          topProducts(first: Int!): [Product!]!
+        }
+
+        type Review {
+          body: String!
+          author: User!
+          product: Product!
+        }
+
+        type User {
+          username: String!
+        }
+
+        scalar _Any
+
+        union _Entity = Product
+
+        type _Service {
+          sdl: String!
+        }
+    """
+
+    assert schema.as_str() == textwrap.dedent(expected).strip()
+
+    del Review


### PR DESCRIPTION
## Description

Right now using `@strawberry.federation.field(requires=["email"])` does nothing, email is not sent to resolve_reference, after checking the schema I found out that the `requires` was printed as an array instead of how graphql wants it: https://www.apollographql.com/docs/federation/federation-spec/#requires

```graphql
# extended from the Users service
extend type User @key(fields: "id") {
  id: ID! @external
  email: String @external
  reviews: [Review] @requires(fields: "email")
}
```

this field allows people to do

```python
@strawberry.federation.field(requires=["size", "weight"])
@strawberry.federation.field(requires=["size"])
```

to specify what fields they want

`@provides` has the same bug, so I fixed it as well

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
