### PR TITLE
Fix how we print federation directives on objects

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,17 @@
+Release type: patch
+
+This release fixes an issue with the federation printer that
+prevented using federation directives with types that were
+implementing interfaces.
+
+This is now allowed:
+
+```python
+@strawberry.interface
+class SomeInterface:
+    id: strawberry.ID
+
+@strawberry.federation.type(keys=["upc"], extend=True)
+class Product(SomeInterface):
+    upc: str = strawberry.federation.field(external=True)
+```

--- a/strawberry/printer.py
+++ b/strawberry/printer.py
@@ -91,8 +91,8 @@ def _print_object(type_, schema: BaseSchema) -> str:
         print_description(type_)
         + print_extends(type_, schema)
         + f"type {type_.name}"
-        + print_federation_key_directive(type_, schema)
         + print_implemented_interfaces(type_)
+        + print_federation_key_directive(type_, schema)
         + print_fields(type_, schema)
     )
 

--- a/tests/federation/test_printer.py
+++ b/tests/federation/test_printer.py
@@ -68,6 +68,51 @@ def test_entities_type_when_no_type_has_keys():
     del Review
 
 
+def test_entities_extending_interface():
+    @strawberry.interface
+    class SomeInterface:
+        id: strawberry.ID
+
+    @strawberry.federation.type(keys=["upc"], extend=True)
+    class Product(SomeInterface):
+        upc: str = strawberry.federation.field(external=True)
+
+    @strawberry.federation.type
+    class Query:
+        @strawberry.field
+        def top_products(self, first: int) -> List[Product]:
+            return []
+
+    schema = strawberry.federation.Schema(query=Query)
+
+    expected = """
+        extend type Product implements SomeInterface @key(fields: "upc") {
+          id: ID!
+          upc: String! @external
+        }
+
+        type Query {
+          _service: _Service!
+          _entities(representations: [_Any!]!): [_Entity]!
+          topProducts(first: Int!): [Product!]!
+        }
+
+        interface SomeInterface {
+          id: ID!
+        }
+
+        scalar _Any
+
+        union _Entity = Product
+
+        type _Service {
+          sdl: String!
+        }
+    """
+
+    assert schema.as_str() == textwrap.dedent(expected).strip()
+
+
 def test_fields_requires_are_printed_correctly():
     global Review
 


### PR DESCRIPTION
## Description

The key directive for federation was printed before `implements Interface` which was
wrong. This PR fixes that :)

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

