### PR TITLE
Add the app-dir to the python path when exporting the schema

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Fixes a bug in the `export-schema` command around the handling of local modules.

--- a/strawberry/cli/commands/export_schema.py
+++ b/strawberry/cli/commands/export_schema.py
@@ -1,3 +1,5 @@
+import sys
+
 import click
 
 from strawberry import Schema
@@ -7,7 +9,20 @@ from strawberry.utils.importer import import_module_symbol
 
 @click.command(short_help="Exports the schema")
 @click.argument("schema", type=str)
-def export_schema(schema: str):
+@click.option(
+    "--app-dir",
+    default=".",
+    type=str,
+    show_default=True,
+    help=(
+        "Look for the module in the specified directory, by adding this to the "
+        "PYTHONPATH. Defaults to the current working directory. "
+        "Works the same as `--app-dir` in uvicorn."
+    ),
+)
+def export_schema(schema: str, app_dir):
+    sys.path.insert(0, app_dir)
+
     try:
         schema_symbol = import_module_symbol(schema, default_symbol_name="schema")
     except (ImportError, AttributeError) as exc:

--- a/tests/cli/test_export_schema.py
+++ b/tests/cli/test_export_schema.py
@@ -25,6 +25,15 @@ def test_default_schema_symbol_name(cli_runner):
     assert result.exit_code == 0
 
 
+def test_app_dir_option(cli_runner):
+    selector = "sample_module"
+    result = cli_runner.invoke(
+        cmd_export_schema, ["--app-dir=./tests/fixtures/sample_package", selector]
+    )
+
+    assert result.exit_code == 0
+
+
 def test_invalid_module(cli_runner):
     selector = "not.existing.module"
     result = cli_runner.invoke(cmd_export_schema, [selector])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
The `export-schema` command was inconsistent with the debug server command, as it did not include the `app-dir` argument that modifies the PYTHONPATH. Without this argument, the command couldn't find local modules as the current working directory was not added to the path.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Closes #1232 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
