### PR TITLE
Cache selected fields property on the field `info`.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+This release caches attributes on the `Info` type which aren't delegated to the core info object.

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,3 +3,6 @@ plugins = ./strawberry/ext/mypy_plugin.py
 implicit_reexport = False
 ; Disabled because of this bug: https://github.com/python/mypy/issues/9689
 ; disallow_untyped_decorators = True
+
+[mypy-cached_property.*]
+ignore_missing_imports = True

--- a/mypy_tests.ini
+++ b/mypy_tests.ini
@@ -18,3 +18,6 @@ ignore_missing_imports = True
 
 [mypy-dotenv.*]
 ignore_missing_imports = True
+
+[mypy-cached_property.*]
+ignore_missing_imports = True

--- a/strawberry/types/info.py
+++ b/strawberry/types/info.py
@@ -2,6 +2,8 @@ import dataclasses
 import warnings
 from typing import TYPE_CHECKING, Any, Dict, Generic, List, Optional, TypeVar, Union
 
+from cached_property import cached_property  # type: ignore
+
 from graphql import GraphQLResolveInfo, OperationDefinitionNode
 from graphql.language import FieldNode
 from graphql.pyutils.path import Path
@@ -36,7 +38,7 @@ class Info(Generic[ContextType, RootValueType]):
         )
         return self._raw_info.field_nodes
 
-    @property
+    @cached_property
     def selected_fields(self) -> List[SelectedField]:
         info = self._raw_info
         return list(map(SelectedField, info.field_nodes))

--- a/strawberry/types/info.py
+++ b/strawberry/types/info.py
@@ -2,7 +2,7 @@ import dataclasses
 import warnings
 from typing import TYPE_CHECKING, Any, Dict, Generic, List, Optional, TypeVar, Union
 
-from cached_property import cached_property  # type: ignore
+from cached_property import cached_property
 
 from graphql import GraphQLResolveInfo, OperationDefinitionNode
 from graphql.language import FieldNode


### PR DESCRIPTION
## Description

Follow-up to #1165. Selected fields are the only property that aren't trivially delegated to the graphql-core object, so it seems worth caching.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
