### PR TITLE
ASGI integration: return 400 Bad Request if json input malformed

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Fixes returning "500 Internal Server Error" responses to requests with malformed json when running with ASGI integration.

--- a/strawberry/asgi/__init__.py
+++ b/strawberry/asgi/__init__.py
@@ -274,7 +274,13 @@ class HTTPHandler(BaseGraphQLApp, ABC):
         if request.method == "POST":
             content_type = request.headers.get("Content-Type", "")
             if "application/json" in content_type:
-                data = await request.json()
+                try:
+                    data = await request.json()
+                except json.JSONDecodeError:
+                    return PlainTextResponse(
+                        "Unable to parse request body as JSON",
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                    )
             elif content_type.startswith("multipart/form-data"):
                 multipart_data = await request.form()
                 operations = json.loads(multipart_data.get("operations", "{}"))

--- a/tests/asgi/test_query.py
+++ b/tests/asgi/test_query.py
@@ -12,6 +12,13 @@ def test_simple_query(schema, test_client):
     assert response.json() == {"data": {"hello": "Hello world"}}
 
 
+def test_fails_when_request_body_has_invalid_json(test_client):
+    response = test_client.post(
+        "/", data='{"qeury": "{__typena"', headers={"content-type": "application/json"}
+    )
+    assert response.status_code == 400
+
+
 def test_returns_errors(schema, test_client):
     response = test_client.post("/", json={"query": "{ donut }"})
 

--- a/tests/flask/test_view.py
+++ b/tests/flask/test_view.py
@@ -24,6 +24,15 @@ def test_graphql_query(flask_client):
     assert data["data"]["hello"] == "strawberry"
 
 
+def test_fails_when_request_body_has_invalid_json(flask_client):
+    response = flask_client.post(
+        "/graphql",
+        data='{"qeury": "{__typena"',
+        headers={"content-type": "application/json"},
+    )
+    assert response.status_code == 400
+
+
 def test_graphiql_view(flask_client):
     flask_client.environ_base["HTTP_ACCEPT"] = "text/html"
     response = flask_client.get("/graphql")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Fixes returning "500 Internal Server Error" responses to requests with malformed JSON when running with ASGI integration.
This is described in the issue [#1214 ](https://github.com/strawberry-graphql/strawberry/issues/1214)
Django, Sanic and Flask integrations handle this scenario as expected. I've also added a test for Flask as it was missing. 

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* [#1214 ](https://github.com/strawberry-graphql/strawberry/issues/1214)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
