### PR TITLE
Ability to run subscriptions code snippet as it is

### DIFF
--- a/docs/operations/testing.md
+++ b/docs/operations/testing.md
@@ -102,6 +102,20 @@ async def test_mutaton():
 And finally, a test for our [`count` Subscription](docs/general/subscriptions.md):
 
 ```python
+import asyncio
+import pytest as pytest
+import strawberry
+
+@strawberry.type
+class Subscription:
+    @strawberry.subscription
+    async def count(self, target: int = 100) -> int:
+        for i in range(target):
+            yield i
+            await asyncio.sleep(0.5)
+
+schema = strawberry.Schema(query=Query, subscription=Subscription)
+
 @pytest.mark.asyncio
 async def test_subscription():
     query = """
@@ -118,6 +132,7 @@ async def test_subscription():
         assert result.data == {"count": index}
 
         index += 1
+
 ```
 
 As you can see testing Subscriptions is a bit more complicated because we want to check

--- a/docs/operations/testing.md
+++ b/docs/operations/testing.md
@@ -103,7 +103,7 @@ And finally, a test for our [`count` Subscription](docs/general/subscriptions.md
 
 ```python
 import asyncio
-import pytest as pytest
+import pytest
 import strawberry
 
 @strawberry.type
@@ -113,6 +113,12 @@ class Subscription:
         for i in range(target):
             yield i
             await asyncio.sleep(0.5)
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def hello() -> str:
+        return "world"
 
 schema = strawberry.Schema(query=Query, subscription=Subscription)
 
@@ -132,7 +138,6 @@ async def test_subscription():
         assert result.data == {"count": index}
 
         index += 1
-
 ```
 
 As you can see testing Subscriptions is a bit more complicated because we want to check


### PR DESCRIPTION
Allows you to copy the snippet of code from this documentation and run it as is, without code changes. The "testing subscriptions" snippet has been updated for the same.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
I have imported the necessary packages and have also created the dependent `subscription` class. I have also defined `schema` in order for the code to run as is.
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR
#1294 
*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
