### PR TITLE
Parse Decimal/UUID scalar similar to other builtin scalars

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+This release updates the Decimal and UUID scalar parsers to exclude the original_error exception and format the error message similar to other builtin scalars.

--- a/strawberry/schema/types/base_scalars.py
+++ b/strawberry/schema/types/base_scalars.py
@@ -21,7 +21,7 @@ def wrap_parser(parser: Callable, type_: str) -> Callable:
     return inner
 
 
-def parse_decimal(value: str):
+def parse_decimal(value: str) -> decimal.Decimal:
     try:
         return decimal.Decimal(value)
     except decimal.DecimalException:

--- a/tests/schema/types/test_decimal.py
+++ b/tests/schema/types/test_decimal.py
@@ -1,5 +1,7 @@
 from decimal import Decimal
 
+from graphql import GraphQLError
+
 import strawberry
 
 
@@ -31,3 +33,40 @@ def test_decimal_as_input():
 
     assert not result.errors
     assert result.data["exampleDecimal"] == "3.14"
+
+
+def test_serialization_of_incorrect_decimal_string():
+    """
+    Test GraphQLError is raised for an invalid Decimal.
+    The error should exclude "original_error".
+    """
+
+    @strawberry.type
+    class Query:
+        ok: bool
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        def decimal_input(self, decimal_input: Decimal) -> Decimal:
+            assert isinstance(decimal_input, Decimal)
+            return decimal_input
+
+    schema = strawberry.Schema(query=Query, mutation=Mutation)
+
+    result = schema.execute_sync(
+        """
+            mutation decimalInput($value: Decimal!) {
+                decimalInput(decimalInput: $value)
+            }
+        """,
+        variable_values={"value": "fail"},
+    )
+
+    assert result.errors
+    assert isinstance(result.errors[0], GraphQLError)
+    assert result.errors[0].original_error is None
+    assert result.errors[0].message == (
+        "Variable '$value' got invalid value 'fail'; Value cannot represent a "
+        'Decimal: "fail".'
+    )

--- a/tests/schema/types/test_decimal.py
+++ b/tests/schema/types/test_decimal.py
@@ -49,7 +49,6 @@ def test_serialization_of_incorrect_decimal_string():
     class Mutation:
         @strawberry.mutation
         def decimal_input(self, decimal_input: Decimal) -> Decimal:
-            assert isinstance(decimal_input, Decimal)
             return decimal_input
 
     schema = strawberry.Schema(query=Query, mutation=Mutation)

--- a/tests/schema/types/test_uuid.py
+++ b/tests/schema/types/test_uuid.py
@@ -51,7 +51,6 @@ def test_serialization_of_incorrect_uuid_string():
     class Mutation:
         @strawberry.mutation
         def uuid_input(self, uuid_input: uuid.UUID) -> uuid.UUID:
-            assert isinstance(uuid_input, uuid.UUID)
             return uuid_input
 
     schema = strawberry.Schema(query=Query, mutation=Mutation)


### PR DESCRIPTION
This updates the `Decimal`/`UUID` scalar parser to function similar to the `Date`/`DateTime` scalars, specifically it handles `ValueError` and ensures `original_error` is not defined.

The motivation for making this change is that I'm handling internal server errors similar to #1221 and currently this excludes type errors for the `UUID` scalar.

I'm not sure what the compatibility guarantees this project makes about error messages, but since it's currently just returning the standard library message I assume a change like this won't break anyone's code, but it could technically be considered a breaking change.

~Assuming this change is accepted we might also want to make a similar change for the `Decimal` scalar.~

## Types of Changes

- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
