### PR TITLE
Fix name generation for nested generic types

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,40 @@
+Release type: patch
+
+This release fixes an issue with the name generation for nested generics,
+the following:
+
+```python
+T = TypeVar("T")
+K = TypeVar("K")
+V = TypeVar("V")
+
+@strawberry.type
+class Value(Generic[T]):
+    value: T
+
+@strawberry.type
+class DictItem(Generic[K, V]):
+    key: K
+    value: V
+
+@strawberry.type
+class Query:
+    d: Value[List[DictItem[int, str]]]
+```
+
+now yields the correct schema:
+
+```graphql
+type IntStrDictItem {
+  key: Int!
+  value: String!
+}
+
+type IntStrDictItemListValue {
+  value: [IntStrDictItem!]!
+}
+
+type Query {
+  d: IntStrDictItemListValue!
+}
+```

--- a/strawberry/schema/name_converter.py
+++ b/strawberry/schema/name_converter.py
@@ -138,6 +138,9 @@ class NameConverter:
             if strawberry_type.is_generic:
                 types = type_.__args__  # type: ignore
                 name = self.from_generic(strawberry_type, types)
+            elif strawberry_type.concrete_of:
+                types = list(strawberry_type.type_var_map.values())
+                name = self.from_generic(strawberry_type, types)
             else:
                 name = strawberry_type.name
         else:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This PR fixes an issue discovered by @bikeshedder. The name generation for generic types was broken when nesting generic types.

```python
T = TypeVar("T")
K = TypeVar("K")
V = TypeVar("V")

@strawberry.type
class Value(Generic[T]):
    value: T

@strawberry.type
class DictItem(Generic[K, V]):
    key: K
    value: V

@strawberry.type
class Query:
    d: Value[List[DictItem[int, str]]]
```

This would generate the wrong schema. The PR fixes is by checking also `is_concrete_of` when generating the name. Ideally we should have only one codepath, but I'm not sure how to fix that at the moment, maybe the unit tests should only pass resolved types. @BryceBeagle you might have some ideas :)

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

