### PR TITLE
Fix #1504 where the pydantic integration fails when defining input and output types

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+Fix bug #1504 in the Pydantic integration, where it was impossible to define
+both an input and output type based on the same Pydantic base class.

--- a/strawberry/experimental/pydantic/conversion.py
+++ b/strawberry/experimental/pydantic/conversion.py
@@ -45,8 +45,12 @@ def _convert_from_pydantic_to_strawberry_type(
     if hasattr(type_, "_type_definition"):
         # in the case of an interface, the concrete type may be more specific
         # than the type in the field definition
-        if hasattr(type(data), "_strawberry_type"):
-            type_ = type(data)._strawberry_type
+        if type_._type_definition.is_input:  # type: ignore
+            if hasattr(type(data), "_strawberry_input_type"):
+                type_ = type(data)._strawberry_input_type
+        else:
+            if hasattr(type(data), "_strawberry_type"):
+                type_ = type(data)._strawberry_type
         return convert_pydantic_model_to_strawberry_class(
             type_, model_instance=data_from_model, extra=extra
         )

--- a/strawberry/experimental/pydantic/conversion.py
+++ b/strawberry/experimental/pydantic/conversion.py
@@ -45,12 +45,9 @@ def _convert_from_pydantic_to_strawberry_type(
     if hasattr(type_, "_type_definition"):
         # in the case of an interface, the concrete type may be more specific
         # than the type in the field definition
-        if type_._type_definition.is_input:  # type: ignore
-            if hasattr(type(data), "_strawberry_input_type"):
-                type_ = type(data)._strawberry_input_type
-        else:
-            if hasattr(type(data), "_strawberry_type"):
-                type_ = type(data)._strawberry_type
+        # don't check _strawberry_input_type because inputs can't be interfaces
+        if hasattr(type(data), "_strawberry_type"):
+            type_ = type(data)._strawberry_type
         return convert_pydantic_model_to_strawberry_class(
             type_, model_instance=data_from_model, extra=extra
         )

--- a/strawberry/experimental/pydantic/object_type.py
+++ b/strawberry/experimental/pydantic/object_type.py
@@ -67,16 +67,11 @@ def replace_pydantic_types(type_: Any, is_input: bool):
         return replaced_type
 
     if issubclass(type_, BaseModel):
-        if is_input:
-            if hasattr(type_, "_strawberry_input_type"):
-                return type_._strawberry_input_type
-            else:
-                raise UnregisteredTypeException(type_)
+        attr = "_strawberry_input_type" if is_input else "_strawberry_type"
+        if hasattr(type_, attr):
+            return getattr(type_, attr)
         else:
-            if hasattr(type_, "_strawberry_type"):
-                return type_._strawberry_type
-            else:
-                raise UnregisteredTypeException(type_)
+            raise UnregisteredTypeException(type_)
 
     return type_
 

--- a/tests/experimental/pydantic/test_basic.py
+++ b/tests/experimental/pydantic/test_basic.py
@@ -168,6 +168,10 @@ def test_referencing_other_input_models_fails_when_not_registered():
         password: Optional[str]
         group: Group
 
+    @strawberry.experimental.pydantic.type(Group)
+    class GroupType:
+        name: strawberry.auto
+
     with pytest.raises(
         strawberry.experimental.pydantic.UnregisteredTypeException,
         match=("Cannot find a Strawberry Type for (.*) did you forget to register it?"),

--- a/tests/experimental/pydantic/test_basic.py
+++ b/tests/experimental/pydantic/test_basic.py
@@ -615,7 +615,42 @@ def test_both_output_and_input_type():
             pass
 
     # This triggers the exception from #1504
-    strawberry.Schema(query=Query, mutation=Mutation)
+    schema = strawberry.Schema(query=Query, mutation=Mutation)
+    expected_schema = """
+input GroupInput {
+  users: [UserInput!]!
+}
+
+type GroupOutput {
+  users: [UserOutput!]!
+}
+
+type Mutation {
+  updateGroup(group: GroupInput!): GroupOutput!
+}
+
+type Query {
+  groups: [GroupOutput!]!
+}
+
+input UserInput {
+  name: String!
+  work: WorkInput = null
+}
+
+type UserOutput {
+  name: String!
+  work: WorkOutput
+}
+
+input WorkInput {
+  time: Float!
+}
+
+type WorkOutput {
+  time: Float!
+}"""
+    assert schema.as_str().strip() == expected_schema.strip()
 
     assert Group._strawberry_type == GroupOutput
     assert Group._strawberry_input_type == GroupInput

--- a/tests/experimental/pydantic/test_basic.py
+++ b/tests/experimental/pydantic/test_basic.py
@@ -159,6 +159,27 @@ def test_referencing_other_models_fails_when_not_registered():
             group: strawberry.auto
 
 
+def test_referencing_other_input_models_fails_when_not_registered():
+    class Group(pydantic.BaseModel):
+        name: str
+
+    class User(pydantic.BaseModel):
+        age: int
+        password: Optional[str]
+        group: Group
+
+    with pytest.raises(
+        strawberry.experimental.pydantic.UnregisteredTypeException,
+        match=("Cannot find a Strawberry Type for (.*) did you forget to register it?"),
+    ):
+
+        @strawberry.experimental.pydantic.input(User)
+        class UserInputType:
+            age: strawberry.auto
+            password: strawberry.auto
+            group: strawberry.auto
+
+
 def test_referencing_other_registered_models():
     class Group(pydantic.BaseModel):
         name: str

--- a/tests/experimental/pydantic/test_conversion.py
+++ b/tests/experimental/pydantic/test_conversion.py
@@ -958,5 +958,8 @@ def test_can_convert_both_output_and_input_type():
     )
     group = GroupOutput.from_pydantic(origin_group)
     final_group = group.to_pydantic()
+    assert origin_group == final_group
 
+    group_input = GroupInput.from_pydantic(origin_group)
+    final_group = group_input.to_pydantic()
     assert origin_group == final_group


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
We were using a single class variable to store both the Strawberry output type and input type associated with a given Pydantic base class. This meant that we would get incorrect type definitions (input types referencing output types in their fields and vice versa) depending on the order the Strawberry types were defined in.

I added a second variable to track the Strawberry input type and updated the usages of the variable to choose the correct one based on whether we are defining an input type or not.

Note that error types have the same problem in main, but they are also just pretty broken right now so I didn't address that here.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #1504 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
