### PR TITLE
Fix aiohttp subscription request separation

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+release type: patch
+
+This release fixes that AIOHTTP subscription requests were not properly separated.
+This could lead to subscriptions terminating each other.

--- a/tests/aiohttp/test_subscriptions.py
+++ b/tests/aiohttp/test_subscriptions.py
@@ -102,6 +102,15 @@ async def test_subscription_cancellation(aiohttp_client):
     app.router.add_route("*", "/graphql", view)
     aiohttp_app_client = await aiohttp_client(app)
 
+    # Note Python 3.7 does not support Task.get_name/get_coro so we have to use
+    # repr(Task) to check whether expected tasks are running.
+    def get_result_handler_tasks():
+        return [
+            task
+            for task in asyncio.all_tasks()
+            if "WebSocketHandler.handle_async_results" in repr(task)
+        ]
+
     async with aiohttp_app_client.ws_connect("/graphql", protocols=[GRAPHQL_WS]) as ws:
         await ws.send_json({"type": GQL_CONNECTION_INIT})
         await ws.send_json(
@@ -121,8 +130,7 @@ async def test_subscription_cancellation(aiohttp_client):
         assert response["payload"]["data"] == {"infinity": "Hi"}
 
         # Assert that a handle_async_results task is running
-        coroutine_name = "WebSocketHandler.handle_async_results"
-        assert any([coroutine_name in repr(t) for t in asyncio.all_tasks()])
+        assert len(get_result_handler_tasks()) == 1
 
         await ws.send_json({"type": GQL_STOP, "id": "demo"})
         response = await ws.receive_json()
@@ -136,7 +144,7 @@ async def test_subscription_cancellation(aiohttp_client):
         assert ws.closed
 
         # Assert that the handle_async_results task is not running anymore
-        assert not any([coroutine_name in repr(t) for t in asyncio.all_tasks()])
+        assert len(get_result_handler_tasks()) == 0
 
 
 async def test_subscription_errors(aiohttp_client):
@@ -444,3 +452,61 @@ async def test_resolving_enums(aiohttp_client):
         # make sure the WebSocket is disconnected now
         await ws.receive(timeout=2)  # receive close
         assert ws.closed
+
+
+async def test_task_cancellation_separation(aiohttp_client):
+    view = GraphQLView(schema=schema, keep_alive=False)
+    app = web.Application()
+    app.router.add_route("*", "/graphql", view)
+    aiohttp_app_client = await aiohttp_client(app)
+
+    # Note Python 3.7 does not support Task.get_name/get_coro so we have to use
+    # repr(Task) to check whether expected tasks are running.
+    def get_result_handler_tasks():
+        return [
+            task
+            for task in asyncio.all_tasks()
+            if "WebSocketHandler.handle_async_results" in repr(task)
+        ]
+
+    connection1 = aiohttp_app_client.ws_connect("/graphql", protocols=[GRAPHQL_WS])
+    connection2 = aiohttp_app_client.ws_connect("/graphql", protocols=[GRAPHQL_WS])
+
+    async with connection1 as ws1, connection2 as ws2:
+        start_payload = {
+            "type": GQL_START,
+            "id": "demo",
+            "payload": {"query": 'subscription { infinity(message: "Hi") }'},
+        }
+
+        assert len(get_result_handler_tasks()) == 0
+
+        await ws1.send_json({"type": GQL_CONNECTION_INIT})
+        await ws1.send_json(start_payload)
+        await ws1.receive_json()
+
+        assert len(get_result_handler_tasks()) == 1
+
+        await ws2.send_json({"type": GQL_CONNECTION_INIT})
+        await ws2.send_json(start_payload)
+        await ws2.receive_json()
+
+        assert len(get_result_handler_tasks()) == 2
+
+        await ws1.send_json({"type": GQL_STOP, "id": "demo"})
+        await ws1.send_json({"type": GQL_CONNECTION_TERMINATE})
+
+        async for msg in ws1:
+            # Receive all outstanding messages including the final close message
+            pass
+
+        assert len(get_result_handler_tasks()) == 1
+
+        await ws2.send_json({"type": GQL_STOP, "id": "demo"})
+        await ws2.send_json({"type": GQL_CONNECTION_TERMINATE})
+
+        async for msg in ws2:
+            # Receive all outstanding messages including the final close message
+            pass
+
+        assert len(get_result_handler_tasks()) == 0

--- a/tests/aiohttp/test_subscriptions.py
+++ b/tests/aiohttp/test_subscriptions.py
@@ -120,8 +120,9 @@ async def test_subscription_cancellation(aiohttp_client):
         assert response["id"] == "demo"
         assert response["payload"]["data"] == {"infinity": "Hi"}
 
-        assert "demo" in view.tasks.keys()
-        assert "demo" in view.subscriptions.keys()
+        # Assert that a handle_async_results task is running
+        coroutine_name = "WebSocketHandler.handle_async_results"
+        assert any([coroutine_name in repr(t) for t in asyncio.all_tasks()])
 
         await ws.send_json({"type": GQL_STOP, "id": "demo"})
         response = await ws.receive_json()
@@ -134,8 +135,8 @@ async def test_subscription_cancellation(aiohttp_client):
         await ws.receive(timeout=2)  # receive close
         assert ws.closed
 
-        assert "demo" not in view.tasks.keys()
-        assert "demo" not in view.subscriptions.keys()
+        # Assert that the handle_async_results task is not running anymore
+        assert not any([coroutine_name in repr(t) for t in asyncio.all_tasks()])
 
 
 async def test_subscription_errors(aiohttp_client):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
This PR fixes that request specific aiohttp subscription variables (keep alive task reference, async result handler references...) were not stored separate for each request. Among other things, this caused the termination of a single subscription to terminate all other active subscriptions as well.

Now the [aiohttp request's storage](https://docs.aiohttp.org/en/stable/web_advanced.html#request-s-storage) is used instead of view instance variables.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* None

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
