### PR TITLE
Throw an error when using a Union or Interface as an argument type

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,22 @@
+Release type: patch
+
+This release adds a new exception called `InvalidArgument` and it will be raised when we use Union or Interface as an argument type
+For example this will raise an exception:
+```python
+￼import strawberry
+￼
+@strawberry.type
+class Noun:
+    text: str
+
+@strawberry.type
+class Verb:
+        text: str
+
+Word = strawberry.union("Word", types=(Noun, Verb))
+
+@strawberry.field
+def add_word(word: Word) -> bool:
+    _word = word
+    return True
+￼```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
 Release type: patch
 
-This release adds a new exception called `InvalidFieldArgument` which is raised when if a Union or Interface is used as an argument type.
+This release adds a new exception called `InvalidFieldArgument` which is raised when a Union or Interface is used as an argument type.
 For example this will raise an exception:
 ```python
 import strawberry

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,22 +1,21 @@
 Release type: patch
 
-This release adds a new exception called `InvalidArgument` and it will be raised when we use Union or Interface as an argument type
+This release adds a new exception called `InvalidFieldArgument` which is raised when if a Union or Interface is used as an argument type.
 For example this will raise an exception:
 ```python
-￼import strawberry
-￼
+import strawberry
+
 @strawberry.type
 class Noun:
     text: str
 
 @strawberry.type
 class Verb:
-        text: str
+    text: str
 
 Word = strawberry.union("Word", types=(Noun, Verb))
 
 @strawberry.field
 def add_word(word: Word) -> bool:
-    _word = word
-    return True
-￼```
+	...
+```

--- a/strawberry/exceptions.py
+++ b/strawberry/exceptions.py
@@ -169,3 +169,9 @@ class MissingQueryError(Exception):
         message = 'Request data is missing a "query" value'
 
         super().__init__(message)
+
+
+class InvalidArgument(Exception):
+    def __init__(self, field_name: str, argument_type: str):
+        message = f'"{field_name}" is "{argument_type}" and invalid as an argument type'
+        super().__init__(message)

--- a/strawberry/exceptions.py
+++ b/strawberry/exceptions.py
@@ -171,7 +171,8 @@ class MissingQueryError(Exception):
         super().__init__(message)
 
 
-class InvalidArgument(Exception):
-    def __init__(self, field_name: str, argument_type: str):
-        message = f'"{field_name}" is "{argument_type}" and invalid as an argument type'
+class InvalidFieldArgument(Exception):
+    def __init__(self, field_name: str, argument_name: str, argument_type: str):
+        message = f'Argument "{argument_name}" on field "{field_name}" cannot be of type\
+            "{argument_type}"'
         super().__init__(message)

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -18,7 +18,7 @@ from cached_property import cached_property  # type: ignore
 
 from strawberry.annotation import StrawberryAnnotation
 from strawberry.arguments import UNSET, StrawberryArgument
-from strawberry.exceptions import InvalidArgument
+from strawberry.exceptions import InvalidFieldArgument
 from strawberry.type import StrawberryType
 from strawberry.types.info import Info
 from strawberry.union import StrawberryUnion
@@ -108,10 +108,18 @@ class StrawberryField(dataclasses.Field, GraphQLNameMixin):
             if isinstance(argument.type_annotation.annotation, str):
                 continue
             elif isinstance(argument.type, StrawberryUnion):
-                raise InvalidArgument(argument.python_name, "Union")
+                raise InvalidFieldArgument(
+                    self.python_name,
+                    argument.python_name,
+                    "Union",
+                )
             elif getattr(argument.type, "_type_definition", False):
                 if argument.type._type_definition.is_interface:
-                    raise InvalidArgument(argument.python_name, "Interface")
+                    raise InvalidFieldArgument(
+                        self.python_name,
+                        argument.python_name,
+                        "Interface",
+                    )
 
         self.base_resolver = resolver
 

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -18,8 +18,10 @@ from cached_property import cached_property  # type: ignore
 
 from strawberry.annotation import StrawberryAnnotation
 from strawberry.arguments import UNSET, StrawberryArgument
+from strawberry.exceptions import InvalidArgument
 from strawberry.type import StrawberryType
 from strawberry.types.info import Info
+from strawberry.union import StrawberryUnion
 from strawberry.utils.mixins import GraphQLNameMixin
 
 from .permission import BasePermission
@@ -101,6 +103,15 @@ class StrawberryField(dataclasses.Field, GraphQLNameMixin):
         # Allow for StrawberryResolvers or bare functions to be provided
         if not isinstance(resolver, StrawberryResolver):
             resolver = StrawberryResolver(resolver)
+
+        for argument in resolver.arguments:
+            if isinstance(argument.type_annotation.annotation, str):
+                continue
+            elif isinstance(argument.type, StrawberryUnion):
+                raise InvalidArgument(argument.python_name, "Union")
+            elif getattr(argument.type, "_type_definition", False):
+                if argument.type._type_definition.is_interface:
+                    raise InvalidArgument(argument.python_name, "Interface")
 
         self.base_resolver = resolver
 

--- a/tests/fields/test_arguments.py
+++ b/tests/fields/test_arguments.py
@@ -7,7 +7,7 @@ from typing_extensions import Annotated
 
 import strawberry
 from strawberry.arguments import UNSET
-from strawberry.exceptions import InvalidArgument, MultipleStrawberryArgumentsError
+from strawberry.exceptions import InvalidFieldArgument, MultipleStrawberryArgumentsError
 from strawberry.type import StrawberryList, StrawberryOptional
 
 
@@ -423,7 +423,7 @@ def test_annotated_python_39():
 
 
 def test_union_as_an_argument_type():
-    with pytest.raises(InvalidArgument):
+    with pytest.raises(InvalidFieldArgument):
 
         @strawberry.type
         class Noun:
@@ -441,7 +441,7 @@ def test_union_as_an_argument_type():
 
 
 def test_interface_as_an_argument_type():
-    with pytest.raises(InvalidArgument):
+    with pytest.raises(InvalidFieldArgument):
 
         @strawberry.interface
         class Adjective:

--- a/tests/fields/test_arguments.py
+++ b/tests/fields/test_arguments.py
@@ -448,5 +448,20 @@ def test_interface_as_an_argument_type():
             text: str
 
         @strawberry.field
-        def add_word(adjective: Adjective) -> bool:
+        def add_adjective(adjective: Adjective) -> bool:
             return True
+
+
+def test_resolver_with_invalid_field_argument_type():
+    with pytest.raises(InvalidFieldArgument):
+
+        @strawberry.interface
+        class Adjective:
+            text: str
+
+        def add_adjective_resolver(adjective: Adjective) -> bool:
+            return True
+
+        @strawberry.type
+        class Mutation:
+            add_adjective: bool = strawberry.field(resolver=add_adjective_resolver)

--- a/tests/fields/test_arguments.py
+++ b/tests/fields/test_arguments.py
@@ -7,7 +7,7 @@ from typing_extensions import Annotated
 
 import strawberry
 from strawberry.arguments import UNSET
-from strawberry.exceptions import MultipleStrawberryArgumentsError
+from strawberry.exceptions import InvalidArgument, MultipleStrawberryArgumentsError
 from strawberry.type import StrawberryList, StrawberryOptional
 
 
@@ -420,3 +420,33 @@ def test_annotated_python_39():
     assert argument.type == str
     assert argument.description == "This is a description"
     assert argument.type is str
+
+
+def test_union_as_an_argument_type():
+    with pytest.raises(InvalidArgument):
+
+        @strawberry.type
+        class Noun:
+            text: str
+
+        @strawberry.type
+        class Verb:
+            text: str
+
+        Word = strawberry.union("Word", types=(Noun, Verb))
+
+        @strawberry.field
+        def add_word(word: Word) -> bool:
+            return True
+
+
+def test_interface_as_an_argument_type():
+    with pytest.raises(InvalidArgument):
+
+        @strawberry.interface
+        class Adjective:
+            text: str
+
+        @strawberry.field
+        def add_word(adjective: Adjective) -> bool:
+            return True


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Hello dear friends @jkimbo  @patrick91 @BryceBeagle 
This patch is about raising an exception when we use invalid arguments such as Union and Interface. issue #1065 
Hope it can help
If anything needs to be changed or fixed, just let me know
***With Respect***
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

#1065 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
