### PR TITLE
Add deprecation support to arguments and input fields (mutations)

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+This release adds `deprecation_reason` support to arguments and mutations.

--- a/strawberry/arguments.py
+++ b/strawberry/arguments.py
@@ -40,10 +40,17 @@ def is_unset(value: Any) -> bool:
 class StrawberryArgumentAnnotation:
     description: Optional[str]
     name: Optional[str]
+    deprecation_reason: Optional[str]
 
-    def __init__(self, description: Optional[str] = None, name: Optional[str] = None):
+    def __init__(
+        self,
+        description: Optional[str] = None,
+        name: Optional[str] = None,
+        deprecation_reason: Optional[str] = None,
+    ):
         self.description = description
         self.name = name
+        self.deprecation_reason = deprecation_reason
 
 
 class StrawberryArgument:
@@ -55,6 +62,7 @@ class StrawberryArgument:
         is_subscription: bool = False,
         description: Optional[str] = None,
         default: object = UNSET,
+        deprecation_reason: Optional[str] = None,
     ) -> None:
         self.python_name = python_name  # type: ignore
         self.graphql_name = graphql_name
@@ -62,6 +70,7 @@ class StrawberryArgument:
         self.description = description
         self._type: Optional[StrawberryType] = None
         self.type_annotation = type_annotation
+        self.deprecation_reason = deprecation_reason
 
         # TODO: Consider moving this logic to a function
         self.default = UNSET if default is inspect.Parameter.empty else default
@@ -98,6 +107,7 @@ class StrawberryArgument:
 
                 self.description = arg.description
                 self.graphql_name = arg.name
+                self.deprecation_reason = arg.deprecation_reason
 
 
 def convert_argument(
@@ -190,9 +200,13 @@ def convert_arguments(
 
 
 def argument(
-    description: Optional[str] = None, name: Optional[str] = None
+    description: Optional[str] = None,
+    name: Optional[str] = None,
+    deprecation_reason: Optional[str] = None,
 ) -> StrawberryArgumentAnnotation:
-    return StrawberryArgumentAnnotation(description=description, name=name)
+    return StrawberryArgumentAnnotation(
+        description=description, name=name, deprecation_reason=deprecation_reason
+    )
 
 
 # TODO: check exports

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -82,6 +82,7 @@ class GraphQLCoreConverter:
             type_=argument_type,
             default_value=default_value,
             description=argument.description,
+            deprecation_reason=argument.deprecation_reason,
         )
 
     def from_enum(self, enum: EnumDefinition) -> CustomGraphQLEnumType:
@@ -175,6 +176,7 @@ class GraphQLCoreConverter:
             type_=field_type,
             default_value=default_value,
             description=field.description,
+            deprecation_reason=field.deprecation_reason,
         )
 
     def from_input_object(self, object_type: type) -> GraphQLInputObjectType:

--- a/tests/schema/test_arguments.py
+++ b/tests/schema/test_arguments.py
@@ -31,6 +31,27 @@ def test_argument_descriptions():
     )
 
 
+def test_argument_deprecation_reason():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def hello(  # type: ignore
+            name: Annotated[
+                str, strawberry.argument(deprecation_reason="Your reason")  # noqa: F722
+            ] = "Patrick"
+        ) -> str:
+            return f"Hi {name}"
+
+    schema = strawberry.Schema(query=Query)
+
+    assert str(schema) == dedent(
+        """\
+        type Query {
+          hello(name: String! = "Patrick" @deprecated(reason: "Your reason")): String!
+        }"""
+    )
+
+
 def test_argument_names():
     @strawberry.input
     class HelloInput:

--- a/tests/schema/test_mutation.py
+++ b/tests/schema/test_mutation.py
@@ -1,5 +1,6 @@
 import dataclasses
 import typing
+from textwrap import dedent
 
 import strawberry
 from strawberry.arguments import UNSET, is_unset
@@ -231,3 +232,28 @@ def test_converting_to_dict_with_unset():
 
     assert not result.errors
     assert result.data["say"] == "Hello 🤨"
+
+
+def test_mutation_deprecation_reason():
+    @strawberry.type
+    class Query:
+        hello: str = "world"
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation(deprecation_reason="Your reason")
+        def say(self, name: str) -> str:
+            return f"Hello {name}!"
+
+    schema = strawberry.Schema(query=Query, mutation=Mutation)
+
+    assert str(schema) == dedent(
+        """\
+        type Mutation {
+          say(name: String!): String! @deprecated(reason: "Your reason")
+        }
+
+        type Query {
+          hello: String!
+        }"""
+    )


### PR DESCRIPTION
This adds deprecation support to arguments and input fields (mutations).

## Types of Changes

- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
