### PR TITLE
Support using docstrings as GraphQL descriptions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,52 @@
+Release type: minor
+
+Support using docstrings are GraphQL descriptions
+
+It is now possible to use python docstrings to provide GraphQL descriptions.
+
+## Example
+
+Here is an example of using docstrings in types and fields:
+
+```
+def external_resolver() -> int:
+    """ External resolver with docstring"""
+    return 2
+
+@strawberry.type
+class Query:
+    """
+    Main entrypoint to GraphQL data
+
+    It can now be documented with docstrings
+"""
+
+    x: int = strawberry.field(default=1, description="Dataclass field")
+    y: int = strawberry.field(resolver=external_resolver)
+
+    @strawberry.field
+    def z(self) -> int:
+        """ Method resolver with docstring """
+        return 3
+```
+
+It produces this GraphQL schema:
+
+```
+"""
+Main entrypoint to GraphQL data
+
+It can now be documented with docstrings
+"""
+type Query {
+  """Dataclass field"""
+  x: Int!
+
+  """External resolver with docstring"""
+  y: Int!
+
+  """Method resolver with docstring """
+  z: Int!
+}
+
+```

--- a/strawberry/enum.py
+++ b/strawberry/enum.py
@@ -1,5 +1,6 @@
 import dataclasses
-from enum import EnumMeta
+import inspect
+from enum import Enum, EnumMeta
 from typing import Any, Callable, List, Mapping, Optional, TypeVar, Union, overload
 
 from strawberry.type import StrawberryType
@@ -82,9 +83,24 @@ def enum(
     """
 
     def wrap(cls: EnumType) -> EnumType:
+        # Fallback to docstring as GraphQL description
+        nonlocal description
+        if (
+            description is None
+            and cls.__doc__ is not None
+            and cls.__doc__ is not UndocumentedEnum.__doc__
+        ):
+            description = inspect.cleandoc(cls.__doc__)
+
         return _process_enum(cls, name, description)
 
     if not _cls:
         return wrap
 
     return wrap(_cls)
+
+
+class UndocumentedEnum(Enum):
+    # `Enum` automatically adds 'An enumeration.' as docstring
+    # This is used to detect and ignore it
+    pass

--- a/strawberry/experimental/pydantic/object_type.py
+++ b/strawberry/experimental/pydantic/object_type.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import builtins
 import dataclasses
+import inspect
 import warnings
 from functools import partial
 from typing import (
@@ -149,6 +150,11 @@ def type(
     use_pydantic_alias: bool = True,
 ) -> Callable[..., Type[StrawberryTypeFromPydantic[PydanticModel]]]:
     def wrap(cls: Any) -> Type[StrawberryTypeFromPydantic[PydanticModel]]:
+        # Fallback to docstring as GraphQL description
+        nonlocal description
+        if description is None and cls.__doc__ is not None:
+            description = inspect.cleandoc(cls.__doc__)
+
         model_fields = model.__fields__
         original_fields_set = set(fields) if fields else set([])
 

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -90,7 +90,7 @@ class StrawberryField(dataclasses.Field):
 
         self.type_annotation = type_annotation
 
-        self.description: Optional[str] = description
+        self._description: Optional[str] = description
         self.origin = origin
 
         self._base_resolver: Optional[StrawberryResolver] = None
@@ -190,6 +190,14 @@ class StrawberryField(dataclasses.Field):
         #       If we want to change when the exception is thrown, this line can be
         #       removed.
         _ = resolver.arguments
+
+    @property
+    def description(self) -> Optional[str]:
+        if self._description is not None:
+            return self._description
+        if self._base_resolver is not None:
+            return self._base_resolver._description
+        return None
 
     @property  # type: ignore
     def type(self) -> Union[StrawberryType, type]:  # type: ignore

--- a/strawberry/object_type.py
+++ b/strawberry/object_type.py
@@ -207,6 +207,11 @@ def type(
                 exc = ObjectIsNotClassError.type
             raise exc(cls)
 
+        # Fallback to docstring as GraphQL description
+        nonlocal description
+        if description is None and cls.__doc__ is not None:
+            description = inspect.cleandoc(cls.__doc__)
+
         wrapped = _wrap_dataclass(cls)
         return _process_type(
             wrapped,

--- a/strawberry/types/fields/resolver.py
+++ b/strawberry/types/fields/resolver.py
@@ -29,6 +29,10 @@ class StrawberryResolver(Generic[T]):
         description: Optional[str] = None,
         type_override: Optional[Union[StrawberryType, type]] = None,
     ):
+        # Fallback to docstring as GraphQL description
+        if description is None and func.__doc__ is not None:
+            description = inspect.cleandoc(func.__doc__)
+
         self.wrapped_func = func
         self._description = description
         self._type_override = type_override

--- a/tests/schema/test_basic.py
+++ b/tests/schema/test_basic.py
@@ -132,6 +132,7 @@ def test_type_description():
     @strawberry.type
     class TypeB:
         """Docstring description"""
+
         b: str
 
     @strawberry.type
@@ -302,6 +303,7 @@ def test_enum_description():
     @strawberry.enum
     class SaladType(Enum):
         """Not as good as ice-cream"""
+
         LETTUCE = "lettuce"
 
     @strawberry.type


### PR DESCRIPTION
## Description

The most "pythonic" way of adding documentation to classes/functions is using docstrings, and it is well supported by all kinds of tools.

This PR modifies Strawberry to use support it too, adding the docstrings as GraphQL descriptions (Unless a description is explicitly provided with strawberry decorators)

It supports object types (type/input/interface), enums and fields with resolvers.

Unfortunately python attributes do not support docstrings, so regular dataclass fields (fields not backed by resolvers) will need to continue using `@strawberry.field(description=...)`

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
