### PR TITLE
Fix `strawberry.argument` annotation being ignored when using deferred annotations

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Fix `strawberry.argument` annotation being ignored when using deferred annotations

--- a/strawberry/arguments.py
+++ b/strawberry/arguments.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import enum
 import inspect
+import sys
 from typing import Any, Dict, List, Mapping, Optional, Type, Union, cast
 
 from typing_extensions import Annotated, get_args, get_origin
@@ -132,6 +133,10 @@ def get_arguments_from_annotations(
             if default is inspect.Parameter.empty or is_unset(default)
             else default
         )
+
+        if isinstance(annotation, str):
+            module = sys.modules[origin.__module__]
+            annotation = eval(annotation, module.__dict__)
 
         if get_origin(annotation) is Annotated:
             argument = StrawberryArgument.from_annotated(

--- a/tests/types/test_arguments.py
+++ b/tests/types/test_arguments.py
@@ -361,6 +361,31 @@ def test_annotated_argument_with_rename():
     assert argument.default == "Patrick"
 
 
+def test_annotated_argument_with_rename_deferred():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def name(  # type: ignore
+            arg: "Annotated[str, strawberry.argument(name='argument')]" = "Patrick",
+        ) -> "str":
+            return "Name"
+
+    definition = Query._type_definition
+
+    assert definition.name == "Query"
+
+    assert len(definition.fields[0].arguments) == 1
+
+    argument = definition.fields[0].arguments[0]
+
+    assert argument.graphql_name == "argument"
+    assert argument.python_name == "arg"
+    assert argument.type == str
+    assert argument.is_optional is False
+    assert argument.description is None
+    assert argument.default == "Patrick"
+
+
 def test_multiple_annotated_arguments_exception():
     with pytest.raises(MultipleStrawberryArgumentsError) as error:
 


### PR DESCRIPTION
## Description

Fix `strawberry.argument` annotation being ignored when using deferred annotations

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

- #1025

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
