### PR TITLE
dependencies: require typing-extensions 3.10.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ django = {version = ">=2,<4", optional = true}
 graphql-core = {version = "^3.1.0"}
 asgiref = {version = "^3.2", optional = true}
 flask = {version = "^1.1", optional = true}
-typing_extensions = "^3.7.4"
+typing_extensions = "^3.10.0"
 opentelemetry-api = {version = "^0.17b0", optional = true}
 opentelemetry-sdk = {version = "^0.17b0", optional = true}
 python-dateutil = "^2.7.0"


### PR DESCRIPTION
Strawberry uses TypeGuard from typing-extensions, which is only
available starting with version 3.10.0

Signed-off-by: Tobias Wiese <tobias@tobiaswiese.com>