### PR TITLE
Fix misleading type name in schema basics docs

### DIFF
--- a/docs/general/schema-basics.md
+++ b/docs/general/schema-basics.md
@@ -325,7 +325,7 @@ class Mutation:
     ...
 ```
 
-Not only does this facilitate passing the PostAndMediaInput type around within
+Not only does this facilitate passing the AddBookInput type around within
 our schema, it also provides a basis for annotating fields with descriptions
 that are automatically exposed by GraphQL-enabled tools:
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The docs refer to `PostAndMediaInput` which is nowhere to be found on that page. From context it looks like it should be replaced with `AddBookInput` from the example above.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
