### PR TITLE
Change Info type to lazy access all properties to improve performance

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+This release improves execution performance significantly by lazy loading
+attributes on the `Info` type 🏎

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -41,7 +41,6 @@ from strawberry.scalars import is_scalar
 from strawberry.schema.config import StrawberryConfig
 from strawberry.type import StrawberryList, StrawberryOptional, StrawberryType
 from strawberry.types.info import Info
-from strawberry.types.nodes import SelectedField
 from strawberry.types.types import TypeDefinition
 from strawberry.union import StrawberryUnion
 from strawberry.utils.await_maybe import await_maybe
@@ -354,15 +353,8 @@ class GraphQLCoreConverter:
 
         def _strawberry_info_from_graphql(info: GraphQLResolveInfo) -> Info:
             return Info(
-                field_name=info.field_name,
-                field_nodes=info.field_nodes,  # deprecated
-                selected_fields=list(map(SelectedField, info.field_nodes)),
-                context=info.context,
-                root_value=info.root_value,
-                variable_values=info.variable_values,
-                return_type=field.type,
-                operation=info.operation,
-                path=info.path,
+                _raw_info=info,
+                _field=field,
             )
 
         def _get_result(_source: Any, info: Info, **kwargs):

--- a/strawberry/types/info.py
+++ b/strawberry/types/info.py
@@ -1,11 +1,16 @@
 import dataclasses
-from typing import Any, Dict, Generic, List, Optional, TypeVar, Union
+import warnings
+from typing import TYPE_CHECKING, Any, Dict, Generic, List, Optional, TypeVar, Union
 
-from graphql import OperationDefinitionNode
+from graphql import GraphQLResolveInfo, OperationDefinitionNode
 from graphql.language import FieldNode
 from graphql.pyutils.path import Path
 
 from strawberry.type import StrawberryType
+
+
+if TYPE_CHECKING:
+    from strawberry.field import StrawberryField
 
 from .nodes import SelectedField
 
@@ -16,15 +21,50 @@ RootValueType = TypeVar("RootValueType")
 
 @dataclasses.dataclass
 class Info(Generic[ContextType, RootValueType]):
-    field_name: str
-    field_nodes: List[FieldNode]  # deprecated
-    selected_fields: List[SelectedField]
-    context: ContextType
-    root_value: RootValueType
-    variable_values: Dict[str, Any]
+    _raw_info: GraphQLResolveInfo
+    _field: "StrawberryField"
+
+    @property
+    def field_name(self) -> str:
+        return self._raw_info.field_name
+
+    @property
+    def field_nodes(self) -> List[FieldNode]:  # deprecated
+        warnings.warn(
+            "`info.field_nodes` is deprecated, use `selected_fields` instead",
+            DeprecationWarning,
+        )
+        return self._raw_info.field_nodes
+
+    @property
+    def selected_fields(self) -> List[SelectedField]:
+        info = self._raw_info
+        return list(map(SelectedField, info.field_nodes))
+
+    @property
+    def context(self) -> ContextType:
+        return self._raw_info.context
+
+    @property
+    def root_value(self) -> RootValueType:
+        return self._raw_info.root_value
+
+    @property
+    def variable_values(self) -> Dict[str, Any]:
+        return self._raw_info.variable_values
+
     # TODO: merge type with StrawberryType when StrawberryObject is implemented
-    return_type: Optional[Union[type, StrawberryType]]
+    @property
+    def return_type(self) -> Optional[Union[type, StrawberryType]]:
+        return self._field.type
+
     # TODO: create an abstraction on these fields
-    operation: OperationDefinitionNode
-    path: Path
+    @property
+    def operation(self) -> OperationDefinitionNode:
+        return self._raw_info.operation
+
+    @property
+    def path(self) -> Path:
+        return self._raw_info.path
+
     # TODO: parent_type as strawberry types

--- a/tests/schema/test_info.py
+++ b/tests/schema/test_info.py
@@ -174,3 +174,21 @@ def test_return_type_from_field():
 
     assert not result.errors
     assert result.data["field"] == 0
+
+
+def test_field_nodes_deprecation():
+    def resolver(info):
+        info.field_nodes
+        return 0
+
+    @strawberry.type
+    class Query:
+        field: int = strawberry.field(resolver=resolver)
+
+    schema = strawberry.Schema(query=Query)
+
+    with pytest.deprecated_call():
+        result = schema.execute_sync("{ field }")
+
+    assert not result.errors
+    assert result.data["field"] == 0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

I was building some benchmarks for Strawberry in Django (to compare against Graphene and DRF) and I noticed that Strawberry was about 2x slower that Graphene (v3). I traced the issue to the custom info object that we create so this PR changes the Info type to lazy load all of it's fields so that we don't pay the performance penalty if a resolver doesn't request it. A future optimisation could be to only create the Info type if the resolver asks for it.

Also while I was at it I added a deprecation warning when accessing the `field_nodes` property.

Benchmark code here: https://github.com/jkimbo/django-graphql-benchmarks

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
