### PR TITLE
Fix field inheritance with new `StrawberryAnnotation`s

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Fix for regression when defining inherited types with explicit fields.

--- a/strawberry/types/type_resolver.py
+++ b/strawberry/types/type_resolver.py
@@ -103,7 +103,7 @@ def _get_fields(cls: Type) -> List[StrawberryField]:
             field.origin = field.origin or cls
 
             # Make sure types are StrawberryAnnotations
-            if not isinstance(field.type, StrawberryAnnotation):
+            if not isinstance(field.type_annotation, StrawberryAnnotation):
                 module = sys.modules[field.origin.__module__]
                 field.type_annotation = StrawberryAnnotation(
                     annotation=field.type_annotation, namespace=module.__dict__

--- a/tests/objects/test_inheritance.py
+++ b/tests/objects/test_inheritance.py
@@ -1,0 +1,15 @@
+from typing import Optional
+
+import strawberry
+
+
+def test_inherited_fields():
+    @strawberry.type
+    class A:
+        a: str = strawberry.field(default="")
+
+    @strawberry.type
+    class B(A):
+        b: Optional[str] = strawberry.field(default=None)
+
+    assert strawberry.Schema(query=B)


### PR DESCRIPTION
## Description

The type resolver ensures that fields' type annotations are StrawberryAnnotations, but a typo was checking the wrong field. This resulted in StrawberryAnnotations getting recursively wrapped and causing errors downstream.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #1075.

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
