### PR TITLE
Make the annotation parser aware about _Unset

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+This release fixes a bug in the annotation parser that prevents using strict typinh for Optional arguments which have their default set to UNSET.

--- a/strawberry/annotation.py
+++ b/strawberry/annotation.py
@@ -30,6 +30,7 @@ from strawberry.type import (
     StrawberryTypeVar,
 )
 from strawberry.types.types import TypeDefinition
+from strawberry.unset import _Unset
 from strawberry.utils.typing import is_generic, is_type_var
 
 
@@ -113,7 +114,10 @@ class StrawberryAnnotation:
     def create_optional(self, evaled_type: Any) -> StrawberryOptional:
         types = evaled_type.__args__
         non_optional_types = tuple(
-            filter(lambda x: x is not type(None), types)  # noqa: E721
+            filter(
+                lambda x: x is not type(None) and x is not _Unset,  # noqa: E721
+                types,
+            )
         )
 
         # Note that passing a single type to `Union` is equivalent to not using `Union`

--- a/strawberry/arguments.py
+++ b/strawberry/arguments.py
@@ -24,19 +24,11 @@ from strawberry.type import StrawberryList, StrawberryOptional, StrawberryType
 from .exceptions import MultipleStrawberryArgumentsError, UnsupportedTypeError
 from .scalars import is_scalar
 from .types.types import TypeDefinition
+from .unset import _Unset
 
 
 if TYPE_CHECKING:
     from strawberry.schema.config import StrawberryConfig
-
-
-class _Unset:
-    def __str__(self):
-        return ""
-
-    def __bool__(self):
-        return False
-
 
 UNSET: Any = _Unset()
 

--- a/strawberry/unset.py
+++ b/strawberry/unset.py
@@ -1,0 +1,6 @@
+class _Unset:
+    def __str__(self):
+        return ""
+
+    def __bool__(self):
+        return False

--- a/tests/schema/test_arguments.py
+++ b/tests/schema/test_arguments.py
@@ -103,3 +103,46 @@ def test_optional_argument_unset():
     )
     assert not result.errors
     assert result.data == {"hello": "Hi there"}
+
+
+def test_optional_input_field_unset():
+    @strawberry.input
+    class TestInput:
+        name: Optional[str] = UNSET
+        age: Optional[int] = UNSET
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def hello(self, input: TestInput) -> str:
+            if is_unset(input.name):
+                return "Hi there"
+            return f"Hi {input.name}"
+
+    schema = strawberry.Schema(query=Query)
+
+    assert (
+        str(schema)
+        == dedent(
+            """
+        type Query {
+          hello(input: TestInput!): String!
+        }
+
+        input TestInput {
+          name: String
+          age: Int
+        }
+        """
+        ).strip()
+    )
+
+    result = schema.execute_sync(
+        """
+        query {
+            hello(input: {})
+        }
+    """
+    )
+    assert not result.errors
+    assert result.data == {"hello": "Hi there"}

--- a/tests/schema/test_arguments.py
+++ b/tests/schema/test_arguments.py
@@ -1,10 +1,10 @@
 from textwrap import dedent
-from typing import Optional, Union
+from typing import Optional
 
 from typing_extensions import Annotated
 
 import strawberry
-from strawberry.arguments import UNSET, _Unset, is_unset
+from strawberry.arguments import UNSET, is_unset
 
 
 def test_argument_descriptions():
@@ -103,102 +103,3 @@ def test_optional_argument_unset():
     )
     assert not result.errors
     assert result.data == {"hello": "Hi there"}
-
-
-def test_optional_argument_unset_with_exhaustive_typing():
-    @strawberry.type
-    class Query:
-        @strawberry.field
-        def hello(
-            self,
-            name: Union[_Unset, Optional[str]] = UNSET,
-            age: Union[int, None, _Unset] = UNSET,
-        ) -> str:
-            if is_unset(name):
-                return "Hi there"
-            return f"Hi {name}"
-
-    schema = strawberry.Schema(query=Query)
-
-    assert str(schema) == dedent(
-        """\
-        type Query {
-          hello(name: String, age: Int): String!
-        }"""
-    )
-
-
-def test_optional_input_field_unset():
-    @strawberry.input
-    class TestInput:
-        name: Optional[str] = UNSET
-        age: Optional[int] = UNSET
-
-    @strawberry.type
-    class Query:
-        @strawberry.field
-        def hello(self, input: TestInput) -> str:
-            if is_unset(input.name):
-                return "Hi there"
-            return f"Hi {input.name}"
-
-    schema = strawberry.Schema(query=Query)
-
-    assert (
-        str(schema)
-        == dedent(
-            """
-        type Query {
-          hello(input: TestInput!): String!
-        }
-
-        input TestInput {
-          name: String
-          age: Int
-        }
-        """
-        ).strip()
-    )
-
-    result = schema.execute_sync(
-        """
-        query {
-            hello(input: {})
-        }
-    """
-    )
-    assert not result.errors
-    assert result.data == {"hello": "Hi there"}
-
-
-def test_optional_input_field_unset_with_exhaustive_typing():
-    @strawberry.input
-    class TestInput:
-        name: Union[_Unset, Optional[str]] = UNSET
-        age: Union[_Unset, None, int] = UNSET
-
-    @strawberry.type
-    class Query:
-        @strawberry.field
-        def hello(self, input: TestInput) -> str:
-            if is_unset(input.name):
-                return "Hi there"
-            return f"Hi {input.name}"
-
-    schema = strawberry.Schema(query=Query)
-
-    assert (
-        str(schema)
-        == dedent(
-            """
-        type Query {
-          hello(input: TestInput!): String!
-        }
-
-        input TestInput {
-          name: String
-          age: Int
-        }
-        """
-        ).strip()
-    )

--- a/tests/types/resolving/test_optionals.py
+++ b/tests/types/resolving/test_optionals.py
@@ -3,10 +3,33 @@ from typing import List, Optional, Union
 import strawberry
 from strawberry.annotation import StrawberryAnnotation
 from strawberry.type import StrawberryOptional
+from strawberry.unset import _Unset
 
 
 def test_basic_optional():
     annotation = StrawberryAnnotation(Optional[str])
+    resolved = annotation.resolve()
+
+    assert isinstance(resolved, StrawberryOptional)
+    assert resolved.of_type is str
+
+    assert resolved == StrawberryOptional(of_type=str)
+    assert resolved == Optional[str]
+
+
+def test_optional_with_unset():
+    annotation = StrawberryAnnotation(Union[_Unset, Optional[str]])
+    resolved = annotation.resolve()
+
+    assert isinstance(resolved, StrawberryOptional)
+    assert resolved.of_type is str
+
+    assert resolved == StrawberryOptional(of_type=str)
+    assert resolved == Optional[str]
+
+
+def test_optional_with_unset_as_union():
+    annotation = StrawberryAnnotation(Union[_Unset, None, str])
     resolved = annotation.resolve()
 
     assert isinstance(resolved, StrawberryOptional)

--- a/tests/types/resolving/test_optionals.py
+++ b/tests/types/resolving/test_optionals.py
@@ -39,6 +39,17 @@ def test_optional_with_unset_as_union():
     assert resolved == Optional[str]
 
 
+def test_optional_union_containing_a_real_union_and_unset():
+    annotation = StrawberryAnnotation(Union[str, int, None, _Unset])
+    resolved = annotation.resolve()
+
+    assert isinstance(resolved, StrawberryOptional)
+    assert resolved.of_type == Union[str, int]
+
+    assert resolved == StrawberryOptional(of_type=Union[str, int])
+    assert resolved == Optional[Union[str, int]]
+
+
 def test_optional_list():
     annotation = StrawberryAnnotation(Optional[List[bool]])
     resolved = annotation.resolve()


### PR DESCRIPTION
## Description

The PR makes the annotation parser aware of the `_Unset` class type inside the Union with None to allow for strict argument typing and still correctly work with strawberry's type generation.

### Why is this change needed

When specifying a union field arg like this the following:

```python
name: Union[_Unset, Optional[str]] = UNSET,
age: Union[int, None, _Unset] = UNSET,
```

Strawberry will incorrectly try to convert `Union[_Unset, str]` into a GraphQL enum. Preventing the usage of stricter type annotations to ensure type checkers are aware of the third `_Unset` type that is set by defaulting to `UNSET`

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

Relates to #872.

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
