### PR TITLE
Fix name generation of generics when passing generics with args

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,16 @@
+Release type: patch
+
+This release fixes the naming generation of generics when
+passing a generic type to another generic, like so:
+
+```python
+@strawberry.type
+class Edge(Generic[T]):
+    node: T
+
+@strawberry.type
+class Connection(Generic[T]):
+    edges: List[T]
+
+Connection[Edge[int]]
+```

--- a/strawberry/schema/name_converter.py
+++ b/strawberry/schema/name_converter.py
@@ -110,9 +110,6 @@ class NameConverter:
             name = self.get_from_type(type_)
             names.append(name)
 
-        # we want to generate types from inside out, for example
-        # getting `ValueOptionalListStr` from `Value[Optional[List[str]]]`
-        # so we reverse the list of names, since it goes outside in
         return "".join(names) + generic_type_name
 
     def get_from_type(self, type_: Union[StrawberryType, type]) -> str:
@@ -138,7 +135,11 @@ class NameConverter:
         elif hasattr(type_, "_type_definition"):
             strawberry_type = type_._type_definition  # type: ignore
 
-            name = strawberry_type.name
+            if strawberry_type.is_generic:
+                types = type_.__args__  # type: ignore
+                name = self.from_generic(strawberry_type, types)
+            else:
+                name = strawberry_type.name
         else:
             name = type_.__name__  # type: ignore
 

--- a/tests/objects/generics/test_names.py
+++ b/tests/objects/generics/test_names.py
@@ -1,4 +1,4 @@
-from typing import Generic, NewType, TypeVar
+from typing import Generic, List, NewType, TypeVar
 
 import pytest
 
@@ -52,3 +52,27 @@ def test_name_generation(types, expected_name):
     type_definition = Example._type_definition  # type: ignore
 
     assert config.name_converter.from_generic(type_definition, types) == expected_name
+
+
+def test_nested_generics():
+    config = StrawberryConfig()
+
+    @strawberry.type
+    class Edge(Generic[T]):
+        node: T
+
+    @strawberry.type
+    class Connection(Generic[T]):
+        edges: List[T]
+
+    type_definition = Connection._type_definition  # type: ignore
+
+    assert (
+        config.name_converter.from_generic(
+            type_definition,
+            [
+                Edge[int],
+            ],
+        )
+        == "IntEdgeConnection"
+    )


### PR DESCRIPTION
This PR fixes an issue found by @AndrewIngram and shown here:

https://la4de.github.io/strawberry-playground/#UEsDBAoAAAAAAGKOdlM9+3KddgMAAHYDAAAJAAAAc2NoZW1hLnB5ZnJvbSB0eXBpbmcgaW1wb3J0IEdlbmVyaWMsIExpc3QsIFR5cGVWYXIsIE9wdGlvbmFsCgppbXBvcnQgc3RyYXdiZXJyeQoKTm9kZVR5cGUgPSBUeXBlVmFyKCJOb2RlVHlwZSIpCkVkZ2VUeXBlID0gVHlwZVZhcihuYW1lPSJFZGdlVHlwZSIpCgoKQHN0cmF3YmVycnkudHlwZQpjbGFzcyBQYWdlSW5mbzoKICAgIGhhc19uZXh0X3BhZ2U6IGJvb2wKICAgIGhhc19wcmV2aW91c19wYWdlOiBib29sCiAgICBzdGFydF9jdXJzb3I6IE9wdGlvbmFsW3N0cl0KICAgIGVuZF9jdXJzb3I6IE9wdGlvbmFsW3N0cl0KCgpAc3RyYXdiZXJyeS50eXBlCmNsYXNzIEVkZ2UoR2VuZXJpY1tOb2RlVHlwZV0pOgogICAgbm9kZTogTm9kZVR5cGUKICAgIGN1cnNvcjogc3RyCgoKQHN0cmF3YmVycnkudHlwZQpjbGFzcyBDb25uZWN0aW9uKEdlbmVyaWNbRWRnZVR5cGVdKToKICAgIGVkZ2VzOiBMaXN0W0VkZ2VUeXBlXQogICAgcGFnZV9pbmZvOiBQYWdlSW5mbwogICAgCgpAc3RyYXdiZXJyeS50eXBlCmNsYXNzIFVzZXI6CiAgICBuYW1lOiBzdHIKICAgIGFnZTogaW50CgpAc3RyYXdiZXJyeS50eXBlCmNsYXNzIFF1ZXJ5OgogICAgQHN0cmF3YmVycnkuZmllbGQKICAgIGRlZiBhbGxfdXNlcnMoc2VsZiwgZmlyc3Q6IE9wdGlvbmFsW2ludF0sIGxhc3Q6IE9wdGlvbmFsW2ludF0sIGFmdGVyOiBPcHRpb25hbFtzdHJdLCBiZWZvcmU6IE9wdGlvbmFsW3N0cl0pIC0+IENvbm5lY3Rpb25bRWRnZVtVc2VyXV06CiAgICAgICAgcGFzcwogICAgCiAgICBAc3RyYXdiZXJyeS5maWVsZAogICAgZGVmIHVzZXIoc2VsZikgLT4gVXNlcjoKICAgICAgICByZXR1cm4gVXNlcihuYW1lPSJQYXRyaWNrIiwgYWdlPTEwMCkKCnNjaGVtYSA9IHN0cmF3YmVycnkuU2NoZW1hKHF1ZXJ5PVF1ZXJ5KVBLAwQKAAAAAABijnZTbsyYDSEAAAAhAAAACQAAAHF1ZXJ5LmdxbHsKICB1c2VyIHsKICAgIG5hbWUKICAgIGFnZQogIH0KfVBLAwQKAAAAAABijnZTqLu+cwMAAAADAAAADgAAAHZhcmlhYmxlcy5qc29uewp9UEsBAhQACgAAAAAAYo52Uz37cp12AwAAdgMAAAkAAAAAAAAAAAAAAAAAAAAAAHNjaGVtYS5weVBLAQIUAAoAAAAAAGKOdlNuzJgNIQAAACEAAAAJAAAAAAAAAAAAAAAAAJ0DAABxdWVyeS5ncWxQSwECFAAKAAAAAABijnZTqLu+cwMAAAADAAAADgAAAAAAAAAAAAAAAADlAwAAdmFyaWFibGVzLmpzb25QSwUGAAAAAAMAAwCqAAAAFAQAAAAA

