### PR TITLE
Bugfix: django dependency specification

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+This fixes the previous release that introduced a direct dependency on Django.

--- a/poetry.lock
+++ b/poetry.lock
@@ -1568,7 +1568,7 @@ sanic = ["sanic"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "86b63cfdb1b1e223459f623649aa909a2735e94e9f27f67994f0362b03b6c829"
+content-hash = "52af03401a0011d5d6738f0a543692428185a5133b1d1237427436eb0da08689"
 
 [metadata.files]
 aiofiles = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,8 @@ click = {version = ">=7.0,<9.0", optional = true}
 pygments = "^2.3"
 uvicorn = {version = ">=0.11.6,<0.16.0", optional = true}
 Django = [
-    {version = ">=2.2,<4", python = "<3.8", optional = true},
-    {version = ">=2.2,<5", python = ">=3.8", optional = true}
+    {version = ">=2.2,<4", markers = "python_version < '3.8' and extra == 'django'", optional = true},
+    {version = ">=2.2,<5", markers = "python_version >= '3.8' and extra == 'django'", optional = true}
 ]
 graphql-core = "~3.1.0"
 asgiref = {version = "^3.2", optional = true}
@@ -106,7 +106,7 @@ pytest-xprocess = "^0.18.1"
 aiohttp = ["aiohttp", "pytest-aiohttp"]
 asgi = ["starlette"]
 debug-server = ["starlette", "uvicorn"]
-django = ["django", "pytest-django", "asgiref"]
+django = ["Django", "pytest-django", "asgiref"]
 flask = ["flask", "pytest-flask"]
 opentelemetry = ["opentelemetry-api", "opentelemetry-sdk"]
 pydantic = ["pydantic"]


### PR DESCRIPTION
This works:
``` toml
Django = [
    {version = ">=2.2,<4", markers = "python_version < '3.8' and extra == 'django'", optional = true},
    {version = ">=2.2,<5", markers = "python_version >= '3.8' and extra == 'django'", optional = true}
]
```

I built the package locally and it produces this metadata:
```
[...]
Classifier: Programming Language :: Python :: 3.9
Classifier: Topic :: Software Development :: Libraries
Classifier: Topic :: Software Development :: Libraries :: Python Modules
Provides-Extra: aiohttp
Provides-Extra: asgi
Provides-Extra: chalice
Provides-Extra: debug-server
Provides-Extra: django
Provides-Extra: fastapi
Provides-Extra: flask
Provides-Extra: opentelemetry
Provides-Extra: pydantic
Provides-Extra: sanic
Requires-Dist: Django (>=2.2,<4); python_version < "3.8" and extra == "django"
Requires-Dist: Django (>=2.2,<5); python_version >= "3.8" and extra == "django"
Requires-Dist: aiohttp (>=3.7.4.post0,<4.0.0); extra == "aiohttp"
Requires-Dist: asgiref (>=3.2,<4.0); extra == "django"
Requires-Dist: cached-property (>=1.5.2,<2.0.0)
[...]
```

I tested the marker:
``` python
Python 3.9.9 (main, Nov 21 2021, 03:23:44)
[Clang 13.0.0 (clang-1300.0.29.3)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from packaging.markers import Marker
>>> Marker('python_version >= "3.8" and extra == "django"').evaluate(environment={'extra': 'django'})
True
>>> Marker('python_version >= "3.8" and extra == "django"').evaluate(environment={'extra': 'pouet'})
False
>>> Marker('python_version >= "3.10" and extra == "django"').evaluate(environment={'extra': 'django'})
False
```

Closes #1488 