### PR TITLE
Make Django `JsonResponse` params configurable in views

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,30 @@
+Release type: patch
+
+This release adds support for passing `json_encoder` and `json_dumps_params` to Django [`JsonResponse`](https://docs.djangoproject.com/en/stable/ref/request-response/#jsonresponse-objects) via a view.
+
+
+```python
+from json import JSONEncoder
+
+from django.urls import path
+from strawberry.django.views import AsyncGraphQLView
+
+from .schema import schema
+
+# Pass the JSON params to `.as_view`
+urlpatterns = [
+    path(
+        "graphql",
+        AsyncGraphQLView.as_view(
+            schema=schema,
+            json_encoder=JSONEncoder,
+            json_dumps_params={"separators": (",", ":")},
+        ),
+    ),
+]
+
+# … or set them in a custom view
+class CustomAsyncGraphQLView(AsyncGraphQLView):
+    json_encoder = JSONEncoder
+    json_dumps_params = {"separators": (",", ":")}
+```

--- a/docs/integrations/django.md
+++ b/docs/integrations/django.md
@@ -24,11 +24,19 @@ project, this is needed to provide the template for the GraphiQL interface.
 
 ## Options
 
-The `GraphQLView` accepts two options at the moment:
+The `GraphQLView` accepts five options at the moment:
 
-- schema: mandatory, the schema created by `strawberry.Schema`.
-- graphiql: optional, defaults to `True`, whether to enable the GraphiQL
+- `schema`: mandatory, the schema created by `strawberry.Schema`.
+- `graphiql`: optional, defaults to `True`, whether to enable the GraphiQL
   interface.
+- `subscriptions_enabled`: optional boolean paramenter enabling subscriptions
+  in the GraphiQL interface, defaults to `False`.
+- `json_encoder`: optional JSON encoder, defaults to `DjangoJSONEncoder`, will
+  be used to serialize the data.
+- `json_dumps_params`: optional dictionary of keyword arguments to pass to
+  the `json.dumps` call used to generate the response. To get the most compact
+  JSON representation, you should specify `{"separators": (",", ":")}`,
+  defaults to `None`.
 
 ## Extending the view
 


### PR DESCRIPTION
## Description

[`JsonResponse`](https://docs.djangoproject.com/en/3.2/ref/request-response/#jsonresponse-objects) allows configuring three options: `encoder`, `safe` and `json_dumps_params`.
This PR adds support for passing `encoder` (as `json_encoder`) and `json_dumps_params` to the response objects via a GraphQL view.
I do not add the `safe` option because the views defined by Strawberry respond only with dictionaries, do not they?

Also, what do you think about setting `json_dumps_params = {"separators": (",", ":")}` by default to use compact JSON representations (e.g., `{"data":{"hello":"strawberry"}}` instead of `{"data": {"hello": "strawberry"}}`)?

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
