### PR TITLE
Use object_type methods to correctly construct strawberry fields

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Get a field resolver correctly when extending from a pydantic model

--- a/tests/experimental/pydantic/test_basic.py
+++ b/tests/experimental/pydantic/test_basic.py
@@ -160,12 +160,12 @@ def test_type_with_fields_coming_from_strawberry_and_pydantic():
     assert field1.python_name == "age"
     assert field1.type is int
 
-    assert field2.python_name == "password"
-    assert isinstance(field2.type, StrawberryOptional)
-    assert field2.type.of_type is str
+    assert field2.python_name == "name"
+    assert field2.type is str
 
-    assert field3.python_name == "name"
-    assert field3.type is str
+    assert field3.python_name == "password"
+    assert isinstance(field3.type, StrawberryOptional)
+    assert field3.type.of_type is str
 
 
 @pytest.mark.xfail(
@@ -222,12 +222,12 @@ def test_type_with_nested_fields_coming_from_strawberry_and_pydantic():
     assert field1.python_name == "age"
     assert field1.type is int
 
-    assert field2.python_name == "password"
-    assert isinstance(field2.type, StrawberryOptional)
-    assert field2.type.of_type is str
+    assert field2.python_name == "name"
+    assert field2.type is Name
 
-    assert field3.python_name == "name"
-    assert field3.type is Name
+    assert field3.python_name == "password"
+    assert isinstance(field3.type, StrawberryOptional)
+    assert field3.type.of_type is str
 
 
 def test_type_with_aliased_pydantic_field():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Fix for #1109

Note: This PR also changes how we avoid the issue where a field without a default value is defined after a field with a default value. The fix I've implemented is to sort the fields. This will change the order in which they are shown in the schema but I don't think it's a big issue. 

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #1109

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
