### PR TITLE
Fix federation support under mypy

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+This release fixes our MyPy plugin and re-adds support
+for typechecking classes created with the apollo federation decorator.

--- a/strawberry/ext/mypy_plugin.py
+++ b/strawberry/ext/mypy_plugin.py
@@ -693,6 +693,7 @@ class StrawberryPlugin(Plugin):
             for strawberry_decorator in {
                 "strawberry.object_type.type",
                 "strawberry.federation.type",
+                "strawberry.federation.object_type.type",
                 "strawberry.schema_directive.schema_directive",
                 "strawberry.object_type.input",
                 "strawberry.object_type.interface",

--- a/tests/mypy/test_decorators.yml
+++ b/tests/mypy/test_decorators.yml
@@ -36,3 +36,29 @@
     NameInterface(n="Patrick")
   out: |
     main:8: error: Unexpected keyword argument "n" for "NameInterface"
+
+- case: test_federation_type
+  main: |
+    import strawberry
+
+    @strawberry.federation.type
+    class User:
+        name: str
+
+    User(name="Patrick")
+    User(n="Patrick")
+  out: |
+    main:8: error: Unexpected keyword argument "n" for "User"
+
+- case: test_federation_input
+  main: |
+    import strawberry
+
+    @strawberry.input
+    class EditUserInput:
+        name: str
+
+    EditUserInput(name="Patrick")
+    EditUserInput(n="Patrick")
+  out: |
+    main:8: error: Unexpected keyword argument "n" for "EditUserInput"


### PR DESCRIPTION
This PR adds a missing path for mypy that prevented type checking from
working when using the federation decorator
