### PR TITLE
Use class MRO to determine field origin

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Fix type resolution when inheriting from types from another module using deferred annotations.

--- a/tests/types/test_deferred_annotations.py
+++ b/tests/types/test_deferred_annotations.py
@@ -1,0 +1,38 @@
+from sys import modules
+from types import ModuleType
+
+import strawberry
+
+
+deferred_module_source = """
+from __future__ import annotations
+
+import strawberry
+
+@strawberry.type
+class User:
+    username: str
+    email: str
+
+@strawberry.interface
+class UserContent:
+    created_by: User
+"""
+
+
+def test_deferred_other_module():
+    mod = ModuleType("tests.deferred_module")
+    modules[mod.__name__] = mod
+
+    try:
+        exec(deferred_module_source, mod.__dict__)
+
+        @strawberry.type
+        class Post(mod.UserContent):
+            title: str
+            body: str
+
+        definition = Post._type_definition
+        assert definition.fields[0].type == mod.User
+    finally:
+        del modules[mod.__name__]


### PR DESCRIPTION
## Description

When generating `StrawberryField`s for a `dataclass`, use the classes MRO to decide the `origin`. This fixes errors that can occur if a name used type annotation in a base class (from a different module) is not available in the module of the child class.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

None

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
