### PR TITLE
Add support for | operator between StrawberryUnion and None

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,20 @@
+Release type: patch
+
+Add support for piping `StrawberryUnion` and `None` when annotating types.
+
+For example:
+```python
+@strawberry.type
+class Cat:
+    name: str
+
+@strawberry.type
+class Dog:
+    name: str
+
+Animal = strawberry.union("Animal", (Cat, Dog))
+
+@strawberry.type
+class Query:
+    animal: Animal | None # This line no longer triggers a TypeError
+```

--- a/strawberry/union.py
+++ b/strawberry/union.py
@@ -28,7 +28,7 @@ from strawberry.exceptions import (
     UnallowedReturnTypeForUnion,
     WrongReturnTypeForUnion,
 )
-from strawberry.type import StrawberryType
+from strawberry.type import StrawberryOptional, StrawberryType
 
 
 if TYPE_CHECKING:
@@ -63,15 +63,15 @@ class StrawberryUnion(StrawberryType):
         # TODO: Is this a bad idea? __eq__ objects are supposed to have the same hash
         return id(self)
 
-    def __or__(self, other):
+    def __or__(self, other: Union[StrawberryType, type]) -> StrawberryType:
         if other is None:
             # Return the correct notation when using `StrawberryUnion | None`.
-            return Optional[self]
-        else:
-            # Raise an error in any other case.
-            # This can be replaced with logic to merge a union with another
-            # union or another type.
-            raise TypeError(f"Cannot use OR operator with {other}")
+            return StrawberryOptional(of_type=self)
+
+        # Raise an error in any other case.
+        # There is Work in progress to deal with more merging cases, see:
+        # https://github.com/strawberry-graphql/strawberry/pull/1455
+        raise InvalidUnionType(other)
 
     @property
     def types(self) -> Tuple[StrawberryType, ...]:

--- a/strawberry/union.py
+++ b/strawberry/union.py
@@ -63,6 +63,16 @@ class StrawberryUnion(StrawberryType):
         # TODO: Is this a bad idea? __eq__ objects are supposed to have the same hash
         return id(self)
 
+    def __or__(self, other):
+        if other is None:
+            # Return the correct notation when using `StrawberryUnion | None`.
+            return Optional[self]
+        else:
+            # Raise an error in any other case.
+            # This can be replaced with logic to merge a union with another
+            # union or another type.
+            raise TypeError(f"Cannot use OR operator with {other}")
+
     @property
     def types(self) -> Tuple[StrawberryType, ...]:
         return tuple(

--- a/tests/schema/test_union.py
+++ b/tests/schema/test_union.py
@@ -2,7 +2,11 @@ from dataclasses import dataclass
 from textwrap import dedent
 from typing import Optional, Union
 
+import pytest
+
 import strawberry
+from strawberry.annotation import StrawberryAnnotation
+from strawberry.exceptions import InvalidUnionType
 
 
 def test_union_as_field():
@@ -449,3 +453,18 @@ def test_union_optional_with_or_operator():
 
     assert not result.errors
     assert result.data["animal"] is None
+
+
+def test_raises_error_when_piping_with_scalar():
+    @strawberry.type
+    class User:
+        name: str
+
+    @strawberry.type
+    class Error:
+        name: str
+
+    UserOrError = strawberry.union("UserOrError", (User, Error))
+
+    with pytest.raises(InvalidUnionType):
+        StrawberryAnnotation(UserOrError | int)

--- a/tests/schema/test_union.py
+++ b/tests/schema/test_union.py
@@ -1,3 +1,4 @@
+import sys
 from dataclasses import dataclass
 from textwrap import dedent
 from typing import Optional, Union
@@ -5,8 +6,6 @@ from typing import Optional, Union
 import pytest
 
 import strawberry
-from strawberry.annotation import StrawberryAnnotation
-from strawberry.exceptions import InvalidUnionType
 
 
 def test_union_as_field():
@@ -421,9 +420,14 @@ def test_union_explicit_type_resolution():
     assert result.data == {"myField": {"__typename": "A", "a": 1}}
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 10),
+    reason="pipe syntax for union is only available on python 3.10+",
+)
 def test_union_optional_with_or_operator():
     """
-    Verify that the `|` operator is supported when annotating unions as optional.
+    Verify that the `|` operator is supported when annotating unions as
+    optional in schemas.
     """
 
     @strawberry.type
@@ -453,18 +457,3 @@ def test_union_optional_with_or_operator():
 
     assert not result.errors
     assert result.data["animal"] is None
-
-
-def test_raises_error_when_piping_with_scalar():
-    @strawberry.type
-    class User:
-        name: str
-
-    @strawberry.type
-    class Error:
-        name: str
-
-    UserOrError = strawberry.union("UserOrError", (User, Error))
-
-    with pytest.raises(InvalidUnionType):
-        StrawberryAnnotation(UserOrError | int)

--- a/tests/schema/test_union.py
+++ b/tests/schema/test_union.py
@@ -415,3 +415,37 @@ def test_union_explicit_type_resolution():
 
     assert not result.errors
     assert result.data == {"myField": {"__typename": "A", "a": 1}}
+
+
+def test_union_optional_with_or_operator():
+    """
+    Verify that the `|` operator is supported when annotating unions as optional.
+    """
+
+    @strawberry.type
+    class Cat:
+        name: str
+
+    @strawberry.type
+    class Dog:
+        name: str
+
+    animal_union = strawberry.union("Animal", (Cat, Dog))
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def animal(self) -> animal_union | None:
+            return None
+
+    schema = strawberry.Schema(query=Query)
+    query = """{
+        animal {
+            __typename
+        }
+    }"""
+
+    result = schema.execute_sync(query, root_value=Query())
+
+    assert not result.errors
+    assert result.data["animal"] is None

--- a/tests/types/resolving/test_union_pipe.py
+++ b/tests/types/resolving/test_union_pipe.py
@@ -1,0 +1,93 @@
+import sys
+from typing import Union
+
+import pytest
+
+import strawberry
+from strawberry.annotation import StrawberryAnnotation
+from strawberry.exceptions import InvalidUnionType
+from strawberry.type import StrawberryOptional
+from strawberry.union import StrawberryUnion
+
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (3, 10),
+    reason="pipe syntax for union is only available on python 3.10+",
+)
+
+
+def test_union_short_syntax():
+    @strawberry.type
+    class User:
+        name: str
+
+    @strawberry.type
+    class Error:
+        name: str
+
+    annotation = StrawberryAnnotation(User | Error)
+    resolved = annotation.resolve()
+
+    assert isinstance(resolved, StrawberryUnion)
+    assert resolved.types == (User, Error)
+
+    assert resolved == StrawberryUnion(
+        name=None,
+        type_annotations=(StrawberryAnnotation(User), StrawberryAnnotation(Error)),
+    )
+    assert resolved == Union[User, Error]
+
+
+def test_union_none():
+    @strawberry.type
+    class User:
+        name: str
+
+    annotation = StrawberryAnnotation(User | None)
+    resolved = annotation.resolve()
+
+    assert isinstance(resolved, StrawberryOptional)
+    assert resolved.of_type == User
+
+    assert resolved == StrawberryOptional(
+        of_type=User,
+    )
+    assert resolved == Union[User, None]
+
+
+def test_strawberry_union_and_none():
+    @strawberry.type
+    class User:
+        name: str
+
+    @strawberry.type
+    class Error:
+        name: str
+
+    UserOrError = strawberry.union("UserOrError", (User, Error))
+    annotation = StrawberryAnnotation(UserOrError | None)
+    resolved = annotation.resolve()
+
+    assert isinstance(resolved, StrawberryOptional)
+
+    assert resolved == StrawberryOptional(
+        of_type=StrawberryUnion(
+            name="UserOrError",
+            type_annotations=(StrawberryAnnotation(User), StrawberryAnnotation(Error)),
+        )
+    )
+
+
+def test_raises_error_when_piping_with_scalar():
+    @strawberry.type
+    class User:
+        name: str
+
+    @strawberry.type
+    class Error:
+        name: str
+
+    UserOrError = strawberry.union("UserOrError", (User, Error))
+
+    with pytest.raises(InvalidUnionType):
+        StrawberryAnnotation(UserOrError | int)


### PR DESCRIPTION
This is an attempt to fix https://github.com/strawberry-graphql/strawberry/issues/1539.

Adds support for annotating unions are optional with the new OR notation.

Note that we are also interested in merging unions at some point (see https://github.com/strawberry-graphql/strawberry/issues/711), but in this PR we only handle a union with `None`.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

Closes https://github.com/strawberry-graphql/strawberry/issues/1539

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
