### PR TITLE
chore(docs): Add docs for custom pydantic types with __get_validators__

### DIFF
--- a/docs/integrations/pydantic.md
+++ b/docs/integrations/pydantic.md
@@ -265,9 +265,9 @@ input_data = UserInput(id='abc', name='Jake')
 instance = input_data.to_pydantic()
 ```
 
-### Classes with \_\_get_validators\_\_
+### Classes with `\_\_get_validators\_\_`
 
-Pydantic BaseModels may define a custom type with [\_\_get_validators\_\_](https://pydantic-docs.helpmanual.io/usage/types/#classes-with-__get_validators__)
+Pydantic BaseModels may define a custom type with [`\_\_get_validators\_\_`](https://pydantic-docs.helpmanual.io/usage/types/#classes-with-__get_validators__)
 logic. You will need to add a scalar type and add the mapping to the `scalar_overrides`
 argument in the Schema class.
 

--- a/docs/integrations/pydantic.md
+++ b/docs/integrations/pydantic.md
@@ -265,9 +265,9 @@ input_data = UserInput(id='abc', name='Jake')
 instance = input_data.to_pydantic()
 ```
 
-### Classes with `\_\_get_validators\_\_`
+### Classes with `__get_validators__`
 
-Pydantic BaseModels may define a custom type with [`\_\_get_validators\_\_`](https://pydantic-docs.helpmanual.io/usage/types/#classes-with-__get_validators__)
+Pydantic BaseModels may define a custom type with [`__get_validators__`](https://pydantic-docs.helpmanual.io/usage/types/#classes-with-__get_validators__)
 logic. You will need to add a scalar type and add the mapping to the `scalar_overrides`
 argument in the Schema class.
 


### PR DESCRIPTION
Adds documentation for users to convert pydantic models that use fields that are a custom type.

[Discord thread](https://discord.com/channels/689806334337482765/932705359334899883/932817103835254815)

Not sure where to place it. I put it at the bottom of docs. 
For a follow up MR. [We should catch / detect this error beforehand and suggest what to do?](https://discord.com/channels/689806334337482765/932705359334899883/932746286334087168)

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
