### PR TITLE
Improve strawberry.enum typing by using generics

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,8 +2,9 @@ Release type: patch
 
 Improve typing of `@strawberry.enum()` by:
 
-1. Using a `TypeVar` bound on `EnumMeta` instead of `EnumMeta`, which allows type-checkers (like pyright)
-   to detect the fields of the enum being decorated. For example, for the following enum:
+1. Using a `TypeVar` bound on `EnumMeta` instead of `EnumMeta`, which allows
+   type-checkers (like pyright) to detect the fields of the enum being
+   decorated. For example, for the following enum:
 
 ```python
 @strawberry.enum
@@ -13,10 +14,11 @@ class IceCreamFlavour(Enum):
     CHOCOLATE = "chocolate"
 ```
 
-   Prior to this change, pyright would complain if you tried to access
-   `IceCreamFlavour.VANILLA`, since the type information of `IceCreamFlavour` was being
-   erased by the `EnumMeta` typing  .
+Prior to this change, pyright would complain if you tried to access
+`IceCreamFlavour.VANILLA`, since the type information of `IceCreamFlavour` was
+being erased by the `EnumMeta` typing .
 
-2. Overloading it so that type-checkers (like pyright) knows in what cases it returns a decorator
-   (when it's called with keyword arguments, e.g. `@strawberry.enum(name="IceCreamFlavor")`),
-   versus when it returns the original enum type (without keyword arguments.
+2. Overloading it so that type-checkers (like pyright) knows in what cases it
+   returns a decorator (when it's called with keyword arguments, e.g.
+   `@strawberry.enum(name="IceCreamFlavor")`), versus when it returns the
+   original enum type (without keyword arguments.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,22 @@
+Release type: patch
+
+Improve typing of `@strawberry.enum()` by:
+
+1. Using a `TypeVar` bound on `EnumMeta` instead of `EnumMeta`, which allows type-checkers (like pyright)
+   to detect the fields of the enum being decorated. For example, for the following enum:
+
+```python
+@strawberry.enum
+class IceCreamFlavour(Enum):
+    VANILLA = "vanilla"
+    STRAWBERRY = "strawberry"
+    CHOCOLATE = "chocolate"
+```
+
+   Prior to this change, pyright would complain if you tried to access
+   `IceCreamFlavour.VANILLA`, since the type information of `IceCreamFlavour` was being
+   erased by the `EnumMeta` typing  .
+
+2. Overloading it so that type-checkers (like pyright) knows in what cases it returns a decorator
+   (when it's called with keyword arguments, e.g. `@strawberry.enum(name="IceCreamFlavor")`),
+   versus when it returns the original enum type (without keyword arguments.

--- a/strawberry/enum.py
+++ b/strawberry/enum.py
@@ -1,6 +1,6 @@
 import dataclasses
 from enum import EnumMeta
-from typing import Any, Callable, List, Mapping, Optional, TypeVar, Union
+from typing import Any, Callable, List, Mapping, Optional, TypeVar, Union, overload
 
 from strawberry.type import StrawberryType
 
@@ -34,9 +34,12 @@ class EnumDefinition(StrawberryType):
         return False
 
 
+EnumType = TypeVar("EnumType", bound=EnumMeta)
+
+
 def _process_enum(
-    cls: EnumMeta, name: Optional[str] = None, description: Optional[str] = None
-) -> EnumMeta:
+    cls: EnumType, name: Optional[str] = None, description: Optional[str] = None
+) -> EnumType:
     if not isinstance(cls, EnumMeta):
         raise ObjectIsNotAnEnumError(cls)
 
@@ -57,16 +60,28 @@ def _process_enum(
     return cls
 
 
+@overload
+def enum(_cls: EnumType, *, name=None, description=None) -> EnumType:
+    ...
+
+
+@overload
 def enum(
-    _cls: EnumMeta = None, *, name=None, description=None
-) -> Union[EnumMeta, Callable[[EnumMeta], EnumMeta]]:
+    _cls: None = None, *, name=None, description=None
+) -> Callable[[EnumType], EnumType]:
+    ...
+
+
+def enum(
+    _cls: Optional[EnumType] = None, *, name=None, description=None
+) -> Union[EnumType, Callable[[EnumType], EnumType]]:
     """Registers the enum in the GraphQL type system.
 
     If name is passed, the name of the GraphQL type will be
     the value passed of name instead of the Enum class name.
     """
 
-    def wrap(cls: EnumMeta) -> EnumMeta:
+    def wrap(cls: EnumType) -> EnumType:
         return _process_enum(cls, name, description)
 
     if not _cls:

--- a/tests/mypy/test_enum.yml
+++ b/tests/mypy/test_enum.yml
@@ -80,10 +80,11 @@
     a: IceCreamFlavour
     reveal_type(IceCreamFlavour)
     reveal_type(a)
+    reveal_type(IceCreamFlavour.VANILLA)
   out: |
     main:12: note: Revealed type is "def (value: builtins.object) -> main.IceCreamFlavour*"
     main:13: note: Revealed type is "main.IceCreamFlavour"
-
+    main:14: note: Revealed type is "Literal[main.IceCreamFlavour.VANILLA]?"
 - case: test_enum_with_decorator_and_name
   main: |
     from enum import Enum
@@ -99,6 +100,40 @@
     a: Flavour
     reveal_type(Flavour)
     reveal_type(a)
+    reveal_type(Flavour.VANILLA)
   out: |
     main:12: note: Revealed type is "def (value: builtins.object) -> main.Flavour*"
     main:13: note: Revealed type is "main.Flavour"
+    main:14: note: Revealed type is "Literal[main.Flavour.VANILLA]?"
+- case: test_enum_with_manual_decorator
+  main: |
+    from enum import Enum
+
+    import strawberry
+
+    class IceCreamFlavour(Enum):
+        VANILLA = "vanilla"
+        STRAWBERRY = "strawberry"
+        CHOCOLATE = "chocolate"
+
+    reveal_type(strawberry.enum(IceCreamFlavour))
+    reveal_type(strawberry.enum(IceCreamFlavour).VANILLA)
+  out: |
+    main:10: note: Revealed type is "def (value: builtins.object) -> main.IceCreamFlavour*"
+    main:11: note: Revealed type is "Literal[main.IceCreamFlavour.VANILLA]?"
+- case: test_enum_with_manual_decorator_and_name
+  main: |
+    from enum import Enum
+
+    import strawberry
+
+    class Flavour(Enum):
+        VANILLA = "vanilla"
+        STRAWBERRY = "strawberry"
+        CHOCOLATE = "chocolate"
+
+    reveal_type(strawberry.enum(name="IceCreamFlavour")(Flavour))
+    reveal_type(strawberry.enum(name="IceCreamFlavour")(Flavour).VANILLA)
+  out: |
+    main:10: note: Revealed type is "def (value: builtins.object) -> main.Flavour*"
+    main:11: note: Revealed type is "Literal[main.Flavour.VANILLA]?"

--- a/tests/pyright/test_enum.py
+++ b/tests/pyright/test_enum.py
@@ -1,0 +1,157 @@
+from .utils import Result, requires_pyright, run_pyright, skip_on_windows
+
+
+pytestmark = [skip_on_windows, requires_pyright]
+
+
+CODE_WITH_DECORATOR = """
+from enum import Enum
+
+import strawberry
+
+@strawberry.enum
+class IceCreamFlavour(Enum):
+    VANILLA = "vanilla"
+    STRAWBERRY = "strawberry"
+    CHOCOLATE = "chocolate"
+
+reveal_type(IceCreamFlavour)
+reveal_type(IceCreamFlavour.VANILLA)
+"""
+
+
+def test_enum_with_decorator():
+    results = run_pyright(CODE_WITH_DECORATOR)
+
+    assert results == [
+        Result(
+            type="info",
+            message='Type of "IceCreamFlavour" is "Type[IceCreamFlavour]"',
+            line=12,
+            column=13,
+        ),
+        Result(
+            type="info",
+            message=(
+                'Type of "IceCreamFlavour.VANILLA" is '
+                '"Literal[IceCreamFlavour.VANILLA]"'
+            ),
+            line=13,
+            column=13,
+        ),
+    ]
+
+
+CODE_WITH_DECORATOR_AND_NAME = """
+from enum import Enum
+
+import strawberry
+
+@strawberry.enum(name="IceCreamFlavour")
+class Flavour(Enum):
+    VANILLA = "vanilla"
+    STRAWBERRY = "strawberry"
+    CHOCOLATE = "chocolate"
+
+reveal_type(Flavour)
+reveal_type(Flavour.VANILLA)
+"""
+
+
+def test_enum_with_decorator_and_name():
+    results = run_pyright(CODE_WITH_DECORATOR_AND_NAME)
+
+    assert results == [
+        Result(
+            type="info",
+            message='Type of "Flavour" is "Type[Flavour]"',
+            line=12,
+            column=13,
+        ),
+        Result(
+            type="info",
+            message='Type of "Flavour.VANILLA" is "Literal[Flavour.VANILLA]"',
+            line=13,
+            column=13,
+        ),
+    ]
+
+
+CODE_WITH_MANUAL_DECORATOR = """
+from enum import Enum
+
+import strawberry
+
+class IceCreamFlavour(Enum):
+    VANILLA = "vanilla"
+    STRAWBERRY = "strawberry"
+    CHOCOLATE = "chocolate"
+
+reveal_type(strawberry.enum(IceCreamFlavour))
+reveal_type(strawberry.enum(IceCreamFlavour).VANILLA)
+"""
+
+
+def test_enum_with_manual_decorator():
+    results = run_pyright(CODE_WITH_MANUAL_DECORATOR)
+
+    assert results == [
+        Result(
+            type="info",
+            message=(
+                'Type of "strawberry.enum(IceCreamFlavour)" '
+                'is "Type[IceCreamFlavour]"'
+            ),
+            line=11,
+            column=13,
+        ),
+        Result(
+            type="info",
+            message=(
+                'Type of "strawberry.enum(IceCreamFlavour).VANILLA" '
+                'is "Literal[IceCreamFlavour.VANILLA]"'
+            ),
+            line=12,
+            column=13,
+        ),
+    ]
+
+
+CODE_WITH_MANUAL_DECORATOR_AND_NAME = """
+from enum import Enum
+
+import strawberry
+
+class Flavour(Enum):
+    VANILLA = "vanilla"
+    STRAWBERRY = "strawberry"
+    CHOCOLATE = "chocolate"
+
+reveal_type(strawberry.enum(name="IceCreamFlavour")(Flavour))
+reveal_type(strawberry.enum(name="IceCreamFlavour")(Flavour).VANILLA)
+"""
+
+
+def test_enum_with_manual_decorator_and_name():
+    results = run_pyright(CODE_WITH_MANUAL_DECORATOR_AND_NAME)
+
+    assert results == [
+        Result(
+            type="info",
+            message=(
+                'Type of "strawberry.enum(name="IceCreamFlavour")(Flavour)" '
+                'is "Type[Flavour]"'
+            ),
+            line=11,
+            column=13,
+        ),
+        Result(
+            type="info",
+            message=(
+                'Type of "strawberry.enum(name="IceCreamFlavour")(Flavour).VANILLA" '
+                'is "Literal[Flavour.VANILLA]"'
+            ),
+            line=12,
+            column=13,
+        ),
+    ]


### PR DESCRIPTION
## Description

1. Using a `TypeVar` bound on `EnumMeta` instead of `EnumMeta`, which allows type-checkers (like pyright)
   to detect the fields of the enum being decorated. For example, for the following enum:

```python
@strawberry.enum
class IceCreamFlavour(Enum):
    VANILLA = "vanilla"
    STRAWBERRY = "strawberry"
    CHOCOLATE = "chocolate"
```

   Prior to this change, pyright would complain if you tried to access
   `IceCreamFlavour.VANILLA`, since the type information of `IceCreamFlavour` was being
   erased by the `EnumMeta` typing  .

2. Overloading it so that type-checkers (like pyright) knows in what cases it returns a decorator
   (when it's called with keyword arguments, e.g. `@strawberry.enum(name="IceCreamFlavor")`),
   versus when it returns the original enum type (without keyword arguments.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

NA

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).