### PR TITLE
Always pass `info` to Field.get-result

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+Release type: patch
+
+This release fixes a regression that broke strawberry-graphql-django.
+
+`Field.get_results` now always receives the `info` argument.

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -3,6 +3,7 @@ import typing
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Type, Union
 
 from strawberry.arguments import UNSET
+from strawberry.types.info import Info
 from strawberry.utils.typing import get_parameters, has_type_var, is_type_var
 
 from .arguments import StrawberryArgument
@@ -175,7 +176,7 @@ class StrawberryField(dataclasses.Field):
         return None
 
     def get_result(
-        self, source: Any, args: List[Any], kwargs: Dict[str, Any]
+        self, source: Any, info: Info, args: List[Any], kwargs: Dict[str, Any]
     ) -> Union[Awaitable[Any], Any]:
         """
         Calls the resolver defined for the StrawberryField. If the field doesn't have a

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -317,9 +317,6 @@ class GraphQLCoreConverter:
             info: Info,
             kwargs: Dict[str, Any],
         ) -> Tuple[List[Any], Dict[str, Any]]:
-            if field.base_resolver is None:
-                return [], {}
-
             kwargs = convert_arguments(kwargs, field.arguments)
 
             # the following code allows to omit info and root arguments
@@ -330,14 +327,15 @@ class GraphQLCoreConverter:
 
             args = []
 
-            if field.base_resolver.has_self_arg:
-                args.append(source)
+            if field.base_resolver:
+                if field.base_resolver.has_self_arg:
+                    args.append(source)
 
-            if field.base_resolver.has_root_arg:
-                kwargs["root"] = source
+                if field.base_resolver.has_root_arg:
+                    kwargs["root"] = source
 
-            if field.base_resolver.has_info_arg:
-                kwargs["info"] = info
+                if field.base_resolver.has_info_arg:
+                    kwargs["info"] = info
 
             return args, kwargs
 
@@ -373,7 +371,9 @@ class GraphQLCoreConverter:
                 source=_source, info=strawberry_info, kwargs=kwargs
             )
 
-            result = field.get_result(_source, args=args, kwargs=kwargs)
+            result = field.get_result(
+                _source, info=strawberry_info, args=args, kwargs=kwargs
+            )
 
             if isasyncgen(result):
 


### PR DESCRIPTION
This pull request tries to fix regression caused by #1044.

This needs still more testing and changes to strawberry-django package as well. See https://github.com/strawberry-graphql/strawberry-graphql-django/tree/wip/fix-strawberry-regression.