### PR TITLE
Bring scalar definitions into schema and allow overriding

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,39 @@
+Release type: minor
+
+This release improves how we deal with custom scalars. Instead of being global
+they are now scoped to the schema. This allows you to have multiple schemas in
+the same project with differnet scalars.
+
+Also you can now override the built in scalars with your own custom
+implementation. Out of the box Strawberry provides you with custom scalars for
+common Python types like `datetime` and `Decimal`. If you require a custom
+implementation of one of these built in scalars you can how subclass the
+`Schema` class and override the `get_scalar` function to return your own custom
+implementation:
+
+```python
+from datetime import datetime, timezone
+import strawberry
+
+EpocDateTime = strawberry.scalar(
+    datetime,
+    serialize=lambda value: int(value.timestamp()),
+    parse_value=lambda value: datetime.fromtimestamp(int(value), timezone.utc),
+)
+
+class MySchema(strawberry.Schema):
+    def get_scalar(self, scalar):
+        if scalar == datetime:
+            return EpocDateTime
+        return super().get_scalar(scalar)
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def current_time(self) -> datetime:
+        return datetime.now()
+
+schema = MySchema(Query)
+result = schema.execute_sync("{ currentTime }")
+assert result.data == {"currentTime": 1628683200}
+```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,7 @@ Release type: minor
 
 This release improves how we deal with custom scalars. Instead of being global
 they are now scoped to the schema. This allows you to have multiple schemas in
-the same project with differnet scalars.
+the same project with different scalars.
 
 Also you can now override the built in scalars with your own custom
 implementation. Out of the box Strawberry provides you with custom scalars for

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,9 +7,8 @@ the same project with differnet scalars.
 Also you can now override the built in scalars with your own custom
 implementation. Out of the box Strawberry provides you with custom scalars for
 common Python types like `datetime` and `Decimal`. If you require a custom
-implementation of one of these built in scalars you can how subclass the
-`Schema` class and override the `get_scalar` function to return your own custom
-implementation:
+implementation of one of these built in scalars you can now pass a map of
+overrides to your schema:
 
 ```python
 from datetime import datetime, timezone
@@ -21,19 +20,18 @@ EpocDateTime = strawberry.scalar(
     parse_value=lambda value: datetime.fromtimestamp(int(value), timezone.utc),
 )
 
-class MySchema(strawberry.Schema):
-    def get_scalar(self, scalar):
-        if scalar == datetime:
-            return EpocDateTime
-        return super().get_scalar(scalar)
-
 @strawberry.type
 class Query:
     @strawberry.field
     def current_time(self) -> datetime:
         return datetime.now()
 
-schema = MySchema(Query)
+schema = strawberry.Schema(
+  Query,
+  scalar_overrides={
+    datetime: EpocDateTime,
+  }
+)
 result = schema.execute_sync("{ currentTime }")
 assert result.data == {"currentTime": 1628683200}
 ```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,7 +14,7 @@ overrides to your schema:
 from datetime import datetime, timezone
 import strawberry
 
-EpocDateTime = strawberry.scalar(
+EpochDateTime = strawberry.scalar(
     datetime,
     serialize=lambda value: int(value.timestamp()),
     parse_value=lambda value: datetime.fromtimestamp(int(value), timezone.utc),
@@ -29,7 +29,7 @@ class Query:
 schema = strawberry.Schema(
   Query,
   scalar_overrides={
-    datetime: EpocDateTime,
+    datetime: EpochDateTime,
   }
 )
 result = schema.execute_sync("{ currentTime }")

--- a/TWEET.md
+++ b/TWEET.md
@@ -1,0 +1,3 @@
+This release improves how we deal with custom scalars. Instead of being
+global they are now scoped to the current schema. You can also override
+the built in scalars with your own custom implementation.

--- a/TWEET.md
+++ b/TWEET.md
@@ -1,4 +1,4 @@
-🆕 Release $version is out! Thanks to @jkimbo for this great new feature! 
+🆕 Release $version is out! Thanks to @jkimbo for this great new feature!
 We are now able to override the default scalars, so you don't have to stick
 with the defaults provided by us 😊
 

--- a/TWEET.md
+++ b/TWEET.md
@@ -1,3 +1,11 @@
+🆕 Release $version is out! Thanks to @jkimbo for this great new feature! 
+We are now able to override the default scalars, so you don't have to stick
+with the defaults provided by us 😊
+
+Get it here 👉 $release_url
+
+---
+
 This release improves how we deal with custom scalars. Instead of being
 global they are now scoped to the current schema. You can also override
 the built in scalars with your own custom implementation.

--- a/docs/types/scalars.md
+++ b/docs/types/scalars.md
@@ -160,3 +160,38 @@ query ExampleDataQuery {
   }
 }
 ```
+
+## Overriding built in scalars
+
+To override the behaviour of the built in scalars you can create a custom Schema
+and implement a custom `get_scalar` function.
+
+Here is a full example of replacing the built in `DateTime` scalar with one that
+serializes all datetimes as unix timestamps:
+
+```python
+from datetime import datetime, timezone
+import strawberry
+
+EpocDateTime = strawberry.scalar(
+    datetime,
+    serialize=lambda value: int(value.timestamp()),
+    parse_value=lambda value: datetime.fromtimestamp(int(value), timezone.utc),
+)
+
+class MySchema(strawberry.Schema):
+    def get_scalar(self, scalar):
+        if scalar == datetime:
+            return EpocDateTime
+        return super().get_scalar(scalar)
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def current_time(self) -> datetime:
+        return datetime.now()
+
+schema = MySchema(Query)
+result = schema.execute_sync("{ currentTime }")
+assert result.data == {"currentTime": 1628683200}
+```

--- a/docs/types/scalars.md
+++ b/docs/types/scalars.md
@@ -174,7 +174,7 @@ from datetime import datetime, timezone
 import strawberry
 
 # Define your custom scalar
-EpocDateTime = strawberry.scalar(
+EpochDateTime = strawberry.scalar(
     datetime,
     serialize=lambda value: int(value.timestamp()),
     parse_value=lambda value: datetime.fromtimestamp(int(value), timezone.utc),
@@ -189,7 +189,7 @@ class Query:
 schema = strawberry.Schema(
   Query,
   scalar_overrides={
-    datetime: EpocDateTime,
+    datetime: EpochDateTime,
   }
 )
 result = schema.execute_sync("{ currentTime }")

--- a/docs/types/scalars.md
+++ b/docs/types/scalars.md
@@ -173,12 +173,14 @@ serializes all datetimes as unix timestamps:
 from datetime import datetime, timezone
 import strawberry
 
+# Define your custom scalar
 EpocDateTime = strawberry.scalar(
     datetime,
     serialize=lambda value: int(value.timestamp()),
     parse_value=lambda value: datetime.fromtimestamp(int(value), timezone.utc),
 )
 
+# Create a custom schema
 class MySchema(strawberry.Schema):
     def get_scalar(self, scalar):
         if scalar == datetime:

--- a/docs/types/scalars.md
+++ b/docs/types/scalars.md
@@ -163,8 +163,8 @@ query ExampleDataQuery {
 
 ## Overriding built in scalars
 
-To override the behaviour of the built in scalars you can create a custom Schema
-and implement a custom `get_scalar` function.
+To override the behaviour of the built in scalars you can pass a map of
+overrides to your schema.
 
 Here is a full example of replacing the built in `DateTime` scalar with one that
 serializes all datetimes as unix timestamps:
@@ -180,20 +180,18 @@ EpocDateTime = strawberry.scalar(
     parse_value=lambda value: datetime.fromtimestamp(int(value), timezone.utc),
 )
 
-# Create a custom schema
-class MySchema(strawberry.Schema):
-    def get_scalar(self, scalar):
-        if scalar == datetime:
-            return EpocDateTime
-        return super().get_scalar(scalar)
-
 @strawberry.type
 class Query:
     @strawberry.field
     def current_time(self) -> datetime:
         return datetime.now()
 
-schema = MySchema(Query)
+schema = strawberry.Schema(
+  Query,
+  scalar_overrides={
+    datetime: EpocDateTime,
+  }
+)
 result = schema.execute_sync("{ currentTime }")
 assert result.data == {"currentTime": 1628683200}
 ```

--- a/strawberry/annotation.py
+++ b/strawberry/annotation.py
@@ -19,7 +19,7 @@ except ImportError:  # pragma: no cover
     # ForwardRef is private in python 3.6 and 3.7
     from typing import _ForwardRef as ForwardRef  # type: ignore
 
-from strawberry.custom_scalar import SCALAR_REGISTRY, ScalarDefinition
+from strawberry.custom_scalar import ScalarDefinition
 from strawberry.enum import EnumDefinition
 from strawberry.lazy_type import LazyType
 from strawberry.scalars import SCALAR_TYPES
@@ -202,9 +202,6 @@ class StrawberryAnnotation:
     @classmethod
     def _is_scalar(cls, annotation: Any) -> bool:
         type_ = getattr(annotation, "__supertype__", annotation)
-
-        if type_ in SCALAR_REGISTRY:
-            return True
 
         if type_ in SCALAR_TYPES:
             return True

--- a/strawberry/custom_scalar.py
+++ b/strawberry/custom_scalar.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 from typing import Callable, Mapping, Optional, TypeVar, Union
 
+from graphql import GraphQLScalarType
+
 from strawberry.type import StrawberryType
 
 from .utils.str_converters import to_camel_case
@@ -17,6 +19,10 @@ class ScalarDefinition(StrawberryType):
     serialize: Optional[Callable]
     parse_value: Optional[Callable]
     parse_literal: Optional[Callable]
+
+    # Optionally store the GraphQLScalarType instance so that we don't get
+    # duplicates
+    implementation: Optional[GraphQLScalarType] = None
 
     def copy_with(
         self, type_var_map: Mapping[TypeVar, Union[StrawberryType, type]]

--- a/strawberry/custom_scalar.py
+++ b/strawberry/custom_scalar.py
@@ -1,9 +1,8 @@
 from dataclasses import dataclass
-from typing import Callable, Dict, Mapping, Optional, Type, TypeVar, Union
+from typing import Callable, Mapping, Optional, TypeVar, Union
 
 from strawberry.type import StrawberryType
 
-from .exceptions import ScalarAlreadyRegisteredError
 from .utils.str_converters import to_camel_case
 
 
@@ -29,9 +28,6 @@ class ScalarDefinition(StrawberryType):
         return False
 
 
-SCALAR_REGISTRY: Dict[Type, ScalarDefinition] = {}
-
-
 class ScalarWrapper:
     _scalar_definition: ScalarDefinition
 
@@ -54,9 +50,6 @@ def _process_scalar(
 
     name = name or to_camel_case(cls.__name__)
 
-    if cls in SCALAR_REGISTRY:
-        raise ScalarAlreadyRegisteredError(name)
-
     wrapper = ScalarWrapper(cls)
     wrapper._scalar_definition = ScalarDefinition(
         name=name,
@@ -65,8 +58,6 @@ def _process_scalar(
         parse_literal=parse_literal,
         parse_value=parse_value,
     )
-
-    SCALAR_REGISTRY[cls] = wrapper._scalar_definition
 
     return wrapper
 

--- a/strawberry/exceptions.py
+++ b/strawberry/exceptions.py
@@ -127,13 +127,6 @@ class MultipleStrawberryArgumentsError(Exception):
         super().__init__(message)
 
 
-class ScalarAlreadyRegisteredError(Exception):
-    def __init__(self, scalar_name: str):
-        message = f"Scalar `{scalar_name}` has already been registered"
-
-        super().__init__(message)
-
-
 class WrongNumberOfResultsReturned(Exception):
     def __init__(self, expected: int, received: int):
         message = (

--- a/strawberry/exceptions.py
+++ b/strawberry/exceptions.py
@@ -127,6 +127,13 @@ class MultipleStrawberryArgumentsError(Exception):
         super().__init__(message)
 
 
+class ScalarAlreadyRegisteredError(Exception):
+    def __init__(self, scalar_name: str):
+        message = f"Scalar `{scalar_name}` has already been registered"
+
+        super().__init__(message)
+
+
 class WrongNumberOfResultsReturned(Exception):
     def __init__(self, expected: int, received: int):
         message = (

--- a/strawberry/scalars.py
+++ b/strawberry/scalars.py
@@ -5,13 +5,13 @@ from uuid import UUID
 
 
 ID = NewType("ID", str)
-SCALAR_TYPES = [int, str, float, bytes, bool, UUID, datetime, date, time, Decimal]
+SCALAR_TYPES = [int, str, float, bytes, bool, ID, UUID, datetime, date, time, Decimal]
 
 
 def is_scalar(annotation: Any) -> bool:
     type = getattr(annotation, "__supertype__", annotation)
 
-    if type in SCALAR_TYPES:
+    if type_ in SCALAR_TYPES:
         return True
 
     return hasattr(annotation, "_scalar_definition")

--- a/strawberry/scalars.py
+++ b/strawberry/scalars.py
@@ -9,7 +9,7 @@ SCALAR_TYPES = [int, str, float, bytes, bool, ID, UUID, datetime, date, time, De
 
 
 def is_scalar(annotation: Any) -> bool:
-    type = getattr(annotation, "__supertype__", annotation)
+    type_ = getattr(annotation, "__supertype__", annotation)
 
     if type_ in SCALAR_TYPES:
         return True

--- a/strawberry/scalars.py
+++ b/strawberry/scalars.py
@@ -3,8 +3,6 @@ from decimal import Decimal
 from typing import Any, NewType
 from uuid import UUID
 
-from .custom_scalar import SCALAR_REGISTRY
-
 
 ID = NewType("ID", str)
 SCALAR_TYPES = [int, str, float, bytes, bool, UUID, datetime, date, time, Decimal]
@@ -12,9 +10,6 @@ SCALAR_TYPES = [int, str, float, bytes, bool, UUID, datetime, date, time, Decima
 
 def is_scalar(annotation: Any) -> bool:
     type = getattr(annotation, "__supertype__", annotation)
-
-    if type in SCALAR_REGISTRY:
-        return True
 
     if type in SCALAR_TYPES:
         return True

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -4,7 +4,6 @@ from typing import Any, Collection, Dict, List, Optional, Sequence, Type, Union
 
 from graphql import (
     ExecutionContext as GraphQLExecutionContext,
-    GraphQLScalarType,
     GraphQLSchema,
     get_introspection_query,
     parse,

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -4,6 +4,7 @@ from typing import Any, Collection, Dict, List, Optional, Sequence, Type, Union
 
 from graphql import (
     ExecutionContext as GraphQLExecutionContext,
+    GraphQLScalarType,
     GraphQLSchema,
     get_introspection_query,
     parse,
@@ -18,6 +19,7 @@ from strawberry.custom_scalar import ScalarDefinition
 from strawberry.enum import EnumDefinition
 from strawberry.extensions import Extension
 from strawberry.schema.schema_converter import GraphQLCoreConverter
+from strawberry.schema.types.scalar import DEFAULT_SCALAR_REGISTRY
 from strawberry.types import ExecutionContext, ExecutionResult
 from strawberry.types.types import TypeDefinition
 from strawberry.union import StrawberryUnion
@@ -46,7 +48,7 @@ class Schema:
         self.extensions = extensions
         self.execution_context_class = execution_context_class
         self.config = config or StrawberryConfig()
-        self.schema_converter = GraphQLCoreConverter(self.config)
+        self.schema_converter = GraphQLCoreConverter(self)
         self.directives = directives
 
         query_type = self.schema_converter.from_object(query._type_definition)
@@ -216,3 +218,12 @@ class Schema:
             raise ValueError(f"Invalid Schema. Errors {introspection.errors!r}")
 
         return introspection.data
+
+    def get_scalar_definition(
+        self, scalar: Type
+    ) -> Union[ScalarDefinition, GraphQLScalarType]:
+        if scalar in DEFAULT_SCALAR_REGISTRY:
+            return DEFAULT_SCALAR_REGISTRY[scalar]
+
+        scalar_definition = scalar._scalar_definition
+        return scalar_definition

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -15,7 +15,7 @@ from graphql.subscription import subscribe
 from graphql.type.directives import specified_directives
 from graphql.validation import ValidationRule
 
-from strawberry.custom_scalar import ScalarDefinition
+from strawberry.custom_scalar import ScalarDefinition, ScalarWrapper
 from strawberry.enum import EnumDefinition
 from strawberry.extensions import Extension
 from strawberry.schema.schema_converter import GraphQLCoreConverter
@@ -219,9 +219,9 @@ class Schema:
 
         return introspection.data
 
-    def get_scalar_definition(
+    def get_scalar(
         self, scalar: Type
-    ) -> Union[ScalarDefinition, GraphQLScalarType]:
+    ) -> Union[ScalarWrapper, ScalarDefinition, GraphQLScalarType]:
         if scalar in DEFAULT_SCALAR_REGISTRY:
             return DEFAULT_SCALAR_REGISTRY[scalar]
 

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -39,9 +39,8 @@ from strawberry.exceptions import MissingTypesForGenericError
 from strawberry.field import StrawberryField
 from strawberry.lazy_type import LazyType
 from strawberry.scalars import is_scalar
-from strawberry.schema.config import StrawberryConfig
-from strawberry.type import StrawberryList, StrawberryOptional, StrawberryType
 from strawberry.schema.types.scalar import _make_scalar_definition, _make_scalar_type
+from strawberry.type import StrawberryList, StrawberryOptional, StrawberryType
 from strawberry.types.info import Info
 from strawberry.types.types import TypeDefinition
 from strawberry.union import StrawberryUnion

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -32,7 +32,7 @@ from graphql import (
 )
 
 from strawberry.arguments import UNSET, StrawberryArgument, convert_arguments, is_unset
-from strawberry.custom_scalar import ScalarDefinition, ScalarWrapper
+from strawberry.custom_scalar import ScalarWrapper
 from strawberry.directive import DirectiveDefinition
 from strawberry.enum import EnumDefinition, EnumValue
 from strawberry.exceptions import MissingTypesForGenericError
@@ -41,7 +41,7 @@ from strawberry.lazy_type import LazyType
 from strawberry.scalars import is_scalar
 from strawberry.schema.config import StrawberryConfig
 from strawberry.type import StrawberryList, StrawberryOptional, StrawberryType
-from strawberry.schema.types.scalar import _make_scalar_type
+from strawberry.schema.types.scalar import _make_scalar_definition, _make_scalar_type
 from strawberry.types.info import Info
 from strawberry.types.types import TypeDefinition
 from strawberry.union import StrawberryUnion
@@ -414,13 +414,7 @@ class GraphQLCoreConverter:
                 # Reverse create the ScalarDefinition from the GraphQLScalarType
                 # This is a bit pointless but it's mainly to avoid the type
                 # signature of ConcreteType having to rely on GraphQLScalarType
-                scalar_definition = ScalarDefinition(
-                    name=scalar_definition.name,
-                    description=scalar_definition.name,
-                    serialize=scalar_definition.serialize,
-                    parse_literal=scalar_definition.parse_literal,
-                    parse_value=scalar_definition.parse_value,
-                )
+                scalar_definition = _make_scalar_definition(scalar_definition)
             else:
                 implementation = _make_scalar_type(scalar_definition)
 

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -414,7 +414,11 @@ class GraphQLCoreConverter:
             scalar_definition = scalar._scalar_definition
 
         if scalar_definition.name not in self.type_map:
-            implementation = _make_scalar_type(scalar_definition)
+            implementation = (
+                scalar_definition.implementation
+                if scalar_definition.implementation is not None
+                else _make_scalar_type(scalar_definition)
+            )
 
             self.type_map[scalar_definition.name] = ConcreteType(
                 definition=scalar_definition, implementation=implementation

--- a/strawberry/schema/types/scalar.py
+++ b/strawberry/schema/types/scalar.py
@@ -1,6 +1,7 @@
 import datetime
 import decimal
-from typing import Dict, Type, cast
+from typing import Dict, Type
+from uuid import UUID
 
 from graphql import (
     GraphQLBoolean,
@@ -11,12 +12,10 @@ from graphql import (
     GraphQLString,
 )
 
-from strawberry.custom_scalar import SCALAR_REGISTRY, ScalarDefinition
+from strawberry.custom_scalar import ScalarDefinition
 from strawberry.file_uploads.scalars import Upload
 from strawberry.scalars import ID
-
-from .base_scalars import UUID, Date, DateTime, Decimal, Time
-from .concrete_type import ConcreteType, TypeMap
+from strawberry.schema.types import base_scalars
 
 
 def _make_scalar_type(definition: ScalarDefinition) -> GraphQLScalarType:
@@ -35,28 +34,10 @@ DEFAULT_SCALAR_REGISTRY: Dict[Type, GraphQLScalarType] = {
     float: GraphQLFloat,
     bool: GraphQLBoolean,
     ID: GraphQLID,
-    UUID: _make_scalar_type(UUID._scalar_definition),
+    UUID: _make_scalar_type(base_scalars.UUID._scalar_definition),
     Upload: _make_scalar_type(Upload._scalar_definition),
-    datetime.date: _make_scalar_type(Date._scalar_definition),
-    datetime.datetime: _make_scalar_type(DateTime._scalar_definition),
-    datetime.time: _make_scalar_type(Time._scalar_definition),
-    decimal.Decimal: _make_scalar_type(Decimal._scalar_definition),
+    datetime.date: _make_scalar_type(base_scalars.Date._scalar_definition),
+    datetime.datetime: _make_scalar_type(base_scalars.DateTime._scalar_definition),
+    datetime.time: _make_scalar_type(base_scalars.Time._scalar_definition),
+    decimal.Decimal: _make_scalar_type(base_scalars.Decimal._scalar_definition),
 }
-
-
-def get_scalar_type(annotation: Type, type_map: TypeMap) -> GraphQLScalarType:
-    if annotation in DEFAULT_SCALAR_REGISTRY:
-        return DEFAULT_SCALAR_REGISTRY[annotation]
-
-    if annotation in SCALAR_REGISTRY:
-        scalar_definition = SCALAR_REGISTRY[annotation]
-    else:
-        scalar_definition = annotation._scalar_definition
-
-    if scalar_definition.name not in type_map:
-        type_map[scalar_definition.name] = ConcreteType(
-            definition=scalar_definition,
-            implementation=_make_scalar_type(scalar_definition),
-        )
-
-    return cast(GraphQLScalarType, type_map[scalar_definition.name].implementation)

--- a/strawberry/schema/types/scalar.py
+++ b/strawberry/schema/types/scalar.py
@@ -28,6 +28,16 @@ def _make_scalar_type(definition: ScalarDefinition) -> GraphQLScalarType:
     )
 
 
+def _make_scalar_definition(scalar_type: GraphQLScalarType) -> ScalarDefinition:
+    return ScalarDefinition(
+        name=scalar_type.name,
+        description=scalar_type.name,
+        serialize=scalar_type.serialize,
+        parse_literal=scalar_type.parse_literal,
+        parse_value=scalar_type.parse_value,
+    )
+
+
 DEFAULT_SCALAR_REGISTRY: Dict[Type, GraphQLScalarType] = {
     str: GraphQLString,
     int: GraphQLInt,

--- a/strawberry/schema/types/scalar.py
+++ b/strawberry/schema/types/scalar.py
@@ -1,6 +1,6 @@
 import datetime
 import decimal
-from typing import Dict, Type
+from typing import Dict
 from uuid import UUID
 
 from graphql import (
@@ -38,16 +38,16 @@ def _make_scalar_definition(scalar_type: GraphQLScalarType) -> ScalarDefinition:
     )
 
 
-DEFAULT_SCALAR_REGISTRY: Dict[Type, GraphQLScalarType] = {
-    str: GraphQLString,
-    int: GraphQLInt,
-    float: GraphQLFloat,
-    bool: GraphQLBoolean,
-    ID: GraphQLID,
-    UUID: _make_scalar_type(base_scalars.UUID._scalar_definition),
-    Upload: _make_scalar_type(Upload._scalar_definition),
-    datetime.date: _make_scalar_type(base_scalars.Date._scalar_definition),
-    datetime.datetime: _make_scalar_type(base_scalars.DateTime._scalar_definition),
-    datetime.time: _make_scalar_type(base_scalars.Time._scalar_definition),
-    decimal.Decimal: _make_scalar_type(base_scalars.Decimal._scalar_definition),
+DEFAULT_SCALAR_REGISTRY: Dict[object, ScalarDefinition] = {
+    str: _make_scalar_definition(GraphQLString),
+    int: _make_scalar_definition(GraphQLInt),
+    float: _make_scalar_definition(GraphQLFloat),
+    bool: _make_scalar_definition(GraphQLBoolean),
+    ID: _make_scalar_definition(GraphQLID),
+    UUID: base_scalars.UUID._scalar_definition,
+    Upload: Upload._scalar_definition,
+    datetime.date: base_scalars.Date._scalar_definition,
+    datetime.datetime: base_scalars.DateTime._scalar_definition,
+    datetime.time: base_scalars.Time._scalar_definition,
+    decimal.Decimal: base_scalars.Decimal._scalar_definition,
 }

--- a/strawberry/schema/types/scalar.py
+++ b/strawberry/schema/types/scalar.py
@@ -35,6 +35,7 @@ def _make_scalar_definition(scalar_type: GraphQLScalarType) -> ScalarDefinition:
         serialize=scalar_type.serialize,
         parse_literal=scalar_type.parse_literal,
         parse_value=scalar_type.parse_value,
+        implementation=scalar_type,
     )
 
 

--- a/tests/schema/test_custom_scalar.py
+++ b/tests/schema/test_custom_scalar.py
@@ -85,10 +85,3 @@ def test_custom_scalar_default_serialization():
 
     assert not result.errors
     assert result.data["myStr"] == "valueSuffix"
-
-
-def test_error_when_registering_duplicate_scalar():
-    with pytest.raises(ScalarAlreadyRegisteredError) as error:
-        strawberry.scalar(uuid.UUID, name="UUID", serialize=str, parse_value=uuid.UUID)
-
-    assert str(error.value) == "Scalar `UUID` has already been registered"

--- a/tests/schema/test_custom_scalar.py
+++ b/tests/schema/test_custom_scalar.py
@@ -1,11 +1,7 @@
 import base64
-import uuid
 from typing import NewType
 
-import pytest
-
 import strawberry
-from strawberry.exceptions import ScalarAlreadyRegisteredError
 
 
 Base64Encoded = strawberry.scalar(

--- a/tests/schema/test_scalars.py
+++ b/tests/schema/test_scalars.py
@@ -1,3 +1,4 @@
+import datetime
 from textwrap import dedent
 from uuid import UUID
 
@@ -94,3 +95,32 @@ def test_uuid_input():
     assert result.data == {
         "uuidInput": "e350746c-33b6-4469-86b0-5f16e1e12232",
     }
+
+
+def test_override_built_in_scalars():
+    Jan1st = strawberry.scalar(
+        datetime.date,
+        serialize=lambda value: (
+            datetime.date(2020, 1, 1).isoformat()  # Always return a fixed date
+        ),
+        parse_value=lambda value: datetime.date(2020, 1, 1),
+    )
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def today(self) -> datetime.date:
+            return datetime.date.today()
+
+    class CustomSchema(strawberry.Schema):
+        def get_scalar(self, scalar):
+            if scalar == datetime.date:
+                return Jan1st
+            return super().get_scalar(scalar)
+
+    schema = CustomSchema(Query)
+
+    result = schema.execute_sync("{ today }")
+
+    assert not result.errors
+    assert result.data["today"] == "2020-01-01"

--- a/tests/schema/test_scalars.py
+++ b/tests/schema/test_scalars.py
@@ -110,6 +110,10 @@ def test_override_built_in_scalars():
         def current_time(self) -> datetime:
             return datetime(2021, 8, 11, 12, 0, tzinfo=timezone.utc)
 
+        @strawberry.field
+        def isoformat(self, input_datetime: datetime) -> str:
+            return input_datetime.isoformat()
+
     class CustomSchema(strawberry.Schema):
         def get_scalar(self, scalar):
             if scalar == datetime:
@@ -118,7 +122,15 @@ def test_override_built_in_scalars():
 
     schema = CustomSchema(Query)
 
-    result = schema.execute_sync("{ currentTime }")
+    result = schema.execute_sync(
+        """
+        {
+            currentTime
+            isoformat(inputDatetime: 1628683200)
+        }
+        """
+    )
 
     assert not result.errors
     assert result.data["currentTime"] == 1628683200
+    assert result.data["isoformat"] == "2021-08-11T12:00:00+00:00"

--- a/tests/schema/test_scalars.py
+++ b/tests/schema/test_scalars.py
@@ -100,7 +100,7 @@ def test_uuid_input():
 
 
 def test_override_built_in_scalars():
-    EpocDateTime = strawberry.scalar(
+    EpochDateTime = strawberry.scalar(
         datetime,
         serialize=lambda value: int(value.timestamp()),
         parse_value=lambda value: datetime.fromtimestamp(int(value), timezone.utc),
@@ -119,7 +119,7 @@ def test_override_built_in_scalars():
     schema = strawberry.Schema(
         Query,
         scalar_overrides={
-            datetime: EpocDateTime,
+            datetime: EpochDateTime,
         },
     )
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This PR removes the global scalar registry in favour of a registry per schema. It also adds a new function to the Schema `get_scalar` that allows you to override the built in scalars with a custom implementation.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #1028 and #1061 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
