### PR TITLE
Revert #994: Fix circular import with strawberry-graphql-django package

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+release type: patch
+
+This release fixes circular import issue with `strawberry-graphql-django`
+package introduced by version 0.65.4.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,4 @@
 release type: patch
 
-This release fixes circular import issue with `strawberry-graphql-django`
-package introduced by version 0.65.4.
+This release reverts the changes made in v0.65.4 that caused an issue leading to
+circular imports when using the `strawberry-graphql-django` extension package.

--- a/strawberry/__init__.py
+++ b/strawberry/__init__.py
@@ -1,4 +1,4 @@
-from . import django, experimental, federation
+from . import experimental, federation
 from .arguments import argument
 from .custom_scalar import scalar
 from .directive import directive
@@ -23,7 +23,6 @@ __all__ = [
     "Schema",
     "argument",
     "directive",
-    "django",
     "enum",
     "federation",
     "field",

--- a/strawberry/django/__init__.py
+++ b/strawberry/django/__init__.py
@@ -1,7 +1,7 @@
 try:
     # import modules and objects from external strawberry-graphql-django
     # package so that it can be used through strawberry.django namespace
-    from strawberry_django import *  # type: ignore # noqa: F401, F403
+    from strawberry_django import *  # noqa: F401, F403
 except ModuleNotFoundError:
     import importlib
 


### PR DESCRIPTION
Fix circular import with strawberry-graphql-django package. This issue was introduced by version 0.65.4 where I tried to fix symbol resolution with IDEs.