### PR TITLE
Rename enum exception

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+This release renames an internal exception from `NotAnEnum` to `ObjectIsNotAnEnumError`.

--- a/strawberry/enum.py
+++ b/strawberry/enum.py
@@ -4,7 +4,7 @@ from typing import Any, Callable, List, Mapping, Optional, TypeVar, Union
 
 from strawberry.type import StrawberryType
 
-from .exceptions import NotAnEnum
+from .exceptions import ObjectIsNotAnEnumError
 
 
 @dataclasses.dataclass
@@ -38,7 +38,7 @@ def _process_enum(
     cls: EnumMeta, name: Optional[str] = None, description: Optional[str] = None
 ) -> EnumMeta:
     if not isinstance(cls, EnumMeta):
-        raise NotAnEnum()
+        raise ObjectIsNotAnEnumError(cls)
 
     if not name:
         name = cls.__name__

--- a/strawberry/exceptions.py
+++ b/strawberry/exceptions.py
@@ -12,9 +12,12 @@ from strawberry.type import StrawberryType
 # https://github.com/strawberry-graphql/strawberry/issues/1298
 
 
-class NotAnEnum(Exception):
-    def __init__(self):
-        message = "strawberry.enum can only be used with subclasses of Enum"
+class ObjectIsNotAnEnumError(Exception):
+    def __init__(self, obj: object):
+        message = (
+            "strawberry.enum can only be used with subclasses of Enum. "
+            f"Provided object {obj} is not an enum."
+        )
 
         super().__init__(message)
 

--- a/tests/enums/test_enum.py
+++ b/tests/enums/test_enum.py
@@ -4,7 +4,7 @@ import pytest
 
 import strawberry
 from strawberry.enum import EnumDefinition
-from strawberry.exceptions import NotAnEnum
+from strawberry.exceptions import ObjectIsNotAnEnumError
 
 
 def test_basic_enum():
@@ -62,7 +62,7 @@ def test_can_use_enum_as_arguments():
 
 def test_raises_error_when_using_enum_with_a_not_enum_class():
     expected_error = "strawberry.enum can only be used with subclasses of Enum"
-    with pytest.raises(NotAnEnum, match=expected_error):
+    with pytest.raises(ObjectIsNotAnEnumError, match=expected_error):
 
         @strawberry.enum
         class NormalClass:


### PR DESCRIPTION
Update enum's exception to be consistent with `ObjectIsNotClassError`