### PR TITLE
Return query string from info

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,13 @@
+Release type: patch
+
+This release add query string into the info object that is sent to the resolver
+
+```python
+import strawberry
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def query_string(self, info: Info) -> str:
+        return info.query
+```

--- a/strawberry/types/info.py
+++ b/strawberry/types/info.py
@@ -69,4 +69,8 @@ class Info(Generic[ContextType, RootValueType]):
     def path(self) -> Path:
         return self._raw_info.path
 
+    @property
+    def query(self) -> str:
+        return (self._raw_info.context["request"]._body).decode("utf-8")
+
     # TODO: parent_type as strawberry types

--- a/tests/django/test_views.py
+++ b/tests/django/test_views.py
@@ -329,3 +329,26 @@ def test_can_change_status_code():
 
     assert response.status_code == 418
     assert data == {"data": {"abc": "ABC"}}
+
+
+def test_query_string_in_info():
+    factory = RequestFactory()
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def abc(self, info: Info) -> str:
+            return info.query
+
+    schema = strawberry.Schema(query=Query)
+
+    query = "{ abc }"
+    request = factory.post(
+        "/graphql/", {"query": query}, content_type="application/json"
+    )
+
+    response = GraphQLView.as_view(schema=schema)(request)
+    data = json.loads(response.content.decode())
+
+    assert response.status_code == 200
+    assert data == {"data": {"abc": '{"query": "{ abc }"}'}}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
**Hello Friends**
First of all Thanks for this amazing package
In our company we build APIs with strawberry, and we are all happy because of this handy package
I add some lines of code to add query string into the info object for issue #1146 
I also add an small test for this patch
Hope it can help
If anything needs to be fixed about my codes, just let me know
***With Respect***

I just doubt I have to updated the documentation for these changes or not
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Technically, i just extract the sent query from request body from HttpRequest object and return it as info property
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

#1146 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
