### PR TITLE
Prevent the debug server from setting up its own event loop

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+This releases fixes an issue with the debug server that prevented the
+usage of dataloaders, see: https://github.com/strawberry-graphql/strawberry/issues/940

--- a/strawberry/cli/commands/server.py
+++ b/strawberry/cli/commands/server.py
@@ -57,4 +57,4 @@ def server(schema, host, port, app_dir):
         app.add_websocket_route(path, graphql_app)
 
     print(f"Running strawberry on http://{host}:{port}/ 🍓")
-    uvicorn.run(app, host=host, port=port, log_level="error")
+    uvicorn.run(app, loop="none", host=host, port=port, log_level="error")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
This PR is a possible fix for #940. It configures `uvicorn` to not create its own event loop. This way the `strawberry.dataloader.DataLoader.loop` would be the same as the loop used by `uvicorn`.

While I would probably not configure `uvicorn` the same way in production code, I think it's the simplest (maybe the only) way to make dataloaders work with the debug server command.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #940 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
