### PR TITLE
Removed csrf_exempt from django views

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Remove the (default and likely unexpected) csrf_exempt from django

--- a/strawberry/django/views.py
+++ b/strawberry/django/views.py
@@ -12,7 +12,6 @@ from django.template.exceptions import TemplateDoesNotExist
 from django.template.loader import render_to_string
 from django.template.response import TemplateResponse
 from django.utils.decorators import classonlymethod, method_decorator
-from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
 
 import strawberry
@@ -144,7 +143,6 @@ class GraphQLView(BaseView):
     ) -> GraphQLHTTPResponse:
         return process_result(result)
 
-    @method_decorator(csrf_exempt)
     def dispatch(self, request, *args, **kwargs):
         if not self.is_request_allowed(request):
             return HttpResponseNotAllowed(
@@ -184,7 +182,6 @@ class AsyncGraphQLView(BaseView):
         view._is_coroutine = asyncio.coroutines._is_coroutine
         return view
 
-    @method_decorator(csrf_exempt)
     async def dispatch(self, request, *args, **kwargs):
         if not self.is_request_allowed(request):
             return HttpResponseNotAllowed(

--- a/strawberry/django/views.py
+++ b/strawberry/django/views.py
@@ -13,6 +13,7 @@ from django.template.exceptions import TemplateDoesNotExist
 from django.template.loader import render_to_string
 from django.template.response import TemplateResponse
 from django.utils.decorators import classonlymethod, method_decorator
+from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
 
 import strawberry

--- a/strawberry/django/views.py
+++ b/strawberry/django/views.py
@@ -12,7 +12,7 @@ from django.template import RequestContext, Template
 from django.template.exceptions import TemplateDoesNotExist
 from django.template.loader import render_to_string
 from django.template.response import TemplateResponse
-from django.utils.decorators import classonlymethod
+from django.utils.decorators import classonlymethod, method_decorator
 from django.views.generic import View
 
 import strawberry

--- a/strawberry/django/views.py
+++ b/strawberry/django/views.py
@@ -11,7 +11,7 @@ from django.template import RequestContext, Template
 from django.template.exceptions import TemplateDoesNotExist
 from django.template.loader import render_to_string
 from django.template.response import TemplateResponse
-from django.utils.decorators import classonlymethod, method_decorator
+from django.utils.decorators import classonlymethod
 from django.views.generic import View
 
 import strawberry

--- a/strawberry/django/views.py
+++ b/strawberry/django/views.py
@@ -1,8 +1,8 @@
 import asyncio
 import json
 import os
-from typing import Any, Dict, Optional, Type
 import warnings
+from typing import Any, Dict, Optional, Type
 
 from django.core.exceptions import SuspiciousOperation
 from django.core.serializers.json import DjangoJSONEncoder
@@ -219,22 +219,28 @@ class AsyncGraphQLBaseView(BaseView):
         return StrawberryDjangoContext(request=request, response=response)
 
     async def process_result(
-            self, request: HttpRequest, result: ExecutionResult
+        self, request: HttpRequest, result: ExecutionResult
     ) -> GraphQLHTTPResponse:
         return process_result(result)
 
 
-@method_decorator(csrf_exempt, name='dispatch')  # Prevent breaking change
+@method_decorator(csrf_exempt, name="dispatch")  # Prevent breaking change
 class GraphQLView(GraphQLBaseView):
-
     def __init__(self, *args, **kwargs):
-        warnings.warn('This class adds @method_decorator(csrf_exempt) to dispatch - use GraphQLBaseView if you want to control csrf yourself', stacklevel=2, category=RuntimeWarning)
+        warnings.warn(
+            "This class adds @method_decorator(csrf_exempt) to dispatch - use GraphQLBaseView if you want to control csrf yourself",
+            stacklevel=2,
+            category=RuntimeWarning,
+        )
         super().__init__(*args, **kwargs)
 
 
-@method_decorator(csrf_exempt, name='dispatch')  # Prevent breaking change
+@method_decorator(csrf_exempt, name="dispatch")  # Prevent breaking change
 class AsyncGraphQLView(AsyncGraphQLBaseView):
     def __init__(self, *args, **kwargs):
-        warnings.warn('This class adds @method_decorator(csrf_exempt) to dispatch - use AsyncGraphQLBaseView if you want to control csrf yourself', stacklevel=2, category=RuntimeWarning)
+        warnings.warn(
+            "This class adds @method_decorator(csrf_exempt) to dispatch - use AsyncGraphQLBaseView if you want to control csrf yourself",
+            stacklevel=2,
+            category=RuntimeWarning,
+        )
         super().__init__(*args, **kwargs)
-


### PR DESCRIPTION
I think it's not a good idea to disable security features by default. If one wants an csrf exempt, you can wrap your view in urls with this decorator.

E.g.:

```
from strawberry.django.views import GraphQLView
from django.views.decorators.csrf import csrf_exempt

urlpatterns = [
    path("graphql/", csrf_exempt(GraphQLView.as_view(), name='graphql'))
]
```

I didn't expect this exemp and the server could have been vulnerable to CSRF attacks by default.

## Description

<!--- Describe your changes in detail here. -->
Removed the decorators

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Checklist


- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation. (maybe - not sure?)
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage) (tested in my own project with overwritten dispatch method)
