### PR TITLE
Add custom GraphQL enum type to fix #1007

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,21 @@
+Release type: minor
+
+This release fixes a bug that was preventing the use of an enum member as the
+default value for an argument.
+
+For example:
+
+```python
+@strawberry.enum
+class IceCreamFlavour(Enum):
+    VANILLA = "vanilla"
+    STRAWBERRY = "strawberry"
+    CHOCOLATE = "chocolate"
+    PISTACHIO = "pistachio"
+
+@strawberry.mutation
+def create_flavour(
+    self, flavour: IceCreamFlavour = IceCreamFlavour.STRAWBERRY
+) -> str:
+    return f"{flavour.name}"
+```

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -34,6 +34,10 @@ from .types.concrete_type import ConcreteType
 from .types.scalar import get_scalar_type
 
 
+# graphql-core expects a resolver for an Enum type to return
+# the enum's *value* (not its name or an instance of the enum). We have to
+# subclass the GraphQLEnumType class to enable returning Enum members from
+# resolvers.
 class CustomGraphQLEnumType(GraphQLEnumType):
     def serialize(self, output_value: Any) -> str:
         if isinstance(output_value, Enum):

--- a/tests/schema/test_enum.py
+++ b/tests/schema/test_enum.py
@@ -311,3 +311,26 @@ def test_enum_as_default_argument():
 
     assert not result.errors
     assert result.data["createFlavour"] == "STRAWBERRY"
+
+
+def test_enum_resolver_plain_value():
+    @strawberry.enum
+    class IceCreamFlavour(Enum):
+        VANILLA = "vanilla"
+        STRAWBERRY = "strawberry"
+        CHOCOLATE = "chocolate"
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def best_flavour(self) -> IceCreamFlavour:
+            return "strawberry"  # type: ignore
+
+    schema = strawberry.Schema(query=Query)
+
+    query = "{ bestFlavour }"
+
+    result = schema.execute_sync(query)
+
+    assert not result.errors
+    assert result.data["bestFlavour"] == "STRAWBERRY"

--- a/tests/schema/test_enum.py
+++ b/tests/schema/test_enum.py
@@ -1,5 +1,6 @@
 import typing
 from enum import Enum
+from textwrap import dedent
 from typing import List, Optional
 
 import pytest
@@ -226,3 +227,87 @@ async def test_enum_in_list_async():
 
     assert not result.errors
     assert result.data["bestFlavours"] == ["STRAWBERRY", "PISTACHIO"]
+
+
+def test_enum_as_argument():
+    @strawberry.enum
+    class IceCreamFlavour(Enum):
+        VANILLA = "vanilla"
+        STRAWBERRY = "strawberry"
+        CHOCOLATE = "chocolate"
+        PISTACHIO = "pistachio"
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def create_flavour(self, flavour: IceCreamFlavour) -> str:
+            return f"{flavour.name}"
+
+    schema = strawberry.Schema(query=Query)
+
+    expected = dedent(
+        """
+        enum IceCreamFlavour {
+          VANILLA
+          STRAWBERRY
+          CHOCOLATE
+          PISTACHIO
+        }
+
+        type Query {
+          createFlavour(flavour: IceCreamFlavour!): String!
+        }
+        """
+    ).strip()
+
+    assert str(schema) == expected
+
+    query = "{ createFlavour(flavour: CHOCOLATE) }"
+
+    result = schema.execute_sync(query)
+
+    assert not result.errors
+    assert result.data["createFlavour"] == "CHOCOLATE"
+
+
+def test_enum_as_default_argument():
+    @strawberry.enum
+    class IceCreamFlavour(Enum):
+        VANILLA = "vanilla"
+        STRAWBERRY = "strawberry"
+        CHOCOLATE = "chocolate"
+        PISTACHIO = "pistachio"
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def create_flavour(
+            self, flavour: IceCreamFlavour = IceCreamFlavour.STRAWBERRY
+        ) -> str:
+            return f"{flavour.name}"
+
+    schema = strawberry.Schema(query=Query)
+
+    expected = dedent(
+        """
+        enum IceCreamFlavour {
+          VANILLA
+          STRAWBERRY
+          CHOCOLATE
+          PISTACHIO
+        }
+
+        type Query {
+          createFlavour(flavour: IceCreamFlavour! = STRAWBERRY): String!
+        }
+        """
+    ).strip()
+
+    assert str(schema) == expected
+
+    query = "{ createFlavour }"
+
+    result = schema.execute_sync(query)
+
+    assert not result.errors
+    assert result.data["createFlavour"] == "STRAWBERRY"


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail here. -->

This PR fixes the issue with defining an enum member as the default value for an argument by subclassing the GraphQLEnumType from graphql-core and overriding the serialise function. This has the happy side effect of removing the need for the conversion layer `_convert_enums_to_values` in the field resolvers.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #1007 

