### PR TITLE
Only import django when type checking

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+This release fixes an import error when using strawberry with strawberry django.

--- a/strawberry/__init__.py
+++ b/strawberry/__init__.py
@@ -1,4 +1,6 @@
-from . import django, experimental, federation
+from typing import TYPE_CHECKING
+
+from . import experimental, federation
 from .arguments import argument
 from .custom_scalar import scalar
 from .directive import directive
@@ -12,6 +14,10 @@ from .scalars import ID
 from .schema import Schema
 from .type import input, interface, type
 from .union import union
+
+
+if TYPE_CHECKING:
+    from . import django
 
 
 __all__ = [


### PR DESCRIPTION
#994 broke imports when using strawberry and strawberry django. 

To replicate the issue:

```python
import strawberry
```

with both strawberry-graphql and strawberry-graphql-django installed.

This fix should work as only import django when typechecking :)