### PR TITLE
Allow using a static method as a resolver

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
 Release type: patch
 
-Allow using staticmethods and classmethods as resolvers
+This release fixes an issue that prevented using classmethod and staticmethods as resolvers
 
 ```python
 import strawberry

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,6 @@
 Release type: patch
 
-Allow using a static method as a resolver when the `self` argument is not
-needed.
+Allow using a staticmethods and classmethods as resolvers
 
 ```python
 import strawberry
@@ -12,4 +11,9 @@ class Query:
     @staticmethod
     def static_text() -> str:
         return "Strawberry"
+
+    @strawberry.field
+    @classmethod
+    def class_name(cls) -> str:
+        return cls.__name__
 ```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,15 @@
+Release type: patch
+
+Allow using a static method as a resolver when the `self` argument is not
+needed.
+
+```python
+import strawberry
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    @staticmethod
+    def static_text() -> str:
+        return "Strawberry"
+```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
 Release type: patch
 
-This release fixes an issue that prevented using classmethod and staticmethods as resolvers
+This release fixes an issue that prevented using `classmethod`s and `staticmethod`s as resolvers
 
 ```python
 import strawberry

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
 Release type: patch
 
-Allow using a staticmethods and classmethods as resolvers
+Allow using staticmethods and classmethods as resolvers
 
 ```python
 import strawberry

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
     from .object_type import TypeDefinition
 
 
-_RESOLVER_TYPE = Union[StrawberryResolver, Callable]
+_RESOLVER_TYPE = Union[StrawberryResolver, Callable, staticmethod]
 
 
 class StrawberryField(dataclasses.Field):

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
     from .object_type import TypeDefinition
 
 
-_RESOLVER_TYPE = Union[StrawberryResolver, Callable, staticmethod]
+_RESOLVER_TYPE = Union[StrawberryResolver, Callable, staticmethod, classmethod]
 
 
 class StrawberryField(dataclasses.Field):
@@ -48,7 +48,7 @@ class StrawberryField(dataclasses.Field):
         python_name: Optional[str] = None,
         graphql_name: Optional[str] = None,
         type_annotation: Optional[StrawberryAnnotation] = None,
-        origin: Optional[Union[Type, Callable]] = None,
+        origin: Optional[Union[Type, Callable, staticmethod, classmethod]] = None,
         is_subscription: bool = False,
         description: Optional[str] = None,
         base_resolver: Optional[StrawberryResolver] = None,
@@ -91,7 +91,7 @@ class StrawberryField(dataclasses.Field):
         self.type_annotation = type_annotation
 
         self.description: Optional[str] = description
-        self.origin: Optional[Union[Type, Callable]] = origin
+        self.origin = origin
 
         self._base_resolver: Optional[StrawberryResolver] = None
         if base_resolver is not None:

--- a/strawberry/object_type.py
+++ b/strawberry/object_type.py
@@ -127,12 +127,18 @@ def _process_type(
     for field_ in fields:
         if field_.base_resolver and field_.python_name:
             wrapped_func = field_.base_resolver.wrapped_func
+
+            # Bind the functions to the class object. This is necessary because when
+            # the @strawberry.field decorator is used on @staticmethod/@classmethods,
+            # we get the raw staticmethod/classmethod objects before class evaluation
+            # binds them to the class. We need to do this manually.
             if isinstance(wrapped_func, staticmethod):
                 bound_method = wrapped_func.__get__(cls)
                 field_.base_resolver.wrapped_func = bound_method
             elif isinstance(wrapped_func, classmethod):
                 bound_method = types.MethodType(wrapped_func.__func__, cls)
                 field_.base_resolver.wrapped_func = bound_method
+
             setattr(cls, field_.python_name, wrapped_func)
 
     return cls

--- a/strawberry/object_type.py
+++ b/strawberry/object_type.py
@@ -1,5 +1,6 @@
 import dataclasses
 import inspect
+import types
 from typing import Callable, List, Optional, Sequence, Type, TypeVar, cast, overload
 
 from strawberry.schema_directive import StrawberrySchemaDirective
@@ -123,10 +124,16 @@ def _process_type(
     # https://github.com/python/cpython/blob/577d7c4e/Lib/dataclasses.py#L873-L880
     # so we need to restore them, this will change in future, but for now this
     # solution should suffice
-
     for field_ in fields:
         if field_.base_resolver and field_.python_name:
-            setattr(cls, field_.python_name, field_.base_resolver.wrapped_func)
+            wrapped_func = field_.base_resolver.wrapped_func
+            if isinstance(wrapped_func, staticmethod):
+                bound_method = wrapped_func.__get__(cls)
+                field_.base_resolver.wrapped_func = bound_method
+            elif isinstance(wrapped_func, classmethod):
+                bound_method = types.MethodType(wrapped_func.__func__, cls)
+                field_.base_resolver.wrapped_func = bound_method
+            setattr(cls, field_.python_name, wrapped_func)
 
     return cls
 

--- a/strawberry/types/fields/resolver.py
+++ b/strawberry/types/fields/resolver.py
@@ -21,12 +21,12 @@ T = TypeVar("T")
 class StrawberryResolver(Generic[T]):
     def __init__(
         self,
-        func: Callable[..., T],
+        func: Union[Callable[..., T], staticmethod],
         *,
         description: Optional[str] = None,
         type_override: Optional[Union[StrawberryType, type]] = None,
     ):
-        self.wrapped_func = func
+        self.wrapped_func = func.__func__ if isinstance(func, staticmethod) else func
         self._description = description
         self._type_override = type_override
         """Specify the type manually instead of calculating from wrapped func

--- a/strawberry/types/fields/resolver.py
+++ b/strawberry/types/fields/resolver.py
@@ -47,8 +47,7 @@ class StrawberryResolver(Generic[T]):
     def annotations(self) -> Dict[str, object]:
         """Annotations for the resolver.
 
-        Does not include special args defined in _SPECIAL_ARGS (e.g. self, root, and
-        info).
+        Does not include special args defined in _SPECIAL_ARGS (e.g. self, root, info)
         """
         annotations = self._unbound_wrapped_func.__annotations__
 
@@ -123,7 +122,6 @@ class StrawberryResolver(Generic[T]):
             # No return annotation at all (as opposed to `-> None`)
             return None
 
-        # TODO: PyCharm doesn't like this. Says `() -> ...` has no __module__ attribute
         module = sys.modules[self._module]
         type_annotation = StrawberryAnnotation(
             annotation=return_annotation, namespace=module.__dict__

--- a/strawberry/types/fields/resolver.py
+++ b/strawberry/types/fields/resolver.py
@@ -1,10 +1,10 @@
-from __future__ import annotations
+from __future__ import annotations as _
 
 import builtins
 import inspect
 import sys
 from inspect import isasyncgenfunction, iscoroutinefunction
-from typing import Callable, Generic, List, Mapping, Optional, TypeVar, Union
+from typing import Callable, Dict, Generic, List, Mapping, Optional, TypeVar, Union
 
 from cached_property import cached_property  # type: ignore
 
@@ -19,14 +19,17 @@ T = TypeVar("T")
 
 
 class StrawberryResolver(Generic[T]):
+    # TODO: Move to StrawberryArgument? StrawberryResolver ClassVar?
+    _SPECIAL_ARGS = {"root", "info", "self", "cls"}
+
     def __init__(
         self,
-        func: Union[Callable[..., T], staticmethod],
+        func: Callable[..., T],
         *,
         description: Optional[str] = None,
         type_override: Optional[Union[StrawberryType, type]] = None,
     ):
-        self.wrapped_func = func.__func__ if isinstance(func, staticmethod) else func
+        self.wrapped_func = func
         self._description = description
         self._type_override = type_override
         """Specify the type manually instead of calculating from wrapped func
@@ -34,38 +37,49 @@ class StrawberryResolver(Generic[T]):
         This is used when creating copies of types w/ generics
         """
 
+        self._is_bound = False
+
     # TODO: Use this when doing the actual resolving? How to deal with async resolvers?
     def __call__(self, *args, **kwargs) -> T:
         return self.wrapped_func(*args, **kwargs)
 
     @cached_property
-    def arguments(self) -> List[StrawberryArgument]:
-        # TODO: Move to StrawberryArgument? StrawberryResolver ClassVar?
-        SPECIAL_ARGS = {"root", "self", "info"}
+    def annotations(self) -> Dict[str, object]:
+        """Annotations for the resolver.
 
-        annotations = self.wrapped_func.__annotations__
-        parameters = inspect.signature(self.wrapped_func).parameters
-        function_arguments = set(parameters) - SPECIAL_ARGS
+        Does not include special args defined in _SPECIAL_ARGS (e.g. self, root, and
+        info).
+        """
+        annotations = self._unbound_wrapped_func.__annotations__
 
         annotations = {
             name: annotation
             for name, annotation in annotations.items()
-            if name not in (SPECIAL_ARGS | {"return"})
+            if name not in self._SPECIAL_ARGS
         }
 
-        annotated_arguments = set(annotations)
-        arguments_missing_annotations = function_arguments - annotated_arguments
+        return annotations
+
+    @cached_property
+    def arguments(self) -> List[StrawberryArgument]:
+        parameters = inspect.signature(self._unbound_wrapped_func).parameters
+        function_arguments = set(parameters) - self._SPECIAL_ARGS
+
+        arguments = self.annotations.copy()
+        arguments.pop("return", None)  # Discard return annotation to get just arguments
+
+        arguments_missing_annotations = function_arguments - set(arguments)
 
         if any(arguments_missing_annotations):
             raise MissingArgumentsAnnotationsError(
-                field_name=self.wrapped_func.__name__,
+                field_name=self.name,
                 arguments=arguments_missing_annotations,
             )
 
-        module = sys.modules[self.wrapped_func.__module__]
+        module = sys.modules[self._module]
         annotation_namespace = module.__dict__
-        arguments = []
-        for arg_name, annotation in annotations.items():
+        strawberry_arguments = []
+        for arg_name, annotation in arguments.items():
             parameter = parameters[arg_name]
 
             argument = StrawberryArgument(
@@ -77,40 +91,40 @@ class StrawberryResolver(Generic[T]):
                 default=parameter.default,
             )
 
-            arguments.append(argument)
+            strawberry_arguments.append(argument)
 
-        return arguments
+        return strawberry_arguments
 
     @cached_property
     def has_info_arg(self) -> bool:
-        args = get_func_args(self.wrapped_func)
+        args = get_func_args(self._unbound_wrapped_func)
         return "info" in args
 
     @cached_property
     def has_root_arg(self) -> bool:
-        args = get_func_args(self.wrapped_func)
+        args = get_func_args(self._unbound_wrapped_func)
         return "root" in args
 
     @cached_property
     def has_self_arg(self) -> bool:
-        args = get_func_args(self.wrapped_func)
+        args = get_func_args(self._unbound_wrapped_func)
         return args and args[0] == "self"
 
     @cached_property
     def name(self) -> str:
         # TODO: What to do if resolver is a lambda?
-        return self.wrapped_func.__name__
+        return self._unbound_wrapped_func.__name__
 
     @cached_property
     def type_annotation(self) -> Optional[StrawberryAnnotation]:
         try:
-            return_annotation = self.wrapped_func.__annotations__["return"]
+            return_annotation = self.annotations["return"]
         except KeyError:
             # No return annotation at all (as opposed to `-> None`)
             return None
 
         # TODO: PyCharm doesn't like this. Says `() -> ...` has no __module__ attribute
-        module = sys.modules[self.wrapped_func.__module__]
+        module = sys.modules[self._module]
         type_annotation = StrawberryAnnotation(
             annotation=return_annotation, namespace=module.__dict__
         )
@@ -127,8 +141,8 @@ class StrawberryResolver(Generic[T]):
 
     @cached_property
     def is_async(self) -> bool:
-        return iscoroutinefunction(self.wrapped_func) or isasyncgenfunction(
-            self.wrapped_func
+        return iscoroutinefunction(self._unbound_wrapped_func) or isasyncgenfunction(
+            self._unbound_wrapped_func
         )
 
     def copy_with(
@@ -149,6 +163,17 @@ class StrawberryResolver(Generic[T]):
             description=self._description,
             type_override=type_override,
         )
+
+    @cached_property
+    def _module(self) -> str:
+        return self._unbound_wrapped_func.__module__
+
+    @cached_property
+    def _unbound_wrapped_func(self) -> Callable[..., T]:
+        if isinstance(self.wrapped_func, (staticmethod, classmethod)):
+            return self.wrapped_func.__func__
+
+        return self.wrapped_func
 
 
 __all__ = ["StrawberryResolver"]

--- a/tests/fields/test_resolvers.py
+++ b/tests/fields/test_resolvers.py
@@ -47,6 +47,25 @@ def test_resolver_fields():
     assert definition.fields[0].base_resolver(None) == Query().name()
 
 
+def test_staticmethod_resolver_fields():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        @staticmethod
+        def name() -> str:
+            return "Name"
+
+    definition = Query._type_definition
+
+    assert definition.name == "Query"
+    assert len(definition.fields) == 1
+
+    assert definition.fields[0].python_name == "name"
+    assert definition.fields[0].graphql_name is None
+    assert definition.fields[0].type == str
+    assert definition.fields[0].base_resolver(None) == Query().name()
+
+
 def test_raises_error_when_return_annotation_missing():
     with pytest.raises(MissingReturnAnnotationError) as e:
 

--- a/tests/fields/test_resolvers.py
+++ b/tests/fields/test_resolvers.py
@@ -180,17 +180,17 @@ def test_raises_error_when_missing_type():
 
 
 def test_raises_error_calling_uncallable_resolver():
-    @staticmethod
-    def static_func() -> int:
+    @classmethod
+    def class_func(cls) -> int:
         ...
 
-    # Note that static_func is a raw staticmethod object because it has not been bound
+    # Note that static_func is a raw classmethod object because it has not been bound
     # to a class at this point
-    resolver = StrawberryResolver(static_func)
+    resolver = StrawberryResolver(class_func)
 
     expected_error_message = (
         f"Attempted to call resolver {resolver} with uncallable function "
-        f"{static_func}"
+        f"{class_func}"
     )
 
     with pytest.raises(UncallableResolverError, match=expected_error_message):

--- a/tests/fields/test_resolvers.py
+++ b/tests/fields/test_resolvers.py
@@ -1,4 +1,5 @@
 import dataclasses
+from typing import ClassVar
 
 import pytest
 
@@ -63,7 +64,34 @@ def test_staticmethod_resolver_fields():
     assert definition.fields[0].python_name == "name"
     assert definition.fields[0].graphql_name is None
     assert definition.fields[0].type == str
-    assert definition.fields[0].base_resolver(None) == Query().name()
+    assert definition.fields[0].base_resolver() == Query.name()
+
+    assert Query.name() == "Name"
+    assert Query().name() == "Name"
+
+
+def test_classmethod_resolver_fields():
+    @strawberry.type
+    class Query:
+        my_val: ClassVar[str] = "thingy"
+
+        @strawberry.field
+        @classmethod
+        def val(cls) -> str:
+            return cls.my_val
+
+    definition = Query._type_definition
+
+    assert definition.name == "Query"
+    assert len(definition.fields) == 1
+
+    assert definition.fields[0].python_name == "val"
+    assert definition.fields[0].graphql_name is None
+    assert definition.fields[0].type == str
+    assert definition.fields[0].base_resolver() == Query.val()
+
+    assert Query.val() == "thingy"
+    assert Query().val() == "thingy"
 
 
 def test_raises_error_when_return_annotation_missing():

--- a/tests/fields/test_resolvers.py
+++ b/tests/fields/test_resolvers.py
@@ -184,6 +184,8 @@ def test_raises_error_calling_uncallable_resolver():
     def static_func() -> int:
         ...
 
+    # Note that static_func is a raw staticmethod object because it has not been bound
+    # to a class at this point
     resolver = StrawberryResolver(static_func)
 
     expected_error_message = (

--- a/tests/fields/test_resolvers.py
+++ b/tests/fields/test_resolvers.py
@@ -1,4 +1,5 @@
 import dataclasses
+import re
 from typing import ClassVar
 
 import pytest
@@ -188,7 +189,7 @@ def test_raises_error_calling_uncallable_resolver():
     # to a class at this point
     resolver = StrawberryResolver(class_func)
 
-    expected_error_message = (
+    expected_error_message = re.escape(
         f"Attempted to call resolver {resolver} with uncallable function "
         f"{class_func}"
     )

--- a/tests/fields/test_resolvers.py
+++ b/tests/fields/test_resolvers.py
@@ -185,7 +185,7 @@ def test_raises_error_calling_uncallable_resolver():
     def class_func(cls) -> int:
         ...
 
-    # Note that static_func is a raw classmethod object because it has not been bound
+    # Note that class_func is a raw classmethod object because it has not been bound
     # to a class at this point
     resolver = StrawberryResolver(class_func)
 

--- a/tests/fields/test_resolvers.py
+++ b/tests/fields/test_resolvers.py
@@ -9,6 +9,7 @@ from strawberry.exceptions import (
     MissingFieldAnnotationError,
     MissingReturnAnnotationError,
 )
+from strawberry.types.fields.resolver import StrawberryResolver, UncallableResolverError
 
 
 def test_resolver_as_argument():
@@ -176,6 +177,22 @@ def test_raises_error_when_missing_type():
         'Unable to determine the type of field "missing". Either annotate it '
         "directly, or provide a typed resolver using @strawberry.field."
     )
+
+
+def test_raises_error_calling_uncallable_resolver():
+    @staticmethod
+    def static_func() -> int:
+        ...
+
+    resolver = StrawberryResolver(static_func)
+
+    expected_error_message = (
+        f"Attempted to call resolver {resolver} with uncallable function "
+        f"{static_func}"
+    )
+
+    with pytest.raises(UncallableResolverError, match=expected_error_message):
+        resolver()
 
 
 def test_can_reuse_resolver():

--- a/tests/schema/test_resolvers.py
+++ b/tests/schema/test_resolvers.py
@@ -202,7 +202,7 @@ def test_only_info_function_resolvers():
     assert result.data["helloWithParams"] == "I'm abc for helloWithParams"
 
 
-def test_classmethods_resolvers():
+def test_classmethod_resolvers():
     global User
 
     @strawberry.type
@@ -228,6 +228,26 @@ def test_classmethods_resolvers():
     assert result.data == {"users": [{"name": "Bob"}, {"name": "Nancy"}]}
 
     del User
+
+
+def test_staticmethod_resolvers():
+    class Alphabet:
+        @staticmethod
+        def get_letters() -> List[str]:
+            return ["a", "b", "c"]
+
+    @strawberry.type
+    class Query:
+        letters: List[str] = strawberry.field(resolver=Alphabet.get_letters)
+
+    schema = strawberry.Schema(query=Query)
+
+    query = "{ letters }"
+
+    result = schema.execute_sync(query)
+
+    assert not result.errors
+    assert result.data == {"letters": ["a", "b", "c"]}
 
 
 def test_lambda_resolvers():

--- a/tests/schema/test_resolvers.py
+++ b/tests/schema/test_resolvers.py
@@ -142,11 +142,6 @@ def test_optional_info_and_root_params():
     @strawberry.type
     class Query:
         @strawberry.field
-        @staticmethod
-        def hi() -> str:
-            return "Hi"
-
-        @strawberry.field
         def hello(self) -> str:
             return "I'm a function resolver"
 
@@ -164,7 +159,6 @@ def test_optional_info_and_root_params():
     schema = strawberry.Schema(query=Query)
 
     query = """{
-        hi
         hello
         helloWithParams(x: "abc")
         usesSelf
@@ -173,7 +167,6 @@ def test_optional_info_and_root_params():
     result = schema.execute_sync(query, root_value=Query())
 
     assert not result.errors
-    assert result.data["hi"] == "Hi"
     assert result.data["hello"] == "I'm a function resolver"
     assert result.data["helloWithParams"] == "I'm abc"
     assert result.data["usesSelf"] == "I'm self"

--- a/tests/schema/test_resolvers.py
+++ b/tests/schema/test_resolvers.py
@@ -142,6 +142,11 @@ def test_optional_info_and_root_params():
     @strawberry.type
     class Query:
         @strawberry.field
+        @staticmethod
+        def hi() -> str:
+            return "Hi"
+
+        @strawberry.field
         def hello(self) -> str:
             return "I'm a function resolver"
 
@@ -159,6 +164,7 @@ def test_optional_info_and_root_params():
     schema = strawberry.Schema(query=Query)
 
     query = """{
+        hi
         hello
         helloWithParams(x: "abc")
         usesSelf
@@ -167,6 +173,7 @@ def test_optional_info_and_root_params():
     result = schema.execute_sync(query, root_value=Query())
 
     assert not result.errors
+    assert result.data["hi"] == "Hi"
     assert result.data["hello"] == "I'm a function resolver"
     assert result.data["helloWithParams"] == "I'm abc"
     assert result.data["usesSelf"] == "I'm self"


### PR DESCRIPTION
## Description

In a project I had to define a resolver that gets some data from the root argument.
It was not possible to use `self` because of some mypy warnings. Therefore, I wanted to remove the `self` argument.
It was possible to remove it without using `@staticmethod`, but mypy complained that `Self argument missing for a non-static method (or an invalid type for self)`.

So, I had to add `@staticmethod`.
I tried adding it before `@strawberry.field`, but Python did not add the field to `__dataclass_fields__` and a type was not created correctly.
Then, I tried adding it after `@strawberry.field`, but Strawberry did not like that because `AttributeError: 'staticmethod' object has no attribute '__annotations__'`. The changes fix this problem.



## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
