### PR TITLE
Add support for | to StrawberryUnion

### DIFF
--- a/strawberry/annotation.py
+++ b/strawberry/annotation.py
@@ -50,6 +50,9 @@ class StrawberryAnnotation:
 
         return self.resolve() == other.resolve()
 
+    def __hash__(self) -> int:
+        return hash(self.annotation)
+
     def resolve(self) -> Union[StrawberryType, type]:
         annotation: object
         if isinstance(self.annotation, str):

--- a/strawberry/union.py
+++ b/strawberry/union.py
@@ -28,7 +28,7 @@ from strawberry.exceptions import (
     UnallowedReturnTypeForUnion,
     WrongReturnTypeForUnion,
 )
-from strawberry.type import StrawberryType
+from strawberry.type import StrawberryOptional, StrawberryType
 
 
 if TYPE_CHECKING:
@@ -62,6 +62,14 @@ class StrawberryUnion(StrawberryType):
     def __hash__(self) -> int:
         # TODO: Is this a bad idea? __eq__ objects are supposed to have the same hash
         return id(self)
+
+    def __or__(self, other: Union[StrawberryType, type]) -> StrawberryType:
+        # TODO: shall we add support to merge unions with other unions?
+        # TODO: shall we add support to merge unions with other types?]
+        # current use case is to allow SomeUnion | None, as a nicer way to
+        # mark a field as optional when using a union type
+
+        return StrawberryOptional(of_type=self)
 
     @property
     def types(self) -> Tuple[StrawberryType, ...]:

--- a/strawberry/union.py
+++ b/strawberry/union.py
@@ -64,10 +64,6 @@ class StrawberryUnion(StrawberryType):
         return id(self)
 
     def __or__(self, other: Union[StrawberryType, type]) -> StrawberryType:
-        # TODO: shall we add support to merge unions with other unions?
-        # current use case is to allow SomeUnion | None, as a nicer way to
-        # mark a field as optional when using a union type
-
         if hasattr(other, "_type_definition"):
             return StrawberryUnion(
                 type_annotations=(
@@ -88,7 +84,10 @@ class StrawberryUnion(StrawberryType):
                 )
             )
 
-        return StrawberryOptional(of_type=self)
+        if other is None:
+            return StrawberryOptional(of_type=self)
+
+        raise InvalidUnionType(other)
 
     @property
     def types(self) -> Tuple[StrawberryType, ...]:

--- a/strawberry/union.py
+++ b/strawberry/union.py
@@ -65,9 +65,28 @@ class StrawberryUnion(StrawberryType):
 
     def __or__(self, other: Union[StrawberryType, type]) -> StrawberryType:
         # TODO: shall we add support to merge unions with other unions?
-        # TODO: shall we add support to merge unions with other types?]
         # current use case is to allow SomeUnion | None, as a nicer way to
         # mark a field as optional when using a union type
+
+        if hasattr(other, "_type_definition"):
+            return StrawberryUnion(
+                type_annotations=(
+                    *self.type_annotations,
+                    StrawberryAnnotation(other),
+                )
+            )
+
+        if isinstance(other, StrawberryUnion):
+            return StrawberryUnion(
+                type_annotations=tuple(
+                    set(
+                        (
+                            *self.type_annotations,
+                            *other.type_annotations,
+                        )
+                    )
+                )
+            )
 
         return StrawberryOptional(of_type=self)
 

--- a/strawberry/union.py
+++ b/strawberry/union.py
@@ -29,6 +29,7 @@ from strawberry.exceptions import (
     WrongReturnTypeForUnion,
 )
 from strawberry.type import StrawberryOptional, StrawberryType
+from strawberry.utils.typing import is_union
 
 
 if TYPE_CHECKING:
@@ -71,6 +72,9 @@ class StrawberryUnion(StrawberryType):
                     StrawberryAnnotation(other),
                 )
             )
+
+        if is_union(other):
+            return self | StrawberryAnnotation(other).resolve()
 
         if isinstance(other, StrawberryUnion):
             return StrawberryUnion(

--- a/tests/types/resolving/test_union_pipe.py
+++ b/tests/types/resolving/test_union_pipe.py
@@ -1,0 +1,77 @@
+import sys
+from typing import Union
+
+import pytest
+
+import strawberry
+from strawberry.annotation import StrawberryAnnotation
+from strawberry.type import StrawberryOptional
+from strawberry.union import StrawberryUnion
+
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (3, 10),
+    reason="pipe syntax for union is only available on python 3.10+",
+)
+
+
+def test_python_union_short_syntax():
+    @strawberry.type
+    class User:
+        name: str
+
+    @strawberry.type
+    class Error:
+        name: str
+
+    annotation = StrawberryAnnotation(User | Error)
+    resolved = annotation.resolve()
+
+    assert isinstance(resolved, StrawberryUnion)
+    assert resolved.types == (User, Error)
+
+    assert resolved == StrawberryUnion(
+        name=None,
+        type_annotations=(StrawberryAnnotation(User), StrawberryAnnotation(Error)),
+    )
+    assert resolved == Union[User, Error]
+
+
+def test_python_union_none():
+    @strawberry.type
+    class User:
+        name: str
+
+    annotation = StrawberryAnnotation(User | None)
+    resolved = annotation.resolve()
+
+    assert isinstance(resolved, StrawberryOptional)
+    assert resolved.of_type == User
+
+    assert resolved == StrawberryOptional(
+        of_type=User,
+    )
+    assert resolved == Union[User, None]
+
+
+def test_python_strawberry_union_and_none():
+    @strawberry.type
+    class User:
+        name: str
+
+    @strawberry.type
+    class Error:
+        name: str
+
+    UserOrError = strawberry.union("UserOrError", (User, Error))
+    annotation = StrawberryAnnotation(UserOrError | None)
+    resolved = annotation.resolve()
+
+    assert isinstance(resolved, StrawberryOptional)
+
+    assert resolved == StrawberryOptional(
+        of_type=StrawberryUnion(
+            name="UserOrError",
+            type_annotations=(StrawberryAnnotation(User), StrawberryAnnotation(Error)),
+        )
+    )

--- a/tests/types/resolving/test_union_pipe.py
+++ b/tests/types/resolving/test_union_pipe.py
@@ -134,6 +134,33 @@ def test_strawberry_union_and_another_strawberry_union():
     assert StrawberryAnnotation(Example) in resolved.type_annotations
 
 
+def test_strawberry_union_and_a_union():
+    @strawberry.type
+    class User:
+        name: str
+
+    @strawberry.type
+    class Error:
+        name: str
+
+    @strawberry.type
+    class Example:
+        name: str
+
+    UserOrError = strawberry.union("UserOrError", (User, Error))
+    annotation = StrawberryAnnotation(UserOrError | Union[Example, Error])
+    resolved = annotation.resolve()
+
+    assert isinstance(resolved, StrawberryUnion)
+
+    assert len(resolved.type_annotations) == 3
+
+    # doing this to avoid errors due to order of types
+    assert StrawberryAnnotation(User) in resolved.type_annotations
+    assert StrawberryAnnotation(Error) in resolved.type_annotations
+    assert StrawberryAnnotation(Example) in resolved.type_annotations
+
+
 def test_raises_error_when_piping_with_scalar():
     @strawberry.type
     class User:

--- a/tests/types/resolving/test_union_pipe.py
+++ b/tests/types/resolving/test_union_pipe.py
@@ -75,3 +75,59 @@ def test_python_strawberry_union_and_none():
             type_annotations=(StrawberryAnnotation(User), StrawberryAnnotation(Error)),
         )
     )
+
+
+def test_python_strawberry_union_and_another_type():
+    @strawberry.type
+    class User:
+        name: str
+
+    @strawberry.type
+    class Error:
+        name: str
+
+    @strawberry.type
+    class Example:
+        name: str
+
+    UserOrError = strawberry.union("UserOrError", (User, Error))
+    annotation = StrawberryAnnotation(UserOrError | Example)
+    resolved = annotation.resolve()
+
+    assert isinstance(resolved, StrawberryUnion)
+
+    assert resolved == StrawberryUnion(
+        type_annotations=(
+            StrawberryAnnotation(User),
+            StrawberryAnnotation(Error),
+            StrawberryAnnotation(Example),
+        ),
+    )
+
+
+def test_python_strawberry_union_and_another_strawberry_union():
+    @strawberry.type
+    class User:
+        name: str
+
+    @strawberry.type
+    class Error:
+        name: str
+
+    @strawberry.type
+    class Example:
+        name: str
+
+    UserOrError = strawberry.union("UserOrError", (User, Error))
+    ExampleOrError = strawberry.union("ExampleOrError", (Example, Error))
+    annotation = StrawberryAnnotation(UserOrError | ExampleOrError)
+    resolved = annotation.resolve()
+
+    assert isinstance(resolved, StrawberryUnion)
+
+    assert len(resolved.type_annotations) == 3
+
+    # doing this to avoid errors due to order of types
+    assert StrawberryAnnotation(User) in resolved.type_annotations
+    assert StrawberryAnnotation(Error) in resolved.type_annotations
+    assert StrawberryAnnotation(Example) in resolved.type_annotations

--- a/tests/types/resolving/test_union_pipe.py
+++ b/tests/types/resolving/test_union_pipe.py
@@ -16,7 +16,7 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-def test_python_union_short_syntax():
+def test_union_short_syntax():
     @strawberry.type
     class User:
         name: str
@@ -38,7 +38,7 @@ def test_python_union_short_syntax():
     assert resolved == Union[User, Error]
 
 
-def test_python_union_none():
+def test_union_none():
     @strawberry.type
     class User:
         name: str
@@ -55,7 +55,7 @@ def test_python_union_none():
     assert resolved == Union[User, None]
 
 
-def test_python_strawberry_union_and_none():
+def test_strawberry_union_and_none():
     @strawberry.type
     class User:
         name: str
@@ -78,7 +78,7 @@ def test_python_strawberry_union_and_none():
     )
 
 
-def test_python_strawberry_union_and_another_type():
+def test_strawberry_union_and_another_type():
     @strawberry.type
     class User:
         name: str
@@ -106,7 +106,7 @@ def test_python_strawberry_union_and_another_type():
     )
 
 
-def test_python_strawberry_union_and_another_strawberry_union():
+def test_strawberry_union_and_another_strawberry_union():
     @strawberry.type
     class User:
         name: str

--- a/tests/types/resolving/test_union_pipe.py
+++ b/tests/types/resolving/test_union_pipe.py
@@ -5,6 +5,7 @@ import pytest
 
 import strawberry
 from strawberry.annotation import StrawberryAnnotation
+from strawberry.exceptions import InvalidUnionType
 from strawberry.type import StrawberryOptional
 from strawberry.union import StrawberryUnion
 
@@ -131,3 +132,18 @@ def test_python_strawberry_union_and_another_strawberry_union():
     assert StrawberryAnnotation(User) in resolved.type_annotations
     assert StrawberryAnnotation(Error) in resolved.type_annotations
     assert StrawberryAnnotation(Example) in resolved.type_annotations
+
+
+def test_raises_error_when_piping_with_scalar():
+    @strawberry.type
+    class User:
+        name: str
+
+    @strawberry.type
+    class Error:
+        name: str
+
+    UserOrError = strawberry.union("UserOrError", (User, Error))
+
+    with pytest.raises(InvalidUnionType):
+        StrawberryAnnotation(UserOrError | int)

--- a/tests/types/resolving/test_unions.py
+++ b/tests/types/resolving/test_unions.py
@@ -80,6 +80,33 @@ def test_python_union_none():
     assert resolved == Union[User, None]
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 10),
+    reason="short syntax for union is only available on python 3.10+",
+)
+def test_python_strawberry_union_and_none():
+    @strawberry.type
+    class User:
+        name: str
+
+    @strawberry.type
+    class Error:
+        name: str
+
+    UserOrError = strawberry.union("UserOrError", (User, Error))
+    annotation = StrawberryAnnotation(UserOrError | None)
+    resolved = annotation.resolve()
+
+    assert isinstance(resolved, StrawberryOptional)
+
+    assert resolved == StrawberryOptional(
+        of_type=StrawberryUnion(
+            name="UserOrError",
+            type_annotations=(StrawberryAnnotation(User), StrawberryAnnotation(Error)),
+        )
+    )
+
+
 def test_strawberry_union():
     @strawberry.type
     class User:

--- a/tests/types/resolving/test_unions.py
+++ b/tests/types/resolving/test_unions.py
@@ -1,4 +1,3 @@
-import sys
 from dataclasses import dataclass
 from typing import Generic, TypeVar, Union
 
@@ -7,7 +6,6 @@ import pytest
 import strawberry
 from strawberry.annotation import StrawberryAnnotation
 from strawberry.exceptions import InvalidUnionType
-from strawberry.type import StrawberryOptional
 from strawberry.union import StrawberryUnion, union
 
 
@@ -31,80 +29,6 @@ def test_python_union():
         type_annotations=(StrawberryAnnotation(User), StrawberryAnnotation(Error)),
     )
     assert resolved == Union[User, Error]
-
-
-@pytest.mark.skipif(
-    sys.version_info < (3, 10),
-    reason="short syntax for union is only available on python 3.10+",
-)
-def test_python_union_short_syntax():
-    @strawberry.type
-    class User:
-        name: str
-
-    @strawberry.type
-    class Error:
-        name: str
-
-    annotation = StrawberryAnnotation(User | Error)
-    resolved = annotation.resolve()
-
-    assert isinstance(resolved, StrawberryUnion)
-    assert resolved.types == (User, Error)
-
-    assert resolved == StrawberryUnion(
-        name=None,
-        type_annotations=(StrawberryAnnotation(User), StrawberryAnnotation(Error)),
-    )
-    assert resolved == Union[User, Error]
-
-
-@pytest.mark.skipif(
-    sys.version_info < (3, 10),
-    reason="short syntax for union is only available on python 3.10+",
-)
-def test_python_union_none():
-    @strawberry.type
-    class User:
-        name: str
-
-    annotation = StrawberryAnnotation(User | None)
-    resolved = annotation.resolve()
-
-    assert isinstance(resolved, StrawberryOptional)
-    assert resolved.of_type == User
-
-    assert resolved == StrawberryOptional(
-        of_type=User,
-    )
-    assert resolved == Union[User, None]
-
-
-@pytest.mark.skipif(
-    sys.version_info < (3, 10),
-    reason="short syntax for union is only available on python 3.10+",
-)
-def test_python_strawberry_union_and_none():
-    @strawberry.type
-    class User:
-        name: str
-
-    @strawberry.type
-    class Error:
-        name: str
-
-    UserOrError = strawberry.union("UserOrError", (User, Error))
-    annotation = StrawberryAnnotation(UserOrError | None)
-    resolved = annotation.resolve()
-
-    assert isinstance(resolved, StrawberryOptional)
-
-    assert resolved == StrawberryOptional(
-        of_type=StrawberryUnion(
-            name="UserOrError",
-            type_annotations=(StrawberryAnnotation(User), StrawberryAnnotation(Error)),
-        )
-    )
 
 
 def test_strawberry_union():

--- a/tests/types/resolving/test_unions.py
+++ b/tests/types/resolving/test_unions.py
@@ -7,6 +7,7 @@ import pytest
 import strawberry
 from strawberry.annotation import StrawberryAnnotation
 from strawberry.exceptions import InvalidUnionType
+from strawberry.type import StrawberryOptional
 from strawberry.union import StrawberryUnion, union
 
 
@@ -56,6 +57,27 @@ def test_python_union_short_syntax():
         type_annotations=(StrawberryAnnotation(User), StrawberryAnnotation(Error)),
     )
     assert resolved == Union[User, Error]
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 10),
+    reason="short syntax for union is only available on python 3.10+",
+)
+def test_python_union_none():
+    @strawberry.type
+    class User:
+        name: str
+
+    annotation = StrawberryAnnotation(User | None)
+    resolved = annotation.resolve()
+
+    assert isinstance(resolved, StrawberryOptional)
+    assert resolved.of_type == User
+
+    assert resolved == StrawberryOptional(
+        of_type=User,
+    )
+    assert resolved == Union[User, None]
 
 
 def test_strawberry_union():


### PR DESCRIPTION
This PR adds support for the new union operator to `StrawberryUnion` :)

Supports:
1. Merging with `None` (making a union optional) -> `MyUnion | None`
2. Merging with another union -> `MyUnion | AnotherUnion`
3. Merging with another type -> `MyUnion | AnotherType`
4. Merging with a union -> `MyUnion | Union[AnotherType, YetAnotherType]`