### PR TITLE
Add ability to retain input metadata into Pydantic models.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: minor
+
+Adds the ability to retain input metadata in the experimental Pydantic models with
+a new `with_input_metadata` flag

--- a/docs/integrations/pydantic.md
+++ b/docs/integrations/pydantic.md
@@ -269,7 +269,7 @@ instance = input_data.to_pydantic()
 
 When using pydantic as a validation layer, it is sometimes important to retain metadata about
 the original input while exporting models.
-In strawberry, this is possible via the `with_input_metadata` flag on input models.
+With Strawberry, this is possible via the `with_input_metadata` flag on input models.
 
 ```python
 import strawberry

--- a/docs/integrations/pydantic.md
+++ b/docs/integrations/pydantic.md
@@ -267,9 +267,9 @@ instance = input_data.to_pydantic()
 
 ### Retaining input information
 
-When looking to use pydantic as a validation layer and export models afterwards,
-it is sometimes important to retain metadata about the original input. In strawberry,
-this is possible via the `with_input_metadata` flag on input models.
+When using pydantic as a validation layer, it is sometimes important to retain metadata about
+the original input while exporting models.
+In strawberry, this is possible via the `with_input_metadata` flag on input models.
 
 ```python
 import strawberry

--- a/docs/integrations/pydantic.md
+++ b/docs/integrations/pydantic.md
@@ -264,3 +264,34 @@ input_data = UserInput(id='abc', name='Jake')
 # this will run pydantic's validation
 instance = input_data.to_pydantic()
 ```
+
+### Retaining input information
+
+When looking to use pydantic as a validation layer and export models afterwards,
+it is sometimes important to retain metadata about the original input. In strawberry,
+this is possible via the `with_input_metadata` flag on input models.
+
+```python
+import strawberry
+from typing import List, Optional
+from pydantic import BaseModel
+
+
+class User(BaseModel):
+    id: int
+    name: Optional[str]
+
+
+@strawberry.experimental.pydantic.input(model=User, with_input_metadata=True)
+class UserInput:
+    id: strawberry.auto
+    name: strawberry.auto
+
+input_data = UserInput(id='abc')
+
+# this will run pydantic's validation
+instance = input_data.to_pydantic()
+
+# this will export ONLY the data available at Input
+instance.dict(exclude_unset=True)
+```

--- a/strawberry/experimental/pydantic/object_type.py
+++ b/strawberry/experimental/pydantic/object_type.py
@@ -201,9 +201,9 @@ def type(
         def to_pydantic(self) -> Any:
             instance_kwargs = dataclasses.asdict(
                 self,
-                dict_factory=dict
-                if not with_input_metadata
-                else PydanticInputMetadataDict,
+                dict_factory=(
+                    dict if not with_input_metadata else PydanticInputMetadataDict
+                ),
             )
 
             return model(**instance_kwargs)

--- a/strawberry/experimental/pydantic/object_type.py
+++ b/strawberry/experimental/pydantic/object_type.py
@@ -2,7 +2,7 @@ import builtins
 import dataclasses
 import warnings
 from functools import partial
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Type, cast
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Type, cast
 
 from pydantic import BaseModel
 from pydantic.fields import ModelField
@@ -39,7 +39,7 @@ class PydanticInputMetadataDict(Dict[str, Any]):
     model creation with Pydantic's exclude_unset setting.
     """
 
-    def __init__(self, fields: List[Tuple[str, Any]]) -> None:
+    def __init__(self, fields: Iterable[Tuple[str, Any]]) -> None:
         super().__init__(field for field in fields if not is_unset(field[1]))
 
 

--- a/strawberry/experimental/pydantic/utils.py
+++ b/strawberry/experimental/pydantic/utils.py
@@ -78,7 +78,9 @@ def sort_creation_fields(
     return sorted(fields, key=has_default)
 
 
-def get_default_factory_for_field(field: ModelField) -> Union[NoArgAnyCallable, _Unset]:
+def get_default_factory_for_field(
+    field: ModelField, with_input_metadata: bool = False
+) -> Union[NoArgAnyCallable, _Unset]:
     """
     Gets the default factory for a pydantic field.
 
@@ -86,6 +88,11 @@ def get_default_factory_for_field(field: ModelField) -> Union[NoArgAnyCallable, 
 
     Returns optionally a NoArgAnyCallable representing a default_factory parameter
     """
+    # Short circuit behaviour to allow usage of strawberry input parsing
+    # without losing metadata on provided payload.
+    if not field.required and with_input_metadata:
+        return lambda: UNSET
+
     default_factory = field.default_factory
     default = field.default
 

--- a/tests/experimental/pydantic/test_basic.py
+++ b/tests/experimental/pydantic/test_basic.py
@@ -105,6 +105,31 @@ def test_basic_type_with_input_metadata():
         "frenemy": "frenemy_value"
     }
 
+    # explicit tests for None
+    class User3(pydantic.BaseModel):
+        enemy: Optional[str] = None
+        friend: Optional[str] = pydantic.Field(default_factory=lambda: None)
+        frenemy: str
+
+    @strawberry.experimental.pydantic.type(User3, with_input_metadata=True)
+    class UserType3:
+        enemy: strawberry.auto
+        friend: strawberry.auto
+        frenemy: strawberry.auto
+
+    user_input_3 = UserType3(frenemy="frenemy_value")
+    assert is_unset(user_input_3.friend)
+    assert is_unset(user_input_3.enemy)
+    assert user_input_3.to_pydantic().friend is None
+    assert user_input_3.to_pydantic().dict() == {
+        "enemy": None,
+        "friend": None,
+        "frenemy": "frenemy_value",
+    }
+    assert user_input_3.to_pydantic().dict(exclude_unset=True) == {
+        "frenemy": "frenemy_value"
+    }
+
 
 @pytest.mark.filterwarnings("error")
 def test_basic_type_all_fields_warn():

--- a/tests/experimental/pydantic/test_basic.py
+++ b/tests/experimental/pydantic/test_basic.py
@@ -76,6 +76,7 @@ def test_basic_type_with_input_metadata():
 
     user_input_1 = UserType1(frenemy="frenemy_value")
     assert is_unset(user_input_1.friend)
+    assert user_input_1.friend == "friend_value"
     assert user_input_1.to_pydantic().friend == "friend_value"
     assert user_input_1.to_pydantic().dict() == {
         "friend": "friend_value",


### PR DESCRIPTION
## Background

This is a quick enhancement intended to be backward compatible within the current experimental pydantic model. As a future ref, this should certainly be considered for default behavior before hitting stable.

Achieving GraphQL semantics similar to "PATCH" is usually implemented with Optional input. 
The GraphQL spec suggests that missing optional input is not coerced to values, but rather stays out of the input map ( https://spec.graphql.org/October2021/#sec-Input-Objects.Input-Coercion ).

In Strawberry, a decision has been made to handle this with its own value - UNSET.

Pydantic, on the other side, long has had the ability to introspect fields not provided on instance creation( https://pydantic-docs.helpmanual.io/usage/exporting_models/ ). This is a particularly useful feature when relying on the library as a validation layer and bridge to domain objects.
Currently in Strawberry the only potential workaround to retain the information of "What fields were provided within the request on input?" requires:

* dropping reliance on strawberry.auto and explicitly swapping factories while also introducing incoherent typing
or
* leaking strawberry abstractions within the domain models.


## Description

The proposed solution introduces a backward compatible way to retain the information of a value's presence at input up to the Pydantic validator.


## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

Decided not to open an issue and use this instead.

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
