### PR TITLE
Ensure scalar overrides are used everywhere

### DIFF
--- a/strawberry/annotation.py
+++ b/strawberry/annotation.py
@@ -22,7 +22,6 @@ except ImportError:  # pragma: no cover
 from strawberry.custom_scalar import ScalarDefinition
 from strawberry.enum import EnumDefinition
 from strawberry.lazy_type import LazyType
-from strawberry.scalars import SCALAR_TYPES
 from strawberry.type import (
     StrawberryList,
     StrawberryOptional,
@@ -82,8 +81,6 @@ class StrawberryAnnotation:
             return self.create_list(evaled_type)
         elif self._is_optional(evaled_type):
             return self.create_optional(evaled_type)
-        elif self._is_scalar(evaled_type):
-            return evaled_type
         elif self._is_union(evaled_type):
             return self.create_union(evaled_type)
         elif is_type_var(evaled_type):
@@ -198,15 +195,6 @@ class StrawberryAnnotation:
         annotation_origin = getattr(annotation, "__origin__", None)
 
         return annotation_origin == list
-
-    @classmethod
-    def _is_scalar(cls, annotation: Any) -> bool:
-        type_ = getattr(annotation, "__supertype__", annotation)
-
-        if type_ in SCALAR_TYPES:
-            return True
-
-        return hasattr(annotation, "_scalar_definition")
 
     @classmethod
     def _is_strawberry_type(cls, evaled_type: Any) -> bool:

--- a/strawberry/experimental/pydantic/conversion.py
+++ b/strawberry/experimental/pydantic/conversion.py
@@ -1,7 +1,6 @@
 from typing import Union, cast
 
 from strawberry.field import StrawberryField
-from strawberry.scalars import is_scalar
 from strawberry.type import StrawberryList, StrawberryOptional, StrawberryType
 
 
@@ -26,12 +25,13 @@ def _convert_from_pydantic_to_strawberry_type(
             )
 
         return items
-    elif is_scalar(type_):
-        return data
-    else:
+
+    if hasattr(type_, "_type_definition"):
         return convert_pydantic_model_to_strawberry_class(
             type_, model_instance=data_from_model, extra=extra
         )
+
+    return data
 
 
 def convert_pydantic_model_to_strawberry_class(cls, *, model_instance=None, extra=None):

--- a/strawberry/scalars.py
+++ b/strawberry/scalars.py
@@ -1,14 +1,22 @@
 from datetime import date, datetime, time
 from decimal import Decimal
-from typing import Any, NewType
+from typing import Any, Dict, NewType, Union
 from uuid import UUID
+
+from .custom_scalar import ScalarDefinition, ScalarWrapper
 
 
 ID = NewType("ID", str)
-SCALAR_TYPES = [int, str, float, bytes, bool, ID, UUID, datetime, date, time, Decimal]
+SCALAR_TYPES = [int, str, float, bool, ID, UUID, datetime, date, time, Decimal]
 
 
-def is_scalar(annotation: Any) -> bool:
+def is_scalar(
+    annotation: Any,
+    scalar_registry: Dict[object, Union[ScalarWrapper, ScalarDefinition]],
+) -> bool:
+    if annotation in scalar_registry:
+        return True
+
     type_ = getattr(annotation, "__supertype__", annotation)
 
     if type_ in SCALAR_TYPES:

--- a/strawberry/scalars.py
+++ b/strawberry/scalars.py
@@ -1,13 +1,9 @@
-from datetime import date, datetime, time
-from decimal import Decimal
 from typing import Any, Dict, NewType, Union
-from uuid import UUID
 
 from .custom_scalar import ScalarDefinition, ScalarWrapper
 
 
 ID = NewType("ID", str)
-SCALAR_TYPES = [int, str, float, bool, ID, UUID, datetime, date, time, Decimal]
 
 
 def is_scalar(
@@ -15,11 +11,6 @@ def is_scalar(
     scalar_registry: Dict[object, Union[ScalarWrapper, ScalarDefinition]],
 ) -> bool:
     if annotation in scalar_registry:
-        return True
-
-    type_ = getattr(annotation, "__supertype__", annotation)
-
-    if type_ in SCALAR_TYPES:
         return True
 
     return hasattr(annotation, "_scalar_definition")

--- a/strawberry/union.py
+++ b/strawberry/union.py
@@ -28,7 +28,6 @@ from strawberry.exceptions import (
     UnallowedReturnTypeForUnion,
     WrongReturnTypeForUnion,
 )
-from strawberry.scalars import SCALAR_TYPES
 from strawberry.type import StrawberryType
 
 
@@ -205,14 +204,9 @@ def union(
         raise TypeError("No types passed to `union`")
 
     for _type in types:
-        if _type in SCALAR_TYPES:
-            raise InvalidUnionType(
-                f"Scalar type `{_type.__name__}` cannot be used in a GraphQL Union"
-            )
-
         if not isinstance(_type, TypeVar) and not hasattr(_type, "_type_definition"):
             raise InvalidUnionType(
-                f"Union type `{_type.__name__}` is not a Strawberry type"
+                f"Type `{_type.__name__}` cannot be used in a GraphQL Union"
             )
 
     union_definition = StrawberryUnion(

--- a/tests/types/resolving/test_unions.py
+++ b/tests/types/resolving/test_unions.py
@@ -115,7 +115,7 @@ def test_error_with_empty_type_list():
 
 def test_error_with_scalar_types():
     with pytest.raises(
-        InvalidUnionType, match="Scalar type `int` cannot be used in a GraphQL Union"
+        InvalidUnionType, match="Type `int` cannot be used in a GraphQL Union"
     ):
         strawberry.union("Result", (int,))
 
@@ -126,6 +126,6 @@ def test_error_with_non_strawberry_type():
         a: int
 
     with pytest.raises(
-        InvalidUnionType, match="Union type `A` is not a Strawberry type"
+        InvalidUnionType, match="Type `A` cannot be used in a GraphQL Union"
     ):
         strawberry.union("Result", (A,))

--- a/tests/utils/test_arguments_converter.py
+++ b/tests/utils/test_arguments_converter.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 import strawberry
 from strawberry.annotation import StrawberryAnnotation
 from strawberry.arguments import UNSET, StrawberryArgument, convert_arguments
+from strawberry.schema.types.scalar import DEFAULT_SCALAR_REGISTRY
 
 
 def test_simple_types():
@@ -32,7 +33,9 @@ def test_simple_types():
         ),
     ]
 
-    assert convert_arguments(args, arguments) == {
+    assert convert_arguments(
+        args, arguments, scalar_registry=DEFAULT_SCALAR_REGISTRY
+    ) == {
         "integer": 1,
         "string": "abc",
         "float": 1.2,
@@ -59,7 +62,9 @@ def test_list():
         ),
     ]
 
-    assert convert_arguments(args, arguments) == {
+    assert convert_arguments(
+        args, arguments, scalar_registry=DEFAULT_SCALAR_REGISTRY
+    ) == {
         "integer_list": [1, 2],
         "string_list": ["abc", "cde"],
     }
@@ -85,9 +90,9 @@ def test_input_types():
         ),
     ]
 
-    assert convert_arguments(args, arguments) == {
-        "input": MyInput(abc="example", say_hello_to="Patrick", was=10, fun="yes")
-    }
+    assert convert_arguments(
+        args, arguments, scalar_registry=DEFAULT_SCALAR_REGISTRY
+    ) == {"input": MyInput(abc="example", say_hello_to="Patrick", was=10, fun="yes")}
 
 
 def test_optional_input_types():
@@ -105,7 +110,9 @@ def test_optional_input_types():
         ),
     ]
 
-    assert convert_arguments(args, arguments) == {"input": MyInput(abc="example")}
+    assert convert_arguments(
+        args, arguments, scalar_registry=DEFAULT_SCALAR_REGISTRY
+    ) == {"input": MyInput(abc="example")}
 
 
 def test_list_of_input_types():
@@ -123,9 +130,9 @@ def test_list_of_input_types():
         ),
     ]
 
-    assert convert_arguments(args, arguments) == {
-        "input_list": [MyInput(abc="example")]
-    }
+    assert convert_arguments(
+        args, arguments, scalar_registry=DEFAULT_SCALAR_REGISTRY
+    ) == {"input_list": [MyInput(abc="example")]}
 
 
 def test_optional_list_of_input_types():
@@ -142,9 +149,9 @@ def test_optional_list_of_input_types():
             type_annotation=StrawberryAnnotation(Optional[List[MyInput]]),
         ),
     ]
-    assert convert_arguments(args, arguments) == {
-        "input_list": [MyInput(abc="example")]
-    }
+    assert convert_arguments(
+        args, arguments, scalar_registry=DEFAULT_SCALAR_REGISTRY
+    ) == {"input_list": [MyInput(abc="example")]}
 
 
 def test_nested_input_types():
@@ -190,7 +197,9 @@ def test_nested_input_types():
         ),
     ]
 
-    assert convert_arguments(args, arguments) == {
+    assert convert_arguments(
+        args, arguments, scalar_registry=DEFAULT_SCALAR_REGISTRY
+    ) == {
         "input": AddReleaseFileCommentInput(
             pr_number=12,
             status=ReleaseFileStatus.OK,
@@ -214,7 +223,9 @@ def test_nested_input_types():
         ),
     ]
 
-    assert convert_arguments(args, arguments) == {
+    assert convert_arguments(
+        args, arguments, scalar_registry=DEFAULT_SCALAR_REGISTRY
+    ) == {
         "input": AddReleaseFileCommentInput(
             pr_number=12, status=ReleaseFileStatus.OK, release_info=None
         )
@@ -240,9 +251,9 @@ def test_nested_list_of_complex_types():
         ),
     ]
 
-    assert convert_arguments(args, arguments) == {
-        "input": Input(numbers=[Number(1), Number(2)])
-    }
+    assert convert_arguments(
+        args, arguments, scalar_registry=DEFAULT_SCALAR_REGISTRY
+    ) == {"input": Input(numbers=[Number(1), Number(2)])}
 
 
 def test_uses_default_for_optional_types_when_nothing_is_passed():
@@ -266,7 +277,9 @@ def test_uses_default_for_optional_types_when_nothing_is_passed():
         ),
     ]
 
-    assert convert_arguments(args, arguments) == {"input": Input(UNSET, UNSET)}
+    assert convert_arguments(
+        args, arguments, scalar_registry=DEFAULT_SCALAR_REGISTRY
+    ) == {"input": Input(UNSET, UNSET)}
 
     # case 2
     args = {"input": {"numbersSecond": None}}
@@ -279,7 +292,9 @@ def test_uses_default_for_optional_types_when_nothing_is_passed():
         ),
     ]
 
-    assert convert_arguments(args, arguments) == {"input": Input(UNSET, None)}
+    assert convert_arguments(
+        args, arguments, scalar_registry=DEFAULT_SCALAR_REGISTRY
+    ) == {"input": Input(UNSET, None)}
 
 
 def test_when_optional():
@@ -302,4 +317,7 @@ def test_when_optional():
         )
     ]
 
-    assert convert_arguments(args, arguments) == {}
+    assert (
+        convert_arguments(args, arguments, scalar_registry=DEFAULT_SCALAR_REGISTRY)
+        == {}
+    )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Fixes a bug where passing scalars in the `scalar_overrides` parameter wasn't being applied consistently. This PR makes sure that the schema specific `scalar_registry` is taken into account whenever a scalar is resolved.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #1204

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
