### PR TITLE
Change how we determine if a path is strawberry decorator in MyPy

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,4 @@
-Release type patch:
+Release type: patch
 
 This releases improves the MyPy plugin to be more forgiving of
 settings like `follow_imports = skip` which would break the

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+Release type patch:
+
+This releases improves the MyPy plugin to be more forgiving of
+settings like `follow_imports = skip` which would break the
+type checking.


### PR DESCRIPTION
## Description

When you have `follow_imports = skip` in mypy the path inside the plugin is not the actual path, as show in this example:

![image](https://user-images.githubusercontent.com/667029/126451202-32b8b4e4-64c8-4c73-a8d9-ac8ec16ae9fc.png)

I've changed the plugin to support this kind of paths by check if the path ends with our decorator name; it's pretty unlikely that we'd get someone with a different `strawberry.type` function :D

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation
