### PR TITLE
Unable to use FastAPI example as-is

### DIFF
--- a/docs/integrations/fastapi.md
+++ b/docs/integrations/fastapi.md
@@ -12,7 +12,7 @@ See below example for integrating FastAPI with Strawberry:
 from fastapi import FastAPI
 from strawberry.asgi import GraphQL
 
-from api.schema import Schema
+from api.schema import schema
 
 graphql_app = GraphQL(schema)
 


### PR DESCRIPTION
Unable to use FastAPI example as-is.

## Description

The current example refers to the imported schema as `schema`:
```
graphql_app = GraphQL(schema)
```
But it is imported as `Schema`:
```
from api.schema import Schema
```

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
