### PR TITLE
add option for reloader in strawberry server cli

### DIFF
--- a/strawberry/cli/commands/server.py
+++ b/strawberry/cli/commands/server.py
@@ -16,6 +16,7 @@ from strawberry.utils.importer import import_module_symbol
 @click.argument("schema", type=str)
 @click.option("-h", "--host", default="0.0.0.0", type=str)
 @click.option("-p", "--port", default=8000, type=int)
+@click.option("-r", "--reload", default=True, type=bool)
 @click.option(
     "--app-dir",
     default=".",
@@ -27,7 +28,7 @@ from strawberry.utils.importer import import_module_symbol
         "Works the same as `--app-dir` in uvicorn."
     ),
 )
-def server(schema, host, port, app_dir):
+def server(schema, host, port, reload, app_dir):
     sys.path.insert(0, app_dir)
 
     try:
@@ -40,9 +41,10 @@ def server(schema, host, port, app_dir):
         message = "The `schema` must be an instance of strawberry.Schema"
         raise click.BadArgumentUsage(message)
 
-    reloader = hupper.start_reloader("strawberry.cli.run", verbose=False)
     schema_module = importlib.import_module(schema_symbol.__module__)
-    reloader.watch_files([schema_module.__file__])
+    if reload:
+        reloader = hupper.start_reloader("strawberry.cli.run", verbose=False)
+        reloader.watch_files([schema_module.__file__])
 
     app = Starlette(debug=True)
     app.add_middleware(


### PR DESCRIPTION

## Description
I am facing the problem that strawberry is preventing me from opening graphiql because someone is editing the file all the time. But nobody touches him ...
![изображение](https://user-images.githubusercontent.com/59787538/123176378-80301e80-d4ad-11eb-9b8a-1f794d3e8ba6.png)

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
