### PR TITLE
Fix Pydantic Unions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Fixes a bug in the Pydantic conversion code around `Union` values.

--- a/strawberry/experimental/pydantic/conversion.py
+++ b/strawberry/experimental/pydantic/conversion.py
@@ -27,7 +27,6 @@ def _convert_from_pydantic_to_strawberry_type(
                 return _convert_from_pydantic_to_strawberry_type(
                     option_type, data_from_model=data, extra=extra
                 )
-        return None
     if isinstance(type_, StrawberryList):
         items = []
         for index, item in enumerate(data):

--- a/strawberry/experimental/pydantic/conversion.py
+++ b/strawberry/experimental/pydantic/conversion.py
@@ -3,6 +3,7 @@ from typing import Union, cast
 from strawberry.field import StrawberryField
 from strawberry.scalars import is_scalar
 from strawberry.type import StrawberryList, StrawberryOptional, StrawberryType
+from strawberry.union import StrawberryUnion
 
 
 def _convert_from_pydantic_to_strawberry_type(
@@ -14,6 +15,17 @@ def _convert_from_pydantic_to_strawberry_type(
         return _convert_from_pydantic_to_strawberry_type(
             type_.of_type, data_from_model=data, extra=extra
         )
+    if isinstance(type_, StrawberryUnion):
+        for option_type in type_.types:
+            if hasattr(option_type, "_pydantic_type"):
+                source_type = option_type._pydantic_type  # type: ignore
+            else:
+                source_type = cast(type, option_type)
+            if isinstance(data, source_type):
+                return _convert_from_pydantic_to_strawberry_type(
+                    option_type, data_from_model=data, extra=extra
+                )
+        return None
     if isinstance(type_, StrawberryList):
         items = []
         for index, item in enumerate(data):

--- a/strawberry/experimental/pydantic/object_type.py
+++ b/strawberry/experimental/pydantic/object_type.py
@@ -144,6 +144,7 @@ def type(
         )
 
         model._strawberry_type = cls  # type: ignore
+        cls._pydantic_type = model  # type: ignore
 
         def from_pydantic(instance: Any, extra: Dict[str, Any] = None) -> Any:
             return convert_pydantic_model_to_strawberry_class(

--- a/tests/experimental/pydantic/test_conversion.py
+++ b/tests/experimental/pydantic/test_conversion.py
@@ -265,6 +265,38 @@ def test_can_convert_pydantic_type_to_strawberry_with_union():
     assert user.union_field.field_b == 123
 
 
+def test_can_convert_pydantic_type_to_strawberry_with_union_of_strawberry_types():
+    @strawberry.type
+    class BranchA:
+        field_a: str
+
+    @strawberry.type
+    class BranchB:
+        field_b: int
+
+    class User(pydantic.BaseModel):
+        age: int
+        union_field: Union[BranchA, BranchB]
+
+    @strawberry.experimental.pydantic.type(User, fields=["age", "union_field"])
+    class UserType:
+        pass
+
+    origin_user = User(age=1, union_field=BranchA(field_a="abc"))
+    user = UserType.from_pydantic(origin_user)
+
+    assert user.age == 1
+    assert isinstance(user.union_field, BranchA)
+    assert user.union_field.field_a == "abc"
+
+    origin_user = User(age=1, union_field=BranchB(field_b=123))
+    user = UserType.from_pydantic(origin_user)
+
+    assert user.age == 1
+    assert isinstance(user.union_field, BranchB)
+    assert user.union_field.field_b == 123
+
+
 def test_can_convert_pydantic_type_to_strawberry_with_union_nullable():
     class BranchA(pydantic.BaseModel):
         field_a: str

--- a/tests/experimental/pydantic/test_conversion.py
+++ b/tests/experimental/pydantic/test_conversion.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Union
 
 import pydantic
 
@@ -225,6 +225,88 @@ def test_can_covert_pydantic_type_with_matrix_list_of_nested_model_to_strawberry
             Hour(hour=6),
         ],
     ]
+
+
+def test_can_convert_pydantic_type_to_strawberry_with_union():
+    class BranchA(pydantic.BaseModel):
+        field_a: str
+
+    class BranchB(pydantic.BaseModel):
+        field_b: int
+
+    class User(pydantic.BaseModel):
+        age: int
+        union_field: Union[BranchA, BranchB]
+
+    @strawberry.experimental.pydantic.type(BranchA, fields=["field_a"])
+    class BranchAType:
+        pass
+
+    @strawberry.experimental.pydantic.type(BranchB, fields=["field_b"])
+    class BranchBType:
+        pass
+
+    @strawberry.experimental.pydantic.type(User, fields=["age", "union_field"])
+    class UserType:
+        pass
+
+    origin_user = User(age=1, union_field=BranchA(field_a="abc"))
+    user = UserType.from_pydantic(origin_user)
+
+    assert user.age == 1
+    assert isinstance(user.union_field, BranchAType)
+    assert user.union_field.field_a == "abc"
+
+    origin_user = User(age=1, union_field=BranchB(field_b=123))
+    user = UserType.from_pydantic(origin_user)
+
+    assert user.age == 1
+    assert isinstance(user.union_field, BranchBType)
+    assert user.union_field.field_b == 123
+
+
+def test_can_convert_pydantic_type_to_strawberry_with_union_nullable():
+    class BranchA(pydantic.BaseModel):
+        field_a: str
+
+    class BranchB(pydantic.BaseModel):
+        field_b: int
+
+    class User(pydantic.BaseModel):
+        age: int
+        union_field: Union[None, BranchA, BranchB]
+
+    @strawberry.experimental.pydantic.type(BranchA, fields=["field_a"])
+    class BranchAType:
+        pass
+
+    @strawberry.experimental.pydantic.type(BranchB, fields=["field_b"])
+    class BranchBType:
+        pass
+
+    @strawberry.experimental.pydantic.type(User, fields=["age", "union_field"])
+    class UserType:
+        pass
+
+    origin_user = User(age=1, union_field=BranchA(field_a="abc"))
+    user = UserType.from_pydantic(origin_user)
+
+    assert user.age == 1
+    assert isinstance(user.union_field, BranchAType)
+    assert user.union_field.field_a == "abc"
+
+    origin_user = User(age=1, union_field=BranchB(field_b=123))
+    user = UserType.from_pydantic(origin_user)
+
+    assert user.age == 1
+    assert isinstance(user.union_field, BranchBType)
+    assert user.union_field.field_b == 123
+
+    origin_user = User(age=1, union_field=None)
+    user = UserType.from_pydantic(origin_user)
+
+    assert user.age == 1
+    assert user.union_field is None
 
 
 def test_can_covert_pydantic_type_to_strawberry_with_additional_fields():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

In order to convert Union types from Pydantic models into Strawberry models, we need to check which branch of the Union we have and proceed with the conversion according to that type definition. I had to add a `_pydantic_type` field to our `StrawberryType` instances that are created through the converter so that we can get a reference to the original type of each branch for comparison. This seems a little hacky, but I couldn't think of a better way.

This fix only works for Unions of object types, but that should be fine as GraphQL doesn't support other types of unions.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Closes #1230 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
