### PR TITLE
Expose `python_name` from `Info` type

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+This release adds `python_name` to the `Info` type.

--- a/docs/types/resolvers.md
+++ b/docs/types/resolvers.md
@@ -194,7 +194,8 @@ Info objects contain information for the current execution context:
 
 | Parameter name  | Type                      | Description                                                                             |
 | --------------- | ------------------------- | --------------------------------------------------------------------------------------- |
-| field_name      | `str`                     | The name of the current field                                                           |
+| field_name      | `str`                     | The name of the current field (generally camel-cased)                                   |
+| python_name     | `str`                     | The 'Python name' of the field (generally snake-cased)                                  |
 | context         | `ContextType`             | The value of the context                                                                |
 | root_value      | `RootValueType`           | The value for the root type                                                             |
 | variable_values | `Dict[str, Any]`          | The variables for this operation                                                        |

--- a/strawberry/types/info.py
+++ b/strawberry/types/info.py
@@ -60,6 +60,10 @@ class Info(Generic[ContextType, RootValueType]):
     def return_type(self) -> Optional[Union[type, StrawberryType]]:
         return self._field.type
 
+    @property
+    def python_name(self) -> str:
+        return self._field.python_name
+
     # TODO: create an abstraction on these fields
     @property
     def operation(self) -> OperationDefinitionNode:


### PR DESCRIPTION
This adds `python_name` to the `Info` type. This is useful for implementing custom resolvers, without having to use the `_field` field.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
