### PR TITLE
feat(tools): implement a helper function to merge multiple types e.g. queries, mutations

### DIFF
--- a/strawberry/tools/__init__.py
+++ b/strawberry/tools/__init__.py
@@ -1,6 +1,8 @@
 from .create_type import create_type
+from .merge_types import merge_types
 
 
 __all__ = [
     "create_type",
+    "merge_types",
 ]

--- a/strawberry/tools/merge_types.py
+++ b/strawberry/tools/merge_types.py
@@ -1,0 +1,22 @@
+from typing import Tuple, Type
+
+import strawberry
+
+
+def merge_types(types: Tuple[Type]) -> Type:
+    """Merge multiple Strawberry types into one
+
+    For example, given two queries `A` and `B`, one can merge them as follows:
+
+        merge_types((B, A))
+
+    This is essentially the same as:
+
+        class Query(B, A):
+            ...
+    """
+
+    if not types:
+        raise ValueError("Can't merge types if none are supplied")
+
+    return strawberry.type(type("MegaType", types, {}))

--- a/tests/tools/test_merge_types.py
+++ b/tests/tools/test_merge_types.py
@@ -1,0 +1,78 @@
+from operator import attrgetter
+from textwrap import dedent
+
+import pytest
+
+import strawberry
+from strawberry.tools import merge_types
+
+
+@strawberry.type
+class Person:
+    @strawberry.field
+    def name(self) -> str:
+        return "Eve"
+
+    @strawberry.field
+    def age(self) -> int:
+        return 42
+
+    @strawberry.field
+    def hi(self) -> str:
+        return "Hi"
+
+
+@strawberry.type
+class Greeter:
+    @strawberry.field
+    def hi(self, name: str = "world") -> str:
+        return f"Hello, {name}!"
+
+    @strawberry.field
+    def bye(self, name: str = "world") -> str:
+        return f"Bye, {name}!"
+
+
+def test_inheritance():
+    """It should merge multiple types following the regular inheritance rules"""
+
+    ComboQuery = merge_types((Greeter, Person))
+
+    definition = ComboQuery._type_definition
+    assert len(definition.fields) == 4
+
+    actuals = [attrgetter("python_name", "type")(f) for f in definition.fields]
+    expected = [("hi", str), ("bye", str), ("name", str), ("age", int)]
+    assert actuals == expected
+
+
+def test_empty_list():
+    """It should raise when the `types` argument is empty"""
+
+    with pytest.raises(ValueError):
+        merge_types(())
+
+
+def test_schema():
+    """It should create a valid, usable schema based on a merged query"""
+
+    ComboQuery = merge_types((Greeter, Person))
+    schema = strawberry.Schema(query=ComboQuery)
+
+    sdl = """
+    schema {
+      query: MegaType
+    }
+
+    type MegaType {
+      hi(name: String! = "world"): String!
+      bye(name: String! = "world"): String!
+      name: String!
+      age: Int!
+    }
+    """
+    assert dedent(sdl).strip() == str(schema)
+
+    result = schema.execute_sync("query { hi }")
+    assert not result.errors
+    assert result.data == {"hi": "Hello, world!"}


### PR DESCRIPTION
## Description

Schemas are initialised with a query and possibly a mutation. A larger project can't afford to put everything inside the same query/mutation, thus there is a need to be able to compose queries/mutations. Assuming two queries:

```python
@strawberry.type
class QueryA:
    ...

@strawberry.type
class QueryB:
    ...
```

Currently the way to combine them is via inheritance:

```python
@strawberry.type
class ComboQuery(QueryB, QueryA):
    ...

schema = strawberry.Schema(query=ComboQuery)
```

This PR implements a shortcut for the above:

```python
ComboQuery = merge_types((QueryB, QueryA))
schema = strawberry.Schema(query=ComboQuery)
```

Note I didn't update the docs as I wasn't sure whether this should be in General / Queries or General / Schema Basics (or some other place).

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/strawberry-graphql/strawberry/issues/566

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).