### PR TITLE
Add all_fields and auto support in the pydantic integration

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,23 @@
+Release type: minor
+
+Adds support for the `auto` type annotation described in #1192 to the Pydantic
+integration, which allows a user to define the list of fields without having to
+re-specify the type themselves. This gives better editor and type checker
+support. If you want to expose every field you can instead pass
+`all_fields=True` to the decorators and leave the body empty.
+
+```python
+import pydantic
+import strawberry
+from strawberry.experimental.pydantic import auto
+
+class User(pydantic.BaseModel):
+    age: int
+    password: str
+
+
+@strawberry.experimental.pydantic.type(User)
+class UserType:
+    age: auto
+    password: auto
+```

--- a/docs/integrations/pydantic.md
+++ b/docs/integrations/pydantic.md
@@ -30,23 +30,38 @@ We can create a Strawberry type by using the
 
 ```python
 import strawberry
+from strawberry.experimental.pydantic import auto
 
 from .models import User
 
-@strawberry.experimental.pydantic.type(model=User, fields=[
-    'id',
-    'name',
-    'friends'
-])
+@strawberry.experimental.pydantic.type(model=User)
 class UserType:
-    pass
+    id: auto
+    name: auto
+    friends: auto
 ```
 
 The `strawberry.experimental.pydantic.type` decorator accepts a Pydantic model
-and a list of fields that we want to expose on our GraphQL API.
+and wraps a class that contains dataclass style fields with `auto` as the type
+annotation. The fields marked with `auto` will inherit their types from the
+Pydantic model.
 
-> **Note** specifying the list of field is required to prevent accidentally
-> exposing fields that weren't meant to be exposed on a API
+If you want to include all of the fields from your Pydantic model, you can
+instead pass `all_fields=True` to the decorator.
+
+-> **Note** Care should be taken to avoid accidentally exposing fields that
+-> weren't meant to be exposed on an API using this feature.
+
+```python
+import strawberry
+from strawberry.experimental.pydantic import auto
+
+from .models import User
+
+@strawberry.experimental.pydantic.type(model=User, all_fields=True)
+class UserType:
+    pass
+```
 
 ## Input types
 
@@ -55,16 +70,15 @@ Input types are similar to types; we can create one by using the
 
 ```python
 import strawberry
+from strawberry.experimental.pydantic import auto
 
 from .models import User
 
-@strawberry.experimental.pydantic.input(model=User, fields=[
-    'id',
-    'name',
-    'friends'
-])
+@strawberry.experimental.pydantic.input(model=User)
 class UserInput:
-    pass
+    id: auto
+    name: auto
+    friends: auto
 ```
 
 ## Interface types
@@ -74,6 +88,7 @@ Interface types are similar to normal types; we can create one by using the
 
 ```python
 import strawberry
+from strawberry.experimental.pydantic import auto
 from pydantic import BaseModel
 from typing import List
 
@@ -89,24 +104,18 @@ class AdminUser(User):
     role: int
 
 # strawberry types
-@strawberry.experimental.pydantic.interface(model=User, fields=[
-    'id',
-    'name',
-])
+@strawberry.experimental.pydantic.interface(model=User)
 class UserType:
-    pass
+    id: auto
+    name: auto
 
-@strawberry.experimental.pydantic.type(model=NormalUser, fields=[
-    'friends',
-])
+@strawberry.experimental.pydantic.type(model=NormalUser)
 class NormalUserType(UserType):  # note the base class
-    pass
+    friends: auto
 
-@strawberry.experimental.pydantic.type(model=AdminUser, fields=[
-    'role',
-])
+@strawberry.experimental.pydantic.type(model=AdminUser)
 class AdminUserType(UserType):
-    pass
+    role: auto
 ```
 
 ## Error Types
@@ -118,6 +127,7 @@ Pydantic errors in GraphQL. Let's see an example:
 ```python+schema
 import pydantic
 import strawberry
+from strawberry.experimental.pydantic import auto
 
 class User(BaseModel):
     id: int
@@ -125,13 +135,11 @@ class User(BaseModel):
     signup_ts: Optional[datetime] = None
     friends: List[int] = []
 
-@strawberry.experimental.pydantic.error_type(model=User, fields=[
-    'id',
-    'name',
-    'friends'
-])
+@strawberry.experimental.pydantic.error_type(model=User)
 class UserError:
-    pass
+    id: auto
+    name: auto
+    friends: auto
 
 ---
 
@@ -151,6 +159,7 @@ GraphQL type that aren't defined in the pydantic model
 
 ```python+schema
 import strawberry
+from strawberry.experimental.pydantic import auto
 import pydantic
 
 from .models import User
@@ -159,11 +168,10 @@ class User(BaseModel):
     id: int
     name: str
 
-@strawberry.experimental.pydantic.type(model=User, fields=[
-    'id',
-    'name',
-])
+@strawberry.experimental.pydantic.type(model=User)
 class User:
+    id: auto
+    name: auto
     age: int
 
 ---
@@ -186,6 +194,7 @@ To convert a Pydantic instance to a Strawberry instance you can use
 
 ```python
 import strawberry
+from strawberry.experimental.pydantic import auto
 from typing import List, Optional
 from pydantic import BaseModel
 
@@ -195,12 +204,10 @@ class User(BaseModel):
     name: str
 
 
-@strawberry.experimental.pydantic.type(model=User, fields=[
-    'id',
-    'name',
-])
+@strawberry.experimental.pydantic.type(model=User)
 class UserType:
-    pass
+    id: auto
+    name: auto
 
 instance = User(id='123', name='Jake')
 
@@ -213,6 +220,7 @@ specify the values to assign to them.
 
 ```python
 import strawberry
+from strawberry.experimental.pydantic import auto
 from typing import List, Optional
 from pydantic import BaseModel
 
@@ -222,11 +230,10 @@ class User(BaseModel):
     name: str
 
 
-@strawberry.experimental.pydantic.type(model=User, fields=[
-    'id',
-    'name',
-])
+@strawberry.experimental.pydantic.type(model=User)
 class UserType:
+    id: auto
+    name: auto
     age: int
 
 instance = User(id='123', name='Jake')
@@ -246,6 +253,7 @@ you can use `to_pydantic` on the Strawberry instance:
 
 ```python
 import strawberry
+from strawberry.experimental.pydantic import auto
 from typing import List, Optional
 from pydantic import BaseModel
 
@@ -255,12 +263,10 @@ class User(BaseModel):
     name: str
 
 
-@strawberry.experimental.pydantic.input(model=User, fields=[
-    'id',
-    'name',
-])
+@strawberry.experimental.pydantic.input(model=User)
 class UserInput:
-    pass
+    id: auto
+    name: auto
 
 input_data = UserInput(id='abc', name='Jake')
 

--- a/strawberry/experimental/pydantic/__init__.py
+++ b/strawberry/experimental/pydantic/__init__.py
@@ -1,6 +1,14 @@
 from .error_type import error_type
 from .exceptions import UnregisteredTypeException
 from .object_type import input, interface, type
+from .utils import auto
 
 
-__all__ = ["error_type", "UnregisteredTypeException", "input", "type", "interface"]
+__all__ = [
+    "error_type",
+    "UnregisteredTypeException",
+    "input",
+    "type",
+    "interface",
+    "auto",
+]

--- a/strawberry/experimental/pydantic/error_type.py
+++ b/strawberry/experimental/pydantic/error_type.py
@@ -1,16 +1,21 @@
 import dataclasses
-from typing import Any, List, Optional, Type
+from typing import Any, List, Optional, Tuple, Type, cast
 
 from pydantic import BaseModel
 from pydantic.fields import ModelField
 
 from strawberry.experimental.pydantic.utils import (
+    auto,
+    get_private_fields,
     get_strawberry_type_from_model,
     normalize_type,
 )
-from strawberry.object_type import _process_type
+from strawberry.object_type import _process_type, _wrap_dataclass
+from strawberry.types.type_resolver import _get_fields
 from strawberry.types.types import FederationTypeParams
 from strawberry.utils.typing import get_list_annotation, is_list
+
+from .exceptions import MissingFieldsListError
 
 
 def get_type_for_field(field: ModelField):
@@ -44,26 +49,67 @@ def field_type_to_type(type_):
 def error_type(
     model: Type[BaseModel],
     *,
-    fields: List[str],
+    fields: List[str] = None,
     name: Optional[str] = None,
     description: Optional[str] = None,
     federation: Optional[FederationTypeParams] = None,
+    all_fields: bool = False
 ):
     def wrap(cls):
         model_fields = model.__fields__
-        fields_set = set(fields)
+        fields_set = set(fields) if fields else set([])
+
+        existing_fields = getattr(cls, "__annotations__", {})
+        fields_set = fields_set.union(
+            set(name for name, typ in existing_fields.items() if typ == auto)
+        )
+
+        if all_fields:
+            fields_set = set(model_fields.keys())
+
+        if not fields_set:
+            raise MissingFieldsListError(cls)
+
+        all_model_fields: List[Tuple[str, Any, dataclasses.Field]] = [
+            (
+                name,
+                get_type_for_field(field),
+                dataclasses.field(default=None),  # type: ignore
+            )
+            for name, field in model_fields.items()
+            if name in fields_set
+        ]
+
+        wrapped = _wrap_dataclass(cls)
+        extra_fields = cast(List[dataclasses.Field], _get_fields(wrapped))
+        private_fields = get_private_fields(wrapped)
+
+        all_model_fields.extend(
+            (
+                (
+                    field.name,
+                    field.type,
+                    field,
+                )
+                for field in extra_fields + private_fields
+                if field.type != auto
+            )
+        )
+
+        missing_default = []
+        has_default = []
+        for field in all_model_fields:
+            if field[2].default is dataclasses.MISSING:
+                missing_default.append(field)
+            else:
+                has_default.append(field)
+
+        sorted_fields = missing_default + has_default
 
         cls = dataclasses.make_dataclass(
             cls.__name__,
-            [
-                (
-                    name,
-                    get_type_for_field(field),
-                    dataclasses.field(default=None),  # type: ignore
-                )
-                for name, field in model_fields.items()
-                if name in fields_set
-            ],
+            sorted_fields,
+            bases=cls.__bases__,
         )
 
         _process_type(
@@ -76,6 +122,7 @@ def error_type(
         )
 
         model._strawberry_type = cls  # type: ignore
+        cls._pydantic_type = model  # type: ignore
         return cls
 
     return wrap

--- a/strawberry/experimental/pydantic/exceptions.py
+++ b/strawberry/experimental/pydantic/exceptions.py
@@ -5,7 +5,11 @@ from pydantic import BaseModel
 
 class MissingFieldsListError(Exception):
     def __init__(self, type: Type[BaseModel]):
-        message = f"List of fields to copy from {type} is empty"
+        message = (
+            f"List of fields to copy from {type} is empty. Either pass a "
+            f"`fields` list, set `all_fields` to True, or add fields with the "
+            f"`auto` type"
+        )
 
         super().__init__(message)
 

--- a/strawberry/experimental/pydantic/utils.py
+++ b/strawberry/experimental/pydantic/utils.py
@@ -1,6 +1,8 @@
-from typing import Any, List
+import dataclasses
+from typing import Any, List, Type
 
 from strawberry.experimental.pydantic.exceptions import UnregisteredTypeException
+from strawberry.private import Private
 from strawberry.utils.typing import (
     get_list_annotation,
     get_optional_annotation,
@@ -24,3 +26,15 @@ def get_strawberry_type_from_model(type_: Any):
         return type_._strawberry_type
     else:
         raise UnregisteredTypeException(type_)
+
+
+def get_private_fields(cls: Type) -> List[dataclasses.Field]:
+    private_fields: List[dataclasses.Field] = []
+    for field in dataclasses.fields(cls):
+        if isinstance(field.type, Private):
+            private_fields.append(field)
+    return private_fields
+
+
+class auto:
+    pass

--- a/tests/experimental/pydantic/schema/test_mutation.py
+++ b/tests/experimental/pydantic/schema/test_mutation.py
@@ -1,19 +1,22 @@
+from typing import Union
+
 import pydantic
 
 import strawberry
+from strawberry.experimental.pydantic import auto
 
 
 def test_mutation():
     class User(pydantic.BaseModel):
         name: pydantic.constr(min_length=2)
 
-    @strawberry.experimental.pydantic.input(User, fields=["name"])
+    @strawberry.experimental.pydantic.input(User)
     class CreateUserInput:
-        pass
+        name: auto
 
-    @strawberry.experimental.pydantic.type(User, fields=["name"])
+    @strawberry.experimental.pydantic.type(User)
     class UserType:
-        pass
+        name: auto
 
     @strawberry.type
     class Query:
@@ -45,13 +48,13 @@ def test_mutation_with_validation():
     class User(pydantic.BaseModel):
         name: pydantic.constr(min_length=2)
 
-    @strawberry.experimental.pydantic.input(User, fields=["name"])
+    @strawberry.experimental.pydantic.input(User)
     class CreateUserInput:
-        pass
+        name: auto
 
-    @strawberry.experimental.pydantic.type(User, fields=["name"])
+    @strawberry.experimental.pydantic.type(User)
     class UserType:
-        pass
+        name: auto
 
     @strawberry.type
     class Query:
@@ -90,20 +93,20 @@ def test_mutation_with_validation_of_nested_model():
     class CreateUserModel(pydantic.BaseModel):
         hobby: HobbyInputModel
 
-    @strawberry.experimental.pydantic.input(HobbyInputModel, fields=["name"])
+    @strawberry.experimental.pydantic.input(HobbyInputModel)
     class HobbyInput:
-        pass
+        name: auto
 
-    @strawberry.experimental.pydantic.input(CreateUserModel, fields=["hobby"])
+    @strawberry.experimental.pydantic.input(CreateUserModel)
     class CreateUserInput:
-        pass
+        hobby: auto
 
     class UserModel(pydantic.BaseModel):
         name: str
 
-    @strawberry.experimental.pydantic.type(UserModel, fields=["name"])
+    @strawberry.experimental.pydantic.type(UserModel)
     class UserType:
-        pass
+        name: auto
 
     @strawberry.type
     class Query:
@@ -134,3 +137,64 @@ def test_mutation_with_validation_of_nested_model():
         "  ensure this value has at least 2 characters "
         "(type=value_error.any_str.min_length; limit_value=2)"
     )
+
+
+def test_mutation_with_validation_and_error_type():
+    class User(pydantic.BaseModel):
+        name: pydantic.constr(min_length=2)
+
+    @strawberry.experimental.pydantic.input(User)
+    class CreateUserInput:
+        name: auto
+
+    @strawberry.experimental.pydantic.type(User)
+    class UserType:
+        name: auto
+
+    @strawberry.experimental.pydantic.error_type(User)
+    class UserError:
+        name: auto
+
+    @strawberry.type
+    class Query:
+        h: str
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        def create_user(self, input: CreateUserInput) -> Union[UserType, UserError]:
+            try:
+                data = input.to_pydantic()
+            except pydantic.ValidationError as e:
+                args = {}
+                for error in e.errors():
+                    field = error["loc"][0]  # currently doesn't support nested errors
+                    field_errors = args.get(field, [])
+                    field_errors.append(error["msg"])
+                    args[field] = field_errors
+                return UserError(**args)
+            else:
+                return UserType(data.name)
+
+    schema = strawberry.Schema(query=Query, mutation=Mutation)
+
+    query = """
+        mutation {
+            createUser(input: { name: "P" }) {
+                ... on UserType {
+                    name
+                }
+                ... on UserError {
+                    nameErrors: name
+                }
+            }
+        }
+    """
+
+    result = schema.execute_sync(query)
+
+    assert result.errors is None
+    assert result.data["createUser"].get("name") is None
+    assert result.data["createUser"]["nameErrors"] == [
+        ("ensure this value has at least 2 characters")
+    ]

--- a/tests/experimental/pydantic/test_conversion.py
+++ b/tests/experimental/pydantic/test_conversion.py
@@ -4,6 +4,7 @@ from typing import List, Optional, Union
 import pydantic
 
 import strawberry
+from strawberry.experimental.pydantic import auto
 
 
 def test_can_use_type_standalone():
@@ -11,9 +12,10 @@ def test_can_use_type_standalone():
         age: int
         password: Optional[str]
 
-    @strawberry.experimental.pydantic.type(User, fields=["age", "password"])
+    @strawberry.experimental.pydantic.type(User)
     class UserType:
-        pass
+        age: auto
+        password: auto
 
     user = UserType(age=1, password="abc")
 
@@ -26,9 +28,10 @@ def test_can_convert_pydantic_type_to_strawberry():
         age: int
         password: Optional[str]
 
-    @strawberry.experimental.pydantic.type(User, fields=["age", "password"])
+    @strawberry.experimental.pydantic.type(User)
     class UserType:
-        pass
+        age: auto
+        password: auto
 
     origin_user = User(age=1, password="abc")
     user = UserType.from_pydantic(origin_user)
@@ -42,9 +45,10 @@ def test_can_convert_alias_pydantic_field_to_strawberry():
         age_: int = pydantic.Field(..., alias="age")
         password: Optional[str]
 
-    @strawberry.experimental.pydantic.type(UserModel, fields=["age_", "password"])
+    @strawberry.experimental.pydantic.type(UserModel)
     class User:
-        pass
+        age_: auto
+        password: auto
 
     origin_user = UserModel(age=1, password="abc")
     user = User.from_pydantic(origin_user)
@@ -58,9 +62,10 @@ def test_can_convert_falsy_values_to_strawberry():
         age: int
         password: str
 
-    @strawberry.experimental.pydantic.type(UserModel, fields=["age", "password"])
+    @strawberry.experimental.pydantic.type(UserModel)
     class User:
-        pass
+        age: auto
+        password: auto
 
     origin_user = UserModel(age=0, password="")
     user = User.from_pydantic(origin_user)
@@ -73,8 +78,9 @@ def test_can_convert_pydantic_type_to_strawberry_with_private_field():
     class UserModel(pydantic.BaseModel):
         age: int
 
-    @strawberry.experimental.pydantic.type(model=UserModel, fields=["age"])
+    @strawberry.experimental.pydantic.type(model=UserModel)
     class User:
+        age: auto
         password: strawberry.Private[str]
 
     user = User(age=30, password="qwerty")
@@ -92,16 +98,16 @@ def test_can_convert_pydantic_type_with_nested_data_to_strawberry():
     class WorkModel(pydantic.BaseModel):
         name: str
 
-    @strawberry.experimental.pydantic.type(WorkModel, fields=["name"])
+    @strawberry.experimental.pydantic.type(WorkModel)
     class Work:
-        pass
+        name: auto
 
     class UserModel(pydantic.BaseModel):
         work: WorkModel
 
-    @strawberry.experimental.pydantic.type(UserModel, fields=["work"])
+    @strawberry.experimental.pydantic.type(UserModel)
     class User:
-        pass
+        work: auto
 
     origin_user = UserModel(work=WorkModel(name="Ice Cream inc"))
     user = User.from_pydantic(origin_user)
@@ -113,16 +119,16 @@ def test_can_convert_pydantic_type_with_list_of_nested_data_to_strawberry():
     class WorkModel(pydantic.BaseModel):
         name: str
 
-    @strawberry.experimental.pydantic.type(WorkModel, fields=["name"])
+    @strawberry.experimental.pydantic.type(WorkModel)
     class Work:
-        pass
+        name: auto
 
     class UserModel(pydantic.BaseModel):
         work: List[WorkModel]
 
-    @strawberry.experimental.pydantic.type(UserModel, fields=["work"])
+    @strawberry.experimental.pydantic.type(UserModel)
     class User:
-        pass
+        work: auto
 
     origin_user = UserModel(
         work=[
@@ -139,9 +145,9 @@ def test_can_convert_pydantic_type_with_list_of_nested_int_to_strawberry():
     class UserModel(pydantic.BaseModel):
         hours: List[int]
 
-    @strawberry.experimental.pydantic.type(UserModel, fields=["hours"])
+    @strawberry.experimental.pydantic.type(UserModel)
     class User:
-        pass
+        hours: auto
 
     origin_user = UserModel(
         hours=[
@@ -159,9 +165,9 @@ def test_can_convert_pydantic_type_with_matrix_list_of_nested_int_to_strawberry(
     class UserModel(pydantic.BaseModel):
         hours: List[List[int]]
 
-    @strawberry.experimental.pydantic.type(UserModel, fields=["hours"])
+    @strawberry.experimental.pydantic.type(UserModel)
     class User:
-        pass
+        hours: auto
 
     origin_user = UserModel(
         hours=[
@@ -183,16 +189,16 @@ def test_can_convert_pydantic_type_with_matrix_list_of_nested_model_to_strawberr
     class HourModel(pydantic.BaseModel):
         hour: int
 
-    @strawberry.experimental.pydantic.type(HourModel, fields=["hour"])
+    @strawberry.experimental.pydantic.type(HourModel)
     class Hour:
-        pass
+        hour: auto
 
     class UserModel(pydantic.BaseModel):
         hours: List[List[HourModel]]
 
-    @strawberry.experimental.pydantic.type(UserModel, fields=["hours"])
+    @strawberry.experimental.pydantic.type(UserModel)
     class User:
-        pass
+        hours: auto
 
     origin_user = UserModel(
         hours=[
@@ -239,17 +245,18 @@ def test_can_convert_pydantic_type_to_strawberry_with_union():
         age: int
         union_field: Union[BranchA, BranchB]
 
-    @strawberry.experimental.pydantic.type(BranchA, fields=["field_a"])
+    @strawberry.experimental.pydantic.type(BranchA)
     class BranchAType:
-        pass
+        field_a: auto
 
-    @strawberry.experimental.pydantic.type(BranchB, fields=["field_b"])
+    @strawberry.experimental.pydantic.type(BranchB)
     class BranchBType:
-        pass
+        field_b: auto
 
-    @strawberry.experimental.pydantic.type(User, fields=["age", "union_field"])
+    @strawberry.experimental.pydantic.type(User)
     class UserType:
-        pass
+        age: auto
+        union_field: auto
 
     origin_user = User(age=1, union_field=BranchA(field_a="abc"))
     user = UserType.from_pydantic(origin_user)
@@ -279,9 +286,10 @@ def test_can_convert_pydantic_type_to_strawberry_with_union_of_strawberry_types(
         age: int
         union_field: Union[BranchA, BranchB]
 
-    @strawberry.experimental.pydantic.type(User, fields=["age", "union_field"])
+    @strawberry.experimental.pydantic.type(User)
     class UserType:
-        pass
+        age: auto
+        union_field: auto
 
     origin_user = User(age=1, union_field=BranchA(field_a="abc"))
     user = UserType.from_pydantic(origin_user)
@@ -309,17 +317,18 @@ def test_can_convert_pydantic_type_to_strawberry_with_union_nullable():
         age: int
         union_field: Union[None, BranchA, BranchB]
 
-    @strawberry.experimental.pydantic.type(BranchA, fields=["field_a"])
+    @strawberry.experimental.pydantic.type(BranchA)
     class BranchAType:
-        pass
+        field_a: auto
 
-    @strawberry.experimental.pydantic.type(BranchB, fields=["field_b"])
+    @strawberry.experimental.pydantic.type(BranchB)
     class BranchBType:
-        pass
+        field_b: auto
 
-    @strawberry.experimental.pydantic.type(User, fields=["age", "union_field"])
+    @strawberry.experimental.pydantic.type(User)
     class UserType:
-        pass
+        age: auto
+        union_field: auto
 
     origin_user = User(age=1, union_field=BranchA(field_a="abc"))
     user = UserType.from_pydantic(origin_user)
@@ -352,9 +361,10 @@ def test_can_convert_pydantic_type_to_strawberry_with_enum():
         age: int
         kind: UserKind
 
-    @strawberry.experimental.pydantic.type(User, fields=["age", "kind"])
+    @strawberry.experimental.pydantic.type(User)
     class UserType:
-        pass
+        age: auto
+        kind: auto
 
     origin_user = User(age=1, kind=UserKind.user)
     user = UserType.from_pydantic(origin_user)
@@ -377,21 +387,22 @@ def test_can_convert_pydantic_type_to_strawberry_with_interface():
         age: int
         interface_field: Base
 
-    @strawberry.experimental.pydantic.interface(Base, fields=["base_field"])
+    @strawberry.experimental.pydantic.interface(Base)
     class BaseType:
-        pass
+        base_field: auto
 
-    @strawberry.experimental.pydantic.type(BranchA, fields=["field_a"])
+    @strawberry.experimental.pydantic.type(BranchA)
     class BranchAType(BaseType):
-        pass
+        field_a: auto
 
-    @strawberry.experimental.pydantic.type(BranchB, fields=["field_b"])
+    @strawberry.experimental.pydantic.type(BranchB)
     class BranchBType(BaseType):
-        pass
+        field_b: auto
 
-    @strawberry.experimental.pydantic.type(User, fields=["age", "interface_field"])
+    @strawberry.experimental.pydantic.type(User)
     class UserType:
-        pass
+        age: auto
+        interface_field: auto
 
     origin_user = User(age=1, interface_field=BranchA(field_a="abc", base_field="def"))
     user = UserType.from_pydantic(origin_user)
@@ -412,9 +423,10 @@ def test_can_convert_pydantic_type_to_strawberry_with_additional_fields():
     class UserModel(pydantic.BaseModel):
         password: Optional[str]
 
-    @strawberry.experimental.pydantic.type(UserModel, fields=["password"])
+    @strawberry.experimental.pydantic.type(UserModel)
     class User:
         age: int
+        password: auto
 
     origin_user = UserModel(password="abc")
     user = User.from_pydantic(origin_user, extra={"age": 1})
@@ -431,9 +443,10 @@ def test_can_convert_pydantic_type_to_strawberry_with_additional_nested_fields()
     class UserModel(pydantic.BaseModel):
         password: Optional[str]
 
-    @strawberry.experimental.pydantic.type(UserModel, fields=["password"])
+    @strawberry.experimental.pydantic.type(UserModel)
     class User:
         work: Work
+        password: auto
 
     origin_user = UserModel(password="abc")
     user = User.from_pydantic(origin_user, extra={"work": {"name": "Ice inc"}})
@@ -450,9 +463,10 @@ def test_can_convert_pydantic_type_to_strawberry_with_additional_list_nested_fie
     class UserModel(pydantic.BaseModel):
         password: Optional[str]
 
-    @strawberry.experimental.pydantic.type(UserModel, fields=["password"])
+    @strawberry.experimental.pydantic.type(UserModel)
     class User:
         work: List[Work]
+        password: auto
 
     origin_user = UserModel(password="abc")
     user = User.from_pydantic(
@@ -476,16 +490,17 @@ def test_can_convert_pydantic_type_to_strawberry_with_missing_data_in_nested_typ
     class WorkModel(pydantic.BaseModel):
         name: str
 
-    @strawberry.experimental.pydantic.type(WorkModel, fields=["name"])
+    @strawberry.experimental.pydantic.type(WorkModel)
     class Work:
         year: int
+        name: auto
 
     class UserModel(pydantic.BaseModel):
         work: List[WorkModel]
 
-    @strawberry.experimental.pydantic.type(UserModel, fields=["work"])
+    @strawberry.experimental.pydantic.type(UserModel)
     class User:
-        pass
+        work: auto
 
     origin_user = UserModel(work=[WorkModel(name="Software inc")])
 
@@ -507,16 +522,17 @@ def test_can_convert_pydantic_type_to_strawberry_with_missing_index_data_nested_
     class WorkModel(pydantic.BaseModel):
         name: str
 
-    @strawberry.experimental.pydantic.type(WorkModel, fields=["name"])
+    @strawberry.experimental.pydantic.type(WorkModel)
     class Work:
         year: int
+        name: auto
 
     class UserModel(pydantic.BaseModel):
         work: List[Optional[WorkModel]]
 
-    @strawberry.experimental.pydantic.type(UserModel, fields=["work"])
+    @strawberry.experimental.pydantic.type(UserModel)
     class User:
-        pass
+        work: auto
 
     origin_user = UserModel(
         work=[
@@ -546,16 +562,17 @@ def test_can_convert_pydantic_type_to_strawberry_with_optional_list():
     class WorkModel(pydantic.BaseModel):
         name: str
 
-    @strawberry.experimental.pydantic.type(WorkModel, fields=["name"])
+    @strawberry.experimental.pydantic.type(WorkModel)
     class Work:
+        name: auto
         year: int
 
     class UserModel(pydantic.BaseModel):
         work: Optional[WorkModel]
 
-    @strawberry.experimental.pydantic.type(UserModel, fields=["work"])
+    @strawberry.experimental.pydantic.type(UserModel)
     class User:
-        pass
+        work: auto
 
     origin_user = UserModel(work=None)
 
@@ -570,9 +587,9 @@ def test_can_convert_pydantic_type_to_strawberry_with_optional_nested_value():
     class UserModel(pydantic.BaseModel):
         names: Optional[List[str]]
 
-    @strawberry.experimental.pydantic.type(UserModel, fields=["names"])
+    @strawberry.experimental.pydantic.type(UserModel)
     class User:
-        pass
+        names: auto
 
     origin_user = UserModel(names=None)
 
@@ -588,9 +605,10 @@ def test_can_convert_input_types_to_pydantic():
         age: int
         password: Optional[str]
 
-    @strawberry.experimental.pydantic.input(User, fields=["age", "password"])
+    @strawberry.experimental.pydantic.input(User)
     class UserInput:
-        pass
+        age: auto
+        password: auto
 
     data = UserInput(1, None)
     user = data.to_pydantic()
@@ -604,9 +622,10 @@ def test_can_convert_input_types_to_pydantic_default_values():
         age: int
         password: Optional[str] = None
 
-    @strawberry.experimental.pydantic.input(User, fields=["age", "password"])
+    @strawberry.experimental.pydantic.input(User)
     class UserInput:
-        pass
+        age: auto
+        password: auto
 
     data = UserInput(1)
     user = data.to_pydantic()

--- a/tests/experimental/pydantic/test_error_type.py
+++ b/tests/experimental/pydantic/test_error_type.py
@@ -3,6 +3,7 @@ from typing import List, Optional
 import pydantic
 
 import strawberry
+from strawberry.experimental.pydantic import auto
 from strawberry.type import StrawberryList, StrawberryOptional
 from strawberry.types.types import TypeDefinition
 
@@ -12,9 +13,10 @@ def test_basic_error_type():
         name: str
         age: int
 
-    @strawberry.experimental.pydantic.error_type(UserModel, fields=["name", "age"])
+    @strawberry.experimental.pydantic.error_type(UserModel)
     class UserError:
-        pass
+        name: auto
+        age: auto
 
     definition: TypeDefinition = UserError._type_definition
     assert definition.name == "UserError"
@@ -39,13 +41,13 @@ def test_error_type_with_nested_model():
     class UserModel(pydantic.BaseModel):
         friend: FriendModel
 
-    @strawberry.experimental.pydantic.error_type(FriendModel, fields=["food"])
+    @strawberry.experimental.pydantic.error_type(FriendModel)
     class FriendError:
-        pass
+        food: auto
 
-    @strawberry.experimental.pydantic.error_type(UserModel, fields=["friend"])
+    @strawberry.experimental.pydantic.error_type(UserModel)
     class UserError:
-        pass
+        friend: auto
 
     definition: TypeDefinition = UserError._type_definition
     assert definition.name == "UserError"
@@ -64,13 +66,13 @@ def test_error_type_with_list_nested_model():
     class UserModel(pydantic.BaseModel):
         friends: List[FriendModel]
 
-    @strawberry.experimental.pydantic.error_type(FriendModel, fields=["food"])
+    @strawberry.experimental.pydantic.error_type(FriendModel)
     class FriendError:
-        pass
+        food: auto
 
-    @strawberry.experimental.pydantic.error_type(UserModel, fields=["friends"])
+    @strawberry.experimental.pydantic.error_type(UserModel)
     class UserError:
-        pass
+        friends: auto
 
     definition: TypeDefinition = UserError._type_definition
     assert definition.name == "UserError"
@@ -88,9 +90,9 @@ def test_error_type_with_list_of_scalar():
     class UserModel(pydantic.BaseModel):
         friends: List[int]
 
-    @strawberry.experimental.pydantic.error_type(UserModel, fields=["friends"])
+    @strawberry.experimental.pydantic.error_type(UserModel)
     class UserError:
-        pass
+        friends: auto
 
     definition: TypeDefinition = UserError._type_definition
     assert definition.name == "UserError"
@@ -109,9 +111,9 @@ def test_error_type_with_optional_field():
     class UserModel(pydantic.BaseModel):
         age: Optional[int]
 
-    @strawberry.experimental.pydantic.error_type(UserModel, fields=["age"])
+    @strawberry.experimental.pydantic.error_type(UserModel)
     class UserError:
-        pass
+        age: auto
 
     definition: TypeDefinition = UserError._type_definition
     assert definition.name == "UserError"
@@ -128,9 +130,9 @@ def test_error_type_with_list_of_optional_scalar():
     class UserModel(pydantic.BaseModel):
         age: List[Optional[int]]
 
-    @strawberry.experimental.pydantic.error_type(UserModel, fields=["age"])
+    @strawberry.experimental.pydantic.error_type(UserModel)
     class UserError:
-        pass
+        age: auto
 
     definition: TypeDefinition = UserError._type_definition
 
@@ -149,9 +151,9 @@ def test_error_type_with_optional_list_scalar():
     class UserModel(pydantic.BaseModel):
         age: Optional[List[int]]
 
-    @strawberry.experimental.pydantic.error_type(UserModel, fields=["age"])
+    @strawberry.experimental.pydantic.error_type(UserModel)
     class UserError:
-        pass
+        age: auto
 
     definition: TypeDefinition = UserError._type_definition
 
@@ -170,9 +172,9 @@ def test_error_type_with_optional_list_of_optional_scalar():
     class UserModel(pydantic.BaseModel):
         age: Optional[List[Optional[int]]]
 
-    @strawberry.experimental.pydantic.error_type(UserModel, fields=["age"])
+    @strawberry.experimental.pydantic.error_type(UserModel)
     class UserError:
-        pass
+        age: auto
 
     definition: TypeDefinition = UserError._type_definition
 
@@ -191,16 +193,16 @@ def test_error_type_with_optional_list_of_nested_model():
     class FriendModel(pydantic.BaseModel):
         name: str
 
-    @strawberry.experimental.pydantic.error_type(FriendModel, fields=["name"])
-    class FriendError(pydantic.BaseModel):
-        pass
+    @strawberry.experimental.pydantic.error_type(FriendModel)
+    class FriendError:
+        name: auto
 
     class UserModel(pydantic.BaseModel):
         friends: Optional[List[FriendModel]]
 
-    @strawberry.experimental.pydantic.error_type(UserModel, fields=["friends"])
+    @strawberry.experimental.pydantic.error_type(UserModel)
     class UserError:
-        pass
+        friends: auto
 
     definition: TypeDefinition = UserError._type_definition
 
@@ -218,9 +220,9 @@ def test_error_type_with_matrix_list_of_scalar():
     class UserModel(pydantic.BaseModel):
         age: List[List[int]]
 
-    @strawberry.experimental.pydantic.error_type(UserModel, fields=["age"])
+    @strawberry.experimental.pydantic.error_type(UserModel)
     class UserError:
-        pass
+        age: auto
 
     definition: TypeDefinition = UserError._type_definition
 

--- a/tests/experimental/pydantic/test_fields.py
+++ b/tests/experimental/pydantic/test_fields.py
@@ -3,6 +3,7 @@ import pytest
 import pydantic
 
 import strawberry
+from strawberry.experimental.pydantic import auto
 from strawberry.type import StrawberryOptional
 from strawberry.types.types import TypeDefinition
 
@@ -32,9 +33,9 @@ def test_types(pydantic_type, field_type):
     class Model(pydantic.BaseModel):
         field: pydantic_type
 
-    @strawberry.experimental.pydantic.type(Model, fields=["field"])
+    @strawberry.experimental.pydantic.type(Model)
     class Type:
-        pass
+        field: auto
 
     definition: TypeDefinition = Type._type_definition
     assert definition.name == "Type"
@@ -53,9 +54,9 @@ def test_types_optional(pydantic_type, field_type):
     class Model(pydantic.BaseModel):
         field: pydantic_type
 
-    @strawberry.experimental.pydantic.type(Model, fields=["field"])
+    @strawberry.experimental.pydantic.type(Model)
     class Type:
-        pass
+        field: auto
 
     definition: TypeDefinition = Type._type_definition
     assert definition.name == "Type"
@@ -71,9 +72,9 @@ def test_conint():
     class Model(pydantic.BaseModel):
         field: pydantic.conint(lt=100)
 
-    @strawberry.experimental.pydantic.type(Model, fields=["field"])
+    @strawberry.experimental.pydantic.type(Model)
     class Type:
-        pass
+        field: auto
 
     definition: TypeDefinition = Type._type_definition
     assert definition.name == "Type"
@@ -88,9 +89,9 @@ def test_constr():
     class Model(pydantic.BaseModel):
         field: pydantic.constr(max_length=100)
 
-    @strawberry.experimental.pydantic.type(Model, fields=["field"])
+    @strawberry.experimental.pydantic.type(Model)
     class Type:
-        pass
+        field: auto
 
     definition: TypeDefinition = Type._type_definition
     assert definition.name == "Type"
@@ -125,6 +126,6 @@ def test_unsupported_types(pydantic_type):
         strawberry.experimental.pydantic.exceptions.UnsupportedTypeError
     ):
 
-        @strawberry.experimental.pydantic.type(Model, fields=["field"])
+        @strawberry.experimental.pydantic.type(Model)
         class Type:
-            pass
+            field: auto


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This adds support for the `auto` type annotation described in #1192 to the Pydantic integration, which allows a user to define the list of fields without having to re-specify the type themselves. This gives better editor and type checker support (although I didn't update the Mypy integration).

I haven't marked the `fields` list as deprecated, I wasn't sure if we wanted to do that in this release or not, but that's an easy change.

I also did a bit of cleanup on the error_type section, since it was missing a lot of the logic in the type function that allows for more complex input types.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

* Closes #1192 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
