### PR TITLE
Don't import TypeGuard if TYPE_CHECKING is false

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+Release type: patch
+
+
+This release removes a `TypeGuard` import to prevent errors
+when using older versions of `typing_extensions`.

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from enum import Enum
 from inspect import isasyncgen, iscoroutine
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Tuple, Type, Union

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -1,8 +1,14 @@
 from enum import Enum
 from inspect import isasyncgen, iscoroutine
-from typing import Any, Callable, Dict, List, Tuple, Type, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Tuple, Type, Union
 
-from typing_extensions import TypeGuard
+
+# TypeGuard is only available in typing_extensions => 3.10, we don't want
+# to force updates to the typing_extensions package so we only use it when
+# TYPE_CHECKING is enabled.
+
+if TYPE_CHECKING:
+    from typing_extensions import TypeGuard
 
 from graphql import (
     GraphQLArgument,


### PR DESCRIPTION
## Description

Small patch to prevent issues when using older version of `typing_extensions`.

I don't think we should force people to upgrade as we only use TypeGuards for
type checking.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

