### PR TITLE
Add quotes to pip extra install commands in docs for ZSH compat

### DIFF
--- a/docs/extensions/opentelemetry.md
+++ b/docs/extensions/opentelemetry.md
@@ -13,7 +13,7 @@ This extension adds tracing information that is compatible with [Open Telemetry]
 This extension requires additional requirements:
 
 ```
-pip install strawberry-graphql[opentelemetry]
+pip install 'strawberry-graphql[opentelemetry]'
 ```
 
 </Note>

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@ After that we need a new virtualenv:
 Activate the virtualenv and then install strawberry plus the debug server.
 
     source virtualenv/bin/activate
-    pip install strawberry-graphql[debug-server]
+    pip install 'strawberry-graphql[debug-server]'
 
 ## Step 2: Define the schema
 

--- a/docs/integrations/asgi.md
+++ b/docs/integrations/asgi.md
@@ -9,7 +9,7 @@ use to serve your GraphQL schema. Before using Strawberry's ASGI support make su
 you install all the required dependencies by running:
 
 ```
-pip install strawberry-graphql[asgi]
+pip install 'strawberry-graphql[asgi]'
 ```
 
 Once that's done you can use Strawberry with ASGI like so:

--- a/docs/operations/tracing.md
+++ b/docs/operations/tracing.md
@@ -32,7 +32,7 @@ In addition to Apollo Tracing we also support
 You also need to install the extras for opentelemetry by doing:
 
 ```
-pip install strawberry-graphql[opentelemetry]
+pip install 'strawberry-graphql[opentelemetry]'
 ```
 
 ```python


### PR DESCRIPTION
## Description

Add missing quotes to pip installs in docs to fix problem on zsh.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/strawberry-graphql/strawberry/issues/1326
