### PR TITLE
Fix typo docs at `/operations/testing#testing-mutations`

### DIFF
--- a/docs/operations/testing.md
+++ b/docs/operations/testing.md
@@ -74,7 +74,7 @@ example:
 
 ```python
 @pytest.mark.asyncio
-async def test_mutaton():
+async def test_mutation():
     mutation = """
         mutation TestMutation($title: String!, $author: String!) {
             addBook(title: $title, author: $author) {


### PR DESCRIPTION
From https://strawberry.rocks/docs/operations/testing#testing-mutations

## Description

Fix typo on documents at `/operations/testing#testing-mutations`

```test_mutaton``` -> ```test_mutation```

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
