### PR TITLE
strawberry-graphql-django package integration

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,10 @@
+release type: patch
+
+This release integrates the `strawberry-graphql-django` package into Strawberry
+core so that it's possible to use the Django extension package directly via the
+`strawberry.django` namespace.
+
+You still need to install `strawberry-graphql-django` if you want to use the
+extended Django support.
+
+See: https://github.com/strawberry-graphql/strawberry-graphql-django

--- a/strawberry/django/__init__.py
+++ b/strawberry/django/__init__.py
@@ -1,0 +1,18 @@
+try:
+    # import modules and objects from external strawberry-graphql-django
+    # package so that it can be used through strawberry.django namespace
+    from strawberry_django import *  # noqa: F401, F403
+except ModuleNotFoundError:
+    import importlib
+
+    def __getattr__(name):
+        # try to import submodule and raise exception only if it does not exist
+        import_symbol = f"{__name__}.{name}"
+        try:
+            return importlib.import_module(import_symbol)
+        except ModuleNotFoundError:
+            raise AttributeError(
+                f"Attempted import of {import_symbol} failed. Make sure to install the"
+                "'strawberry-graphql-django' package to use the Strawberry Django "
+                "extension API."
+            )


### PR DESCRIPTION
This PR integrates `strawberry-graphql-django` package into strawberry core so that it is possible to use django package directly through `strawberry.django` namespace.