### PR TITLE
Add ability to change argument graphql name

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,23 @@
+Release type: minor
+
+Add ability to specific the graphql name for a resolver argument. E.g.,
+
+```python
+from typing import Annotated
+import strawberry
+
+
+@strawberry.input
+class HelloInput:
+    name: str = "world"
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def hello(
+        self,
+        input_: Annotated[HelloInput, strawberry.argument(name="input")]
+    ) -> str:
+        return f"Hi {input_.name}"
+```

--- a/strawberry/arguments.py
+++ b/strawberry/arguments.py
@@ -30,9 +30,11 @@ def is_unset(value: Any) -> bool:
 
 class StrawberryArgumentAnnotation:
     description: Optional[str]
+    name: Optional[str]
 
-    def __init__(self, description: Optional[str] = None):
+    def __init__(self, description: Optional[str] = None, name: Optional[str] = None):
         self.description = description
+        self.name = name
 
 
 class StrawberryArgument:
@@ -87,6 +89,7 @@ class StrawberryArgument:
         type_ = annotated_args[0]
         argument_metadata = None
         argument_description = None
+        argument_graphql_name = None
 
         # Find any instances of StrawberryArgumentAnnotation
         # in the other Annotated args, raising an exception if there
@@ -102,13 +105,13 @@ class StrawberryArgument:
 
         if argument_metadata is not None:
             argument_description = argument_metadata.description
+            argument_graphql_name = argument_metadata.name
 
         return cls(
             type_=type_,
             description=argument_description,
             python_name=python_name,
-            # TODO: fetch from StrawberryArgumentAnnotation
-            graphql_name=None,
+            graphql_name=argument_graphql_name,
             default=default,
         )
 
@@ -217,8 +220,10 @@ def convert_arguments(
     return kwargs
 
 
-def argument(description: Optional[str] = None) -> StrawberryArgumentAnnotation:
-    return StrawberryArgumentAnnotation(description=description)
+def argument(
+    description: Optional[str] = None, name: Optional[str] = None
+) -> StrawberryArgumentAnnotation:
+    return StrawberryArgumentAnnotation(description=description, name=name)
 
 
 # TODO: check exports

--- a/tests/schema/test_arguments.py
+++ b/tests/schema/test_arguments.py
@@ -31,6 +31,34 @@ def test_argument_descriptions():
     )
 
 
+def test_argument_names():
+    @strawberry.input
+    class HelloInput:
+        name: str = strawberry.field(default="Patrick", description="Your name")
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def hello(
+            self, input_: Annotated[HelloInput, strawberry.argument(name="input")]
+        ) -> str:
+            return f"Hi {input_.name}"
+
+    schema = strawberry.Schema(query=Query)
+
+    assert str(schema) == dedent(
+        '''\
+        input HelloInput {
+          """Your name"""
+          name: String! = "Patrick"
+        }
+
+        type Query {
+          hello(input: HelloInput!): String!
+        }'''
+    )
+
+
 def test_argument_with_default_value_none():
     @strawberry.type
     class Query:

--- a/tests/types/test_arguments.py
+++ b/tests/types/test_arguments.py
@@ -333,6 +333,34 @@ def test_annotated_argument_with_default_value():
     assert argument.default == "Patrick"
 
 
+def test_annotated_argument_with_rename():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def name(  # type: ignore
+            arg: Annotated[
+                str,
+                strawberry.argument(name="argument"),  # noqa: F722
+            ] = "Patrick"
+        ) -> str:
+            return "Name"
+
+    definition = Query._type_definition
+
+    assert definition.name == "Query"
+
+    assert len(definition.fields[0].arguments) == 1
+
+    argument = definition.fields[0].arguments[0]
+
+    assert argument.graphql_name == "argument"
+    assert argument.python_name == "arg"
+    assert argument.type == str
+    assert argument.is_optional is False
+    assert argument.description is None
+    assert argument.default == "Patrick"
+
+
 def test_multiple_annotated_arguments_exception():
     with pytest.raises(MultipleStrawberryArgumentsError) as error:
 


### PR DESCRIPTION
## Description

Add ability to set the graphql name of an argument using the `strawberry.argument` annotation. This is useful, E.g., to rename an `input` argument to not shadow the python builtin.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #725 

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
