### PR TITLE
Deprecate Chalice's `render_graphiql` parameter by adding a warning

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,3 @@
 Release type: patch
 
-This release deprecate the parameter `render_graphiql` in favour of `graphiql` in Chalice's `GraphQLView`.
+With this release in Chalice's `GraphQLView` the parameter `render_graphiql` is now deprecated and has been replaced with `graphiq`. It will be removed in releases of Strawberry made after 2022-02-22.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,5 @@
 Release type: patch
 
-With this release in Chalice's `GraphQLView` the parameter `render_graphiql` is now deprecated and has been replaced with `graphiq`. It will be removed in releases of Strawberry made after 2022-02-22.
+With this release in Chalice's `GraphQLView` the parameter `render_graphiql` is now
+deprecated and has been replaced with `graphiql`. It will be removed in releases of
+Strawberry made after 2022-02-22.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+This release deprecate the parameter `render_graphiql` in favour of `graphiql` in Chalice's `GraphQLView`.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,4 +2,4 @@ Release type: patch
 
 With this release in Chalice's `GraphQLView` the parameter `render_graphiql` is now
 deprecated and has been replaced with `graphiql`. It will be removed in releases of
-Strawberry made after 2022-02-22.
+Strawberry made after 2022-07-13.

--- a/docs/integrations/chalice.md
+++ b/docs/integrations/chalice.md
@@ -41,7 +41,7 @@ class Mutation:
 
 
 schema = strawberry.Schema(query=Query, mutation=Mutation)
-view = GraphQLView(schema=schema, render_graphiql=True)
+view = GraphQLView(schema=schema, graphiql=True)
 
 
 @app.route("/graphql", methods=["GET", "POST"], content_types=["application/json"])

--- a/strawberry/chalice/views.py
+++ b/strawberry/chalice/views.py
@@ -22,7 +22,7 @@ class GraphQLView:
         if render_graphiql is not None:
             warnings.warn(
                 "`render_graphiql` is deprecated and it will stop working in releases "
-                "of strawberry made after 2022-02-22. Use `graphiql` instead",
+                "of strawberry made after 2022-05-28. Use `graphiql` instead",
                 DeprecationWarning,
             )
             self.graphiql = render_graphiql

--- a/strawberry/chalice/views.py
+++ b/strawberry/chalice/views.py
@@ -22,7 +22,7 @@ class GraphQLView:
         if render_graphiql is not None:
             warnings.warn(
                 "`render_graphiql` is deprecated and it will stop working in releases "
-                "of strawberry made after 2022-06-07. Use `graphiql` instead",
+                "of strawberry made after 2022-07-13. Use `graphiql` instead",
                 DeprecationWarning,
             )
             self.graphiql = render_graphiql

--- a/strawberry/chalice/views.py
+++ b/strawberry/chalice/views.py
@@ -1,3 +1,4 @@
+import warnings
 from http import HTTPStatus
 
 from chalice.app import BadRequestError, CaseInsensitiveMapping, Request, Response
@@ -8,9 +9,19 @@ from strawberry.types import ExecutionResult
 
 
 class GraphQLView:
-    def __init__(self, schema: BaseSchema, render_graphiql: bool = True):
+    def __init__(
+        self, schema: BaseSchema, graphiql: bool = True, render_graphiql: bool = True
+    ):
         self._schema = schema
-        self.graphiql = render_graphiql
+        self.graphiql = graphiql
+
+        if render_graphiql:
+            warnings.warn(
+                "`render_graphiql` is deprecated and it will stop working in releases "
+                "of strawberry made after 2022-02-17. Use `graphiql` instead",
+                DeprecationWarning,
+            )
+            self.graphiql = render_graphiql
 
     @staticmethod
     def render_graphiql() -> str:

--- a/strawberry/chalice/views.py
+++ b/strawberry/chalice/views.py
@@ -22,7 +22,7 @@ class GraphQLView:
         if render_graphiql is not None:
             warnings.warn(
                 "`render_graphiql` is deprecated and it will stop working in releases "
-                "of strawberry made after 2022-05-28. Use `graphiql` instead",
+                "of strawberry made after 2022-06-07. Use `graphiql` instead",
                 DeprecationWarning,
             )
             self.graphiql = render_graphiql

--- a/strawberry/chalice/views.py
+++ b/strawberry/chalice/views.py
@@ -1,5 +1,6 @@
 import warnings
 from http import HTTPStatus
+from typing import Optional
 
 from chalice.app import BadRequestError, CaseInsensitiveMapping, Request, Response
 from strawberry.chalice.graphiql import render_graphiql_page
@@ -10,15 +11,18 @@ from strawberry.types import ExecutionResult
 
 class GraphQLView:
     def __init__(
-        self, schema: BaseSchema, graphiql: bool = True, render_graphiql: bool = True
+        self,
+        schema: BaseSchema,
+        graphiql: bool = True,
+        render_graphiql: Optional[bool] = None,
     ):
         self._schema = schema
         self.graphiql = graphiql
 
-        if render_graphiql:
+        if render_graphiql is not None:
             warnings.warn(
                 "`render_graphiql` is deprecated and it will stop working in releases "
-                "of strawberry made after 2022-02-17. Use `graphiql` instead",
+                "of strawberry made after 2022-02-22. Use `graphiql` instead",
                 DeprecationWarning,
             )
             self.graphiql = render_graphiql

--- a/tests/chalice/app.py
+++ b/tests/chalice/app.py
@@ -35,3 +35,15 @@ def handle_graphql():
     request: Request = app.current_request
     result = view.execute_request(request)
     return result
+
+
+deprecated_graphiql_view = GraphQLView(schema=schema, render_graphiql=True)
+
+
+@app.route(
+    "/deprecated-graphql", methods=["GET", "POST"], content_types=["application/json"]
+)
+def handle_deprecated_graphql():
+    request: Request = app.current_request
+    result = deprecated_graphiql_view.execute_request(request)
+    return result

--- a/tests/chalice/app.py
+++ b/tests/chalice/app.py
@@ -22,7 +22,7 @@ class Mutation:
 
 
 schema = strawberry.Schema(query=Query, mutation=Mutation)
-view = GraphQLView(schema=schema, render_graphiql=True)
+view = GraphQLView(schema=schema, graphiql=True)
 
 
 @app.route("/")

--- a/tests/chalice/test_views.py
+++ b/tests/chalice/test_views.py
@@ -94,3 +94,11 @@ def test_graphiql_query_with_no_request_body():
         response = client.http.post("/graphql", headers=headers, body="")
         assert response.status_code == HTTPStatus.OK
         assert response_is_of_error_type(response)
+
+
+def test_deprecated_render_graphiql():
+    with Client(app) as client:
+        headers = {"Accept": "application/json"}
+        response = client.http.get("/deprecated-graphql", headers=headers)
+        assert response.status_code == HTTPStatus.OK
+        assert response_is_of_error_type(response)

--- a/tests/chalice/test_views.py
+++ b/tests/chalice/test_views.py
@@ -111,5 +111,5 @@ def test_using_deprecated_render_graphiql_raise_warning():
 
     assert record[0].message.args == [
         "`render_graphiql` is deprecated and it will stop working in releases "
-        "of strawberry made after 2022-06-07. Use `graphiql` instead",
+        "of strawberry made after 2022-07-13. Use `graphiql` instead",
     ]

--- a/tests/chalice/test_views.py
+++ b/tests/chalice/test_views.py
@@ -111,5 +111,5 @@ def test_using_deprecated_render_graphiql_raise_warning():
 
     assert record[0].message.args == [
         "`render_graphiql` is deprecated and it will stop working in releases "
-        "of strawberry made after 2022-05-28. Use `graphiql` instead",
+        "of strawberry made after 2022-06-07. Use `graphiql` instead",
     ]

--- a/tests/chalice/test_views.py
+++ b/tests/chalice/test_views.py
@@ -4,8 +4,9 @@ from http import HTTPStatus
 import pytest
 
 from chalice.test import Client, HTTPResponse
+from strawberry.chalice.views import GraphQLView
 
-from .app import app
+from .app import app, schema
 
 
 def test_chalice_server_index_route_returns():
@@ -102,3 +103,13 @@ def test_deprecated_render_graphiql():
         response = client.http.get("/deprecated-graphql", headers=headers)
         assert response.status_code == HTTPStatus.OK
         assert response_is_of_error_type(response)
+
+
+def test_using_deprecated_render_graphiql_raise_warning():
+    with pytest.deprecated_call() as record:
+        GraphQLView(schema=schema, render_graphiql=True)
+
+    assert record[0].message.args == [
+        "`render_graphiql` is deprecated and it will stop working in releases "
+        "of strawberry made after 2022-05-28. Use `graphiql` instead",
+    ]


### PR DESCRIPTION
Deprecate the parameter `render_graphiql` in favour of `graphiql` in Chalice view. 

## Description

Chalice's view is the only one with a different parameter name for enabling/disabling graphiql. Would like to uniform to the others. 


## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
