### PR TITLE
Allow custom scalar overrides based on a newly registered type.

### DIFF
--- a/strawberry/scalars.py
+++ b/strawberry/scalars.py
@@ -5,7 +5,7 @@ from uuid import UUID
 
 
 ID = NewType("ID", str)
-SCALAR_TYPES = [int, str, float, bytes, bool, ID, UUID, datetime, date, time, Decimal]
+SCALAR_TYPES = {int, str, float, bool, ID, UUID, datetime, date, time, Decimal}
 
 
 def is_scalar(annotation: Any) -> bool:

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -17,6 +17,7 @@ from graphql.validation import ValidationRule
 from strawberry.custom_scalar import ScalarDefinition, ScalarWrapper
 from strawberry.enum import EnumDefinition
 from strawberry.extensions import Extension
+from strawberry.scalars import SCALAR_TYPES
 from strawberry.schema.schema_converter import GraphQLCoreConverter
 from strawberry.schema.types.scalar import DEFAULT_SCALAR_REGISTRY
 from strawberry.types import ExecutionContext, ExecutionResult
@@ -56,6 +57,7 @@ class Schema:
         }
         if scalar_overrides:
             scalar_registry.update(scalar_overrides)
+            SCALAR_TYPES.update(scalar_overrides)  # type: ignore
 
         self.schema_converter = GraphQLCoreConverter(self.config, scalar_registry)
         self.directives = directives

--- a/tests/schema/test_scalars.py
+++ b/tests/schema/test_scalars.py
@@ -1,5 +1,7 @@
-from datetime import datetime, timezone
+import base64
+from datetime import datetime, timedelta, timezone
 from textwrap import dedent
+from typing import NewType
 from uuid import UUID
 
 import pytest
@@ -157,3 +159,42 @@ def test_duplicate_scalars():
         TypeError, match="Scalar `MyCustomScalar` has already been registered"
     ):
         strawberry.Schema(Query)
+
+
+Long = strawberry.scalar(NewType("Long", int), description="64-bit int")
+Binary = strawberry.scalar(
+    bytes,
+    name="Binary",
+    serialize=lambda b: base64.b64encode(b).decode("utf8"),
+    parse_value=base64.b64decode,
+)
+Duration = strawberry.scalar(
+    timedelta,
+    name="Duration",
+    serialize=timedelta.total_seconds,
+    parse_value=lambda s: timedelta(seconds=s),
+)
+
+
+def test_custom_builtins():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def long(self, value: Long) -> Long:
+            return value
+
+        @strawberry.field
+        def base64(self, value: bytes) -> bytes:
+            return value
+
+        @strawberry.field
+        def duration(self, value: timedelta) -> timedelta:
+            return value
+
+    schema = strawberry.Schema(
+        Query, scalar_overrides={bytes: Binary, timedelta: Duration}
+    )
+    result = schema.execute_sync(
+        """{ long(value: 1) base64(value: "aGk=") duration(value: 1.0)}"""
+    )
+    assert result.data == {"long": 1, "base64": "aGk=", "duration": 1.0}


### PR DESCRIPTION
## Description
A quick fix for #1204. If scalars are meant to be entirely schema specific, then a better fix would be to refactor the global `is_scalar` functions to be schema methods.

But I think this is an improvement, because custom serialization was probably the intended feature. With this fix, new scalars can use their registered type. 

## Types of Changes
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR
* #1204

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
