### PR TITLE
fix(asgi.md): update example with default arg

### DIFF
--- a/docs/integrations/asgi.md
+++ b/docs/integrations/asgi.md
@@ -46,7 +46,7 @@ the request and the response.
 
 ```python
 class MyGraphQL(GraphQL):
-    async def get_context(self, request: Union[Request, WebSocket], response: Optional[Response]) -> Any:
+    async def get_context(self, request: Union[Request, WebSocket], response: Optional[Response] = None) -> Any:
         return {"example": 1}
 
 


### PR DESCRIPTION
This change ensures the example code works. The code prior to this results in the stack trace below because response is not given a default value.

```
Traceback (most recent call last):
  File "/Users/ossareh/local/dev/src/github.com/erisyon/vega_v3/.venv/lib/python3.9/site-packages/uvicorn/protocols/websockets/websockets_impl.py", line 171, in run_asgi
    result = await self.app(self.scope, self.asgi_receive, self.asgi_send)
  File "/Users/ossareh/local/dev/src/github.com/erisyon/vega_v3/.venv/lib/python3.9/site-packages/uvicorn/middleware/proxy_headers.py", line 59, in __call__
    return await self.app(scope, receive, send)
  File "/Users/ossareh/local/dev/src/github.com/erisyon/vega_v3/.venv/lib/python3.9/site-packages/strawberry/asgi/__init__.py", line 340, in __call__
    await self.handle_websocket(scope=scope, receive=receive, send=send)
  File "/Users/ossareh/local/dev/src/github.com/erisyon/vega_v3/.venv/lib/python3.9/site-packages/strawberry/asgi/__init__.py", line 96, in handle_websocket
    await self.handle_ws_message(ws, message)
  File "/Users/ossareh/local/dev/src/github.com/erisyon/vega_v3/.venv/lib/python3.9/site-packages/strawberry/asgi/__init__.py", line 116, in handle_ws_message
    await self.handle_start(ws, message)
  File "/Users/ossareh/local/dev/src/github.com/erisyon/vega_v3/.venv/lib/python3.9/site-packages/strawberry/asgi/__init__.py", line 135, in handle_start
    context = await self.get_context(ws)
TypeError: get_context() missing 1 required positional argument: 'response'

```


<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

