### PR TITLE
Add support for enabling subscriptions in GraphiQL on Django through a flag on the BaseView class

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,11 @@
+Release type: minor
+
+This release adds support for enabling subscriptions in GraphiQL
+on Django by setting a flag `subscriptions_enabled` on the BaseView class.
+```python
+from strawberry.django.views import AsyncGraphQLView
+
+from .schema import schema
+
+urlpatterns = [path("graphql", AsyncGraphQLView.as_view(schema=schema, graphiql=True, subscriptions_enabled=True))]
+```

--- a/strawberry/django/views.py
+++ b/strawberry/django/views.py
@@ -37,12 +37,14 @@ class TemporalHttpResponse(JsonResponse):
 
 
 class BaseView(View):
+    subscriptions_enabled = False
     graphiql = True
     schema: Optional[BaseSchema] = None
 
-    def __init__(self, schema: BaseSchema, graphiql=True):
+    def __init__(self, schema: BaseSchema, graphiql=True, subscriptions_enabled=False):
         self.schema = schema
         self.graphiql = graphiql
+        self.subscriptions_enabled = subscriptions_enabled
 
     def parse_body(self, request) -> Dict[str, Any]:
         if request.content_type.startswith("multipart/form-data"):
@@ -92,7 +94,7 @@ class BaseView(View):
             )
 
         context = context or {}
-        context.update({"SUBSCRIPTION_ENABLED": "false"})
+        context.update({"SUBSCRIPTION_ENABLED": json.dumps(self.subscriptions_enabled)})
 
         response = TemplateResponse(request=request, template=None, context=context)
         response.content = template.render(RequestContext(request, context))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Following on from this change https://github.com/strawberry-graphql/strawberry/pull/344 (thanks @jkimbo for the reference), I would like to propose allowing subscriptions to be enabled in GraphiQL for Django through a flag.
Without this, as a user I have to define a new AsyncGraphQLView as seen in the example here https://github.com/strawberry-graphql/examples/blob/main/django-subscriptions/api/views.py, to enable subscriptions, where as I would otherwise not need to do so.
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
