### PR TITLE
Import django into strawberry namespace

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+release type: patch
+
+This release fixes the IDE integration where package `strawberry.django` could not be find by some editors like vscode.

--- a/strawberry/__init__.py
+++ b/strawberry/__init__.py
@@ -1,4 +1,4 @@
-from . import experimental, federation
+from . import django, experimental, federation
 from .arguments import argument
 from .custom_scalar import scalar
 from .directive import directive
@@ -23,6 +23,7 @@ __all__ = [
     "Schema",
     "argument",
     "directive",
+    "django",
     "enum",
     "federation",
     "field",

--- a/strawberry/django/__init__.py
+++ b/strawberry/django/__init__.py
@@ -1,7 +1,7 @@
 try:
     # import modules and objects from external strawberry-graphql-django
     # package so that it can be used through strawberry.django namespace
-    from strawberry_django import *  # noqa: F401, F403
+    from strawberry_django import *  # type: ignore # noqa: F401, F403
 except ModuleNotFoundError:
     import importlib
 


### PR DESCRIPTION
This fixes django symbol resolution in some IDE which was originally reported here:
* https://github.com/strawberry-graphql/strawberry-graphql-django/issues/35
* https://github.com/strawberry-graphql/strawberry-graphql-django/issues/36