### PR TITLE
If field is a simple field return a simple resolver

### DIFF
--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -35,7 +35,7 @@ from .types.types import FederationFieldParams, TypeDefinition
 _RESOLVER_TYPE = Union[StrawberryResolver, Callable]
 
 
-def default_resolver(name: str, source: Any):
+def default_resolver(name: str, source: Any, *args, **kwargs):
     return getattr(source, name)
 
 

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -299,6 +299,18 @@ class StrawberryField(dataclasses.Field, GraphQLNameMixin):
     def is_async(self) -> bool:
         return self._has_async_permission_classes or self._has_async_base_resolver
 
+    @property
+    def is_simple_field(self):
+        """
+        Flag indicating if this is a "simple" field that just returns the
+        relevant attribute from the source object. If it is a simple field we
+        can avoid constructing an `Info` object and running any permission
+        checks in the resolver which improves performance.
+
+        Note: if a field is "simple" then `get_result` is not called.
+        """
+        return not self.base_resolver and not self.permission_classes
+
 
 T = TypeVar("T")
 

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -34,9 +34,7 @@ from .types.types import FederationFieldParams, TypeDefinition
 
 _RESOLVER_TYPE = Union[StrawberryResolver, Callable]
 
-
-def default_resolver(name: str, source: Any, *args, **kwargs):
-    return getattr(source, name)
+default_resolver = StrawberryResolver.default_resolver()
 
 
 class StrawberryField(dataclasses.Field, GraphQLNameMixin):

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -35,6 +35,10 @@ from .types.types import FederationFieldParams, TypeDefinition
 _RESOLVER_TYPE = Union[StrawberryResolver, Callable]
 
 
+def default_resolver(name: str, source: Any):
+    return getattr(source, name)
+
+
 class StrawberryField(dataclasses.Field, GraphQLNameMixin):
     python_name: str
 
@@ -278,7 +282,7 @@ class StrawberryField(dataclasses.Field, GraphQLNameMixin):
         if self.base_resolver:
             return self.base_resolver(*args, **kwargs)
 
-        return getattr(source, self.python_name)
+        return default_resolver(self.python_name, source)
 
     @property
     def _has_async_permission_classes(self) -> bool:

--- a/strawberry/resolvers.py
+++ b/strawberry/resolvers.py
@@ -1,6 +1,16 @@
 from typing import Callable
 
+from strawberry.types.fields.resolver import StrawberryResolver
+
 
 def is_default_resolver(func: Callable) -> bool:
     """Check whether the function is a default resolver or a user provided one."""
-    return getattr(func, "_is_default", False)
+    if getattr(func, "_is_default", False):
+        return True
+
+    # Check if func is a partial function
+    if hasattr(func, "func"):
+        resolver: StrawberryResolver = func.func  # type: ignore
+        return resolver.is_default
+
+    return False

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -152,7 +152,7 @@ class GraphQLCoreConverter:
             argument_name = argument.get_graphql_name(self.config.auto_camel_case)
             graphql_arguments[argument_name] = self.from_argument(argument)
 
-        return GraphQLField(
+        g_field = GraphQLField(
             type_=field_type,
             args=graphql_arguments,
             resolve=resolver,
@@ -161,6 +161,10 @@ class GraphQLCoreConverter:
             deprecation_reason=field.deprecation_reason,
             extensions={"python_name": field.python_name},
         )
+
+        g_field._strawberry_field = field  # type: ignore
+
+        return g_field
 
     def from_input_field(self, field: StrawberryField) -> GraphQLInputField:
         field_type: GraphQLType

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -152,7 +152,7 @@ class GraphQLCoreConverter:
             argument_name = argument.get_graphql_name(self.config.auto_camel_case)
             graphql_arguments[argument_name] = self.from_argument(argument)
 
-        g_field = GraphQLField(
+        return GraphQLField(
             type_=field_type,
             args=graphql_arguments,
             resolve=resolver,
@@ -161,10 +161,6 @@ class GraphQLCoreConverter:
             deprecation_reason=field.deprecation_reason,
             extensions={"python_name": field.python_name},
         )
-
-        g_field._strawberry_field = field  # type: ignore
-
-        return g_field
 
     def from_input_field(self, field: StrawberryField) -> GraphQLInputField:
         field_type: GraphQLType

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -312,8 +312,8 @@ class GraphQLCoreConverter:
     def from_resolver(
         self, field: StrawberryField
     ) -> Callable:  # TODO: Take StrawberryResolver
-        if not field.base_resolver and not field.permission_classes:
-            return partial(default_resolver, field.python_name)
+        # if not field.base_resolver and not field.permission_classes:
+        #     return partial(default_resolver, field.python_name)
 
         def _get_arguments(
             source: Any,
@@ -378,9 +378,13 @@ class GraphQLCoreConverter:
             )
 
         def _get_result(_source: Any, info: Info, **kwargs):
-            field_args, field_kwargs = _get_arguments(
-                source=_source, info=info, kwargs=kwargs
-            )
+            if field.base_resolver:
+                field_args, field_kwargs = _get_arguments(
+                    source=_source, info=info, kwargs=kwargs
+                )
+            else:
+                field_args = []
+                field_kwargs = {}
 
             return field.get_result(
                 _source, info=info, args=field_args, kwargs=field_kwargs

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
+from functools import partial
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Tuple, Type, Union, cast
 
 
@@ -39,7 +40,7 @@ from strawberry.exceptions import (
     MissingTypesForGenericError,
     ScalarAlreadyRegisteredError,
 )
-from strawberry.field import StrawberryField
+from strawberry.field import StrawberryField, default_resolver
 from strawberry.lazy_type import LazyType
 from strawberry.scalars import is_scalar
 from strawberry.schema.config import StrawberryConfig
@@ -311,6 +312,9 @@ class GraphQLCoreConverter:
     def from_resolver(
         self, field: StrawberryField
     ) -> Callable:  # TODO: Take StrawberryResolver
+        if not field.base_resolver and not field.permission_classes:
+            return partial(default_resolver, field.python_name)
+
         def _get_arguments(
             source: Any,
             info: Info,

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -40,18 +40,22 @@ from strawberry.exceptions import (
     MissingTypesForGenericError,
     ScalarAlreadyRegisteredError,
 )
-from strawberry.field import StrawberryField, default_resolver
+from strawberry.field import StrawberryField
 from strawberry.lazy_type import LazyType
 from strawberry.scalars import is_scalar
 from strawberry.schema.config import StrawberryConfig
 from strawberry.schema.types.scalar import _make_scalar_type
 from strawberry.type import StrawberryList, StrawberryOptional, StrawberryType
+from strawberry.types.fields.resolver import StrawberryResolver
 from strawberry.types.info import Info
 from strawberry.types.types import TypeDefinition
 from strawberry.union import StrawberryUnion
 from strawberry.utils.await_maybe import await_maybe
 
 from .types.concrete_type import ConcreteType
+
+
+default_resolver = StrawberryResolver.default_resolver()
 
 
 # graphql-core expects a resolver for an Enum type to return

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -390,6 +390,11 @@ class GraphQLCoreConverter:
                 _source, info=info, args=field_args, kwargs=field_kwargs
             )
 
+        def _get_simple_result(_source: Any, info: Info, **kwargs):
+            return field.get_result(
+                _source, info=None, args=[], kwargs={}
+            )
+
         def _resolver(_source: Any, info: GraphQLResolveInfo, **kwargs):
             strawberry_info = _strawberry_info_from_graphql(info)
             _check_permissions(_source, strawberry_info, kwargs)
@@ -402,12 +407,15 @@ class GraphQLCoreConverter:
 
             return await await_maybe(_get_result(_source, strawberry_info, **kwargs))
 
+        if not field.base_resolver and not field.permission_classes:
+            return _get_simple_result
+
         if field.is_async:
             _async_resolver._is_default = not field.base_resolver  # type: ignore
             return _async_resolver
-        else:
-            _resolver._is_default = not field.base_resolver  # type: ignore
-            return _resolver
+
+        _resolver._is_default = not field.base_resolver  # type: ignore
+        return _resolver
 
     def from_scalar(self, scalar: Type) -> GraphQLScalarType:
         scalar_definition: ScalarDefinition


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This PR improves Strawberry performance by returning a simple resolver for fields without a custom resolver or any permission classes.

Benchmarks:

![strawberry-simple-resolvers](https://user-images.githubusercontent.com/691952/134172700-2252d7f3-fd01-4227-ab9c-f93f86c26caa.png)

Note: "simple" fields won't call the `get_result` function on the field. I've implemented the `is_simple_field` check as a property on the field so that custom fields can override it if they always need to post process results from the resolver.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
