### PR TITLE
feat(pydantic): Add mypy extension, typing stubs for conversion of pydantic models

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -19,3 +19,4 @@ comment:
 
 ignore:
   - "strawberry/ext/mypy_plugin.py"
+  - "setup.py"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -20,3 +20,4 @@ comment:
 ignore:
   - "strawberry/ext/mypy_plugin.py"
   - "setup.py"
+  - "strawberry/experimental/pydantic/conversion_types.py"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -16,3 +16,6 @@ comment:
   layout: "header, diff"
   behavior: default
   require_changes: no
+
+ignore:
+  - "strawberry/ext/mypy_plugin.py"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,4 +2,19 @@ Release type: minor
 
 Improves the following for types converted from pydantic BaseModel.
 Adds mypy extension support for `to_pydantic` and `from_pydantic` methods.
-Adds typing stubs for IDE support.
+Adds type hints for IDE support.
+
+```python
+from pydantic import BaseModel
+import strawberry
+
+class UserPydantic(BaseModel):
+    age: int
+
+@strawberry.experimental.pydantic.type(UserPydantic)
+class UserStrawberry:
+    age: strawberry.auto
+
+reveal_type(UserStrawberry(age=123).to_pydantic())
+```
+Mypy will infer the type as "UserPydantic". Previously it would be `Any`.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+Improves the following for types converted from pydantic BaseModel.
+Adds mypy extension support for to_pydantic and from_pydantic methods.
+Adds typing stubs for IDE support.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,5 @@
-Release type: patch
+Release type: minor
+
 Improves the following for types converted from pydantic BaseModel.
-Adds mypy extension support for to_pydantic and from_pydantic methods.
+Adds mypy extension support for `to_pydantic` and `from_pydantic` methods.
 Adds typing stubs for IDE support.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,8 +1,8 @@
 Release type: minor
 
-Improves the following for types converted from pydantic BaseModel.
-Adds mypy extension support for `to_pydantic` and `from_pydantic` methods.
-Adds type hints for IDE support.
+Adds `to_pydantic` and `from_pydantic` type hints for IDE support.
+
+Adds mypy extension support as well.
 
 ```python
 from pydantic import BaseModel
@@ -17,4 +17,4 @@ class UserStrawberry:
 
 reveal_type(UserStrawberry(age=123).to_pydantic())
 ```
-Mypy will infer the type as "UserPydantic". Previously it would be `Any`.
+Mypy will infer the type as "UserPydantic". Previously it would be "Any"

--- a/strawberry/experimental/pydantic/conversion_types.py
+++ b/strawberry/experimental/pydantic/conversion_types.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import Any, Dict, TypeVar
+
+from pydantic import BaseModel
+from typing_extensions import Protocol
+
+from strawberry.types.types import TypeDefinition
+
+
+PydanticModel = TypeVar("PydanticModel", bound=BaseModel)
+
+
+class StrawberryTypeFromPydantic(Protocol[PydanticModel]):
+    """This class does not exist in runtime.
+    It only makes the methods below visible for IDEs"""
+
+    def __init__(self, **kwargs):
+        ...
+
+    @staticmethod
+    def from_pydantic(
+        instance: PydanticModel, extra: Dict[str, Any] = None
+    ) -> PydanticModel:
+        ...
+
+    def to_pydantic(self) -> PydanticModel:
+        ...
+
+    @property
+    def _type_definition(self) -> TypeDefinition:
+        ...
+
+    @property
+    def _pydantic_type(self) -> PydanticModel:
+        ...

--- a/strawberry/experimental/pydantic/conversion_types.py
+++ b/strawberry/experimental/pydantic/conversion_types.py
@@ -21,7 +21,7 @@ class StrawberryTypeFromPydantic(Protocol[PydanticModel]):
     @staticmethod
     def from_pydantic(
         instance: PydanticModel, extra: Dict[str, Any] = None
-    ) -> PydanticModel:
+    ) -> StrawberryTypeFromPydantic[PydanticModel]:
         ...
 
     def to_pydantic(self) -> PydanticModel:

--- a/strawberry/experimental/pydantic/object_type.py
+++ b/strawberry/experimental/pydantic/object_type.py
@@ -13,13 +13,12 @@ from typing import (
     Optional,
     Sequence,
     Type,
-    TypeVar,
     cast,
 )
 
 from pydantic import BaseModel
 from pydantic.fields import ModelField
-from typing_extensions import Literal, Protocol
+from typing_extensions import Literal
 
 from graphql import GraphQLResolveInfo
 
@@ -87,31 +86,10 @@ def get_type_for_field(field: ModelField):
 
 
 if TYPE_CHECKING:
-    PydanticModel = TypeVar("PydanticModel", bound=BaseModel)
-
-    class StrawberryTypeFromPydantic(Protocol[PydanticModel]):
-        """This class does not exist in runtime.
-        It only makes the methods below visible for IDEs"""
-
-        def __init__(self, **kwargs):
-            ...
-
-        @staticmethod
-        def from_pydantic(
-            instance: PydanticModel, extra: Dict[str, Any] = None
-        ) -> PydanticModel:
-            ...
-
-        def to_pydantic(self) -> PydanticModel:
-            ...
-
-        @property
-        def _type_definition(self) -> TypeDefinition:
-            ...
-
-        @property
-        def _pydantic_type(self) -> PydanticModel:
-            ...
+    from strawberry.experimental.pydantic.conversion_types import (
+        PydanticModel,
+        StrawberryTypeFromPydantic,
+    )
 
 
 def type(

--- a/strawberry/experimental/pydantic/object_type.py
+++ b/strawberry/experimental/pydantic/object_type.py
@@ -11,7 +11,6 @@ from typing import (
     Dict,
     List,
     Optional,
-    Protocol,
     Sequence,
     Type,
     TypeVar,
@@ -20,7 +19,7 @@ from typing import (
 
 from pydantic import BaseModel
 from pydantic.fields import ModelField
-from typing_extensions import Literal
+from typing_extensions import Literal, Protocol
 
 from graphql import GraphQLResolveInfo
 

--- a/strawberry/experimental/pydantic/object_type.py
+++ b/strawberry/experimental/pydantic/object_type.py
@@ -195,12 +195,14 @@ def type(
         model._strawberry_type = cls  # type: ignore
         cls._pydantic_type = model  # type: ignore
 
-        def from_pydantic(instance: Any, extra: Dict[str, Any] = None) -> Any:
+        def from_pydantic(
+            instance: PydanticModel, extra: Dict[str, Any] = None
+        ) -> StrawberryTypeFromPydantic[PydanticModel]:
             return convert_pydantic_model_to_strawberry_class(
                 cls=cls, model_instance=instance, extra=extra
             )
 
-        def to_pydantic(self) -> Any:
+        def to_pydantic(self) -> PydanticModel:
             instance_kwargs = dataclasses.asdict(self)
 
             return model(**instance_kwargs)

--- a/strawberry/experimental/pydantic/object_type.py
+++ b/strawberry/experimental/pydantic/object_type.py
@@ -86,9 +86,9 @@ def get_type_for_field(field: ModelField):
 
 
 if TYPE_CHECKING:
-    A = TypeVar("A", bound=BaseModel)
+    PydanticModel = TypeVar("PydanticModel", bound=BaseModel)
 
-    class StrawberryTypeFromPydantic(Generic[A]):
+    class StrawberryTypeFromPydantic(Generic[PydanticModel]):
         """This class does not exist in runtime.
         Its only makes the below methods visible for IDEs"""
 
@@ -96,10 +96,12 @@ if TYPE_CHECKING:
             ...
 
         @staticmethod
-        def from_pydantic(instance: A, extra: Dict[str, Any] = None) -> A:
+        def from_pydantic(
+            instance: PydanticModel, extra: Dict[str, Any] = None
+        ) -> PydanticModel:
             ...
 
-        def to_pydantic(self) -> A:
+        def to_pydantic(self) -> PydanticModel:
             ...
 
         @property
@@ -107,12 +109,12 @@ if TYPE_CHECKING:
             ...
 
         @property
-        def _pydantic_type(self) -> A:
+        def _pydantic_type(self) -> PydanticModel:
             ...
 
 
 def type(
-    model: "Type[A]",
+    model: "Type[PydanticModel]",
     *,
     fields: Optional[List[str]] = None,
     name: Optional[str] = None,
@@ -121,8 +123,8 @@ def type(
     description: Optional[str] = None,
     directives: Optional[Sequence[StrawberrySchemaDirective]] = (),
     all_fields: bool = False,
-) -> "Callable[..., Type[StrawberryTypeFromPydantic[A]]]":
-    def wrap(cls: Any) -> "Type[StrawberryTypeFromPydantic[A]]":
+) -> "Callable[..., Type[StrawberryTypeFromPydantic[PydanticModel]]]":
+    def wrap(cls: Any) -> "Type[StrawberryTypeFromPydantic[PydanticModel]]":
         model_fields = model.__fields__
         fields_set = set(fields) if fields else set([])
 

--- a/strawberry/experimental/pydantic/object_type.py
+++ b/strawberry/experimental/pydantic/object_type.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import builtins
 import dataclasses
 import warnings
@@ -7,9 +9,9 @@ from typing import (
     Any,
     Callable,
     Dict,
-    Generic,
     List,
     Optional,
+    Protocol,
     Sequence,
     Type,
     TypeVar,
@@ -88,9 +90,9 @@ def get_type_for_field(field: ModelField):
 if TYPE_CHECKING:
     PydanticModel = TypeVar("PydanticModel", bound=BaseModel)
 
-    class StrawberryTypeFromPydantic(Generic[PydanticModel]):
+    class StrawberryTypeFromPydantic(Protocol[PydanticModel]):
         """This class does not exist in runtime.
-        Its only makes the below methods visible for IDEs"""
+        It only makes the methods below visible for IDEs"""
 
         def __init__(self, **kwargs):
             ...
@@ -114,7 +116,7 @@ if TYPE_CHECKING:
 
 
 def type(
-    model: "Type[PydanticModel]",
+    model: Type[PydanticModel],
     *,
     fields: Optional[List[str]] = None,
     name: Optional[str] = None,
@@ -123,8 +125,8 @@ def type(
     description: Optional[str] = None,
     directives: Optional[Sequence[StrawberrySchemaDirective]] = (),
     all_fields: bool = False,
-) -> "Callable[..., Type[StrawberryTypeFromPydantic[PydanticModel]]]":
-    def wrap(cls: Any) -> "Type[StrawberryTypeFromPydantic[PydanticModel]]":
+) -> Callable[..., Type[StrawberryTypeFromPydantic[PydanticModel]]]:
+    def wrap(cls: Any) -> Type[StrawberryTypeFromPydantic[PydanticModel]]:
         model_fields = model.__fields__
         fields_set = set(fields) if fields else set([])
 

--- a/strawberry/ext/mypy_plugin.py
+++ b/strawberry/ext/mypy_plugin.py
@@ -280,13 +280,14 @@ def add_method_to_class(
             cls.defs.body.remove(sym.node)
 
     self_type = self_type or fill_typevars(info)
-    if MypyVersion.VERSION >= Decimal("0.93"):
+    # For compat with mypy < 0.93
+    if MypyVersion.VERSION < Decimal("0.93"):
+        function_type = api.named_type("__builtins__.function")  # type: ignore
+    else:
         if isinstance(api, SemanticAnalyzerPluginInterface):
             function_type = api.named_type("builtins.function")
         else:
             function_type = api.named_generic_type("builtins.function", [])
-    else:
-        function_type = api.named_type("__builtins__.function")
 
     if not is_static:
         args = [Argument(Var("self"), self_type, None, ARG_POS)] + args

--- a/strawberry/ext/mypy_plugin.py
+++ b/strawberry/ext/mypy_plugin.py
@@ -303,7 +303,7 @@ def add_static_method_to_class(
     func.is_static = True
     func.info = info
     func.type = set_callable_name(signature, func)
-    func._fullname = info.fullname + "." + name
+    func._fullname = f"{info.fullname}.{name}"
     func.line = info.line
 
     # NOTE: we would like the plugin generated node to dominate, but we still
@@ -349,7 +349,6 @@ def strawberry_pydantic_class_callback(ctx: ClassDefContext) -> None:
         )
 
         # Add from_pydantic
-
         model_argument = Argument(
             variable=Var(name="instance", type=model_type),
             type_annotation=model_type,

--- a/strawberry/ext/mypy_plugin.py
+++ b/strawberry/ext/mypy_plugin.py
@@ -280,10 +280,13 @@ def add_method_to_class(
             cls.defs.body.remove(sym.node)
 
     self_type = self_type or fill_typevars(info)
-    if isinstance(api, SemanticAnalyzerPluginInterface):
-        function_type = api.named_type("builtins.function")
+    if MypyVersion.VERSION >= Decimal("0.93"):
+        if isinstance(api, SemanticAnalyzerPluginInterface):
+            function_type = api.named_type("builtins.function")
+        else:
+            function_type = api.named_generic_type("builtins.function", [])
     else:
-        function_type = api.named_generic_type("builtins.function", [])
+        function_type = api.named_type("__builtins__.function")
 
     if not is_static:
         args = [Argument(Var("self"), self_type, None, ARG_POS)] + args

--- a/strawberry/ext/mypy_plugin.py
+++ b/strawberry/ext/mypy_plugin.py
@@ -265,7 +265,7 @@ def add_static_method_to_class(
 ) -> None:
     """Adds a static method
     Edited add_method_to_class to incorporate static method logic
-    https://github.com/python/mypy/blob/9c05d3d19de74fc10a51aa5b663e6a38bc6abc73/mypy/plugins/common.py # noqa: E501
+    https://github.com/python/mypy/blob/9c05d3d19/mypy/plugins/common.py
     """
     info = cls.info
 

--- a/strawberry/ext/mypy_plugin.py
+++ b/strawberry/ext/mypy_plugin.py
@@ -5,17 +5,22 @@ from typing_extensions import Final
 
 from mypy.nodes import (
     ARG_POS,
+    ARG_STAR2,
     GDEF,
     MDEF,
     Argument,
     AssignmentStmt,
+    Block,
     CallExpr,
     CastExpr,
+    ClassDef,
     Context,
     Expression,
+    FuncDef,
     IndexExpr,
     MemberExpr,
     NameExpr,
+    PassStmt,
     PlaceholderNode,
     RefExpr,
     SymbolTableNode,
@@ -34,8 +39,9 @@ from mypy.plugin import (
     Plugin,
     SemanticAnalyzerPluginInterface,
 )
-from mypy.plugins.common import _get_decorator_bool_argument, add_method
+from mypy.plugins.common import _get_argument, _get_decorator_bool_argument, add_method
 from mypy.plugins.dataclasses import DataclassAttribute
+from mypy.semanal_shared import set_callable_name
 from mypy.server.trigger import make_wildcard_trigger
 from mypy.types import (
     AnyType,
@@ -48,6 +54,8 @@ from mypy.types import (
     UnionType,
     get_proper_type,
 )
+from mypy.typevars import fill_typevars
+from mypy.util import get_unique_redefinition_name
 
 
 # Backwards compatible with the removal of `TypeVarDef` in mypy 0.920.
@@ -245,9 +253,69 @@ def enum_hook(ctx: DynamicClassDefContext) -> None:
     )
 
 
-def strawberry_pydantic_class_callback(ctx: ClassDefContext):
+def add_method_to_class(
+    api: SemanticAnalyzerPluginInterface,
+    cls: ClassDef,
+    name: str,
+    args: List[Argument],
+    return_type: Type,
+    self_type: Optional[Type] = None,
+    tvar_def: Optional[TypeVarDef] = None,
+    is_static: bool = False,
+) -> None:
+    """Adds a new method to a class definition.
+    Edited to add is_static for
+    https://github.com/python/mypy/blob/master/mypy/plugins/common.py
+    because couldn't figure out how to add static methods otherwise"""
+    info = cls.info
+
+    # First remove any previously generated methods with the same name
+    # to avoid clashes and problems in the semantic analyzer.
+    if name in info.names:
+        sym = info.names[name]
+        if sym.plugin_generated and isinstance(sym.node, FuncDef):
+            cls.defs.body.remove(sym.node)
+
+    self_type = self_type or fill_typevars(info)
+    function_type = api.named_type("__builtins__.function")
+
+    if not is_static:
+        args = [Argument(Var("self"), self_type, None, ARG_POS)] + args
+    arg_types, arg_names, arg_kinds = [], [], []
+    for arg in args:
+        assert arg.type_annotation, "All arguments must be fully typed."
+        arg_types.append(arg.type_annotation)
+        arg_names.append(arg.variable.name)
+        arg_kinds.append(arg.kind)
+
+    signature = CallableType(
+        arg_types, arg_kinds, arg_names, return_type, function_type
+    )
+    if tvar_def:
+        signature.variables = [tvar_def]
+
+    func = FuncDef(name, args, Block([PassStmt()]))
+    if is_static:
+        func.is_static = True
+    func.info = info
+    func.type = set_callable_name(signature, func)
+    func._fullname = info.fullname + "." + name
+    func.line = info.line
+
+    # NOTE: we would like the plugin generated node to dominate, but we still
+    # need to keep any existing definitions so they get semantically analyzed.
+    if name in info.names:
+        # Get a nice unique name instead.
+        r_name = get_unique_redefinition_name(name, info.names)
+        info.names[r_name] = info.names[name]
+
+    info.names[name] = SymbolTableNode(MDEF, func, plugin_generated=True)
+    info.defn.defs.body.append(func)
+
+
+def strawberry_pydantic_class_callback(ctx: ClassDefContext) -> None:
     # in future we want to have a proper pydantic plugin, but for now
-    # let's fallback to any, some resources are here:
+    # let's fallback to **kwargs for __init__, some resources are here:
     # https://github.com/samuelcolvin/pydantic/blob/master/pydantic/mypy.py
     # >>> model_index = ctx.cls.decorators[0].arg_names.index("model")
     # >>> model_name = ctx.cls.decorators[0].args[model_index].name
@@ -255,7 +323,44 @@ def strawberry_pydantic_class_callback(ctx: ClassDefContext):
     # >>> model_type = ctx.api.named_type("UserModel")
     # >>> model_type = ctx.api.lookup(model_name, Context())
 
-    ctx.cls.info.fallback_to_any = True
+    model_expression = _get_argument(call=ctx.reason, name="model")  # type: ignore
+    if model_expression is None:
+        ctx.api.fail("model argument in decorator failed to be parsed", ctx.reason)
+
+    else:
+        # Add __init__
+        init_args = [
+            Argument(Var("kwargs"), AnyType(TypeOfAny.explicit), None, ARG_STAR2)
+        ]
+        add_method(ctx, "__init__", init_args, NoneType())
+
+        model_type = _get_type_for_expr(model_expression, ctx.api)
+
+        # Add to_pydantic
+        add_method(
+            ctx,
+            "to_pydantic",
+            args=[],
+            return_type=model_type,
+        )
+
+        # Add from_pydantic
+
+        model_argument = Argument(
+            variable=Var(name="instance", type=model_type),
+            type_annotation=model_type,
+            initializer=None,
+            kind=1,
+        )
+
+        add_method_to_class(
+            ctx.api,
+            ctx.cls,
+            name="from_pydantic",
+            args=[model_argument],
+            return_type=fill_typevars(ctx.cls.info),
+            is_static=True,
+        )
 
 
 def is_dataclasses_field_or_strawberry_field(expr: Expression) -> bool:

--- a/tests/mypy/test_pydantic.decorators.yml
+++ b/tests/mypy/test_pydantic.decorators.yml
@@ -1,0 +1,86 @@
+
+- case: test_converted_pydantic_init_any_kwargs
+  main: |
+    from pydantic import BaseModel
+    import strawberry
+
+    class UserPydantic(BaseModel):
+        age: int
+
+    @strawberry.experimental.pydantic.type(UserPydantic)
+    class UserStrawberry:
+        age: strawberry.auto
+
+    reveal_type(UserStrawberry)
+    reveal_type(UserStrawberry(age=123))
+  out: |
+     main:11: note: Revealed type is "def (**kwargs: Any) -> main.UserStrawberry"
+     main:12: note: Revealed type is "main.UserStrawberry"
+
+- case: test_converted_to_pydantic
+  main: |
+    from pydantic import BaseModel
+    import strawberry
+
+    class UserPydantic(BaseModel):
+        age: int
+
+    @strawberry.experimental.pydantic.type(UserPydantic)
+    class UserStrawberry:
+        age: strawberry.auto
+
+    reveal_type(UserStrawberry(age=123).to_pydantic())
+  out: |
+     main:11: note: Revealed type is "main.UserPydantic"
+
+- case: test_converted_from_pydantic
+  main: |
+    from pydantic import BaseModel
+    import strawberry
+
+    class UserPydantic(BaseModel):
+        age: int
+
+    @strawberry.experimental.pydantic.type(UserPydantic)
+    class UserStrawberry:
+        age: strawberry.auto
+
+    reveal_type(UserStrawberry.from_pydantic(UserPydantic(age=123)))
+  out: |
+     main:11: note: Revealed type is "main.UserStrawberry"
+
+
+- case: test_converted_from_pydantic_raise_error_wrong_instance
+  main: |
+    from pydantic import BaseModel
+    import strawberry
+
+    class UserPydantic(BaseModel):
+        age: int
+
+    @strawberry.experimental.pydantic.type(UserPydantic)
+    class UserStrawberry:
+        age: strawberry.auto
+
+    class AnotherModel(BaseModel):
+        age: int
+
+    UserStrawberry.from_pydantic(AnotherModel(age=123))
+  out: |
+     main:14: error: Argument 1 to "from_pydantic" of "UserStrawberry" has incompatible type "AnotherModel"; expected "UserPydantic"
+
+- case: test_converted_from_pydantic_chained
+  main: |
+    from pydantic import BaseModel
+    import strawberry
+
+    class UserPydantic(BaseModel):
+        age: int
+
+    @strawberry.experimental.pydantic.type(UserPydantic)
+    class UserStrawberry:
+        age: strawberry.auto
+
+    reveal_type(UserStrawberry.from_pydantic(UserPydantic(age=123)).to_pydantic())
+  out: |
+     main:11: note: Revealed type is "main.UserPydantic"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->


<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Add mypy plugin inference for to_pydantic and from_pydantic
Add typing stub for IDEs

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Documentation


Try it out with mypy!
```{python}
from pydantic import BaseModel
import strawberry

class UserPydantic(BaseModel):
    age: int

@strawberry.experimental.pydantic.type(UserPydantic)
class UserStrawberry:
    age: strawberry.auto

reveal_type(UserStrawberry(age=123).to_pydantic())
```
>    main:11: note: Revealed type is "main.UserPydantic"

Previously it would be "Any"

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
