### PR TITLE
Extract operation name and type from execution context

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+Release type: patch
+
+This release `operation_type` to the `ExecutionContext` type that is available
+in extensions. It also gets the `operation_name` from the query if one isn't
+provided by the client.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,4 @@
-Release type: patch
+Release type: minor
 
 This release `operation_type` to the `ExecutionContext` type that is available
 in extensions. It also gets the `operation_name` from the query if one isn't

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -138,7 +138,7 @@ class Schema(BaseSchema):
             context=context_value,
             root_value=root_value,
             variables=variable_values,
-            operation_name=operation_name,
+            _provided_operation_name=operation_name,
         )
 
         result = await execute(
@@ -168,7 +168,7 @@ class Schema(BaseSchema):
             context=context_value,
             root_value=root_value,
             variables=variable_values,
-            operation_name=operation_name,
+            _provided_operation_name=operation_name,
         )
 
         result = execute_sync(

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -138,7 +138,7 @@ class Schema(BaseSchema):
             context=context_value,
             root_value=root_value,
             variables=variable_values,
-            _provided_operation_name=operation_name,
+            provided_operation_name=operation_name,
         )
 
         result = await execute(
@@ -168,7 +168,7 @@ class Schema(BaseSchema):
             context=context_value,
             root_value=root_value,
             variables=variable_values,
-            _provided_operation_name=operation_name,
+            provided_operation_name=operation_name,
         )
 
         result = execute_sync(

--- a/strawberry/types/execution.py
+++ b/strawberry/types/execution.py
@@ -46,7 +46,7 @@ class ExecutionContext:
 
         definition = self._get_first_operation()
         if not definition:
-            raise RuntimeError("Can't get GraphQL operation")
+            return None
 
         if not definition.name:
             return None
@@ -80,7 +80,7 @@ class ExecutionContext:
     def _get_first_operation(self) -> Optional[OperationDefinitionNode]:
         graphql_document = self.graphql_document
         if not graphql_document:
-            raise RuntimeError("No GraphQL document available")
+            return None
 
         definition = next(
             (

--- a/strawberry/types/execution.py
+++ b/strawberry/types/execution.py
@@ -1,5 +1,7 @@
 import dataclasses
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, cast
+
+from typing_extensions import Literal
 
 from graphql import (
     ASTValidationRule,
@@ -7,11 +9,14 @@ from graphql import (
     specified_rules,
 )
 from graphql.error.graphql_error import GraphQLError
-from graphql.language import DocumentNode
+from graphql.language import DocumentNode, OperationDefinitionNode
 
 
 if TYPE_CHECKING:
     from strawberry.schema import Schema
+
+
+graphql_operation_types = Literal["QUERY", "MUTATION"]
 
 
 @dataclasses.dataclass
@@ -20,17 +25,72 @@ class ExecutionContext:
     schema: "Schema"
     context: Any = None
     variables: Optional[Dict[str, Any]] = None
-    operation_name: Optional[str] = None
     root_value: Optional[Any] = None
     validation_rules: Tuple[Type[ASTValidationRule], ...] = dataclasses.field(
         default_factory=lambda: tuple(specified_rules)
     )
+
+    # The operation name that is provided by the request
+    _provided_operation_name: Optional[str] = None
 
     # Values that get populated during the GraphQL execution so that they can be
     # accessed by extensions
     graphql_document: Optional[DocumentNode] = None
     errors: Optional[List[GraphQLError]] = None
     result: Optional[GraphQLExecutionResult] = None
+
+    @property
+    def operation_name(self) -> Optional[str]:
+        if self._provided_operation_name:
+            return self._provided_operation_name
+
+        definition = self._get_first_operation()
+        if not definition:
+            raise RuntimeError("Can't get GraphQL operation")
+
+        if not definition.name:
+            return None
+
+        return definition.name.value
+
+    @property
+    def operation_type(self) -> graphql_operation_types:
+        definition: Optional[OperationDefinitionNode] = None
+
+        graphql_document = self.graphql_document
+        if not graphql_document:
+            raise RuntimeError("No GraphQL document available")
+
+        # If no operation_name has been specified then use the first
+        # OperationDefinitionNode
+        if not self._provided_operation_name:
+            definition = self._get_first_operation()
+        else:
+            for d in graphql_document.definitions:
+                d = cast(OperationDefinitionNode, d)
+                if d.name and d.name.value == self._provided_operation_name:
+                    definition = d
+                    break
+
+        if not definition:
+            raise RuntimeError("Can't get GraphQL operation type")
+
+        return cast(graphql_operation_types, definition.operation.name)
+
+    def _get_first_operation(self) -> Optional[OperationDefinitionNode]:
+        graphql_document = self.graphql_document
+        if not graphql_document:
+            raise RuntimeError("No GraphQL document available")
+
+        definition = next(
+            (
+                node
+                for node in graphql_document.definitions
+                if isinstance(node, OperationDefinitionNode)
+            ),
+            None,
+        )
+        return definition
 
 
 @dataclasses.dataclass

--- a/strawberry/types/execution.py
+++ b/strawberry/types/execution.py
@@ -31,13 +31,16 @@ class ExecutionContext:
     )
 
     # The operation name that is provided by the request
-    _provided_operation_name: Optional[str] = None
+    provided_operation_name: dataclasses.InitVar[Optional[str]] = None
 
     # Values that get populated during the GraphQL execution so that they can be
     # accessed by extensions
     graphql_document: Optional[DocumentNode] = None
     errors: Optional[List[GraphQLError]] = None
     result: Optional[GraphQLExecutionResult] = None
+
+    def __post_init__(self, provided_operation_name):
+        self._provided_operation_name = provided_operation_name
 
     @property
     def operation_name(self) -> Optional[str]:
@@ -82,14 +85,12 @@ class ExecutionContext:
         if not graphql_document:
             return None
 
-        definition = next(
-            (
-                node
-                for node in graphql_document.definitions
-                if isinstance(node, OperationDefinitionNode)
-            ),
-            None,
-        )
+        definition: Optional[OperationDefinitionNode] = None
+        for d in graphql_document.definitions:
+            if isinstance(d, OperationDefinitionNode):
+                definition = d
+                break
+
         return definition
 
 

--- a/strawberry/types/execution.py
+++ b/strawberry/types/execution.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from strawberry.schema import Schema
 
 
-graphql_operation_types = Literal["QUERY", "MUTATION"]
+GraphqlOperationTypes = Literal["QUERY", "MUTATION"]
 
 
 @dataclasses.dataclass
@@ -57,7 +57,7 @@ class ExecutionContext:
         return definition.name.value
 
     @property
-    def operation_type(self) -> graphql_operation_types:
+    def operation_type(self) -> GraphqlOperationTypes:
         definition: Optional[OperationDefinitionNode] = None
 
         graphql_document = self.graphql_document
@@ -78,7 +78,7 @@ class ExecutionContext:
         if not definition:
             raise RuntimeError("Can't get GraphQL operation type")
 
-        return cast(graphql_operation_types, definition.operation.name)
+        return cast(GraphqlOperationTypes, definition.operation.name)
 
     def _get_first_operation(self) -> Optional[OperationDefinitionNode]:
         graphql_document = self.graphql_document

--- a/tests/types/test_execution.py
+++ b/tests/types/test_execution.py
@@ -1,0 +1,101 @@
+import strawberry
+from strawberry.extensions import Extension
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def ping(self) -> str:
+        return "pong"
+
+
+def test_execution_context_operation_name_and_type():
+    operation_name = None
+    operation_type = None
+
+    class MyExtension(Extension):
+        def on_request_end(self):
+            nonlocal operation_name
+            nonlocal operation_type
+
+            execution_context = self.execution_context
+
+            operation_name = execution_context.operation_name
+            operation_type = execution_context.operation_type
+
+    schema = strawberry.Schema(Query, extensions=[MyExtension])
+
+    result = schema.execute_sync("{ ping }")
+    assert not result.errors
+
+    assert operation_name is None
+    assert operation_type == "QUERY"
+
+    # Try again with an operation_name
+    result = schema.execute_sync("query MyOperation { ping }")
+    assert not result.errors
+
+    assert operation_name == "MyOperation"
+    assert operation_type == "QUERY"
+
+    # Try again with an operation_name override
+    result = schema.execute_sync(
+        """
+        query MyOperation { ping }
+        query MyOperation2 { ping }
+        """,
+        operation_name="MyOperation2",
+    )
+    assert not result.errors
+
+    assert operation_name == "MyOperation2"
+    assert operation_type == "QUERY"
+
+
+def test_execution_context_operation_type_mutation():
+    operation_name = None
+    operation_type = None
+
+    class MyExtension(Extension):
+        def on_request_end(self):
+            nonlocal operation_name
+            nonlocal operation_type
+
+            execution_context = self.execution_context
+
+            operation_name = execution_context.operation_name
+            operation_type = execution_context.operation_type
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        def my_mutation(self) -> str:
+            return "hi"
+
+    schema = strawberry.Schema(Query, mutation=Mutation, extensions=[MyExtension])
+
+    result = schema.execute_sync("mutation { myMutation }")
+    assert not result.errors
+
+    assert operation_name is None
+    assert operation_type == "MUTATION"
+
+    # Try again with an operation_name
+    result = schema.execute_sync("mutation MyMutation { myMutation }")
+    assert not result.errors
+
+    assert operation_name == "MyMutation"
+    assert operation_type == "MUTATION"
+
+    # Try again with an operation_name override
+    result = schema.execute_sync(
+        """
+        mutation MyMutation { myMutation }
+        mutation MyMutation2 { myMutation }
+        """,
+        operation_name="MyMutation2",
+    )
+    assert not result.errors
+
+    assert operation_name == "MyMutation2"
+    assert operation_type == "MUTATION"

--- a/tests/types/test_execution.py
+++ b/tests/types/test_execution.py
@@ -149,3 +149,17 @@ def test_error_when_accessing_operation_type_before_parsing():
 
     with pytest.raises(RuntimeError):
         schema.execute_sync("mutation { myMutation }")
+
+
+def test_error_when_accessing_operation_type_with_invalid_operation_name():
+    class MyExtension(Extension):
+        def on_parsing_end(self):
+            execution_context = self.execution_context
+
+            # This should raise a RuntimeError
+            execution_context.operation_type
+
+    schema = strawberry.Schema(Query, extensions=[MyExtension])
+
+    with pytest.raises(RuntimeError):
+        schema.execute_sync("query { ping }", operation_name="MyQuery")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Add properties to ExecutionContext to extract the operation name and type from the graphql document.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
