### PR TITLE
Improve type checker support for return value for strawberry.union

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,18 @@
+Release type: minor
+
+This release improves type checking support for `strawberry.union` and now allows
+to use unions without any type issues, like so:
+
+```python
+@strawberry.type
+class User:
+    name: str
+
+@strawberry.type
+class Error:
+    message: str
+
+UserOrError = strawberry.union("UserOrError", (User, Error))
+
+x: UserOrError = User(name="Patrick")
+```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,7 @@
 Release type: minor
 
 This release improves type checking support for `strawberry.union` and now allows
-to use unions without any type issues, like so:
+to use unions without any type issue, like so:
 
 ```python
 @strawberry.type

--- a/strawberry/union.py
+++ b/strawberry/union.py
@@ -174,6 +174,11 @@ class StrawberryUnion(StrawberryType):
 Types = TypeVar("Types", bound=Type)
 
 
+# We return a Union type here in order to allow to use the union type as type
+# annotation.
+# For the `types` argument we'd ideally use a TypeVarTuple, but that's not
+# yet supported in any python implementation (or in typing_extensions).
+# See https://www.python.org/dev/peps/pep-0646/ for more information
 def union(
     name: str, types: Tuple[Types, ...], *, description: str = None
 ) -> Union[Types]:  # type: ignore

--- a/strawberry/union.py
+++ b/strawberry/union.py
@@ -171,9 +171,12 @@ class StrawberryUnion(StrawberryType):
         return _resolve_union_type
 
 
+Types = TypeVar("Types", bound=Type)
+
+
 def union(
-    name: str, types: Tuple[Type, ...], *, description: str = None
-) -> StrawberryUnion:
+    name: str, types: Tuple[Types, ...], *, description: str = None
+) -> Union[Types]:  # type: ignore
     """Creates a new named Union type.
 
     Example usages:
@@ -201,4 +204,4 @@ def union(
         description=description,
     )
 
-    return union_definition
+    return union_definition  # type: ignore

--- a/tests/pyright/test_union.py
+++ b/tests/pyright/test_union.py
@@ -1,0 +1,41 @@
+from .utils import Result, requires_pyright, run_pyright, skip_on_windows
+
+
+pytestmark = [skip_on_windows, requires_pyright]
+
+
+CODE = """
+import strawberry
+
+
+@strawberry.type
+class User:
+    name: str
+
+
+@strawberry.type
+class Error:
+    message: str
+
+UserOrError = strawberry.union("UserOrError", (User, Error))
+
+reveal_type(UserOrError)
+
+x: UserOrError = User(name="Patrick")
+
+reveal_type(x)
+"""
+
+
+def test_pyright():
+    results = run_pyright(CODE)
+
+    assert results == [
+        Result(
+            type="info",
+            message='Type of "UserOrError" is "Type[User] | Type[Error]"',
+            line=16,
+            column=13,
+        ),
+        Result(type="info", message='Type of "x" is "User"', line=20, column=13),
+    ]


### PR DESCRIPTION
This PR improves support of strawberry.union types for type checkers. It basically tells we are returning a Union type :)

~~I need to check if this works on MyPy, as I only tested Pyright at the moment :)~~

We have a plugin for MyPy so we are good :)