### PR TITLE
fix-pydantic-interface

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Fixes a bug where Pydantic types inheriting from interfaces were not considered to satisfy the interface.

--- a/strawberry/experimental/pydantic/object_type.py
+++ b/strawberry/experimental/pydantic/object_type.py
@@ -132,6 +132,7 @@ def type(
         cls = dataclasses.make_dataclass(
             cls.__name__,
             sorted_fields,
+            bases=cls.__bases__,
         )
 
         _process_type(

--- a/tests/experimental/pydantic/schema/test_interface.py
+++ b/tests/experimental/pydantic/schema/test_interface.py
@@ -1,0 +1,52 @@
+from typing import List
+
+from pydantic import BaseModel
+
+import strawberry
+
+
+def test_pydantic_query_interface():
+    @strawberry.interface
+    class Cheese:
+        name: str
+
+    class SwissModel(BaseModel):
+        canton: str
+
+    @strawberry.experimental.pydantic.type(model=SwissModel, fields=["canton"])
+    class Swiss(Cheese):
+        pass
+
+    class ItalianModel(BaseModel):
+        province: str
+
+    @strawberry.experimental.pydantic.type(model=ItalianModel, fields=["province"])
+    class Italian(Cheese):
+        pass
+
+    @strawberry.type
+    class Root:
+        @strawberry.field
+        def assortment(self) -> List[Cheese]:
+            return [
+                Italian(name="Asiago", province="Friuli"),
+                Swiss(name="Tomme", canton="Vaud"),
+            ]
+
+    schema = strawberry.Schema(query=Root, types=[Swiss, Italian])
+
+    query = """{
+        assortment {
+            name
+            ... on Italian { province }
+            ... on Swiss { canton }
+        }
+    }"""
+
+    result = schema.execute_sync(query)
+
+    assert not result.errors
+    assert result.data["assortment"] == [
+        {"name": "Asiago", "province": "Friuli"},
+        {"canton": "Vaud", "name": "Tomme"},
+    ]

--- a/tests/experimental/pydantic/schema/test_interface.py
+++ b/tests/experimental/pydantic/schema/test_interface.py
@@ -29,8 +29,8 @@ def test_pydantic_query_interface():
         @strawberry.field
         def assortment(self) -> List[Cheese]:
             return [
-                Italian(name="Asiago", province="Friuli"),
-                Swiss(name="Tomme", canton="Vaud"),
+                Italian(name="Asiago", province="Friuli"),  # type: ignore
+                Swiss(name="Tomme", canton="Vaud"),  # type: ignore
             ]
 
     schema = strawberry.Schema(query=Root, types=[Swiss, Italian])

--- a/tests/experimental/pydantic/test_conversion.py
+++ b/tests/experimental/pydantic/test_conversion.py
@@ -92,7 +92,7 @@ def test_can_convert_pydantic_type_with_nested_data_to_strawberry():
         name: str
 
     @strawberry.experimental.pydantic.type(WorkModel, fields=["name"])
-    class Work(pydantic.BaseModel):
+    class Work:
         pass
 
     class UserModel(pydantic.BaseModel):
@@ -113,7 +113,7 @@ def test_can_convert_pydantic_type_with_list_of_nested_data_to_strawberry():
         name: str
 
     @strawberry.experimental.pydantic.type(WorkModel, fields=["name"])
-    class Work(pydantic.BaseModel):
+    class Work:
         pass
 
     class UserModel(pydantic.BaseModel):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

Currently you can't use interfaces with types converted from Pydantic with the `strawberry.experimental.pydantic.type` decorator. If you have such a class that also inherits from an interface, the resulting type does not satisfy the interface as you would expect, see the issue for details.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/strawberry-graphql/strawberry/issues/1244

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
