### PR TITLE
Make the server command inform about missing dependencies

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+Release type: patch
+
+This release makes the `strawberry server` command inform the user about missing
+dependencies required by the builtin debug server.
+
+Also `hupper` a package only used by said command has been made optional.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ include = ["strawberry/py.typed"]
 python = "^3.7"
 starlette = {version = ">=0.13.6,<0.17.0", optional = true}
 click = {version = "^7.0", optional = true}
-hupper = "^1.5"
+hupper = {version = "^1.5", optional = true}
 pygments = "^2.3"
 uvicorn = {version = ">=0.11.6,<0.14.0", optional = true}
 django = {version = ">=2,<4", optional = true}
@@ -85,7 +85,7 @@ types-aiofiles = "^0.1.7"
 
 [tool.poetry.extras]
 aiohttp = ["aiohttp", "pytest-aiohttp"]
-debug-server = ["starlette", "uvicorn"]
+debug-server = ["starlette", "uvicorn", "hupper"]
 django = ["django", "pytest-django", "asgiref"]
 flask = ["flask", "pytest-flask"]
 opentelemetry = ["opentelemetry-api", "opentelemetry-sdk"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ pydantic = {version = "^1.6.1", optional = false}
 email-validator = {version = "^1.1.3", optional = false}
 starlette = ">=0.13.6,<0.17.0"
 uvicorn = ">=0.11.6,<0.14.0"
+hupper = "^1.5"
 sanic = "^20.12.2"
 aiohttp = "^3.7.4.post0"
 pytest-aiohttp = "^0.3.0"

--- a/strawberry/cli/commands/server.py
+++ b/strawberry/cli/commands/server.py
@@ -2,10 +2,6 @@ import importlib
 import sys
 
 import click
-import hupper
-import uvicorn
-from starlette.applications import Starlette
-from starlette.middleware.cors import CORSMiddleware
 
 from strawberry import Schema
 from strawberry.asgi import GraphQL
@@ -29,6 +25,18 @@ from strawberry.utils.importer import import_module_symbol
 )
 def server(schema, host, port, app_dir):
     sys.path.insert(0, app_dir)
+
+    try:
+        import hupper
+        import uvicorn
+        from starlette.applications import Starlette
+        from starlette.middleware.cors import CORSMiddleware
+    except ImportError:
+        message = (
+            "The debug server requires additional packages, install them by running:\n"
+            "pip install strawberry-graphql[debug-server]"
+        )
+        raise click.ClickException(message)
 
     try:
         schema_symbol = import_module_symbol(schema, default_symbol_name="schema")

--- a/strawberry/cli/commands/server.py
+++ b/strawberry/cli/commands/server.py
@@ -64,5 +64,5 @@ def server(schema, host, port, app_dir):
         app.add_route(path, graphql_app)
         app.add_websocket_route(path, graphql_app)
 
-    print(f"Running strawberry on http://{host}:{port}/ 🍓")
+    print(f"Running strawberry on http://{host}:{port}/graphql 🍓")
     uvicorn.run(app, loop="none", host=host, port=port, log_level="error")

--- a/tests/cli/test_server.py
+++ b/tests/cli/test_server.py
@@ -1,3 +1,7 @@
+import sys
+
+import pytest
+
 import hupper
 import uvicorn
 
@@ -67,3 +71,18 @@ def test_invalid_schema_instance(cli_runner):
 
     assert result.exit_code == 2
     assert expected_error in result.output
+
+
+@pytest.mark.parametrize("dependency", ["hupper", "uvicorn", "starlette.applications"])
+def test_missing_debug_server_dependencies(cli_runner, mocker, dependency):
+    mocker.patch.dict(sys.modules, {dependency: None})
+
+    schema = "tests.fixtures.sample_package.sample_module"
+    result = cli_runner.invoke(cmd_server, [schema])
+
+    assert result.exit_code == 1
+    assert result.output == (
+        "Error: "
+        "The debug server requires additional packages, install them by running:\n"
+        "pip install strawberry-graphql[debug-server]\n"
+    )

--- a/tests/cli/test_server.py
+++ b/tests/cli/test_server.py
@@ -17,7 +17,7 @@ def test_cli_cmd_server(cli_runner):
     assert hupper.start_reloader.call_count == 1
     assert uvicorn.run.call_count == 1
 
-    assert result.output == "Running strawberry on http://0.0.0.0:8000/ 🍓\n"
+    assert result.output == "Running strawberry on http://0.0.0.0:8000/graphql 🍓\n"
 
 
 def test_cli_cmd_server_app_dir_option(cli_runner):
@@ -30,7 +30,7 @@ def test_cli_cmd_server_app_dir_option(cli_runner):
     assert hupper.start_reloader.call_count == 1
     assert uvicorn.run.call_count == 1
 
-    assert result.output == "Running strawberry on http://0.0.0.0:8000/ 🍓\n"
+    assert result.output == "Running strawberry on http://0.0.0.0:8000/graphql 🍓\n"
 
 
 def test_default_schema_symbol_name(cli_runner):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
@patrick91 mentionend somewhere that it would be nice if the `strawberry server` command would let the user know if they're missing dependencies required by the debug server instead of just failing. So that's what this PR adds.

While I was at it I made `hupper` an optional dependency since it's only used by said command and I adjusted the URL printed by the server command to match the docs.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* no. 3 on my sticky note

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
