### PR TITLE
Inject custom FastAPI dependencies into context object without overriding default context

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Change `context_getter` in `strawberry.fastapi.GraphQLRouter` to merge, rather than overwrite, default and custom getters.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,6 @@
 Release type: patch
 
 Change `context_getter` in `strawberry.fastapi.GraphQLRouter` to merge, rather than overwrite, default and custom getters.
+
+This mean now you can always access the `request` instance from `info.context`, even when using
+a custom context getter.

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -45,13 +45,14 @@ class GraphQLRouter(APIRouter):
                 "background_tasks": background_tasks,
                 **custom_getter,
             }
-            
 
         sig = signature(dependency)
         sig = sig.replace(
             parameters=[
                 *list(sig.parameters.values())[:-1],
-                sig.parameters["custom_getter: Dict[str, Any]"].replace(default=Depends(custom_getter)),
+                sig.parameters["custom_getter: Dict[str, Any]"].replace(
+                    default=Depends(custom_getter)
+                ),
             ]
         )
         dependency.__signature__ = sig

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -85,7 +85,8 @@ class GraphQLRouter(APIRouter):
         @self.post(path)
         async def handle_http_query(
             request: Request,
-            context=Depends(self.__get_context) | Depends(self.context_getter) if self.context_getter is not None else Depends(self.__get_context),
+            custom_context=Depends(self.context_getter),
+            default_context=Depends(self.__get_context),
             root_value=Depends(self.root_value_getter),
         ) -> Response:
             content_type = request.headers.get("content-type", "")
@@ -117,7 +118,8 @@ class GraphQLRouter(APIRouter):
                     "No GraphQL query found in the request",
                     status_code=status.HTTP_400_BAD_REQUEST,
                 )
-
+            
+            context = default_context if custom_context == default_context else default_context | custom_context
             result = await self.execute(
                 request_data.query,
                 variables=request_data.variables,

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -62,7 +62,7 @@ class GraphQLRouter(APIRouter):
         self.keep_alive_interval = keep_alive_interval
         self.debug = debug
         self.root_value_getter = root_value_getter or self.__get_root_value
-        self.context_getter = context_getter
+        self.context_getter = context_getter or self.__get_context
         self.protocols = subscription_protocols
         self.connection_init_wait_timeout = connection_init_wait_timeout
 

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -37,15 +37,19 @@ class GraphQLRouter(APIRouter):
             background_tasks: BackgroundTasks,
             request: Request = None,
             ws: WebSocket = None,
-            custom_getter: Optional[Dict[str, Any]] = None
+            custom_getter: Optional[Dict[str, Any]] = None,
         ):
-            return {"request": request or ws, "background_tasks": background_tasks, **custom_getter}
+            return {
+                "request": request or ws,
+                "background_tasks": background_tasks,
+                **custom_getter,
+            }
 
         sig = signature(dependency)
         sig = sig.replace(
             parameters=[
                 *list(sig.parameters.values())[:-1],
-                sig.parameters["custom_getter"].replace(default=Depends(custom_getter))
+                sig.parameters["custom_getter"].replace(default=Depends(custom_getter)),
             ]
         )
         dependency.__signature__ = sig

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -61,7 +61,7 @@ class GraphQLRouter(APIRouter):
         self.keep_alive = keep_alive
         self.keep_alive_interval = keep_alive_interval
         self.debug = debug
-        self.root_value_getter = root_value_getter | self.__get_root_value
+        self.root_value_getter = root_value_getter or self.__get_root_value
         self.context_getter = context_getter
         self.protocols = subscription_protocols
         self.connection_init_wait_timeout = connection_init_wait_timeout

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -35,8 +35,8 @@ class GraphQLRouter(APIRouter):
         custom_getter: Callable[..., Optional[Dict[str, Any]]]
     ) -> Callable[..., Dict[str, Any]]:
         async def dependency(
-            background_tasks: BackgroundTasks,
             custom_getter: Dict[str, Any],
+            background_tasks: BackgroundTasks,
             request: Request = None,
             ws: WebSocket = None,
         ) -> Callable[..., Dict[str, Any]]:
@@ -49,7 +49,7 @@ class GraphQLRouter(APIRouter):
         sig = signature(dependency)
         sig = sig.replace(
             parameters=[
-                *list(sig.parameters.values())[:-1],
+                *list(sig.parameters.values())[1:],
                 sig.parameters["custom_getter"].replace(default=Depends(custom_getter)),
             ]
         )

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -36,9 +36,9 @@ class GraphQLRouter(APIRouter):
     ) -> Callable[..., Dict[str, Any]]:
         async def dependency(
             background_tasks: BackgroundTasks,
+            custom_getter: Dict[str, Any],
             request: Request = None,
             ws: WebSocket = None,
-            custom_getter: Dict[str, Any] = {},
         ):
             return {
                 "request": request or ws,

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -61,8 +61,8 @@ class GraphQLRouter(APIRouter):
         self.keep_alive = keep_alive
         self.keep_alive_interval = keep_alive_interval
         self.debug = debug
-        self.root_value_getter = root_value_getter or self.__get_root_value
-        self.context_getter = context_getter or self.__get_context
+        self.root_value_getter = root_value_getter | self.__get_root_value
+        self.context_getter = context_getter | self.__get_context
         self.protocols = subscription_protocols
         self.connection_init_wait_timeout = connection_init_wait_timeout
 

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -10,6 +10,7 @@ from starlette.types import ASGIApp
 from starlette.websockets import WebSocket
 
 from fastapi import APIRouter, Depends
+from inspect import signature
 from strawberry.asgi.utils import get_graphiql_html
 from strawberry.exceptions import MissingQueryError
 from strawberry.fastapi.handlers import GraphQLTransportWSHandler, GraphQLWSHandler

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -40,11 +40,11 @@ class GraphQLRouter(APIRouter):
             ws: WebSocket = None,
             custom_getter: Optional[Dict[str, Any]] = None,
         ):
-            return {
+            default_context = {
                 "request": request or ws,
                 "background_tasks": background_tasks,
-                **custom_getter,
             }
+            return {**default_context, **custom_getter} if custom_getter is not None else default_context
 
         sig = signature(dependency)
         sig = sig.replace(

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -40,7 +40,7 @@ class GraphQLRouter(APIRouter):
             custom_getter: Optional[Dict[str, Any]] = None
         )
             return {"request": request or ws, "background_tasks": background_tasks, **custom_getter}
-        
+
         sig = signature(dependency)
         sig = sig.replace(
             parameters=[
@@ -133,7 +133,7 @@ class GraphQLRouter(APIRouter):
                     "No GraphQL query found in the request",
                     status_code=status.HTTP_400_BAD_REQUEST,
                 )
-            
+
             result = await self.execute(
                 request_data.query,
                 variables=request_data.variables,

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -1,5 +1,6 @@
 import json
 from datetime import timedelta
+from inspect import signature
 from typing import Any, Callable, Dict, Optional, Sequence
 
 from starlette import status
@@ -10,7 +11,6 @@ from starlette.types import ASGIApp
 from starlette.websockets import WebSocket
 
 from fastapi import APIRouter, Depends
-from inspect import signature
 from strawberry.asgi.utils import get_graphiql_html
 from strawberry.exceptions import MissingQueryError
 from strawberry.fastapi.handlers import GraphQLTransportWSHandler, GraphQLWSHandler

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -50,7 +50,7 @@ class GraphQLRouter(APIRouter):
         sig = sig.replace(
             parameters=[
                 *list(sig.parameters.values())[:-1],
-                sig.parameters["custom_getter: Dict[str, Any]"].replace(
+                sig.parameters["custom_getter"].replace(
                     default=Depends(custom_getter)
                 ),
             ]

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -1,6 +1,6 @@
 import json
 from datetime import timedelta
-from typing import Any, Callable, Optional, Sequence
+from typing import Any, Callable, Dict, Optional, Sequence
 
 from starlette import status
 from starlette.background import BackgroundTasks

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -44,7 +44,11 @@ class GraphQLRouter(APIRouter):
                 "request": request or ws,
                 "background_tasks": background_tasks,
             }
-            return {**default_context, **custom_getter} if custom_getter is not None else default_context
+            return (
+                {**default_context, **custom_getter}
+                if custom_getter is not None
+                else default_context
+            )
 
         sig = signature(dependency)
         sig = sig.replace(

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -86,7 +86,7 @@ class GraphQLRouter(APIRouter):
         self.context_getter = (
             self.__get_context_getter(context_getter)
             if context_getter is not None
-            else lambda: None
+            else self.__get_context_getter(lambda: None)
         )
         self.protocols = subscription_protocols
         self.connection_init_wait_timeout = connection_init_wait_timeout

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -35,7 +35,7 @@ class GraphQLRouter(APIRouter):
         custom_getter: Callable[..., Optional[Dict[str, Any]]]
     ) -> Callable[..., Dict[str, Any]]:
         def dependency(
-            custom_getter: Dict[str, Any],
+            custom_getter: Optional[Dict[str, Any]],
             background_tasks: BackgroundTasks,
             request: Request = None,
             ws: WebSocket = None,

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -40,7 +40,11 @@ class GraphQLRouter(APIRouter):
             ws: WebSocket = None,
             custom_getter: Optional[Dict[str, Any]] = {},
         ):
-            return {"request": request or ws, "background_tasks": background_tasks, **custom_getter}
+            return {
+                "request": request or ws,
+                "background_tasks": background_tasks,
+                **custom_getter,
+            }
 
         sig = signature(dependency)
         sig = sig.replace(

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -43,6 +43,10 @@ class GraphQLRouter(APIRouter):
             return {
                 "request": request or ws,
                 "background_tasks": background_tasks,
+            } if custom_getter is None else
+            {
+                "request": request or ws,
+                "background_tasks": background_tasks,
                 **custom_getter,
             }
 
@@ -50,7 +54,7 @@ class GraphQLRouter(APIRouter):
         sig = sig.replace(
             parameters=[
                 *list(sig.parameters.values())[:-1],
-                sig.parameters["custom_getter"].replace(default=Depends(custom_getter)),
+                sig.parameters["custom_getter: Dict[str, Any]"].replace(default=Depends(custom_getter)),
             ]
         )
         dependency.__signature__ = sig

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -62,7 +62,7 @@ class GraphQLRouter(APIRouter):
         self.keep_alive_interval = keep_alive_interval
         self.debug = debug
         self.root_value_getter = root_value_getter | self.__get_root_value
-        self.context_getter = context_getter | self.__get_context
+        self.context_getter = context_getter
         self.protocols = subscription_protocols
         self.connection_init_wait_timeout = connection_init_wait_timeout
 
@@ -85,7 +85,7 @@ class GraphQLRouter(APIRouter):
         @self.post(path)
         async def handle_http_query(
             request: Request,
-            context=Depends(self.context_getter),
+            context=Depends(self.__get_context) | Depends(self.context_getter) if self.context_getter is not None else Depends(self.__get_context),
             root_value=Depends(self.root_value_getter),
         ) -> Response:
             content_type = request.headers.get("content-type", "")

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -83,7 +83,11 @@ class GraphQLRouter(APIRouter):
         self.keep_alive_interval = keep_alive_interval
         self.debug = debug
         self.root_value_getter = root_value_getter or self.__get_root_value
-        self.context_getter = self.__get_context_getter(context_getter) if context_getter is not None else lambda: None
+        self.context_getter = (
+            self.__get_context_getter(context_getter)
+            if context_getter is not None
+            else lambda: None
+        )
         self.protocols = subscription_protocols
         self.connection_init_wait_timeout = connection_init_wait_timeout
 

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -38,17 +38,9 @@ class GraphQLRouter(APIRouter):
             background_tasks: BackgroundTasks,
             request: Request = None,
             ws: WebSocket = None,
-            custom_getter: Optional[Dict[str, Any]] = None,
+            custom_getter: Optional[Dict[str, Any]] = {},
         ):
-            default_context = {
-                "request": request or ws,
-                "background_tasks": background_tasks,
-            }
-            return (
-                {**default_context, **custom_getter}
-                if custom_getter is not None
-                else default_context
-            )
+            return {"request": request or ws, "background_tasks": background_tasks, **custom_getter}
 
         sig = signature(dependency)
         sig = sig.replace(
@@ -90,7 +82,7 @@ class GraphQLRouter(APIRouter):
         self.context_getter = (
             self.__get_context_getter(context_getter)
             if context_getter is not None
-            else self.__get_context_getter(lambda: None)
+            else self.__get_context_getter(lambda: {})
         )
         self.protocols = subscription_protocols
         self.connection_init_wait_timeout = connection_init_wait_timeout

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -46,14 +46,18 @@ class GraphQLRouter(APIRouter):
                 **(custom_getter or {}),
             }
 
+        # replace the signature parameters of dependency...
+        # ...with the old parameters minus the first argument of dependency on line 38 as it will be replaced...
+        # ...with the value obtained by injecting custom_getter context as a dependency.
         sig = signature(dependency)
-        sig = sig.replace( # replace the signature parameters of dependency...
+        sig = sig.replace(
             parameters=[
-                *list(sig.parameters.values())[1:], # ...with the old parameters minus the first argument of dependency on line 38 as it will be replaced...
-                sig.parameters["custom_getter"].replace(default=Depends(custom_getter)), # ...with the value obtained by injecting custom_getter context as a dependency.
+                *list(sig.parameters.values())[1:], 
+                sig.parameters["custom_getter"].replace(default=Depends(custom_getter)),
             ],
         )
-        # there is an ongoing issue in MyPy with types and .__signature__ applied to Callables: https://github.com/python/mypy/issues/5958, as of 14/12/21
+        # there is an ongoing issue in MyPy with types and .__signature__ applied to Callables:
+        # https://github.com/python/mypy/issues/5958, as of 14/12/21
         # as such, the below line has its typing ignored by MyPy
         dependency.__signature__ = sig # type: ignore
         return dependency

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -50,9 +50,7 @@ class GraphQLRouter(APIRouter):
         sig = sig.replace(
             parameters=[
                 *list(sig.parameters.values())[:-1],
-                sig.parameters["custom_getter"].replace(
-                    default=Depends(custom_getter)
-                ),
+                sig.parameters["custom_getter"].replace(default=Depends(custom_getter)),
             ]
         )
         dependency.__signature__ = sig

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -47,7 +47,7 @@ class GraphQLRouter(APIRouter):
             }
 
         # replace the signature parameters of dependency...
-        # ...with the old parameters minus the first argument of dependency on line 38 as it will be replaced...
+        # ...with the old parameters minus the first argument as it will be replaced...
         # ...with the value obtained by injecting custom_getter context as a dependency.
         sig = signature(dependency)
         sig = sig.replace(
@@ -56,7 +56,7 @@ class GraphQLRouter(APIRouter):
                 sig.parameters["custom_getter"].replace(default=Depends(custom_getter)),
             ],
         )
-        # there is an ongoing issue in MyPy with types and .__signature__ applied to Callables:
+        # there is an ongoing issue with types and .__signature__ applied to Callables:
         # https://github.com/python/mypy/issues/5958, as of 14/12/21
         # as such, the below line has its typing ignored by MyPy
         dependency.__signature__ = sig  # type: ignore

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -38,7 +38,7 @@ class GraphQLRouter(APIRouter):
             background_tasks: BackgroundTasks,
             request: Request = None,
             ws: WebSocket = None,
-            custom_getter: Optional[Dict[str, Any]] = {},
+            custom_getter: Dict[str, Any] = {},
         ):
             return {
                 "request": request or ws,

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -83,7 +83,7 @@ class GraphQLRouter(APIRouter):
         self.keep_alive_interval = keep_alive_interval
         self.debug = debug
         self.root_value_getter = root_value_getter or self.__get_root_value
-        self.context_getter = self.__get_context_getter(context_getter or lambda: None)
+        self.context_getter = self.__get_context_getter(context_getter) if context_getter is not None else lambda: None
         self.protocols = subscription_protocols
         self.connection_init_wait_timeout = connection_init_wait_timeout
 

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -39,7 +39,7 @@ class GraphQLRouter(APIRouter):
             custom_getter: Dict[str, Any],
             request: Request = None,
             ws: WebSocket = None,
-        ):
+        ) -> Callable[..., Dict[str, Any]]:
             return {
                 "request": request or ws,
                 "background_tasks": background_tasks,

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -43,12 +43,9 @@ class GraphQLRouter(APIRouter):
             return {
                 "request": request or ws,
                 "background_tasks": background_tasks,
-            } if custom_getter is None else
-            {
-                "request": request or ws,
-                "background_tasks": background_tasks,
                 **custom_getter,
             }
+            
 
         sig = signature(dependency)
         sig = sig.replace(

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -32,7 +32,7 @@ class GraphQLRouter(APIRouter):
 
     @staticmethod
     def __get_context_getter(
-        custom_getter: Callable[..., Optional[Dict[str, Any]]] = lambda: None
+        custom_getter: Callable[..., Optional[Dict[str, Any]]]
     ) -> Callable[..., Dict[str, Any]]:
         async def dependency(
             background_tasks: BackgroundTasks,
@@ -83,7 +83,7 @@ class GraphQLRouter(APIRouter):
         self.keep_alive_interval = keep_alive_interval
         self.debug = debug
         self.root_value_getter = root_value_getter or self.__get_root_value
-        self.context_getter = self.__get_context_getter(context_getter)
+        self.context_getter = self.__get_context_getter(context_getter or lambda: None)
         self.protocols = subscription_protocols
         self.connection_init_wait_timeout = connection_init_wait_timeout
 

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -38,7 +38,7 @@ class GraphQLRouter(APIRouter):
             request: Request = None,
             ws: WebSocket = None,
             custom_getter: Optional[Dict[str, Any]] = None
-        )
+        ):
             return {"request": request or ws, "background_tasks": background_tasks, **custom_getter}
 
         sig = signature(dependency)

--- a/tests/fastapi/test_context.py
+++ b/tests/fastapi/test_context.py
@@ -1,25 +1,23 @@
-
-import pytest
-
 from starlette.testclient import TestClient
 
 import strawberry
-from strawberry.types import Info
 from fastapi import FastAPI
 from strawberry.fastapi import GraphQLRouter
+from strawberry.types import Info
+
 
 def test_with_context_getter():
     @strawberry.type
     class Query:
         @strawberry.field
         def abc(self, info: Info) -> str:
-            assert info.context.get('request') != None
-            assert info.context.get('strawberry') == 'rocks'
+            assert info.context.get("request") != None
+            assert info.context.get("strawberry") == "rocks"
             return "abc"
-    
+
     def get_context():
         return {"strawberry": "rocks"}
-    
+
     app = FastAPI()
     schema = strawberry.Schema(query=Query)
     graphql_app = GraphQLRouter(schema)
@@ -27,19 +25,20 @@ def test_with_context_getter():
 
     test_client = TestClient(app)
     response = test_client.post("/graphql", json={"query": "{ abc }"})
-    
+
     assert response.status_code == 200
     assert response.json() == {"data": {"abc": "abc"}}
-    
+
+
 def test_without_context_getter():
     @strawberry.type
     class Query:
         @strawberry.field
         def abc(self, info: Info) -> str:
-            assert info.context.get('request') != None
-            assert info.context.get('strawberry') == None
+            assert info.context.get("request") != None
+            assert info.context.get("strawberry") == None
             return "abc"
-    
+
     app = FastAPI()
     schema = strawberry.Schema(query=Query)
     graphql_app = GraphQLRouter(schema)
@@ -47,6 +46,6 @@ def test_without_context_getter():
 
     test_client = TestClient(app)
     response = test_client.post("/graphql", json={"query": "{ abc }"})
-    
+
     assert response.status_code == 200
     assert response.json() == {"data": {"abc": "abc"}}

--- a/tests/fastapi/test_context.py
+++ b/tests/fastapi/test_context.py
@@ -20,8 +20,8 @@ def test_with_context_getter():
 
     app = FastAPI()
     schema = strawberry.Schema(query=Query)
-    graphql_app = GraphQLRouter(schema)
-    app.include_router(graphql_app, context_getter=get_context, prefix="/graphql")
+    graphql_app = GraphQLRouter(schema=schema, context_getter=get_context)
+    app.include_router(graphql_app, prefix="/graphql")
 
     test_client = TestClient(app)
     response = test_client.post("/graphql", json={"query": "{ abc }"})

--- a/tests/fastapi/test_context.py
+++ b/tests/fastapi/test_context.py
@@ -11,7 +11,7 @@ def test_with_context_getter():
     class Query:
         @strawberry.field
         def abc(self, info: Info) -> str:
-            assert info.context.get("request") != None
+            assert info.context.get("request") is not None
             assert info.context.get("strawberry") == "rocks"
             return "abc"
 
@@ -35,8 +35,8 @@ def test_without_context_getter():
     class Query:
         @strawberry.field
         def abc(self, info: Info) -> str:
-            assert info.context.get("request") != None
-            assert info.context.get("strawberry") == None
+            assert info.context.get("request") is not None
+            assert info.context.get("strawberry") is None
             return "abc"
 
     app = FastAPI()

--- a/tests/fastapi/test_context.py
+++ b/tests/fastapi/test_context.py
@@ -1,0 +1,52 @@
+
+import pytest
+
+from starlette.testclient import TestClient
+
+import strawberry
+from strawberry.types import Info
+from fastapi import FastAPI
+from strawberry.fastapi import GraphQLRouter
+
+def test_with_context_getter():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def abc(self, info: Info) -> str:
+            assert info.context.get('request') != None
+            assert info.context.get('strawberry') == 'rocks'
+            return "abc"
+    
+    def get_context():
+        return {"strawberry": "rocks"}
+    
+    app = FastAPI()
+    schema = strawberry.Schema(query=Query)
+    graphql_app = GraphQLRouter(schema)
+    app.include_router(graphql_app, context_getter=get_context, prefix="/graphql")
+
+    test_client = TestClient(app)
+    response = test_client.post("/graphql", json={"query": "{ abc }"})
+    
+    assert response.status_code == 200
+    assert response.json() == {"data": {"abc": "abc"}}
+    
+def test_without_context_getter():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def abc(self, info: Info) -> str:
+            assert info.context.get('request') != None
+            assert info.context.get('strawberry') == None
+            return "abc"
+    
+    app = FastAPI()
+    schema = strawberry.Schema(query=Query)
+    graphql_app = GraphQLRouter(schema)
+    app.include_router(graphql_app, prefix="/graphql")
+
+    test_client = TestClient(app)
+    response = test_client.post("/graphql", json={"query": "{ abc }"})
+    
+    assert response.status_code == 200
+    assert response.json() == {"data": {"abc": "abc"}}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
The `__get_context()` dependency injector has been renamed to `__get_context_getter()` and changed to incorporate the injection of a custom `context_getter()` dependency injector.

@Kludex wrote the solution to be in terms of `signature` so that the default and custom context getters can be merged and stored within `self.context_getter`. In this way, the method functions need not be altered by this change. If the `context_getter` object is `None` then a null-closure is passed to the injector instead.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #1493

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
