### PR TITLE
Lazily get the loop in dataloaders

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+This release changes when we fetch the event loop in dataloaders
+to prevent using the wrong event loop in some occasions.

--- a/strawberry/dataloader.py
+++ b/strawberry/dataloader.py
@@ -47,12 +47,19 @@ class DataLoader(Generic[K, T]):
         self.load_fn = load_fn
         self.max_batch_size = max_batch_size
 
-        self.loop = loop or get_event_loop()
+        self._loop = loop
 
         self.cache = cache
 
         if self.cache:
             self.cache_map = {}
+
+    @property
+    def loop(self) -> AbstractEventLoop:
+        if self._loop is None:
+            self._loop = get_event_loop()
+
+        return self._loop
 
     def load(self, key: K) -> Awaitable[T]:
         if self.cache:

--- a/tests/test_dataloaders.py
+++ b/tests/test_dataloaders.py
@@ -194,3 +194,22 @@ async def test_cache_disabled_immediate_await(mocker):
     assert a == b
 
     mock_loader.assert_has_calls([mocker.call([1]), mocker.call([1])])
+
+
+def test_works_when_created_in_a_different_loop(mocker):
+    async def idx(keys):
+        return keys
+
+    mock_loader = mocker.Mock(side_effect=idx)
+    loader = DataLoader(load_fn=mock_loader, cache=False)
+
+    loop = asyncio.new_event_loop()
+
+    async def run():
+        return await loader.load(1)
+
+    data = loop.run_until_complete(run())
+
+    assert data == 1
+
+    mock_loader.assert_called_once_with([1])


### PR DESCRIPTION
Dataloaders could be created in a different context,
we shouldn't assume that the current loop is the one
that the dataloader is going to be used in 😊

The error can be reproduce with this snippet:

```python
import asyncio
import strawberry
from aiohttp import web
from strawberry.aiohttp.views import GraphQLView
from strawberry.dataloader import DataLoader

@strawberry.type
class User:
    id: strawberry.ID

async def load_users(keys: list[strawberry.ID]) -> list[User]:
    return [User(id=key) for key in keys]

user_loader = DataLoader(load_fn=load_users)

@strawberry.type
class Query:
    @strawberry.field
    async def get_user(self, user_id: strawberry.ID) -> User:
        return await user_loader.load(user_id)

schema = strawberry.Schema(Query)

app = web.Application()
app.add_routes([web.view("/", GraphQLView(schema))])
web.run_app(app)
```

I need to write a test for this before merging it, I might have missed some edge cases too :) but feel free to review it :)