### PR TITLE
Correctly nest OTel spans

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,23 @@
+Release type: minor
+
+Nests the resolver under the correct span; prior to this change your span would have looked something like:
+
+```
+GraphQL Query
+  GraphQL Parsing
+  GraphQL Validation
+  my_resolver
+  my_span_of_interest #1
+    my_sub_span_of_interest #2
+```
+
+After this change you'll have:
+
+```
+GraphQL Query
+  GraphQL Parsing
+  GraphQL Validation
+  GraphQL Handling: my_resolver
+    my_span_of_interest #1
+      my_sub_span_of_interest #2
+```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -17,7 +17,7 @@ After this change you'll have:
 GraphQL Query
   GraphQL Parsing
   GraphQL Validation
-  GraphQL Handling: my_resolver
+  GraphQL Resolving: my_resolver
     my_span_of_interest #1
       my_sub_span_of_interest #2
 ```

--- a/strawberry/extensions/tracing/opentelemetry.py
+++ b/strawberry/extensions/tracing/opentelemetry.py
@@ -109,7 +109,7 @@ class OpenTelemetryExtension(Extension):
             return result
 
         with self._tracer.start_as_current_span(
-            f"GraphQL Handling: {info.field_name}",
+            f"GraphQL Resolving: {info.field_name}",
             context=trace.set_span_in_context(self._span_holder[RequestStage.REQUEST]),
         ) as span:
             self.add_tags(span, info, kwargs)
@@ -129,7 +129,7 @@ class OpenTelemetryExtensionSync(OpenTelemetryExtension):
             return result
 
         with self._tracer.start_as_current_span(
-            "GraphQL Handling: {info.field_name}",
+            "GraphQL Resolving: {info.field_name}",
             context=trace.set_span_in_context(self._span_holder[RequestStage.REQUEST]),
         ) as span:
             self.add_tags(span, info, kwargs)

--- a/strawberry/extensions/tracing/opentelemetry.py
+++ b/strawberry/extensions/tracing/opentelemetry.py
@@ -121,7 +121,9 @@ class OpenTelemetryExtension(Extension):
             return result
 
         with _use_span(self._span_holder[RequestStage.REQUEST], self._tracer):
-            with self._tracer.start_span(info.field_name, kind=SpanKind.SERVER) as span:
+            with self._tracer.start_as_current_span(
+                info.field_name, kind=SpanKind.SERVER
+            ) as span:
                 self.add_tags(span, info, kwargs)
                 result = _next(root, info, *args, **kwargs)
 
@@ -139,7 +141,9 @@ class OpenTelemetryExtensionSync(OpenTelemetryExtension):
             return result
 
         with _use_span(self._span_holder[RequestStage.REQUEST], self._tracer):
-            with self._tracer.start_span(info.field_name, kind=SpanKind.SERVER) as span:
+            with self._tracer.start_as_current_span(
+                info.field_name, kind=SpanKind.SERVER
+            ) as span:
                 self.add_tags(span, info, kwargs)
                 result = _next(root, info, *args, **kwargs)
 

--- a/tests/schema/extensions/test_opentelemetry.py
+++ b/tests/schema/extensions/test_opentelemetry.py
@@ -96,7 +96,7 @@ async def test_open_tracing(global_tracer_mock, mocker):
     # it is a context manager, all other spans are a child of this
     global_tracer_mock.return_value.start_as_current_span.assert_has_calls(
         [
-            mocker.call("GraphQL Handling: person", context=mocker.ANY),
+            mocker.call("GraphQL Resolving: person", context=mocker.ANY),
             mocker.call().__enter__(),
             mocker.call().__enter__().set_attribute("component", "graphql"),
             mocker.call().__enter__().set_attribute("graphql.parentType", "Query"),

--- a/tests/schema/extensions/test_opentelemetry.py
+++ b/tests/schema/extensions/test_opentelemetry.py
@@ -28,16 +28,6 @@ class Query:
 
 @pytest.mark.asyncio
 async def test_opentelemetry_uses_global_tracer(global_tracer_mock):
-    @strawberry.type
-    class Person:
-        name: str = "Jess"
-
-    @strawberry.type
-    class Query:
-        @strawberry.field
-        async def person(self) -> Person:
-            return Person()
-
     schema = strawberry.Schema(query=Query, extensions=[OpenTelemetryExtension])
 
     query = """
@@ -54,17 +44,7 @@ async def test_opentelemetry_uses_global_tracer(global_tracer_mock):
 
 
 @pytest.mark.asyncio
-async def test_opentelemetry_Sync_uses_global_tracer(global_tracer_mock):
-    @strawberry.type
-    class Person:
-        name: str = "Jess"
-
-    @strawberry.type
-    class Query:
-        @strawberry.field
-        async def person(self) -> Person:
-            return Person()
-
+async def test_opentelemetry_sync_uses_global_tracer(global_tracer_mock):
     schema = strawberry.Schema(query=Query, extensions=[OpenTelemetryExtensionSync])
 
     query = """
@@ -80,6 +60,19 @@ async def test_opentelemetry_Sync_uses_global_tracer(global_tracer_mock):
     global_tracer_mock.assert_called_once_with("strawberry")
 
 
+def _instrumentation_stages(mocker, query):
+    return [
+        mocker.call("GraphQL Query", kind=SpanKind.SERVER),
+        mocker.call().set_attribute("component", "graphql"),
+        mocker.call().set_attribute("query", query),
+        mocker.call("GraphQL Parsing", context=mocker.ANY),
+        mocker.call().end(),
+        mocker.call("GraphQL Validation", context=mocker.ANY),
+        mocker.call().end(),
+        mocker.call().end(),
+    ]
+
+
 @pytest.mark.asyncio
 async def test_open_tracing(global_tracer_mock, mocker):
     schema = strawberry.Schema(query=Query, extensions=[OpenTelemetryExtension])
@@ -93,22 +86,22 @@ async def test_open_tracing(global_tracer_mock, mocker):
 
     await schema.execute(query)
 
+    # start_span is called by the Extension framework to instrument
+    # phases of pre-request handling logic; parsing, validation, etc
     global_tracer_mock.return_value.start_span.assert_has_calls(
+        _instrumentation_stages(mocker, query)
+    )
+
+    # start_as_current_span is called at the very start of request handling
+    # it is a context manager, all other spans are a child of this
+    global_tracer_mock.return_value.start_as_current_span.assert_has_calls(
         [
-            mocker.call("GraphQL Query", kind=SpanKind.SERVER),
-            mocker.call().set_attribute("component", "graphql"),
-            mocker.call().set_attribute("query", query),
-            mocker.call("GraphQL Parsing", context=mocker.ANY),
-            mocker.call().end(),
-            mocker.call("GraphQL Validation", context=mocker.ANY),
-            mocker.call().end(),
-            mocker.call("person", kind=SpanKind.SERVER),
+            mocker.call("GraphQL Handling: person", context=mocker.ANY),
             mocker.call().__enter__(),
             mocker.call().__enter__().set_attribute("component", "graphql"),
             mocker.call().__enter__().set_attribute("graphql.parentType", "Query"),
             mocker.call().__enter__().set_attribute("graphql.path", "person"),
             mocker.call().__exit__(None, None, None),
-            mocker.call().end(),
         ]
     )
 
@@ -128,20 +121,9 @@ async def test_open_tracing_uses_operation_name(global_tracer_mock, mocker):
 
     global_tracer_mock.return_value.start_span.assert_has_calls(
         [
+            # if operation_name is supplied it is added to this span's tag
             mocker.call("GraphQL Query: Example", kind=SpanKind.SERVER),
-            mocker.call().set_attribute("component", "graphql"),
-            mocker.call().set_attribute("query", query),
-            mocker.call("GraphQL Parsing", context=mocker.ANY),
-            mocker.call().end(),
-            mocker.call("GraphQL Validation", context=mocker.ANY),
-            mocker.call().end(),
-            mocker.call("person", kind=SpanKind.SERVER),
-            mocker.call().__enter__(),
-            mocker.call().__enter__().set_attribute("component", "graphql"),
-            mocker.call().__enter__().set_attribute("graphql.parentType", "Query"),
-            mocker.call().__enter__().set_attribute("graphql.path", "person"),
-            mocker.call().__exit__(None, None, None),
-            mocker.call().end(),
+            *_instrumentation_stages(mocker, query)[1:],
         ]
     )
 
@@ -164,7 +146,7 @@ async def test_tracing_add_kwargs(global_tracer_mock, mocker):
 
     await schema.execute(query)
 
-    global_tracer_mock.return_value.start_span.assert_has_calls(
+    global_tracer_mock.return_value.start_as_current_span.assert_has_calls(
         [
             mocker.call().__enter__().set_attribute("graphql.parentType", "Query"),
             mocker.call().__enter__().set_attribute("graphql.path", "hi"),
@@ -196,7 +178,7 @@ async def test_tracing_filter_kwargs(global_tracer_mock, mocker):
 
     await schema.execute(query)
 
-    global_tracer_mock.return_value.start_span.assert_has_calls(
+    global_tracer_mock.return_value.start_as_current_span.assert_has_calls(
         [
             mocker.call().__enter__().set_attribute("graphql.parentType", "Query"),
             mocker.call().__enter__().set_attribute("graphql.path", "hi"),


### PR DESCRIPTION
This fixes an issue in the current opentelemetry extension where spans are not correctly nested.

## Description

As per https://github.com/strawberry-graphql/strawberry/issues/1275 and a discussion on discord we decided it would be best to use the nested span option in OTel to represent a graphql resolver handling the request.

Here is what spans look like now: 

<img width="1719" alt="Screen Shot 2021-09-28 at 12 58 37 PM" src="https://user-images.githubusercontent.com/260015/135142645-a7f05182-4caf-4959-ab73-f65e1a75edb9.png">

Note that I added a "GraphQL Handling: <foo>" prefix to the span name to keep it clear what strawberry is doing for you versus your own spans.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Closes https://github.com/strawberry-graphql/strawberry/issues/1275

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
