### PR TITLE
Start permissions documentation

### DIFF
--- a/docs/guides/permissions.md
+++ b/docs/guides/permissions.md
@@ -25,10 +25,12 @@ class Query:
     user: str = strawberry.field(permission_classes=[IsAuthenticated])
 ```
 
-If the `has_permission` method returns `False` or a falsy value then an error
-will be raised using the `message` class attribute. See
-[Dealing with Errors](/docs/guides/errors) for more information on how errors
-are handled.
+Your `has_permission` method should do the work to check if this request
+has permission to the field. If the `has_permission` method returns `True` or
+a truthy value then the field access will go ahead. If the `has_permission`
+method returns `False` or a falsy value then an error will be raised using
+the `message` class attribute. See [Dealing with Errors](/docs/guides/errors)
+for more information on how errors are handled.
 
 ```json
 {
@@ -40,6 +42,7 @@ are handled.
   ]
 }
 ```
+
 
 ## Accessing user information
 

--- a/docs/guides/permissions.md
+++ b/docs/guides/permissions.md
@@ -6,7 +6,7 @@ title: Permissions
 
 Permissions can be managed using `Permission` classes. A `Permission` class
 extends `BasePermission` and has a `has_permission` method. It can be added to a
-field using the `permission_classes` keyword argument. A simple example looks
+field using the `permission_classes` keyword argument. A basic example looks
 like this:
 
 ```python
@@ -42,7 +42,6 @@ for more information on how errors are handled.
   ]
 }
 ```
-
 
 ## Accessing user information
 

--- a/docs/guides/permissions.md
+++ b/docs/guides/permissions.md
@@ -4,7 +4,10 @@ title: Permissions
 
 # Permissions
 
-Permissions can be managed using `Permission` classes. A `Permission` class extends `BasePermission` and has a `has_permission` method. It can be added to a field using the `permission_classes` keyword argument. A simple example looks like this:
+Permissions can be managed using `Permission` classes. A `Permission` class
+extends `BasePermission` and has a `has_permission` method. It can be added to a
+field using the `permission_classes` keyword argument. A simple example looks
+like this:
 
 ```python
 import strawberry
@@ -22,7 +25,10 @@ class Query:
     user: str = strawberry.field(permission_classes=[IsAuthenticated])
 ```
 
-If the `has_permission` method fails then an error will be raised using the `message` class attribute. See [Dealing with Errors](/docs/guides/errors) for more information on how errors are handled.
+If the `has_permission` method returns `False` or a falsy value then an error
+will be raised using the `message` class attribute. See
+[Dealing with Errors](/docs/guides/errors) for more information on how errors
+are handled.
 
 ```json
 {
@@ -35,12 +41,19 @@ If the `has_permission` method fails then an error will be raised using the `mes
 }
 ```
 
-
 ## Accessing user information
 
-Accessing the current user information to implement your permission checks depends on the web framework you are using. Most frameworks will have a `Request` object where you can either access the current user directly or access headers/cookies/query parameters to authenticate the user. All the Strawberry integrations provide this Request object in the `info.context` object that is accessible in every resolver and in the `has_permission` function. You can find more details about a specific framework integration under the "Integrations" heading in the navigation. 
+Accessing the current user information to implement your permission checks
+depends on the web framework you are using. Most frameworks will have a
+`Request` object where you can either access the current user directly or access
+headers/cookies/query parameters to authenticate the user. All the Strawberry
+integrations provide this Request object in the `info.context` object that is
+accessible in every resolver and in the `has_permission` function. You can find
+more details about a specific framework integration under the "Integrations"
+heading in the navigation.
 
-In this example we are using `starlette` which uses the [ASGI](/docs/integrations/asgi) integration:
+In this example we are using `starlette` which uses the
+[ASGI](/docs/integrations/asgi) integration:
 
 ```python
 from myauth import authenticate_header, authenticate_query_param
@@ -60,10 +73,18 @@ class IsAuthenticated(BasePermission):
         return False
 ```
 
-Here we retrieve the `request` object from the `context` provided by `info`. This object will be either a `Request` or `Websocket` instance from `starlette` (see: [Request docs](https://www.starlette.io/requests/) and [Websocket docs](https://www.starlette.io/websockets/)).
+Here we retrieve the `request` object from the `context` provided by `info`.
+This object will be either a `Request` or `Websocket` instance from `starlette`
+(see: [Request docs](https://www.starlette.io/requests/) and
+[Websocket docs](https://www.starlette.io/websockets/)).
 
-In the next step we take either the `Authorization` header or the `auth` query parameter out of the `request` object, depending on which is available. We then pass those on to some authenticate methods we've implemented ourselves.
+In the next step we take either the `Authorization` header or the `auth` query
+parameter out of the `request` object, depending on which is available. We then
+pass those on to some authenticate methods we've implemented ourselves.
 
-Beyond providing hooks, Authentication is not currently Strawberry's responsibility. You should provide your own helpers to figure out if a request has the permissions you expect.
+Beyond providing hooks, Authentication is not currently Strawberry's
+responsibility. You should provide your own helpers to figure out if a request
+has the permissions you expect.
 
-*For more discussion on Authentication see [Issue #830](https://github.com/strawberry-graphql/strawberry/issues/830).*
+_For more discussion on Authentication see_
+_[Issue #830](https://github.com/strawberry-graphql/strawberry/issues/830)._

--- a/docs/guides/permissions.md
+++ b/docs/guides/permissions.md
@@ -4,4 +4,73 @@ title: Permissions
 
 # Permissions
 
-Documentation coming soon
+Permissions can be managed using `Permission` classes. A `Permission` class extends `BasePermission` and has a `has_permission` method. It can be hooked up to a field using the `permission_classes` keyword argument. A simple example looks like this:
+
+```python
+import strawberry
+from strawberry.permission import BasePermission
+from strawberry.types import Info
+
+class IsAuthenticated(BasePermission):
+    message = "User is not authenticated"
+
+    def has_permission(self, source: Any, info: Info, **kwargs) -> bool:
+        return False
+
+@strawberry.type
+class Query:
+    user: str = strawberry.field(permission_classes=[IsAuthenticated])
+```
+
+If the `has_permission` method fails then an error will be raised using the `message` class attribute. See [Dealing with Errors](/docs/guides/errors) for more information.
+
+```json
+{
+  "data": null,
+  "errors": [
+    {
+      "message": "User is not authenticated"
+    }
+  ]
+}
+```
+
+In a simple use case you could obtain all the information you need to execute the `has_permission` check from the `source` and `info` objects.
+
+For more complex cases it might need more information from the Request. This can be provided by extending the `GraphQL` class to provide more context. The `Permission` class can then use that context from the `Info` object.
+
+```python
+from strawberry.asgi import GraphQL
+
+from starlette.requests import Request
+from starlette.websockets import WebSocket
+
+
+class MyGraphQL(GraphQL):
+    async def get_context(self, request: typing.Union[Request, WebSocket]) -> Any:
+        return {
+            "auth": request.headers["Authorization"] or request.query_params["auth"]
+        }
+```
+
+In this example the `MyGraphQL` class extends the Strawberry `GraphQL` class to provide a `get_context` helper. This helper is used to fill the `Info` object. You should be aware that `Request` and `WebSocket` objects have different attributes and methods, and you may need to handle retrieving authorization details from them differently.
+
+*For more information on using context see the [Data Loaders](/docs/guides/dataloaders) docs.*
+
+The `Info` object can then be accessed in a `Permission` class like:
+
+```python
+from myauth import authenticate
+
+class IsAuthenticated(BasePermission):
+    message = "User is not authenticated"
+
+    def has_permission(self, source: Any, info: Info, **kwargs) -> bool:
+        return authenticate(info.context["auth"])
+```
+
+Here we are taking the `auth` key out of the `info.context` dictionary and passing it to an `authenticate` method we have implemented somewhere else in our codebase.
+
+Beyond providing hooks, Authentication is not currently Strawberry's responsibility. You should provide your own helpers to figure out if a request has the permissions you expect.
+
+*For more discussion on Authentication see [Issue #830](https://github.com/strawberry-graphql/strawberry/issues/830).*

--- a/docs/guides/permissions.md
+++ b/docs/guides/permissions.md
@@ -38,7 +38,7 @@ If the `has_permission` method fails then an error will be raised using the `mes
 
 ## Accessing user information
 
-Accessing the current user information to implement your permission checks depends on the web framework you are using. Most frameworks will have a Request object where you can either access the current user directly or access headers/cookies/query parameters to authenticate the user. All the Strawberry integrations will provide this Request object in the `info.context` object that is accessible in every resolver and in the `has_permission` function. You can find more details about a specific framework integration under the "Integrations" heading in the navigation. 
+Accessing the current user information to implement your permission checks depends on the web framework you are using. Most frameworks will have a `Request` object where you can either access the current user directly or access headers/cookies/query parameters to authenticate the user. All the Strawberry integrations provide this Request object in the `info.context` object that is accessible in every resolver and in the `has_permission` function. You can find more details about a specific framework integration under the "Integrations" heading in the navigation. 
 
 In this example we are using `starlette` which uses the [ASGI](/docs/integrations/asgi) integration:
 

--- a/docs/guides/permissions.md
+++ b/docs/guides/permissions.md
@@ -22,7 +22,7 @@ class Query:
     user: str = strawberry.field(permission_classes=[IsAuthenticated])
 ```
 
-If the `has_permission` method fails then an error will be raised using the `message` class attribute. See [Dealing with Errors](/docs/guides/errors) for more information.
+If the `has_permission` method fails then an error will be raised using the `message` class attribute. See [Dealing with Errors](/docs/guides/errors) for more information on how errors are handled.
 
 ```json
 {

--- a/docs/guides/permissions.md
+++ b/docs/guides/permissions.md
@@ -35,7 +35,12 @@ If the `has_permission` method fails then an error will be raised using the `mes
 }
 ```
 
-In most use cases you can obtain all the information you need to execute the `has_permission` check from the `source` and `info` objects. For example the `info` object contains a `context` dictionary, which includes the Request object. The Request object can be used to retrieve headers, query parameters, or cookies that can be used for auth like so:
+
+## Accessing user information
+
+Accessing the current user information to implement your permission checks depends on the web framework you are using. Most frameworks will have a Request object where you can either access the current user directly or access headers/cookies/query parameters to authenticate the user. All the Strawberry integrations will provide this Request object in the `info.context` object that is accessible in every resolver and in the `has_permission` function. You can find more details about a specific framework integration under the "Integrations" heading in the navigation. 
+
+In this example we are using `starlette` which uses the [ASGI](/docs/integrations/asgi) integration:
 
 ```python
 from myauth import authenticate_header, authenticate_query_param

--- a/docs/guides/permissions.md
+++ b/docs/guides/permissions.md
@@ -49,9 +49,9 @@ class IsAuthenticated(BasePermission):
     def has_permission(self, source: Any, info: Info, **kwargs) -> bool:
         request: Union[Request, Websocket] = info.context["request"]
         if "Authorization" in request.headers:
-          return authenticate_header(request)
+            return authenticate_header(request)
         if "auth" in request.query_params:
-          return authenticate_query_params(request)
+            return authenticate_query_params(request)
         return False
 ```
 

--- a/docs/guides/permissions.md
+++ b/docs/guides/permissions.md
@@ -4,7 +4,7 @@ title: Permissions
 
 # Permissions
 
-Permissions can be managed using `Permission` classes. A `Permission` class extends `BasePermission` and has a `has_permission` method. It can be hooked up to a field using the `permission_classes` keyword argument. A simple example looks like this:
+Permissions can be managed using `Permission` classes. A `Permission` class extends `BasePermission` and has a `has_permission` method. It can be added to a field using the `permission_classes` keyword argument. A simple example looks like this:
 
 ```python
 import strawberry


### PR DESCRIPTION
Adds basic examples from permissions tests, shows how errors will be returned and explains how this could be combined with `get_context` to obtain details from the `Request` object.

## Description

This change adds documentation for the current state of the `BasePermission` class and its behaviour in the system. I am not particularly familiar with Strawberry, but I needed this documentation myself, so I thought a good learning process would be to write it.

To help readers understand the documentation I've explained how the `has_permission` method will return an error, and included details about how you might implement the `has_permission` method. Including suggesting how to add details to the `Info.context` object.

I haven't checked that my approach works, and I don't know if this is the suggested way to do permission. However I figured that just writing something would be a good start and would allow for iteration.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

Not sure, seems like documentation is in meta-issues

## Checklist

Hi, I haven't done any of this! I've just submitted this through the github editor. Would love pointers if there is anything I'm missing. I couldn't see anything in CONTRIBUTING about documentation.

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
