### PR TITLE
Unable to install `strawberry[asgi]`

### DIFF
--- a/docs/integrations/asgi.md
+++ b/docs/integrations/asgi.md
@@ -9,7 +9,7 @@ use to serve your GraphQL schema. Before using Strawberry's ASGI support make su
 you install all the required dependencies by running:
 
 ```
-pip install strawberry[asgi]
+pip install strawberry-graphql[asgi]
 ```
 
 Once that's done you can use Strawberry with ASGI like so:


### PR DESCRIPTION
Trying to install `pip install strawberry[asgi]` fails unexpectedly.

## Description

I am not sure whether this is a bug or not, but running `pip install strawberry[asgi]` as described in the docs, yields:
```
Collecting strawberry[asgi]
  Using cached strawberry-3.0.tar.gz (267 kB)
  WARNING: strawberry 3.0 does not provide the extra 'asgi'
ERROR: Could not find a version that satisfies the requirement magic>=0.1
  (from strawberry[asgi]) (from versions: none)
ERROR: No matching distribution found for magic>=0.1
  (from strawberry[asgi])
```
And a similar output arises from `pip install strawberry`, however `pip install strawberry-graphql[asgi]` seems to work.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
