### PR TITLE
Add support for async permission classes

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,7 @@
 Release type: minor
 
 This release adds support for asynchronous permission classes. The only difference to
-the synchronous variant is that the `has_permission` method is asynchronous.
+their synchronous counterpart is that the `has_permission` method is asynchronous.
 
 ```python
 from strawberry.permission import BasePermission

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,14 @@
+Release type: minor
+
+This release adds support for asynchronous permission classes. The only difference to
+the synchronous variant is that the `has_permission` method is asynchronous.
+
+```python
+from strawberry.permission import BasePermission
+
+class IsAuthenticated(BasePermission):
+    message = "User is not authenticated"
+
+    async def has_permission(self, source, info, **kwargs):
+        return True
+```

--- a/docs/guides/permissions.md
+++ b/docs/guides/permissions.md
@@ -27,14 +27,11 @@ class Query:
     user: str = strawberry.field(permission_classes=[IsAuthenticated])
 ```
 
-Your `has_permission` method should do the work to check if this request
-has permission to access the field.
+Your `has_permission` method should check if this request has permission to access the
+field. Note that the `has_permission` method can also be asynchronous.
 
-If the `has_permission` method returns a truthy value or an awaitable resolving to a
-truthy value then the field access will go ahead.
-
-If the `has_permission` method returns a falsy value or an awaitable resolving to a
-falsy value then an error will be raised using the `message` class attribute.
+If the `has_permission` method returns a truthy value then the field access will go
+ahead. Otherwise, an error will be raised using the `message` class attribute.
 
 Take a look at our [Dealing with Errors Guide](/docs/guides/errors) for more information
 on how errors are handled.

--- a/docs/guides/permissions.md
+++ b/docs/guides/permissions.md
@@ -28,7 +28,7 @@ class Query:
 ```
 
 Your `has_permission` method should do the work to check if this request
-has permission to the field.
+has permission to access the field.
 
 If the `has_permission` method returns a truthy value or an awaitable resolving to a
 truthy value then the field access will go ahead.

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -1,5 +1,6 @@
 import builtins
 import dataclasses
+import inspect
 from typing import (
     Any,
     Awaitable,
@@ -245,6 +246,13 @@ class StrawberryField(dataclasses.Field, GraphQLNameMixin):
 
         if self.base_resolver:
             return self.base_resolver(*args, **kwargs)
+
+        if inspect.isawaitable(source):
+
+            async def wrapper():
+                return getattr(await source, self.python_name)
+
+            return wrapper()
 
         return getattr(source, self.python_name)
 

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -251,12 +251,20 @@ class StrawberryField(dataclasses.Field, GraphQLNameMixin):
 
         return getattr(source, self.python_name)
 
-    @cached_property
-    def has_async_permission_classes(self) -> bool:
+    @property
+    def _has_async_permission_classes(self) -> bool:
         for permission_class in self.permission_classes:
             if inspect.iscoroutinefunction(permission_class.has_permission):
                 return True
         return False
+
+    @property
+    def _has_async_base_resolver(self) -> bool:
+        return self.base_resolver is not None and self.base_resolver.is_async
+
+    @cached_property
+    def is_async(self) -> bool:
+        return self._has_async_permission_classes or self._has_async_base_resolver
 
 
 def field(

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -14,7 +14,7 @@ from typing import (
     Union,
 )
 
-from cached_property import cached_property
+from cached_property import cached_property  # type: ignore
 
 from strawberry.annotation import StrawberryAnnotation
 from strawberry.arguments import UNSET, StrawberryArgument

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -1,6 +1,5 @@
 import builtins
 import dataclasses
-import inspect
 from typing import (
     Any,
     Awaitable,
@@ -246,13 +245,6 @@ class StrawberryField(dataclasses.Field, GraphQLNameMixin):
 
         if self.base_resolver:
             return self.base_resolver(*args, **kwargs)
-
-        if inspect.isawaitable(source):
-
-            async def wrapper():
-                return getattr(await source, self.python_name)
-
-            return wrapper()
 
         return getattr(source, self.python_name)
 

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -1,5 +1,6 @@
 import builtins
 import dataclasses
+import inspect
 from typing import (
     Any,
     Awaitable,
@@ -12,6 +13,8 @@ from typing import (
     TypeVar,
     Union,
 )
+
+from cached_property import cached_property
 
 from strawberry.annotation import StrawberryAnnotation
 from strawberry.arguments import UNSET, StrawberryArgument
@@ -247,6 +250,13 @@ class StrawberryField(dataclasses.Field, GraphQLNameMixin):
             return self.base_resolver(*args, **kwargs)
 
         return getattr(source, self.python_name)
+
+    @cached_property
+    def has_async_permission_classes(self) -> bool:
+        for permission_class in self.permission_classes:
+            if inspect.iscoroutinefunction(permission_class.has_permission):
+                return True
+        return False
 
 
 def field(

--- a/strawberry/permission.py
+++ b/strawberry/permission.py
@@ -1,4 +1,4 @@
-from typing import Any, Awaitable, Union
+from typing import Any, Awaitable, Optional, Union
 
 from strawberry.types.info import Info
 
@@ -7,6 +7,8 @@ class BasePermission:
     """
     Base class for creating permissions
     """
+
+    message: Optional[str] = None
 
     def has_permission(
         self, source: Any, info: Info, **kwargs

--- a/strawberry/permission.py
+++ b/strawberry/permission.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Awaitable, Union
 
 from strawberry.types.info import Info
 
@@ -8,7 +8,9 @@ class BasePermission:
     Base class for creating permissions
     """
 
-    def has_permission(self, source: Any, info: Info, **kwargs) -> bool:
+    def has_permission(
+        self, source: Any, info: Info, **kwargs
+    ) -> Union[bool, Awaitable[bool]]:
         raise NotImplementedError(
             "Permission classes should override has_permission method"
         )

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -394,7 +394,7 @@ class GraphQLCoreConverter:
 
             return result
 
-        if field.has_async_permission_classes:
+        if field.is_async:
             _async_resolver._is_default = not field.base_resolver  # type: ignore
             return _async_resolver
         else:

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -375,8 +375,8 @@ class GraphQLCoreConverter:
                 path=info.path,
             )
 
-        # TODO: have a async variant of this function. graphql-core handles them
-        # TODO: out of the box and way better than our "async resolving hacks" below.
+        # TODO: maybe having an async resolver function (graphql-core can handle those)
+        # TODO: could simplify the code below.
         def _resolver(_source: Any, info: GraphQLResolveInfo, **kwargs):
             strawberry_info = _strawberry_info_from_graphql(info)
 
@@ -384,7 +384,8 @@ class GraphQLCoreConverter:
                 source=_source, info=strawberry_info, kwargs=kwargs
             )
 
-            # This makes sure we always check permissions before resolving the field
+            # Make sure we always check permissions before resolving the field
+            # TODO: what if the permission class is async but get_result is sync
             if not _has_async_permission_classes():
                 _check_permissions(_source, strawberry_info, kwargs)
 

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -356,12 +356,6 @@ class GraphQLCoreConverter:
                     message = getattr(permission, "message", None)
                     raise PermissionError(message)
 
-        def _has_async_permission_classes() -> bool:
-            for permission_class in field.permission_classes:
-                if inspect.iscoroutinefunction(permission_class.has_permission):
-                    return True
-            return False
-
         def _strawberry_info_from_graphql(info: GraphQLResolveInfo) -> Info:
             return Info(
                 field_name=info.field_name,
@@ -383,9 +377,6 @@ class GraphQLCoreConverter:
                 _source, info=info, args=field_args, kwargs=field_kwargs
             )
 
-        has_async_base_resolver = inspect.iscoroutinefunction(field.base_resolver)
-        has_async_perms = _has_async_permission_classes()
-
         def _resolver(_source: Any, info: GraphQLResolveInfo, **kwargs):
             strawberry_info = _strawberry_info_from_graphql(info)
             _check_permissions(_source, strawberry_info, kwargs)
@@ -403,7 +394,7 @@ class GraphQLCoreConverter:
 
             return result
 
-        if has_async_perms or has_async_base_resolver:
+        if field.has_async_permission_classes:
             _async_resolver._is_default = not field.base_resolver  # type: ignore
             return _async_resolver
         else:

--- a/strawberry/utils/await_maybe.py
+++ b/strawberry/utils/await_maybe.py
@@ -1,0 +1,7 @@
+import inspect
+
+
+async def await_maybe(value):
+    if inspect.iscoroutine(value):
+        return await value
+    return value

--- a/tests/schema/test_permission.py
+++ b/tests/schema/test_permission.py
@@ -76,6 +76,36 @@ async def test_raises_permission_error_for_subscription():
     assert result.errors[0].message == "You are not authorized"
 
 
+@pytest.mark.asyncio
+async def test_sync_permissions_work_with_async_resolvers():
+    class IsAuthorized(BasePermission):
+        message = "User is not authorized"
+
+        def has_permission(self, source, info, **kwargs) -> bool:
+            return info.context["user"] == "Patrick"
+
+    @strawberry.type
+    class User:
+        name: str
+        email: str
+
+    @strawberry.type
+    class Query:
+        @strawberry.field(permission_classes=[IsAuthorized])
+        async def user(self, name: str) -> User:
+            return User(name=name, email="patrick.arminio@gmail.com")
+
+    schema = strawberry.Schema(query=Query)
+
+    query = '{ user(name: "patrick") { email } }'
+    result = await schema.execute(query, context_value={"user": "Patrick"})
+    assert result.data["user"]["email"] == "patrick.arminio@gmail.com"
+
+    query = '{ user(name: "marco") { email } }'
+    result = await schema.execute(query, context_value={"user": "Marco"})
+    assert result.errors[0].message == "User is not authorized"
+
+
 def test_can_use_source_when_testing_permission():
     class CanSeeEmail(BasePermission):
         message = "Cannot see email for this user"
@@ -176,60 +206,6 @@ def test_can_use_on_simple_fields():
 
 
 @pytest.mark.asyncio
-async def test_async_resolver_with_async_permission_class():
-    class CanSeeEmail(BasePermission):
-        message = "Cannot see email for this user"
-
-        async def has_permission(self, source, info, **kwargs) -> bool:
-            return False
-
-    @strawberry.type
-    class User:
-        name: str
-        email: str
-
-    @strawberry.type
-    class Query:
-        @strawberry.field(permission_classes=[CanSeeEmail])
-        async def user(self, name: str) -> User:
-            return User(name=name, email="patrick.arminio@gmail.com")
-
-    schema = strawberry.Schema(query=Query)
-
-    query = '{ user(name: "patrick") { email } }'
-
-    result = await schema.execute(query)
-    assert result.errors[0].message == "Cannot see email for this user"
-
-
-@pytest.mark.asyncio
-async def test_sync_resolver_with_async_permission_class():
-    class CanSeeEmail(BasePermission):
-        message = "Cannot see email for this user"
-
-        async def has_permission(self, source, info, **kwargs) -> bool:
-            return False
-
-    @strawberry.type
-    class User:
-        name: str
-        email: str
-
-    @strawberry.type
-    class Query:
-        @strawberry.field(permission_classes=[CanSeeEmail])
-        def user(self, name: str) -> User:
-            return User(name=name, email="patrick.arminio@gmail.com")
-
-    schema = strawberry.Schema(query=Query)
-
-    query = '{ user(name: "patrick") { email } }'
-
-    result = await schema.execute(query)
-    assert result.errors[0].message == "Cannot see email for this user"
-
-
-@pytest.mark.asyncio
 async def test_dataclass_field_with_async_permission_class():
     class CanSeeEmail(BasePermission):
         message = "Cannot see email for this user"
@@ -257,3 +233,63 @@ async def test_dataclass_field_with_async_permission_class():
     query = '{ user(name: "marco") { email } }'
     result = await schema.execute(query)
     assert result.errors[0].message == "Cannot see email for this user"
+
+
+@pytest.mark.asyncio
+async def test_async_resolver_with_async_permission_class():
+    class IsAuthorized(BasePermission):
+        message = "User is not authorized"
+
+        async def has_permission(self, source, info, **kwargs) -> bool:
+            return info.context["user"] == "Patrick"
+
+    @strawberry.type
+    class User:
+        name: str
+        email: str
+
+    @strawberry.type
+    class Query:
+        @strawberry.field(permission_classes=[IsAuthorized])
+        async def user(self, name: str) -> User:
+            return User(name=name, email="patrick.arminio@gmail.com")
+
+    schema = strawberry.Schema(query=Query)
+
+    query = '{ user(name: "patrick") { email } }'
+    result = await schema.execute(query, context_value={"user": "Patrick"})
+    assert result.data["user"]["email"] == "patrick.arminio@gmail.com"
+
+    query = '{ user(name: "marco") { email } }'
+    result = await schema.execute(query, context_value={"user": "Marco"})
+    assert result.errors[0].message == "User is not authorized"
+
+
+@pytest.mark.asyncio
+async def test_sync_resolver_with_async_permission_class():
+    class IsAuthorized(BasePermission):
+        message = "User is not authorized"
+
+        async def has_permission(self, source, info, **kwargs) -> bool:
+            return info.context["user"] == "Patrick"
+
+    @strawberry.type
+    class User:
+        name: str
+        email: str
+
+    @strawberry.type
+    class Query:
+        @strawberry.field(permission_classes=[IsAuthorized])
+        def user(self, name: str) -> User:
+            return User(name=name, email="patrick.arminio@gmail.com")
+
+    schema = strawberry.Schema(query=Query)
+
+    query = '{ user(name: "patrick") { email } }'
+    result = await schema.execute(query, context_value={"user": "Patrick"})
+    assert result.data["user"]["email"] == "patrick.arminio@gmail.com"
+
+    query = '{ user(name: "marco") { email } }'
+    result = await schema.execute(query, context_value={"user": "Marco"})
+    assert result.errors[0].message == "User is not authorized"

--- a/tests/schema/test_permission.py
+++ b/tests/schema/test_permission.py
@@ -173,3 +173,85 @@ def test_can_use_on_simple_fields():
 
     result = schema.execute_sync(query)
     assert result.errors[0].message == "Cannot see email for this user"
+
+
+@pytest.mark.asyncio
+async def test_async_resolver_with_async_permission_class():
+    class CanSeeEmail(BasePermission):
+        message = "Cannot see email for this user"
+
+        async def has_permission(self, source, info, **kwargs) -> bool:
+            return False
+
+    @strawberry.type
+    class User:
+        name: str
+        email: str
+
+    @strawberry.type
+    class Query:
+        @strawberry.field(permission_classes=[CanSeeEmail])
+        async def user(self, name: str) -> User:
+            return User(name=name, email="patrick.arminio@gmail.com")
+
+    schema = strawberry.Schema(query=Query)
+
+    query = '{ user(name: "patrick") { email } }'
+
+    result = await schema.execute(query)
+    assert result.errors[0].message == "Cannot see email for this user"
+
+
+@pytest.mark.asyncio
+async def test_sync_resolver_with_async_permission_class():
+    class CanSeeEmail(BasePermission):
+        message = "Cannot see email for this user"
+
+        async def has_permission(self, source, info, **kwargs) -> bool:
+            return False
+
+    @strawberry.type
+    class User:
+        name: str
+        email: str
+
+    @strawberry.type
+    class Query:
+        @strawberry.field(permission_classes=[CanSeeEmail])
+        def user(self, name: str) -> User:
+            return User(name=name, email="patrick.arminio@gmail.com")
+
+    schema = strawberry.Schema(query=Query)
+
+    query = '{ user(name: "patrick") { email } }'
+
+    result = await schema.execute(query)
+    assert result.errors[0].message == "Cannot see email for this user"
+
+
+@pytest.mark.asyncio
+async def test_dataclass_field_with_async_permission_class():
+    class CanSeeEmail(BasePermission):
+        message = "Cannot see email for this user"
+
+        async def has_permission(self, source, info, **kwargs) -> bool:
+            return False
+
+    @strawberry.type
+    class User:
+        name: str
+        email: str = strawberry.field(permission_classes=[CanSeeEmail])
+
+    @strawberry.type
+    class Query:
+        @strawberry.field()
+        async def user(self, name: str) -> User:
+            return User(name=name, email="patrick.arminio@gmail.com")
+
+    schema = strawberry.Schema(query=Query)
+
+    query = '{ user(name: "patrick") { email } }'
+
+    result = await schema.execute(query)
+    print(result)
+    assert result.errors[0].message == "Cannot see email for this user"

--- a/tests/schema/test_permission.py
+++ b/tests/schema/test_permission.py
@@ -235,7 +235,7 @@ async def test_dataclass_field_with_async_permission_class():
         message = "Cannot see email for this user"
 
         async def has_permission(self, source, info, **kwargs) -> bool:
-            return False
+            return source.name.lower() == "patrick"
 
     @strawberry.type
     class User:
@@ -251,7 +251,9 @@ async def test_dataclass_field_with_async_permission_class():
     schema = strawberry.Schema(query=Query)
 
     query = '{ user(name: "patrick") { email } }'
-
     result = await schema.execute(query)
-    print(result)
+    assert result.data["user"]["email"] == "patrick.arminio@gmail.com"
+
+    query = '{ user(name: "marco") { email } }'
+    result = await schema.execute(query)
     assert result.errors[0].message == "Cannot see email for this user"

--- a/tests/schema/test_permission.py
+++ b/tests/schema/test_permission.py
@@ -306,7 +306,7 @@ async def test_mixed_sync_and_async_permission_classes():
     class IsAuthorizedSync(BasePermission):
         message = "User is not authorized (sync)"
 
-        async def has_permission(self, source, info, **kwargs) -> bool:
+        def has_permission(self, source, info, **kwargs) -> bool:
             return info.context.get("passSync", False)
 
     @strawberry.type


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
This PR adds support for async permissions. I made sure sync and async permission classes and resolvers can be combined and that permissions are always checked before the protected resolver was called.

This ended up being really messy (just like when we had to write async wrappers to handle enum conversion), so I decided to have separate sync and async resolve functions in the schema coverter. Looking at graphql-core code that's how it's supposed to be. Before we would put extra async functionality (enum conversion and now permission checks) into an async wrapper that graphql-core would call to finalize async values returned from resolvers, which worked but was hard to extend and maintain.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

* Fixes #1085

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
