### PR TITLE
Prevent mypy from crashing when _get_type_for_expr returns None

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+This release fixes an issue with the MyPy plugin that prevented using
+TextChoices from django in `strawberry.enum`.


### PR DESCRIPTION
## Description

A small fix to make sure we don't crash when `_get_type_for_expr` in the mypy plugin returns None.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

Closes #1201

