### PR TITLE
Validation for Permission classes

### DIFF
--- a/strawberry/permission.py
+++ b/strawberry/permission.py
@@ -1,9 +1,13 @@
 import abc
-from typing import Any, Awaitable, Optional, Union
+from typing import TYPE_CHECKING, Any, Awaitable, Optional, Union
 from warnings import warn
 
 from strawberry.type import StrawberryOptional
 from strawberry.types.info import Info
+
+
+if TYPE_CHECKING:
+    from strawberry.field import StrawberryField
 
 
 class BasePermission(abc.ABC):
@@ -17,12 +21,10 @@ class BasePermission(abc.ABC):
     def has_permission(
         self, source: Any, info: Info, **kwargs
     ) -> Union[bool, Awaitable[bool]]:
-        raise NotImplementedError(
-            "Permission classes should override has_permission method"
-        )
+        ...
 
     @classmethod
-    def assert_valid_for_field(cls, field) -> None:
+    def assert_valid_for_field(cls, field: "StrawberryField") -> None:
         # assert all abstact methods are implemented in a subclass
         not_implemented_methods = getattr(cls, "__abstractmethods__", None)
         if not_implemented_methods:

--- a/strawberry/permission.py
+++ b/strawberry/permission.py
@@ -1,18 +1,44 @@
+import abc
 from typing import Any, Awaitable, Optional, Union
+from warnings import warn
 
+from strawberry.type import StrawberryOptional
 from strawberry.types.info import Info
 
 
-class BasePermission:
+class BasePermission(abc.ABC):
     """
     Base class for creating permissions
     """
 
     message: Optional[str] = None
 
+    @abc.abstractclassmethod
     def has_permission(
         self, source: Any, info: Info, **kwargs
     ) -> Union[bool, Awaitable[bool]]:
         raise NotImplementedError(
             "Permission classes should override has_permission method"
         )
+
+    @classmethod
+    def assert_valid_for_field(cls, field) -> None:
+        # assert all abstact methods are implemented in a subclass
+        not_implemented_methods = getattr(cls, "__abstractmethods__", None)
+        if not_implemented_methods:
+            method_names = ", ".join(not_implemented_methods)
+            raise NotImplementedError(
+                f"Permission class {cls.__name__} "
+                f"should have the following methods implemented: {method_names}"
+            )
+
+        # check that field can retrun `null` if permission check doesn't pass
+        if not isinstance(field.type, StrawberryOptional):
+            documentation_link = (
+                "https://strawberry.rocks/docs/guides/"
+                "permissions#setting-permissions-on-non-optional-fields"
+            )
+            warn(
+                f"Setting permission class on a non-optional field '{field.name}'. "
+                f"For more details check the documentation: {documentation_link}"
+            )

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -311,7 +311,6 @@ class GraphQLCoreConverter:
     def from_resolver(
         self, field: StrawberryField
     ) -> Callable:  # TODO: Take StrawberryResolver
-        # check that permission classes are valid
         for permission_class in field.permission_classes:
             permission_class.assert_valid_for_field(field)
 

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -311,6 +311,10 @@ class GraphQLCoreConverter:
     def from_resolver(
         self, field: StrawberryField
     ) -> Callable:  # TODO: Take StrawberryResolver
+        # check that permission classes are valid
+        for permission_class in field.permission_classes:
+            permission_class.assert_valid_for_field(field)
+
         def _get_arguments(
             source: Any,
             info: Info,


### PR DESCRIPTION
Added two validation rules for Permission classes that should be checked on schema initialization:

1. Permission classes should to have `has_permission` method implemented.
2. The user should receive a warning if a Permission class is added to a non-optional field.

## Description
This is a draft PR because I'm not sure that these changes are even needed. As far as I understood, [this page](https://github.com/strawberry-graphql/strawberry/issues/268) states that there are plans to deprecate Permission classes. But I've recently run into a problem with Permissions on non-optional fields on my project, so I figured the warning would be helpful to users while this feature is still in use. And if the Permission class lacks the `has_permission` method, it makes sense to fail during initialization, not while resolving queries.

I also doubt that schema converter is the best place to run these checks, maybe you have suggestions about this?

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
