### PR TITLE
Swap JS CDN for graphqli interface to use unpkg.com

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Switch CDN used to load GraphQLi dependencies from jsdelivr.com to unpkg.com

--- a/strawberry/static/graphiql.html
+++ b/strawberry/static/graphiql.html
@@ -18,25 +18,25 @@
     </style>
 
     <link rel="stylesheet"
-        href="https://cdn.jsdelivr.net/npm/graphiql-with-extensions@0.14.3/graphiqlWithExtensions.css"
+        href="https://unpkg.com/graphiql-with-extensions@0.14.3/graphiqlWithExtensions.css"
         integrity="sha384-GBqwox+q8UtVEyBLBKloN5QDlBDsQnuoSUfMeJH1ZtDiCrrk103D7Bg/WjIvl4ya" crossorigin="anonymous" />
-    <script src="https://cdn.jsdelivr.net/npm/whatwg-fetch@2.0.3/fetch.min.js"
-        integrity="sha384-dcF7KoWRaRpjcNbVPUFgatYgAijf8DqW6NWuqLdfB5Sb4Cdbb8iHX7bHsl9YhpKa"
+    <script src="https://unpkg.com/whatwg-fetch@2.0.3/fetch.js"
+        integrity="sha384-KaKx4aJnrltBb2dne61B/MRPA4uRfQvv6YW99RgjHax8TRjFxcC4BC19EEX0te/6"
         crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/react@16.8.6/umd/react.production.min.js"
+    <script src="https://unpkg.com/react@16.8.6/umd/react.production.min.js"
         integrity="sha384-qn+ML/QkkJxqn4LLs1zjaKxlTg2Bl/6yU/xBTJAgxkmNGc6kMZyeskAG0a7eJBR1"
         crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/react-dom@16.8.6/umd/react-dom.production.min.js"
+    <script src="https://unpkg.com/react-dom@16.8.6/umd/react-dom.production.min.js"
         integrity="sha384-85IMG5rvmoDsmMeWK/qUU4kwnYXVpC+o9hoHMLi4bpNR+gMEiPLrvkZCgsr7WWgV"
         crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/graphiql-with-extensions@0.14.3/graphiqlWithExtensions.min.js"
+    <script src="https://unpkg.com/graphiql-with-extensions@0.14.3/graphiqlWithExtensions.min.js"
         integrity="sha384-TqI6gT2PjmSrnEOTvGHLad1U4Vm5VoyzMmcKK0C/PLCWTnwPyXhCJY6NYhC/tp19"
         crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/js-cookie@3.0.0-rc.2/dist/js.cookie.umd.min.js"></script>
+    <script src="https://unpkg.com/js-cookie@3.0.0-rc.2/dist/js.cookie.umd.min.js"></script>
 
     <!-- breaking changes in subscriptions-transport-ws since 0.9.0 -->
-    <script src="https://cdn.jsdelivr.net/npm/subscriptions-transport-ws@0.8.3/browser/client.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/graphiql-subscriptions-fetcher@0.0.2/browser/client.js"></script>
+    <script src="https://unpkg.com/subscriptions-transport-ws@0.8.3/browser/client.js"></script>
+    <script src="https://unpkg.com/graphiql-subscriptions-fetcher@0.0.2/browser/client.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
Change is based on a conversation in Discord regarding a number of
reports (including my own) of graphiql-subscriptions-fetcher not loading
from the existing (JSDelivr) CDN.

JKimbo suggested a switch to use unpkg.com which I have confirmed
resolved the issue. Suggested all other files should also be swapped

I have confirmed that all of the files are now loading, whatwg-fetch
required a switch to the un-minified variant with the sha384 hash
updated along with it. The GraphQLI interface is now loading and
operating as expected.

Message linked to discussion thread https://discord.com/channels/689806334337482765/773519351423827978/871285294123581441

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
