### PR TITLE
Fix init of Strawberry types from pydantic

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Fix init of Strawberry types from pydantic by skipping fields that have resolvers.

--- a/strawberry/experimental/pydantic/conversion.py
+++ b/strawberry/experimental/pydantic/conversion.py
@@ -66,8 +66,9 @@ def convert_pydantic_model_to_strawberry_class(cls, *, model_instance=None, extr
         data_from_model = (
             getattr(model_instance, python_name, None) if model_instance else None
         )
-        kwargs[python_name] = _convert_from_pydantic_to_strawberry_type(
-            field.type, data_from_model, extra=data_from_extra
-        )
+        if field.init:
+            kwargs[python_name] = _convert_from_pydantic_to_strawberry_type(
+                field.type, data_from_model, extra=data_from_extra
+            )
 
     return cls(**kwargs)

--- a/strawberry/experimental/pydantic/conversion.py
+++ b/strawberry/experimental/pydantic/conversion.py
@@ -66,6 +66,9 @@ def convert_pydantic_model_to_strawberry_class(cls, *, model_instance=None, extr
         data_from_model = (
             getattr(model_instance, python_name, None) if model_instance else None
         )
+
+        # only convert and add fields to kwargs if they are present in the `__init__`
+        # method of the class
         if field.init:
             kwargs[python_name] = _convert_from_pydantic_to_strawberry_type(
                 field.type, data_from_model, extra=data_from_extra

--- a/tests/experimental/pydantic/test_conversion.py
+++ b/tests/experimental/pydantic/test_conversion.py
@@ -650,3 +650,21 @@ def test_can_convert_input_types_to_pydantic_default_values():
 
     assert user.age == 1
     assert user.password is None
+
+
+def test_can_convert_pydantic_type_to_strawberry_with_additional_field_resolvers():
+    class UserModel(pydantic.BaseModel):
+        password: Optional[str]
+
+    @strawberry.experimental.pydantic.type(UserModel)
+    class User:
+        password: strawberry.auto
+
+        @strawberry.field
+        def age() -> int:
+            return 42
+
+    origin_user = UserModel(password="abc")
+    user = User.from_pydantic(origin_user)
+    assert user.password == "abc"
+    assert User._type_definition.fields[0].base_resolver() == 42

--- a/tests/experimental/pydantic/test_conversion.py
+++ b/tests/experimental/pydantic/test_conversion.py
@@ -653,18 +653,24 @@ def test_can_convert_input_types_to_pydantic_default_values():
 
 
 def test_can_convert_pydantic_type_to_strawberry_with_additional_field_resolvers():
+    def some_resolver() -> int:
+        return 84
+
     class UserModel(pydantic.BaseModel):
         password: Optional[str]
+        new_age: int
 
     @strawberry.experimental.pydantic.type(UserModel)
     class User:
         password: strawberry.auto
+        new_age: int = strawberry.field(resolver=some_resolver)
 
         @strawberry.field
         def age() -> int:
             return 42
 
-    origin_user = UserModel(password="abc")
+    origin_user = UserModel(password="abc", new_age=21)
     user = User.from_pydantic(origin_user)
     assert user.password == "abc"
-    assert User._type_definition.fields[0].base_resolver() == 42
+    assert User._type_definition.fields[0].base_resolver() == 84
+    assert User._type_definition.fields[1].base_resolver() == 42


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

`from_pydantic` fails if additional fields with resolvers are added. This is fixed by checking if a field should be init'ed.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*  Fixes #1450
* Fixes #1446

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
