### PR TITLE
Use the same route for http and ws in ASGI integration docs

### DIFF
--- a/docs/integrations/fastapi.md
+++ b/docs/integrations/fastapi.md
@@ -18,7 +18,7 @@ graphql_app = GraphQL(schema)
 
 app = FastAPI()
 app.add_route("/graphql", graphql_app)
-app.add_websocket_route("/subscriptions", graphql_app)
+app.add_websocket_route("/graphql", graphql_app)
 ```
 
 For more information about Strawberry ASGI refer to [asgi.md](./asgi.md)

--- a/docs/integrations/starlette.md
+++ b/docs/integrations/starlette.md
@@ -18,7 +18,7 @@ graphql_app = GraphQL(schema)
 
 app = Starlette()
 app.add_route("/graphql", graphql_app)
-app.add_websocket_route("/subscriptions", graphql_app)
+app.add_websocket_route("/graphql", graphql_app)
 ```
 
 For more information about Strawberry ASGI refer to [the documentation on ASGI](./asgi.md)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
GraphiQL expects a single graphql endpoint for both http and ws requests. Our fastapi and the recently added starlette docs propose a separate route (/subscriptions) for subscriptions. This results in the errors shown in #1227. The fix is easy: just use one route.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

* Closes #1227

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
