### PR TITLE
fix(pydantic): Fix TypeError when converting BaseModel with NewType field

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Fixes TypeError when converting a pydantic BaseModel with NewType field

--- a/strawberry/experimental/pydantic/fields.py
+++ b/strawberry/experimental/pydantic/fields.py
@@ -3,6 +3,7 @@ from typing import Optional
 from uuid import UUID
 
 import pydantic
+from pydantic.typing import is_new_type, new_type_supertype
 
 from .exceptions import UnsupportedTypeError
 
@@ -75,5 +76,8 @@ def get_basic_type(type_):
 
         if type_ is None:
             raise UnsupportedTypeError()
+
+    if is_new_type(type_):
+        return new_type_supertype(type_)
 
     return type_

--- a/strawberry/experimental/pydantic/object_type.py
+++ b/strawberry/experimental/pydantic/object_type.py
@@ -37,21 +37,21 @@ def replace_pydantic_types(type_: Any):
         # Literal does not have types in its __args__ so we return early
         return type_
     if hasattr(type_, "__args__"):
-        new_type = type_.copy_with(
+        replaced_type = type_.copy_with(
             tuple(replace_pydantic_types(t) for t in type_.__args__)
         )
 
-        if isinstance(new_type, TypeDefinition):
+        if isinstance(replaced_type, TypeDefinition):
             # TODO: Not sure if this is necessary. No coverage in tests
             # TODO: Unnecessary with StrawberryObject
 
-            new_type = builtins.type(
-                new_type.name,
+            replaced_type = builtins.type(
+                replaced_type.name,
                 (),
-                {"_type_definition": new_type},
+                {"_type_definition": replaced_type},
             )
 
-        return new_type
+        return replaced_type
 
     if issubclass(type_, BaseModel):
         if hasattr(type_, "_strawberry_type"):

--- a/tests/experimental/pydantic/test_conversion.py
+++ b/tests/experimental/pydantic/test_conversion.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, List, Optional, Union, cast
+from typing import Any, List, NewType, Optional, Union, cast
 
 import pytest
 
@@ -701,6 +701,25 @@ def test_can_convert_input_types_to_pydantic_default_values_defaults_declared_fi
     assert password_field.python_name == "password"
     assert isinstance(password_field.type, StrawberryOptional)
     assert password_field.type.of_type is str
+
+
+def test_can_convert_pydantic_type_to_strawberry_newtype():
+    Password = NewType("Password", str)
+
+    class User(BaseModel):
+        age: int
+        password: Optional[Password]
+
+    @strawberry.experimental.pydantic.type(User)
+    class UserType:
+        age: strawberry.auto
+        password: strawberry.auto
+
+    origin_user = User(age=1, password="abc")
+    user = UserType.from_pydantic(origin_user)
+
+    assert user.age == 1
+    assert user.password == "abc"
 
 
 def test_sort_creation_fields():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Previously you would get an error 
```
TypeError: issubclass() arg 1 must be a class
```
as we would call issubclass on the NewType

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
