### PR TITLE
Implement explicit interface type resolution

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,9 @@
+Release type: patch
+
+This releases fixes an issue where you were not allowed
+to return a non-strawberry type for fields that return
+and interface. Now this works as long as each type
+implementing the interface implements an `is_type_of`
+classmethod. Previous automatic duck typing on types
+that implement an interface now requires explicit
+resolution using this classmethod.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,7 @@ Release type: patch
 
 This releases fixes an issue where you were not allowed
 to return a non-strawberry type for fields that return
-and interface. Now this works as long as each type
+an interface. Now this works as long as each type
 implementing the interface implements an `is_type_of`
 classmethod. Previous automatic duck typing on types
 that implement an interface now requires explicit

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,4 @@
-Release type: patch
+Release type: minor
 
 This releases fixes an issue where you were not allowed
 to return a non-strawberry type for fields that return

--- a/strawberry/experimental/pydantic/object_type.py
+++ b/strawberry/experimental/pydantic/object_type.py
@@ -147,10 +147,17 @@ def type(
 
         sorted_fields = missing_default + has_default
 
+        # Implicitly define `is_type_of` to support interfaces/unions that use
+        # pydantic objects (not the corresponding strawberry type)
+        @classmethod
+        def is_type_of(cls, obj, _info) -> bool:
+            return isinstance(obj, (cls, model))
+
         cls = dataclasses.make_dataclass(
             cls.__name__,
             sorted_fields,
             bases=cls.__bases__,
+            namespace={"is_type_of": is_type_of},
         )
 
         _process_type(

--- a/strawberry/experimental/pydantic/object_type.py
+++ b/strawberry/experimental/pydantic/object_type.py
@@ -7,6 +7,8 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple, Type, cast
 from pydantic import BaseModel
 from pydantic.fields import ModelField
 
+from graphql import GraphQLResolveInfo
+
 import strawberry
 from strawberry.arguments import UNSET
 from strawberry.experimental.pydantic.conversion import (
@@ -149,8 +151,8 @@ def type(
 
         # Implicitly define `is_type_of` to support interfaces/unions that use
         # pydantic objects (not the corresponding strawberry type)
-        @classmethod
-        def is_type_of(cls, obj, _info) -> bool:
+        @classmethod  # type: ignore
+        def is_type_of(cls: Type, obj: Any, _info: GraphQLResolveInfo) -> bool:
             return isinstance(obj, (cls, model))
 
         cls = dataclasses.make_dataclass(

--- a/strawberry/object_type.py
+++ b/strawberry/object_type.py
@@ -106,6 +106,7 @@ def _process_type(
 
     interfaces = _get_interfaces(cls)
     fields = _get_fields(cls)
+    is_type_of = getattr(cls, "is_type_of", None)
 
     cls._type_definition = TypeDefinition(
         name=name,
@@ -117,6 +118,7 @@ def _process_type(
         origin=cls,
         extend=extend,
         _fields=fields,
+        is_type_of=is_type_of,
     )
 
     # dataclasses removes attributes from the class here:

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -283,8 +283,10 @@ class GraphQLCoreConverter:
         if object_type.is_type_of:
             is_type_of = object_type.is_type_of
         elif object_type.interfaces:
+
             def is_type_of(obj: Any, _info: GraphQLResolveInfo) -> bool:
                 return isinstance(obj, object_type.origin)
+
         else:
             is_type_of = None
 

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -283,10 +283,8 @@ class GraphQLCoreConverter:
         if object_type.is_type_of:
             is_type_of = object_type.is_type_of
         elif object_type.interfaces:
-
             def is_type_of(obj: Any, _info: GraphQLResolveInfo) -> bool:
                 return isinstance(obj, object_type.origin)
-
         else:
             is_type_of = None
 

--- a/strawberry/types/types.py
+++ b/strawberry/types/types.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import dataclasses
 from typing import (
     TYPE_CHECKING,
+    Any,
+    Callable,
     List,
     Mapping,
     Optional,
@@ -17,6 +19,8 @@ from strawberry.utils.typing import is_generic as is_type_generic
 
 
 if TYPE_CHECKING:
+    from graphql import GraphQLResolveInfo
+
     from strawberry.field import StrawberryField
     from strawberry.schema_directive import StrawberrySchemaDirective
 
@@ -31,6 +35,7 @@ class TypeDefinition(StrawberryType):
     interfaces: List["TypeDefinition"]
     extend: bool
     directives: Optional[Sequence[StrawberrySchemaDirective]]
+    is_type_of: Optional[Callable[[Any, GraphQLResolveInfo], bool]]
 
     _fields: List["StrawberryField"]
 
@@ -85,6 +90,7 @@ class TypeDefinition(StrawberryType):
             interfaces=self.interfaces,
             description=self.description,
             extend=self.extend,
+            is_type_of=self.is_type_of,
             _fields=fields,
             concrete_of=self,
             type_var_map=type_var_map,

--- a/strawberry/union.py
+++ b/strawberry/union.py
@@ -139,9 +139,7 @@ class StrawberryUnion(StrawberryType):
             # defined on the union's inner types
             if not hasattr(root, "_type_definition"):
                 for inner_type in type_.types:
-                    if inner_type.is_type_of is None:
-                        break
-                    elif inner_type.is_type_of(root, info):
+                    if inner_type.is_type_of is not None and inner_type.is_type_of(root, info):
                         return inner_type.name
 
                 # Couldn't resolve using `is_type_of``

--- a/strawberry/union.py
+++ b/strawberry/union.py
@@ -135,9 +135,16 @@ class StrawberryUnion(StrawberryType):
 
             from strawberry.types.types import TypeDefinition
 
-            # Make sure that the type that's passed in is an Object type
+            # If the type given is not an Object type, try resolving using `is_type_of`
+            # defined on the union's inner types
             if not hasattr(root, "_type_definition"):
-                # TODO: If root=python dict, this won't work
+                for inner_type in type_.types:
+                    if inner_type.is_type_of is None:
+                        break
+                    elif inner_type.is_type_of(root, info):
+                        return inner_type.name
+
+                # Couldn't resolve using `is_type_of``
                 raise WrongReturnTypeForUnion(info.field_name, str(type(root)))
 
             return_type: Optional[GraphQLType]

--- a/strawberry/union.py
+++ b/strawberry/union.py
@@ -139,7 +139,9 @@ class StrawberryUnion(StrawberryType):
             # defined on the union's inner types
             if not hasattr(root, "_type_definition"):
                 for inner_type in type_.types:
-                    if inner_type.is_type_of is not None and inner_type.is_type_of(root, info):
+                    if inner_type.is_type_of is not None and inner_type.is_type_of(
+                        root, info
+                    ):
                         return inner_type.name
 
                 # Couldn't resolve using `is_type_of``

--- a/tests/experimental/pydantic/schema/test_basic.py
+++ b/tests/experimental/pydantic/schema/test_basic.py
@@ -352,6 +352,45 @@ def test_basic_type_with_union():
     assert result.data["user"]["unionField"]["fieldB"] == 10
 
 
+def test_basic_type_with_union_pydantic_types():
+    class BranchA(pydantic.BaseModel):
+        field_a: str
+
+    class BranchB(pydantic.BaseModel):
+        field_b: int
+
+    class User(pydantic.BaseModel):
+        union_field: Union[BranchA, BranchB]
+
+    @strawberry.experimental.pydantic.type(BranchA, fields=["field_a"])
+    class BranchAType:
+        pass
+
+    @strawberry.experimental.pydantic.type(BranchB, fields=["field_b"])
+    class BranchBType:
+        pass
+
+    @strawberry.experimental.pydantic.type(User, fields=["age", "union_field"])
+    class UserType:
+        pass
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def user(self) -> UserType:
+            # note that BranchB is a pydantic type, not a strawberry type
+            return UserType(union_field=BranchB(field_b=10))
+
+    schema = strawberry.Schema(query=Query)
+
+    query = "{ user { unionField { ... on BranchBType { fieldB } } } }"
+
+    result = schema.execute_sync(query)
+
+    assert not result.errors
+    assert result.data["user"]["unionField"]["fieldB"] == 10
+
+
 def test_basic_type_with_enum():
     @strawberry.enum
     class UserKind(Enum):

--- a/tests/schema/test_interface.py
+++ b/tests/schema/test_interface.py
@@ -107,6 +107,10 @@ def test_interface_duck_typing():
     class Anime(Entity):
         name: str
 
+        @classmethod
+        def is_type_of(cls, obj, _info) -> bool:
+            return isinstance(obj, AnimeORM)
+
     @dataclass
     class AnimeORM:
         id: int
@@ -130,7 +134,7 @@ def test_interface_duck_typing():
     assert result.data == {"anime": {"name": "One Piece"}}
 
 
-def test_interface_type_resolution():
+def test_interface_explicit_type_resolution():
     @dataclass
     class AnimeORM:
         id: int
@@ -154,14 +158,13 @@ def test_interface_type_resolution():
         def node(self) -> Node:
             return AnimeORM(id=1, name="One Piece")  # type: ignore
 
-    schema = strawberry.Schema(query=Query)
+    schema = strawberry.Schema(query=Query, types=[Anime])
 
     query = "{ node { __typename, id } }"
     result = schema.execute_sync(query)
 
     assert not result.errors
     assert result.data == {"node": {"__typename": "Anime", "id": 1}}
-    # errors with: "type object 'AnimeORM' has no attribute '_type_definition'"
 
 
 @pytest.mark.xfail(reason="We don't support returning dictionaries yet")


### PR DESCRIPTION
## Description

The behavioral changes included in this PR are:
a) duck typing on fields that return interfaces or types implementing an interface now requires an explicit `is_type_of` opt-in
b) adding an explicit `is_type_of` opt-in is now implemented with a `is_type_of` classmethod

This seems like it might require a change to the documentation mentioning the classmethod, which I can make assuming this approach looks good.

Also, what release type should this be? Technically it is a breaking change, though it's quite minor.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/strawberry-graphql/strawberry/issues/1405

## Checklist

I did dev work within a codespace based on your template (which was very convenient), so at the very least all the pre-commit scripts ran correctly. I also ran the test suite, which passes.

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
