### PR TITLE
fix(pyright): Use information instead of info for pyright tests

### DIFF
--- a/tests/pyright/test_enum.py
+++ b/tests/pyright/test_enum.py
@@ -25,13 +25,13 @@ def test_enum_with_decorator():
 
     assert results == [
         Result(
-            type="info",
+            type="information",
             message='Type of "IceCreamFlavour" is "Type[IceCreamFlavour]"',
             line=12,
             column=13,
         ),
         Result(
-            type="info",
+            type="information",
             message=(
                 'Type of "IceCreamFlavour.VANILLA" is '
                 '"Literal[IceCreamFlavour.VANILLA]"'
@@ -63,13 +63,13 @@ def test_enum_with_decorator_and_name():
 
     assert results == [
         Result(
-            type="info",
+            type="information",
             message='Type of "Flavour" is "Type[Flavour]"',
             line=12,
             column=13,
         ),
         Result(
-            type="info",
+            type="information",
             message='Type of "Flavour.VANILLA" is "Literal[Flavour.VANILLA]"',
             line=13,
             column=13,
@@ -97,7 +97,7 @@ def test_enum_with_manual_decorator():
 
     assert results == [
         Result(
-            type="info",
+            type="information",
             message=(
                 'Type of "strawberry.enum(IceCreamFlavour)" '
                 'is "Type[IceCreamFlavour]"'
@@ -106,7 +106,7 @@ def test_enum_with_manual_decorator():
             column=13,
         ),
         Result(
-            type="info",
+            type="information",
             message=(
                 'Type of "strawberry.enum(IceCreamFlavour).VANILLA" '
                 'is "Literal[IceCreamFlavour.VANILLA]"'
@@ -137,7 +137,7 @@ def test_enum_with_manual_decorator_and_name():
 
     assert results == [
         Result(
-            type="info",
+            type="information",
             message=(
                 'Type of "strawberry.enum(name="IceCreamFlavour")(Flavour)" '
                 'is "Type[Flavour]"'
@@ -146,7 +146,7 @@ def test_enum_with_manual_decorator_and_name():
             column=13,
         ),
         Result(
-            type="info",
+            type="information",
             message=(
                 'Type of "strawberry.enum(name="IceCreamFlavour")(Flavour).VANILLA" '
                 'is "Literal[Flavour.VANILLA]"'

--- a/tests/pyright/test_federation.py
+++ b/tests/pyright/test_federation.py
@@ -43,10 +43,13 @@ def test_pyright():
             column=1,
         ),
         Result(
-            type="info", message='Type of "User" is "Type[User]"', line=18, column=13
+            type="information",
+            message='Type of "User" is "Type[User]"',
+            line=18,
+            column=13,
         ),
         Result(
-            type="info",
+            type="information",
             message='Type of "User.__init__" is "(self: User, name: str) -> None"',
             line=19,
             column=13,

--- a/tests/pyright/test_fields.py
+++ b/tests/pyright/test_fields.py
@@ -38,10 +38,13 @@ def test_pyright():
             column=1,
         ),
         Result(
-            type="info", message='Type of "User" is "Type[User]"', line=13, column=13
+            type="information",
+            message='Type of "User" is "Type[User]"',
+            line=13,
+            column=13,
         ),
         Result(
-            type="info",
+            type="information",
             message='Type of "User.__init__" is "(self: User, name: str) -> None"',
             line=14,
             column=13,

--- a/tests/pyright/test_fields_input.py
+++ b/tests/pyright/test_fields_input.py
@@ -37,10 +37,13 @@ def test_pyright():
             column=1,
         ),
         Result(
-            type="info", message='Type of "User" is "Type[User]"', line=13, column=13
+            type="information",
+            message='Type of "User" is "Type[User]"',
+            line=13,
+            column=13,
         ),
         Result(
-            type="info",
+            type="information",
             message='Type of "User.__init__" is "(self: User, name: str) -> None"',
             line=14,
             column=13,

--- a/tests/pyright/test_fields_resolver.py
+++ b/tests/pyright/test_fields_resolver.py
@@ -41,10 +41,13 @@ def test_pyright():
             column=1,
         ),
         Result(
-            type="info", message='Type of "User" is "Type[User]"', line=17, column=13
+            type="information",
+            message='Type of "User" is "Type[User]"',
+            line=17,
+            column=13,
         ),
         Result(
-            type="info",
+            type="information",
             message='Type of "User.__init__" is "(self: User, name: str) -> None"',
             line=18,
             column=13,

--- a/tests/pyright/test_private.py
+++ b/tests/pyright/test_private.py
@@ -42,9 +42,15 @@ def test_pyright():
             column=1,
         ),
         Result(
-            type="info", message='Type of "patrick.name" is "str"', line=14, column=13
+            type="information",
+            message='Type of "patrick.name" is "str"',
+            line=14,
+            column=13,
         ),
         Result(
-            type="info", message='Type of "patrick.age" is "int"', line=15, column=13
+            type="information",
+            message='Type of "patrick.age" is "int"',
+            line=15,
+            column=13,
         ),
     ]

--- a/tests/pyright/test_union.py
+++ b/tests/pyright/test_union.py
@@ -32,10 +32,10 @@ def test_pyright():
 
     assert results == [
         Result(
-            type="info",
+            type="information",
             message='Type of "UserOrError" is "Type[User] | Type[Error]"',
             line=16,
             column=13,
         ),
-        Result(type="info", message='Type of "x" is "User"', line=20, column=13),
+        Result(type="information", message='Type of "x" is "User"', line=20, column=13),
     ]


### PR DESCRIPTION
[Pyright's latest release](https://github.com/microsoft/pyright/releases/tag/1.1.209) changed `info` to `information`. This broke the CI tests
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
