### PR TITLE
Pydantic enums and interfaces

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Fix the Pydantic conversion method for Enum values, and add a mechanism to specify an interface type when converting from Pydantic. The Pydantic interface is really a base dataclass for the subclasses to extend. When you do the conversion, you have to use `strawberry.experimental.pydantic.interface` to let us know that this type is an interface. You also have to use your converted interface type as the base class for the sub types as normal.

--- a/docs/integrations/pydantic.md
+++ b/docs/integrations/pydantic.md
@@ -38,7 +38,7 @@ from .models import User
     'name',
     'friends'
 ])
-class User:
+class UserType:
     pass
 ```
 
@@ -64,6 +64,48 @@ from .models import User
     'friends'
 ])
 class UserInput:
+    pass
+```
+
+## Interface types
+
+Interface types are similar to normal types; we can create one by using the
+`strawberry.experimental.pydantic.interface` decorator:
+
+```python
+import strawberry
+from pydantic import BaseModel
+from typing import List
+
+# pydantic types
+class User(BaseModel):
+    id: int
+    name: str
+
+class NormalUser(User):
+    friends: List[int] = []
+
+class AdminUser(User):
+    role: int
+
+# strawberry types
+@strawberry.experimental.pydantic.interface(model=User, fields=[
+    'id',
+    'name',
+])
+class UserType:
+    pass
+
+@strawberry.experimental.pydantic.type(model=NormalUser, fields=[
+    'friends',
+])
+class NormalUserType(UserType):  # note the base class
+    pass
+
+@strawberry.experimental.pydantic.type(model=AdminUser, fields=[
+    'role',
+])
+class AdminUserType(UserType):
     pass
 ```
 

--- a/strawberry/experimental/pydantic/__init__.py
+++ b/strawberry/experimental/pydantic/__init__.py
@@ -1,6 +1,6 @@
 from .error_type import error_type
 from .exceptions import UnregisteredTypeException
-from .object_type import input, type
+from .object_type import input, interface, type
 
 
-__all__ = ["error_type", "UnregisteredTypeException", "input", "type"]
+__all__ = ["error_type", "UnregisteredTypeException", "input", "type", "interface"]

--- a/strawberry/experimental/pydantic/conversion.py
+++ b/strawberry/experimental/pydantic/conversion.py
@@ -1,5 +1,6 @@
 from typing import Union, cast
 
+from strawberry.enum import EnumDefinition
 from strawberry.field import StrawberryField
 from strawberry.scalars import is_scalar
 from strawberry.type import StrawberryList, StrawberryOptional, StrawberryType
@@ -27,6 +28,8 @@ def _convert_from_pydantic_to_strawberry_type(
                 return _convert_from_pydantic_to_strawberry_type(
                     option_type, data_from_model=data, extra=extra
                 )
+    if isinstance(type_, EnumDefinition):
+        return data
     if isinstance(type_, StrawberryList):
         items = []
         for index, item in enumerate(data):

--- a/strawberry/experimental/pydantic/conversion.py
+++ b/strawberry/experimental/pydantic/conversion.py
@@ -45,6 +45,10 @@ def _convert_from_pydantic_to_strawberry_type(
     elif is_scalar(type_):
         return data
     else:
+        # in the case of an interface, the concrete type may be more specific
+        # than the type in the field definition
+        if hasattr(type(data), "_strawberry_type"):
+            type_ = type(data)._strawberry_type
         return convert_pydantic_model_to_strawberry_class(
             type_, model_instance=data_from_model, extra=extra
         )

--- a/strawberry/experimental/pydantic/object_type.py
+++ b/strawberry/experimental/pydantic/object_type.py
@@ -132,6 +132,7 @@ def type(
         cls = dataclasses.make_dataclass(
             cls.__name__,
             sorted_fields,
+            bases=cls.__bases__,
         )
 
         _process_type(
@@ -165,3 +166,5 @@ def type(
 
 
 input = partial(type, is_input=True)
+
+interface = partial(type, is_interface=True)

--- a/tests/experimental/pydantic/test_conversion.py
+++ b/tests/experimental/pydantic/test_conversion.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import List, Optional, Union
 
 import pydantic
@@ -339,6 +340,27 @@ def test_can_convert_pydantic_type_to_strawberry_with_union_nullable():
 
     assert user.age == 1
     assert user.union_field is None
+
+
+def test_can_convert_pydantic_type_to_strawberry_with_enum():
+    @strawberry.enum
+    class UserKind(Enum):
+        user = 0
+        admin = 1
+
+    class User(pydantic.BaseModel):
+        age: int
+        kind: UserKind
+
+    @strawberry.experimental.pydantic.type(User, fields=["age", "kind"])
+    class UserType:
+        pass
+
+    origin_user = User(age=1, kind=UserKind.user)
+    user = UserType.from_pydantic(origin_user)
+
+    assert user.age == 1
+    assert user.kind == UserKind.user
 
 
 def test_can_convert_pydantic_type_to_strawberry_with_additional_fields():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Fix the Pydantic conversion method for Enum values, and add a mechanism to specify an interface type when converting from Pydantic. The Pydantic interface is really just a base dataclass for the subclasses to extend. When you do the conversion, you have to use `strawberry.experimental.pydantic.interface` to let us know that this type is an interface. You also have to use your converted interface type as the base class for the sub types as normal.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

* Closes #1238 
* Closes #1239 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
