### PR TITLE
Improve formatting for GraphQLErrors

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+We change the logging format at `process_errors` for `GraphQLError` errors.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,11 @@
 Release type: patch
 
-We change the logging format at `process_errors` for `GraphQLError` errors.
+This release improves the default logging format for errors to include more information about the errors. For example it will show were an error was originated in a request:
+
+```
+GraphQL request:2:5
+1 | query {
+2 |     example
+  |     ^
+3 | }
+```

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -103,8 +103,9 @@ class Schema:
         self, errors: List[GraphQLError], execution_context: ExecutionContext
     ) -> None:
         for error in errors:
-            actual_error = error.original_error or error
-            logger.error(actual_error, exc_info=actual_error)
+            logger.error(
+                error, exc_info=error.original_error, stack_info=True, stacklevel=3
+            )
 
     async def execute(
         self,

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -177,11 +177,7 @@ class Schema:
         if result.errors:
             self.process_errors(result.errors, execution_context=execution_context)
 
-        return ExecutionResult(
-            data=result.data,
-            errors=result.errors,
-            extensions=result.extensions,
-        )
+        return result
 
     async def subscribe(
         self,

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -1,3 +1,4 @@
+import sys
 import logging
 from typing import Any, Collection, Dict, List, Optional, Sequence, Type, Union
 
@@ -102,10 +103,18 @@ class Schema:
     def process_errors(
         self, errors: List[GraphQLError], execution_context: ExecutionContext
     ) -> None:
+        kwargs: Dict[str, Any] = {
+            "stack_info": True,
+        }
+
+        # stacklevel was added in version 3.8
+        # https://docs.python.org/3/library/logging.html#logging.Logger.debug
+
+        if sys.version_info >= (3, 8):
+            kwargs["stacklevel"] = 3
+
         for error in errors:
-            logger.error(
-                error, exc_info=error.original_error, stack_info=True, stacklevel=3
-            )
+            logger.error(error, exc_info=error.original_error, **kwargs)
 
     async def execute(
         self,

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -140,11 +140,7 @@ class Schema:
         if result.errors:
             self.process_errors(result.errors, execution_context=execution_context)
 
-        return ExecutionResult(
-            data=result.data,
-            errors=result.errors,
-            extensions=result.extensions,
-        )
+        return result
 
     def execute_sync(
         self,

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -1,5 +1,5 @@
-import sys
 import logging
+import sys
 from typing import Any, Collection, Dict, List, Optional, Sequence, Type, Union
 
 from graphql import (

--- a/tests/schema/test_execution.py
+++ b/tests/schema/test_execution.py
@@ -1,5 +1,6 @@
 import textwrap
 from typing import Optional
+from textwrap import dedent
 
 import pytest
 
@@ -174,11 +175,11 @@ async def test_logging_exceptions(caplog):
 
     schema = strawberry.Schema(query=Query)
 
-    query = """
+    query = dedent("""
         query {
             example
         }
-    """
+    """).strip()
 
     result = await schema.execute(
         query,
@@ -192,7 +193,17 @@ async def test_logging_exceptions(caplog):
     record = caplog.records[0]
 
     assert record.levelname == "ERROR"
-    assert record.message == "test"
+    assert record.message == dedent(
+        """
+        test
+
+        GraphQL request:2:5
+        1 | query {
+        2 |     example
+          |     ^
+        3 | }
+    """
+    ).strip()
     assert record.name == "strawberry.execution"
     assert record.exc_info[0] is ValueError
 

--- a/tests/schema/test_execution.py
+++ b/tests/schema/test_execution.py
@@ -1,6 +1,6 @@
 import textwrap
-from typing import Optional
 from textwrap import dedent
+from typing import Optional
 
 import pytest
 
@@ -175,11 +175,13 @@ async def test_logging_exceptions(caplog):
 
     schema = strawberry.Schema(query=Query)
 
-    query = dedent("""
+    query = dedent(
+        """
         query {
             example
         }
-    """).strip()
+    """
+    ).strip()
 
     result = await schema.execute(
         query,
@@ -193,8 +195,10 @@ async def test_logging_exceptions(caplog):
     record = caplog.records[0]
 
     assert record.levelname == "ERROR"
-    assert record.message == dedent(
-        """
+    assert (
+        record.message
+        == dedent(
+            """
         test
 
         GraphQL request:2:5
@@ -203,7 +207,8 @@ async def test_logging_exceptions(caplog):
           |     ^
         3 | }
     """
-    ).strip()
+        ).strip()
+    )
     assert record.name == "strawberry.execution"
     assert record.exc_info[0] is ValueError
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
We change the logging format at `process_errors` for `GraphQLError` errors. We use their formatting system by invoking `str()` on the class but still using the original exception via the `exc_info` parameter of the `logging` module.
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #996 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
