### PR TITLE
Enable concurreny on release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,7 @@
 name: Release
 
+concurrency: release
+
 on:
   push:
     branches:


### PR DESCRIPTION
This PR should fix our release workflow. We have an issue where merging multiple PRs in a short period of time would confuse the workflow on who created the release and what the release PR was.

[Here's an example](https://github.com/strawberry-graphql/strawberry/blob/main/CHANGELOG.md#0810---2021-10-04)

If I understood correctly adding `concurrency: name` should stop the release workflow from running more than once at the time, thus fixing this problem :)

Ref: https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency