### PR TITLE
Fix bug in pydantic conversion for nested Optional values

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,3 +143,19 @@ present, your code will not be merged.
   code.
 - If your changes warrant a documentation change, the pull request must also
   update the documentation.
+
+##### RELEASE.md files
+
+When you submit a PR, make sure to include a RELEASE.md file. We use that to automatically do releases here on GitHub and, most importantly, to PyPI!
+
+So as soon as your PR is merged, a release will be made.
+
+Here's an example of RELEASE.md:
+
+```
+Release type: patch
+
+Description of the changes, ideally with some examples, if adding a new feature.
+```
+
+Release type can be one of patch, minor or major. We use [semver](https://semver.org/), so make sure to pick the appropriate type. If in doubt feel free to ask :)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Fixes a bug in the Pydantic conversion code around complex `Optional` values.

--- a/strawberry/experimental/pydantic/conversion.py
+++ b/strawberry/experimental/pydantic/conversion.py
@@ -11,6 +11,8 @@ def _convert_from_pydantic_to_strawberry_type(
     data = data_from_model if data_from_model is not None else extra
 
     if isinstance(type_, StrawberryOptional):
+        if data is None:
+            return data
         return _convert_from_pydantic_to_strawberry_type(
             type_.of_type, data_from_model=data, extra=extra
         )

--- a/tests/experimental/pydantic/test_conversion.py
+++ b/tests/experimental/pydantic/test_conversion.py
@@ -361,6 +361,47 @@ def test_can_covert_pydantic_type_to_strawberry_with_missing_index_data_in_neste
     ]
 
 
+def test_can_covert_pydantic_type_to_strawberry_with_optional_list():
+    class WorkModel(pydantic.BaseModel):
+        name: str
+
+    @strawberry.experimental.pydantic.type(WorkModel, fields=["name"])
+    class Work:
+        year: int
+
+    class UserModel(pydantic.BaseModel):
+        work: Optional[WorkModel]
+
+    @strawberry.experimental.pydantic.type(UserModel, fields=["work"])
+    class User:
+        pass
+
+    origin_user = UserModel(work=None)
+
+    user = User.from_pydantic(
+        origin_user,
+    )
+
+    assert user.work is None
+
+
+def test_can_covert_pydantic_type_to_strawberry_with_optional_nested_value():
+    class UserModel(pydantic.BaseModel):
+        names: Optional[List[str]]
+
+    @strawberry.experimental.pydantic.type(UserModel, fields=["names"])
+    class User:
+        pass
+
+    origin_user = UserModel(names=None)
+
+    user = User.from_pydantic(
+        origin_user,
+    )
+
+    assert user.names is None
+
+
 def test_can_convert_input_types_to_pydantic():
     class User(pydantic.BaseModel):
         age: int

--- a/tests/experimental/pydantic/test_conversion.py
+++ b/tests/experimental/pydantic/test_conversion.py
@@ -20,7 +20,7 @@ def test_can_use_type_standalone():
     assert user.password == "abc"
 
 
-def test_can_covert_pydantic_type_to_strawberry():
+def test_can_convert_pydantic_type_to_strawberry():
     class User(pydantic.BaseModel):
         age: int
         password: Optional[str]
@@ -36,7 +36,7 @@ def test_can_covert_pydantic_type_to_strawberry():
     assert user.password == "abc"
 
 
-def test_can_covert_alias_pydantic_field_to_strawberry():
+def test_can_convert_alias_pydantic_field_to_strawberry():
     class UserModel(pydantic.BaseModel):
         age_: int = pydantic.Field(..., alias="age")
         password: Optional[str]
@@ -52,7 +52,7 @@ def test_can_covert_alias_pydantic_field_to_strawberry():
     assert user.password == "abc"
 
 
-def test_can_covert_falsy_values_to_strawberry():
+def test_can_convert_falsy_values_to_strawberry():
     class UserModel(pydantic.BaseModel):
         age: int
         password: str
@@ -87,7 +87,7 @@ def test_can_convert_pydantic_type_to_strawberry_with_private_field():
     assert definition.fields[0].type == int
 
 
-def test_can_covert_pydantic_type_with_nested_data_to_strawberry():
+def test_can_convert_pydantic_type_with_nested_data_to_strawberry():
     class WorkModel(pydantic.BaseModel):
         name: str
 
@@ -108,7 +108,7 @@ def test_can_covert_pydantic_type_with_nested_data_to_strawberry():
     assert user.work.name == "Ice Cream inc"
 
 
-def test_can_covert_pydantic_type_with_list_of_nested_data_to_strawberry():
+def test_can_convert_pydantic_type_with_list_of_nested_data_to_strawberry():
     class WorkModel(pydantic.BaseModel):
         name: str
 
@@ -134,7 +134,7 @@ def test_can_covert_pydantic_type_with_list_of_nested_data_to_strawberry():
     assert user.work == [Work(name="Ice Cream inc"), Work(name="Wall Street")]
 
 
-def test_can_covert_pydantic_type_with_list_of_nested_int_to_strawberry():
+def test_can_convert_pydantic_type_with_list_of_nested_int_to_strawberry():
     class UserModel(pydantic.BaseModel):
         hours: List[int]
 
@@ -154,7 +154,7 @@ def test_can_covert_pydantic_type_with_list_of_nested_int_to_strawberry():
     assert user.hours == [8, 9, 10]
 
 
-def test_can_covert_pydantic_type_with_matrix_list_of_nested_int_to_strawberry():
+def test_can_convert_pydantic_type_with_matrix_list_of_nested_int_to_strawberry():
     class UserModel(pydantic.BaseModel):
         hours: List[List[int]]
 
@@ -178,7 +178,7 @@ def test_can_covert_pydantic_type_with_matrix_list_of_nested_int_to_strawberry()
     ]
 
 
-def test_can_covert_pydantic_type_with_matrix_list_of_nested_model_to_strawberry():
+def test_can_convert_pydantic_type_with_matrix_list_of_nested_model_to_strawberry():
     class HourModel(pydantic.BaseModel):
         hour: int
 
@@ -227,7 +227,7 @@ def test_can_covert_pydantic_type_with_matrix_list_of_nested_model_to_strawberry
     ]
 
 
-def test_can_covert_pydantic_type_to_strawberry_with_additional_fields():
+def test_can_convert_pydantic_type_to_strawberry_with_additional_fields():
     class UserModel(pydantic.BaseModel):
         password: Optional[str]
 
@@ -242,7 +242,7 @@ def test_can_covert_pydantic_type_to_strawberry_with_additional_fields():
     assert user.password == "abc"
 
 
-def test_can_covert_pydantic_type_to_strawberry_with_additional_nested_fields():
+def test_can_convert_pydantic_type_to_strawberry_with_additional_nested_fields():
     @strawberry.type
     class Work:
         name: str
@@ -261,7 +261,7 @@ def test_can_covert_pydantic_type_to_strawberry_with_additional_nested_fields():
     assert user.password == "abc"
 
 
-def test_can_covert_pydantic_type_to_strawberry_with_additional_list_nested_fields():
+def test_can_convert_pydantic_type_to_strawberry_with_additional_list_nested_fields():
     @strawberry.type
     class Work:
         name: str
@@ -291,7 +291,7 @@ def test_can_covert_pydantic_type_to_strawberry_with_additional_list_nested_fiel
     assert user.password == "abc"
 
 
-def test_can_covert_pydantic_type_to_strawberry_with_missing_data_in_nested_type():
+def test_can_convert_pydantic_type_to_strawberry_with_missing_data_in_nested_type():
     class WorkModel(pydantic.BaseModel):
         name: str
 
@@ -322,7 +322,7 @@ def test_can_covert_pydantic_type_to_strawberry_with_missing_data_in_nested_type
     ]
 
 
-def test_can_covert_pydantic_type_to_strawberry_with_missing_index_data_in_nested_type():
+def test_can_convert_pydantic_type_to_strawberry_with_missing_index_data_nested_type():
     class WorkModel(pydantic.BaseModel):
         name: str
 
@@ -361,7 +361,7 @@ def test_can_covert_pydantic_type_to_strawberry_with_missing_index_data_in_neste
     ]
 
 
-def test_can_covert_pydantic_type_to_strawberry_with_optional_list():
+def test_can_convert_pydantic_type_to_strawberry_with_optional_list():
     class WorkModel(pydantic.BaseModel):
         name: str
 
@@ -385,7 +385,7 @@ def test_can_covert_pydantic_type_to_strawberry_with_optional_list():
     assert user.work is None
 
 
-def test_can_covert_pydantic_type_to_strawberry_with_optional_nested_value():
+def test_can_convert_pydantic_type_to_strawberry_with_optional_nested_value():
     class UserModel(pydantic.BaseModel):
         names: Optional[List[str]]
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

We weren't actually doing a null check when converting an `Optional[x]` value from pydantic to strawberry. This is fine if `x` is scalar, but if it isn't it leads to null iteration errors on the nested type when the value is `None`. Since None should be valid for Optional types, this seems incorrect.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #1228 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
