### PR TITLE
Update await_maybe

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+This release modifies the internal utility function `await_maybe` towards updating mypy to 0.920.

--- a/strawberry/utils/await_maybe.py
+++ b/strawberry/utils/await_maybe.py
@@ -8,7 +8,7 @@ AwaitableOrValue = Union[Awaitable[T], T]
 
 
 async def await_maybe(value: AwaitableOrValue):
-    if inspect.iscoroutine(value):
+    if inspect.isawaitable(value):
         return await value
 
     return value


### PR DESCRIPTION
Replace `iscoroutine` with `isawaitable` in `await_maybe` towards the update to mypy 0.920.

## Details

We are currently on version 0.910 of mypy, and are working towards updating to 0.920 in https://github.com/strawberry-graphql/strawberry/pull/1503.

In the new mypy version we get the following error in `await_maybe`:
```
strawberry/utils/await_maybe.py:12: error: Incompatible types in "await" (actual type "CoroutineType", expected type "Awaitable[Any]")
```

This PR modifies the function to use `isawaitable` instead of `iscorotuine`, which fixes the error.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
