### PR TITLE
Implement parser handling incorrect input in DateTime scalar (#1035)

### DIFF
--- a/.github/release-check-action/RELEASE.md
+++ b/.github/release-check-action/RELEASE.md
@@ -1,0 +1,9 @@
+Release type: minor
+
+Implement parser handling incorrect input in DateTime scalar (#1035)
+
+Giving incorrect iso string to Time, Date or DateTime now raises a GraphQLError, without an original error.
+
+This is the same behaviour that graphql-core has: https://github.com/graphql-python/graphql-core/blob/b80085385dd4f818abb38c27e84f6fd16289684a/src/graphql/type/scalars.py#L37-L61
+
+The GraphQL error will include the error message raised by the string parser, eg `Value cannot represent a DateTime: "2021-13-01T09:00:00". month must be in 1..12`

--- a/.github/release-check-action/RELEASE.md
+++ b/.github/release-check-action/RELEASE.md
@@ -1,9 +1,5 @@
 Release type: minor
 
-Implement parser handling incorrect input in DateTime scalar (#1035)
+Matching the behaviour of `graphql-core`, passing an incorrect ISO string value for a Time, Date or DateTime scalar now raises a `GraphQLError` instead of the original parsing error.
 
-Giving incorrect iso string to Time, Date or DateTime now raises a GraphQLError, without an original error.
-
-This is the same behaviour that graphql-core has: https://github.com/graphql-python/graphql-core/blob/b80085385dd4f818abb38c27e84f6fd16289684a/src/graphql/type/scalars.py#L37-L61
-
-The GraphQL error will include the error message raised by the string parser, eg `Value cannot represent a DateTime: "2021-13-01T09:00:00". month must be in 1..12`
+The `GraphQLError` will include the error message raised by the string parser, e.g. `Value cannot represent a DateTime: "2021-13-01T09:00:00". month must be in 1..12`

--- a/strawberry/schema/types/base_scalars.py
+++ b/strawberry/schema/types/base_scalars.py
@@ -11,7 +11,7 @@ from graphql import GraphQLError
 from strawberry.custom_scalar import scalar
 
 
-def wrap_iso_parser(parser: Callable, _type) -> Callable:
+def wrap_iso_parser(parser: Callable, _type: str) -> Callable:
     def inner(value: str):
         try:
             return parser(value)

--- a/strawberry/schema/types/base_scalars.py
+++ b/strawberry/schema/types/base_scalars.py
@@ -9,14 +9,12 @@ from graphql import GraphQLError
 from strawberry.custom_scalar import scalar
 
 
-def wrap_iso_parser(parser: Callable) -> Callable:
+def wrap_iso_parser(parser: Callable, _type) -> Callable:
     def inner(value: str):
         try:
             return parser(value)
         except ValueError as e:
-            raise GraphQLError(
-                f'Expected ISO formatted string, received "{value}". {e}'
-            )
+            raise GraphQLError(f'Value cannot represent a {_type}: "{value}". {e}')
 
     return inner
 
@@ -36,7 +34,7 @@ DateTime = scalar(
     name="DateTime",
     description="Date with time (isoformat)",
     serialize=isoformat,
-    parse_value=wrap_iso_parser(dateutil.parser.isoparse),
+    parse_value=wrap_iso_parser(dateutil.parser.isoparse, "DateTime"),
 )
 Time = scalar(
     datetime.time,

--- a/strawberry/schema/types/base_scalars.py
+++ b/strawberry/schema/types/base_scalars.py
@@ -11,12 +11,12 @@ from graphql import GraphQLError
 from strawberry.custom_scalar import scalar
 
 
-def wrap_iso_parser(parser: Callable, _type: str) -> Callable:
+def wrap_iso_parser(parser: Callable, type_: str) -> Callable:
     def inner(value: str):
         try:
             return parser(value)
         except ValueError as e:
-            raise GraphQLError(f'Value cannot represent a {_type}: "{value}". {e}')
+            raise GraphQLError(f'Value cannot represent a {type_}: "{value}". {e}')
 
     return inner
 

--- a/strawberry/schema/types/base_scalars.py
+++ b/strawberry/schema/types/base_scalars.py
@@ -3,7 +3,9 @@ import decimal
 import uuid
 from operator import methodcaller
 from typing import Callable
+
 import dateutil.parser
+
 from graphql import GraphQLError
 
 from strawberry.custom_scalar import scalar
@@ -27,7 +29,7 @@ Date = scalar(
     name="Date",
     description="Date (isoformat)",
     serialize=isoformat,
-    parse_value=datetime.date.fromisoformat,
+    parse_value=wrap_iso_parser(datetime.date.fromisoformat, "Date"),
 )
 DateTime = scalar(
     datetime.datetime,
@@ -41,7 +43,7 @@ Time = scalar(
     name="Time",
     description="Time (isoformat)",
     serialize=isoformat,
-    parse_value=datetime.time.fromisoformat,
+    parse_value=wrap_iso_parser(datetime.time.fromisoformat, "Time"),
 )
 
 Decimal = scalar(

--- a/tests/schema/types/test_date.py
+++ b/tests/schema/types/test_date.py
@@ -7,79 +7,61 @@ from graphql import GraphQLError
 import strawberry
 
 
-@pytest.mark.parametrize(
-    "typing,instance,serialized",
-    [
-        (datetime.date, datetime.date(2019, 10, 25), "2019-10-25"),
-    ],
-)
-def test_serialization(typing, instance, serialized):
+def test_serialization():
     @strawberry.type
     class Query:
         @strawberry.field
-        def serialize(self) -> typing:
-            return instance
+        def serialize(self) -> datetime.date:
+            return datetime.date(2019, 10, 25)
 
     schema = strawberry.Schema(Query)
 
     result = schema.execute_sync("{ serialize }")
 
     assert not result.errors
-    assert result.data["serialize"] == serialized
+    assert result.data["serialize"] == "2019-10-25"
 
 
-@pytest.mark.parametrize(
-    "typing,name,instance,serialized",
-    [
-        (datetime.date, "Date", datetime.date(2019, 10, 25), "2019-10-25"),
-    ],
-)
-def test_deserialization(typing, name, instance, serialized):
+def test_deserialization():
     @strawberry.type
     class Query:
         deserialized = None
 
         @strawberry.field
-        def deserialize(self, arg: typing) -> bool:
+        def deserialize(self, arg: datetime.date) -> bool:
             Query.deserialized = arg
             return True
 
     schema = strawberry.Schema(Query)
 
-    query = f"""query Deserialize($value: {name}!) {{
+    query = """query Deserialize($value: Date!) {
         deserialize(arg: $value)
-    }}"""
-    result = schema.execute_sync(query, variable_values={"value": serialized})
+    }"""
+    result = schema.execute_sync(query, variable_values={"value": "2019-10-25"})
 
     assert not result.errors
-    assert Query.deserialized == instance
+    assert Query.deserialized == datetime.date(2019, 10, 25)
 
 
-@pytest.mark.parametrize(
-    "typing,instance,serialized",
-    [
-        (datetime.date, datetime.date(2019, 10, 25), "2019-10-25"),
-    ],
-)
-def test_deserialization_with_parse_literal(typing, instance, serialized):
+def test_deserialization_with_parse_literal():
     @strawberry.type
     class Query:
         deserialized = None
 
         @strawberry.field
-        def deserialize(self, arg: typing) -> bool:
+        def deserialize(self, arg: datetime.date) -> bool:
             Query.deserialized = arg
             return True
 
     schema = strawberry.Schema(Query)
 
-    query = f"""query Deserialize {{
-        deserialize(arg: "{serialized}")
-    }}"""
+    query = """query Deserialize {
+        deserialize(arg: "2019-10-25")
+    }"""
     result = schema.execute_sync(query)
 
     assert not result.errors
-    assert Query.deserialized == instance
+    assert Query.deserialized == datetime.date(2019, 10, 25)
 
 
 def execute_mutation(value):

--- a/tests/schema/types/test_date.py
+++ b/tests/schema/types/test_date.py
@@ -78,7 +78,6 @@ def execute_mutation(value):
 
     schema = strawberry.Schema(query=Query, mutation=Mutation)
 
-
     return schema.execute_sync(
         """
             mutation dateInput($value: Date!) {
@@ -112,12 +111,13 @@ def test_serialization_of_incorrect_date_string(value):
 
 def test_serialization_error_message_for_incorrect_date_string():
     """
-    Test if error message is using original error message from date lib, and is properly formatted
+    Test if error message is using original error message from
+    date lib, and is properly formatted
     """
 
     result = execute_mutation("2021-13-01")
     assert result.errors
     assert result.errors[0].message == (
         "Variable '$value' got invalid value '2021-13-01'; Value cannot represent a "
-        "Date: \"2021-13-01\". month must be in 1..12"
+        'Date: "2021-13-01". month must be in 1..12'
     )

--- a/tests/schema/types/test_date.py
+++ b/tests/schema/types/test_date.py
@@ -1,0 +1,138 @@
+import datetime
+
+import pytest
+
+from graphql import GraphQLError
+
+import strawberry
+
+
+@pytest.mark.parametrize(
+    "typing,instance,serialized",
+    [
+        (datetime.date, datetime.date(2019, 10, 25), "2019-10-25"),
+    ],
+)
+def test_serialization(typing, instance, serialized):
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def serialize(self) -> typing:
+            return instance
+
+    schema = strawberry.Schema(Query)
+
+    result = schema.execute_sync("{ serialize }")
+
+    assert not result.errors
+    assert result.data["serialize"] == serialized
+
+
+@pytest.mark.parametrize(
+    "typing,name,instance,serialized",
+    [
+        (datetime.date, "Date", datetime.date(2019, 10, 25), "2019-10-25"),
+    ],
+)
+def test_deserialization(typing, name, instance, serialized):
+    @strawberry.type
+    class Query:
+        deserialized = None
+
+        @strawberry.field
+        def deserialize(self, arg: typing) -> bool:
+            Query.deserialized = arg
+            return True
+
+    schema = strawberry.Schema(Query)
+
+    query = f"""query Deserialize($value: {name}!) {{
+        deserialize(arg: $value)
+    }}"""
+    result = schema.execute_sync(query, variable_values={"value": serialized})
+
+    assert not result.errors
+    assert Query.deserialized == instance
+
+
+@pytest.mark.parametrize(
+    "typing,instance,serialized",
+    [
+        (datetime.date, datetime.date(2019, 10, 25), "2019-10-25"),
+    ],
+)
+def test_deserialization_with_parse_literal(typing, instance, serialized):
+    @strawberry.type
+    class Query:
+        deserialized = None
+
+        @strawberry.field
+        def deserialize(self, arg: typing) -> bool:
+            Query.deserialized = arg
+            return True
+
+    schema = strawberry.Schema(Query)
+
+    query = f"""query Deserialize {{
+        deserialize(arg: "{serialized}")
+    }}"""
+    result = schema.execute_sync(query)
+
+    assert not result.errors
+    assert Query.deserialized == instance
+
+
+def execute_mutation(value):
+    @strawberry.type
+    class Query:
+        ok: bool
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        def date_input(self, date_input: datetime.date) -> datetime.date:
+            assert isinstance(date_input, datetime.date)
+            return date_input
+
+    schema = strawberry.Schema(query=Query, mutation=Mutation)
+
+    return schema.execute_sync(
+        f"""
+            mutation {{
+                dateInput(dateInput: "{value}")
+            }}
+        """
+    )
+
+
+@pytest.mark.parametrize(
+    "value",
+    (
+        "2012-12-01T09:00",
+        "2012-13-01",
+        "2012-04-9",
+        "20120411",
+    ),
+)
+def test_serialization_of_incorrect_date_string(value):
+    """
+    Test GraphQLError is raised for incorrect date.
+    The error should exclude "original_error".
+    """
+
+    result = execute_mutation(value)
+    assert result.errors
+    assert isinstance(result.errors[0], GraphQLError)
+    assert result.errors[0].original_error is None
+
+
+def test_serialization_error_message_for_incorrect_date_string():
+    """
+    Test if error message is using original error message from date lib, and is properly formatted
+    """
+
+    result = execute_mutation("2021-13-01")
+    assert result.errors
+    assert result.errors[0].message == (
+        'Value cannot represent a Date: "2021-13-01". month must be in 1..12'
+    )

--- a/tests/schema/types/test_date.py
+++ b/tests/schema/types/test_date.py
@@ -96,12 +96,14 @@ def execute_mutation(value):
 
     schema = strawberry.Schema(query=Query, mutation=Mutation)
 
+
     return schema.execute_sync(
-        f"""
-            mutation {{
-                dateInput(dateInput: "{value}")
-            }}
         """
+            mutation dateInput($value: Date!) {
+                dateInput(dateInput: $value)
+            }
+        """,
+        variable_values={"value": value},
     )
 
 
@@ -134,5 +136,6 @@ def test_serialization_error_message_for_incorrect_date_string():
     result = execute_mutation("2021-13-01")
     assert result.errors
     assert result.errors[0].message == (
-        'Value cannot represent a Date: "2021-13-01". month must be in 1..12'
+        "Variable '$value' got invalid value '2021-13-01'; Value cannot represent a "
+        "Date: \"2021-13-01\". month must be in 1..12"
     )

--- a/tests/schema/types/test_datetime.py
+++ b/tests/schema/types/test_datetime.py
@@ -126,11 +126,12 @@ def execute_mutation(value):
     schema = strawberry.Schema(query=Query, mutation=Mutation)
 
     return schema.execute_sync(
-        f"""
-            mutation {{
-                datetimeInput(datetimeInput: "{value}")
-            }}
         """
+            mutation datetimeInput($value: DateTime!) {
+                datetimeInput(datetimeInput: $value)
+            }
+        """,
+        variable_values={"value": value},
     )
 
 
@@ -168,5 +169,6 @@ def test_serialization_error_message_for_incorrect_datetime_string():
     result = execute_mutation("2021-13-01T09:00:00")
     assert result.errors
     assert result.errors[0].message == (
-        'Value cannot represent a DateTime: "2021-13-01T09:00:00". month must be in 1..12'
+        "Variable '$value' got invalid value '2021-13-01T09:00:00'; Value cannot "
+        "represent a DateTime: \"2021-13-01T09:00:00\". month must be in 1..12"
     )

--- a/tests/schema/types/test_datetime.py
+++ b/tests/schema/types/test_datetime.py
@@ -163,12 +163,13 @@ def test_serialization_of_incorrect_datetime_string(value):
 
 def test_serialization_error_message_for_incorrect_datetime_string():
     """
-    Test if error message is using original error message from datetime lib, and is properly formatted
+    Test if error message is using original error message
+    from datetime lib, and is properly formatted
     """
 
     result = execute_mutation("2021-13-01T09:00:00")
     assert result.errors
     assert result.errors[0].message == (
         "Variable '$value' got invalid value '2021-13-01T09:00:00'; Value cannot "
-        "represent a DateTime: \"2021-13-01T09:00:00\". month must be in 1..12"
+        'represent a DateTime: "2021-13-01T09:00:00". month must be in 1..12'
     )

--- a/tests/schema/types/test_datetime.py
+++ b/tests/schema/types/test_datetime.py
@@ -148,7 +148,7 @@ def execute_mutation(value):
         "2014-04-21T24:00:01",
     ),
 )
-def test_serialization_of_incorrect_datetime_strings(value):
+def test_serialization_of_incorrect_datetime_string(value):
     """
     Test GraphQLError is raised for incorrect datetime.
     The error should exclude "original_error".

--- a/tests/schema/types/test_datetime.py
+++ b/tests/schema/types/test_datetime.py
@@ -172,6 +172,6 @@ def test_serialization_error_message_for_incorrect_datetime_string(execute_mutat
     result = execute_mutation("2021-13-01T09:00:00")
     assert result.errors
     assert result.errors[0].message == (
-        'Expected ISO formatted string, received "2021-13-01T09:00:00". month must be in 1..12'
+        'Value cannot represent a DateTime: "2021-13-01T09:00:00". month must be in 1..12'
     )
 

--- a/tests/schema/types/test_datetime.py
+++ b/tests/schema/types/test_datetime.py
@@ -109,8 +109,7 @@ def test_deserialization_with_parse_literal(typing, instance, serialized):
     assert Query.deserialized == instance
 
 
-@pytest.fixture
-def execute_mutation():
+def execute_mutation(value):
     @strawberry.type
     class Query:
         ok: bool
@@ -126,16 +125,13 @@ def execute_mutation():
 
     schema = strawberry.Schema(query=Query, mutation=Mutation)
 
-    def execute(value):
-        return schema.execute_sync(
-            f"""
-                mutation {{
-                    datetimeInput(datetimeInput: "{value}")
-                }}
-            """
-        )
-
-    return execute
+    return schema.execute_sync(
+        f"""
+            mutation {{
+                datetimeInput(datetimeInput: "{value}")
+            }}
+        """
+    )
 
 
 @pytest.mark.parametrize(
@@ -152,7 +148,7 @@ def execute_mutation():
         "2014-04-21T24:00:01",
     ),
 )
-def test_serialization_of_incorrect_datetime_strings(value, execute_mutation):
+def test_serialization_of_incorrect_datetime_strings(value):
     """
     Test GraphQLError is raised for incorrect datetime.
     The error should exclude "original_error".
@@ -164,7 +160,7 @@ def test_serialization_of_incorrect_datetime_strings(value, execute_mutation):
     assert result.errors[0].original_error is None
 
 
-def test_serialization_error_message_for_incorrect_datetime_string(execute_mutation):
+def test_serialization_error_message_for_incorrect_datetime_string():
     """
     Test if error message is using original error message from datetime lib, and is properly formatted
     """
@@ -174,4 +170,3 @@ def test_serialization_error_message_for_incorrect_datetime_string(execute_mutat
     assert result.errors[0].message == (
         'Value cannot represent a DateTime: "2021-13-01T09:00:00". month must be in 1..12'
     )
-

--- a/tests/schema/types/test_time.py
+++ b/tests/schema/types/test_time.py
@@ -1,0 +1,138 @@
+import datetime
+
+import pytest
+
+from graphql import GraphQLError
+
+import strawberry
+
+
+@pytest.mark.parametrize(
+    "typing,instance,serialized",
+    [
+        (datetime.time, datetime.time(13, 37), "13:37:00"),
+    ],
+)
+def test_serialization(typing, instance, serialized):
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def serialize(self) -> typing:
+            return instance
+
+    schema = strawberry.Schema(Query)
+
+    result = schema.execute_sync("{ serialize }")
+
+    assert not result.errors
+    assert result.data["serialize"] == serialized
+
+
+@pytest.mark.parametrize(
+    "typing,name,instance,serialized",
+    [
+        (datetime.time, "Time", datetime.time(13, 37), "13:37:00"),
+    ],
+)
+def test_deserialization(typing, name, instance, serialized):
+    @strawberry.type
+    class Query:
+        deserialized = None
+
+        @strawberry.field
+        def deserialize(self, arg: typing) -> bool:
+            Query.deserialized = arg
+            return True
+
+    schema = strawberry.Schema(Query)
+
+    query = f"""query Deserialize($value: {name}!) {{
+        deserialize(arg: $value)
+    }}"""
+    result = schema.execute_sync(query, variable_values={"value": serialized})
+
+    assert not result.errors
+    assert Query.deserialized == instance
+
+
+@pytest.mark.parametrize(
+    "typing,instance,serialized",
+    [
+        (datetime.time, datetime.time(13, 37), "13:37:00"),
+    ],
+)
+def test_deserialization_with_parse_literal(typing, instance, serialized):
+    @strawberry.type
+    class Query:
+        deserialized = None
+
+        @strawberry.field
+        def deserialize(self, arg: typing) -> bool:
+            Query.deserialized = arg
+            return True
+
+    schema = strawberry.Schema(Query)
+
+    query = f"""query Deserialize {{
+        deserialize(arg: "{serialized}")
+    }}"""
+    result = schema.execute_sync(query)
+
+    assert not result.errors
+    assert Query.deserialized == instance
+
+
+def execute_mutation(value):
+    @strawberry.type
+    class Query:
+        ok: bool
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        def time_input(self, time_input: datetime.time) -> datetime.time:
+            assert isinstance(time_input, datetime.time)
+            return time_input
+
+    schema = strawberry.Schema(query=Query, mutation=Mutation)
+
+    return schema.execute_sync(
+        f"""
+            mutation {{
+                timeInput(timeInput: "{value}")
+            }}
+        """
+    )
+
+
+@pytest.mark.parametrize(
+    "value",
+    (
+        "2012-12-01T09:00",
+        "03:30+",
+        "03:30+1234567",
+        "03:30-25:40",
+    ),
+)
+def test_serialization_of_incorrect_time_string(value):
+    """
+    Test GraphQLError is raised for incorrect time.
+    The error should exclude "original_error".
+    """
+
+    result = execute_mutation(value)
+    assert result.errors
+    assert isinstance(result.errors[0], GraphQLError)
+    assert result.errors[0].original_error is None
+
+
+def test_serialization_error_message_for_incorrect_time_string():
+    """
+    Test if error message is using original error message from time lib, and is properly formatted
+    """
+
+    result = execute_mutation("25:00")
+    assert result.errors
+    assert result.errors[0].message == (
+        'Value cannot represent a Time: "25:00". hour must be in 0..23'
+    )

--- a/tests/schema/types/test_time.py
+++ b/tests/schema/types/test_time.py
@@ -111,12 +111,13 @@ def test_serialization_of_incorrect_time_string(value):
 
 def test_serialization_error_message_for_incorrect_time_string():
     """
-    Test if error message is using original error message from time lib, and is properly formatted
+    Test if error message is using original error message
+    from time lib, and is properly formatted
     """
 
     result = execute_mutation("25:00")
     assert result.errors
     assert result.errors[0].message == (
         "Variable '$value' got invalid value '25:00'; Value cannot represent a "
-        "Time: \"25:00\". hour must be in 0..23"
+        'Time: "25:00". hour must be in 0..23'
     )

--- a/tests/schema/types/test_time.py
+++ b/tests/schema/types/test_time.py
@@ -7,79 +7,61 @@ from graphql import GraphQLError
 import strawberry
 
 
-@pytest.mark.parametrize(
-    "typing,instance,serialized",
-    [
-        (datetime.time, datetime.time(13, 37), "13:37:00"),
-    ],
-)
-def test_serialization(typing, instance, serialized):
+def test_serialization():
     @strawberry.type
     class Query:
         @strawberry.field
-        def serialize(self) -> typing:
-            return instance
+        def serialize(self) -> datetime.time:
+            return datetime.time(13, 37)
 
     schema = strawberry.Schema(Query)
 
     result = schema.execute_sync("{ serialize }")
 
     assert not result.errors
-    assert result.data["serialize"] == serialized
+    assert result.data["serialize"] == "13:37:00"
 
 
-@pytest.mark.parametrize(
-    "typing,name,instance,serialized",
-    [
-        (datetime.time, "Time", datetime.time(13, 37), "13:37:00"),
-    ],
-)
-def test_deserialization(typing, name, instance, serialized):
+def test_deserialization():
     @strawberry.type
     class Query:
         deserialized = None
 
         @strawberry.field
-        def deserialize(self, arg: typing) -> bool:
+        def deserialize(self, arg: datetime.time) -> bool:
             Query.deserialized = arg
             return True
 
     schema = strawberry.Schema(Query)
 
-    query = f"""query Deserialize($value: {name}!) {{
+    query = """query Deserialize($value: Time!) {
         deserialize(arg: $value)
-    }}"""
-    result = schema.execute_sync(query, variable_values={"value": serialized})
+    }"""
+    result = schema.execute_sync(query, variable_values={"value": "13:37:00"})
 
     assert not result.errors
-    assert Query.deserialized == instance
+    assert Query.deserialized == datetime.time(13, 37)
 
 
-@pytest.mark.parametrize(
-    "typing,instance,serialized",
-    [
-        (datetime.time, datetime.time(13, 37), "13:37:00"),
-    ],
-)
-def test_deserialization_with_parse_literal(typing, instance, serialized):
+def test_deserialization_with_parse_literal():
     @strawberry.type
     class Query:
         deserialized = None
 
         @strawberry.field
-        def deserialize(self, arg: typing) -> bool:
+        def deserialize(self, arg: datetime.time) -> bool:
             Query.deserialized = arg
             return True
 
     schema = strawberry.Schema(Query)
 
-    query = f"""query Deserialize {{
-        deserialize(arg: "{serialized}")
-    }}"""
+    query = """query Deserialize {
+        deserialize(arg: "13:37:00")
+    }"""
     result = schema.execute_sync(query)
 
     assert not result.errors
-    assert Query.deserialized == instance
+    assert Query.deserialized == datetime.time(13, 37)
 
 
 def execute_mutation(value):

--- a/tests/schema/types/test_time.py
+++ b/tests/schema/types/test_time.py
@@ -97,11 +97,12 @@ def execute_mutation(value):
     schema = strawberry.Schema(query=Query, mutation=Mutation)
 
     return schema.execute_sync(
-        f"""
-            mutation {{
-                timeInput(timeInput: "{value}")
-            }}
         """
+            mutation timeInput($value: Time!) {
+                timeInput(timeInput: $value)
+            }
+        """,
+        variable_values={"value": value},
     )
 
 
@@ -134,5 +135,6 @@ def test_serialization_error_message_for_incorrect_time_string():
     result = execute_mutation("25:00")
     assert result.errors
     assert result.errors[0].message == (
-        'Value cannot represent a Time: "25:00". hour must be in 0..23'
+        "Variable '$value' got invalid value '25:00'; Value cannot represent a "
+        "Time: \"25:00\". hour must be in 0..23"
     )


### PR DESCRIPTION
## Description

Raise GraphQL error (without original error) in Date / DateTime / Time parsers when provided incorrect isoformatted string

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #1035

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
