### PR TITLE
Support generating GraphQL descriptions from docstrings

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,73 @@
+Release type: minor
+
+Support using docstrings are GraphQL descriptions
+
+It is now possible to use python docstrings to provide GraphQL descriptions.
+
+## Example
+
+Here is an example of using docstrings in types and fields:
+
+```
+@strawberry.enum
+class EnumType(Enum):
+    """
+    Example enum
+
+    Attributes:
+        FOO: Some description
+        BAR: Another description
+    """
+
+    FOO = "foo"
+    BAR = "bar"
+
+@strawberry.type
+class Query:
+    """
+    The main GraphQL type
+
+    Attributes:
+        enum: A dataclass field
+    """
+    enum: EnumType = EnumType.BAR
+
+    @strawberry.field
+    def resolver(self, arg1: enum, arg2: int) -> int:
+        """
+        A GraphQL field with a resolver and arguments
+
+        Params:
+            arg1: An enum argument
+            arg2: An int argument
+        """
+        return 1
+```
+
+It produces this GraphQL schema:
+
+```
+"""Example enum"""
+enum EnumType {
+  """Some description"""
+  FOO
+
+  """Another description"""
+  BAR
+}
+
+"""The main GraphQL type"""
+type Query {
+  """A dataclass field"""
+  enum: EnumType!
+
+  """A GraphQL field with a resolver and arguments"""
+  resolver(
+    """An enum argument"""
+    arg1: EnumType!
+
+    """An int argument"""
+    arg2: Int!
+  ): Int!
+}
+```

--- a/mypy_tests.ini
+++ b/mypy_tests.ini
@@ -24,3 +24,6 @@ ignore_missing_imports = True
 
 [mypy-sentinel.*]
 ignore_missing_imports = True
+
+[mypy-docstring_parser.*]
+ignore_errors = True

--- a/poetry.lock
+++ b/poetry.lock
@@ -335,6 +335,17 @@ trio = ["trio (>=0.14,<0.20)"]
 wmi = ["wmi (>=1.5.1,<2.0.0)"]
 
 [[package]]
+name = "docstring-parser"
+version = "0.13"
+description = "\"Parse Python docstrings in reST, Google and Numpydoc format\""
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+test = ["pytest", "black"]
+
+[[package]]
 name = "email-validator"
 version = "1.1.3"
 description = "A robust email syntax and deliverability validation library for Python 2.x/3.x."
@@ -1537,7 +1548,7 @@ sanic = ["sanic"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "e42426492200f4b6b0743b02a65de8d14e2d6e973938209b4ebea50ed50088e3"
+content-hash = "cf4ef186cf8ed281a3f6ef8d532b2a2ecd802e97ab0febdda963a35a7adc46f9"
 
 [metadata.files]
 aiofiles = [
@@ -1756,6 +1767,9 @@ django = [
 dnspython = [
     {file = "dnspython-2.2.0-py3-none-any.whl", hash = "sha256:081649da27ced5e75709a1ee542136eaba9842a0fe4c03da4fb0a3d3ed1f3c44"},
     {file = "dnspython-2.2.0.tar.gz", hash = "sha256:e79351e032d0b606b98d38a4b0e6e2275b31a5b85c873e587cc11b73aca026d6"},
+]
+docstring-parser = [
+    {file = "docstring_parser-0.13.tar.gz", hash = "sha256:66dd7eac7232202bf220fd98a5f11491863c01f958a75fdd535c7eccac9ced78"},
 ]
 email-validator = [
     {file = "email_validator-1.1.3-py2.py3-none-any.whl", hash = "sha256:5675c8ceb7106a37e40e2698a57c056756bf3f272cfa8682a4f87ebd95d8440b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ aiohttp = {version = "^3.7.4.post0", optional = true}
 fastapi = {version = ">=0.65.2", optional = true}
 sentinel = "^0.3.0"
 "backports.cached-property" = "^1.0.1"
+docstring-parser = "^0.13"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.0"

--- a/strawberry/directive.py
+++ b/strawberry/directive.py
@@ -10,6 +10,8 @@ from graphql import DirectiveLocation
 
 from strawberry.annotation import StrawberryAnnotation
 from strawberry.arguments import StrawberryArgument
+from strawberry.utils import docstrings
+from strawberry.utils.docstrings import Docstring
 
 
 @dataclasses.dataclass
@@ -19,6 +21,7 @@ class StrawberryDirective:
     resolver: Callable
     locations: List[DirectiveLocation]
     description: Optional[str] = None
+    docstring: Optional[Docstring] = None
 
     @property
     def arguments(self) -> List[StrawberryArgument]:
@@ -63,6 +66,7 @@ def directive(
             graphql_name=name,
             locations=locations,
             description=description,
+            docstring=docstrings.get(f),
             resolver=f,
         )
 

--- a/strawberry/enum.py
+++ b/strawberry/enum.py
@@ -3,6 +3,8 @@ from enum import EnumMeta
 from typing import Any, Callable, List, Mapping, Optional, TypeVar, Union, overload
 
 from strawberry.type import StrawberryType
+from strawberry.utils import docstrings
+from strawberry.utils.docstrings import Docstring
 
 from .exceptions import ObjectIsNotAnEnumError
 
@@ -11,6 +13,7 @@ from .exceptions import ObjectIsNotAnEnumError
 class EnumValue:
     name: str
     value: Any
+    description: Optional[str] = None
 
 
 @dataclasses.dataclass
@@ -18,7 +21,8 @@ class EnumDefinition(StrawberryType):
     wrapped_cls: EnumMeta
     name: str
     values: List[EnumValue]
-    description: Optional[str]
+    description: Optional[str] = None
+    docstring: Optional[Docstring] = None
 
     def __hash__(self) -> int:
         # TODO: Is this enough for unique-ness?
@@ -46,8 +50,6 @@ def _process_enum(
     if not name:
         name = cls.__name__
 
-    description = description
-
     values = [EnumValue(item.name, item.value) for item in cls]  # type: ignore
 
     cls._enum_definition = EnumDefinition(  # type: ignore
@@ -55,6 +57,7 @@ def _process_enum(
         name=name,
         values=values,
         description=description,
+        docstring=docstrings.get(cls),
     )
 
     return cls

--- a/strawberry/experimental/pydantic/error_type.py
+++ b/strawberry/experimental/pydantic/error_type.py
@@ -14,6 +14,7 @@ from strawberry.experimental.pydantic.utils import (
 from strawberry.object_type import _process_type, _wrap_dataclass
 from strawberry.schema_directive import StrawberrySchemaDirective
 from strawberry.types.type_resolver import _get_fields
+from strawberry.utils import docstrings
 from strawberry.utils.typing import get_list_annotation, is_list
 
 from .exceptions import MissingFieldsListError
@@ -93,6 +94,7 @@ def error_type(
             if name in fields_set
         ]
 
+        docstring = docstrings.get(cls)
         wrapped = _wrap_dataclass(cls)
         extra_fields = cast(List[dataclasses.Field], _get_fields(wrapped))
         private_fields = get_private_fields(wrapped)
@@ -121,6 +123,7 @@ def error_type(
             is_input=False,
             is_interface=False,
             description=description,
+            docstring=docstring,
             directives=directives,
         )
 

--- a/strawberry/experimental/pydantic/object_type.py
+++ b/strawberry/experimental/pydantic/object_type.py
@@ -42,6 +42,7 @@ from strawberry.object_type import _process_type, _wrap_dataclass
 from strawberry.schema_directive import StrawberrySchemaDirective
 from strawberry.types.type_resolver import _get_fields
 from strawberry.types.types import TypeDefinition
+from strawberry.utils import docstrings
 
 from .exceptions import MissingFieldsListError, UnregisteredTypeException
 
@@ -187,6 +188,7 @@ def type(
             model=model, auto_fields=auto_fields_set, cls_name=cls.__name__
         )
 
+        docstring = docstrings.get(cls)
         wrapped = _wrap_dataclass(cls)
         extra_strawberry_fields = _get_fields(wrapped)
         extra_fields = cast(List[dataclasses.Field], extra_strawberry_fields)
@@ -254,6 +256,7 @@ def type(
             is_input=is_input,
             is_interface=is_interface,
             description=description,
+            docstring=docstring,
             directives=directives,
         )
 

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -28,6 +28,8 @@ from strawberry.schema_directive import StrawberrySchemaDirective
 from strawberry.type import StrawberryType
 from strawberry.types.info import Info
 from strawberry.union import StrawberryUnion
+from strawberry.utils import docstrings
+from strawberry.utils.docstrings import Docstring
 
 from .permission import BasePermission
 from .types.fields.resolver import StrawberryResolver
@@ -94,6 +96,7 @@ class StrawberryField(dataclasses.Field):
         self.origin = origin
 
         self._base_resolver: Optional[StrawberryResolver] = None
+        self.docstring: Optional[Docstring] = None
         if base_resolver is not None:
             self.base_resolver = base_resolver
 
@@ -174,6 +177,7 @@ class StrawberryField(dataclasses.Field):
     @base_resolver.setter
     def base_resolver(self, resolver: StrawberryResolver) -> None:
         self._base_resolver = resolver
+        self.docstring = docstrings.get(resolver.wrapped_func)
 
         # Don't add field to __init__, __repr__ and __eq__ once it has a resolver
         self.init = False

--- a/strawberry/object_type.py
+++ b/strawberry/object_type.py
@@ -13,6 +13,8 @@ from .exceptions import (
 from .field import StrawberryField, field
 from .types.type_resolver import _get_fields
 from .types.types import TypeDefinition
+from .utils import docstrings
+from .utils.docstrings import Docstring
 from .utils.str_converters import to_camel_case
 from .utils.typing import __dataclass_transform__
 
@@ -100,6 +102,7 @@ def _process_type(
     is_input: bool = False,
     is_interface: bool = False,
     description: Optional[str] = None,
+    docstring: Optional[Docstring] = None,
     directives: Optional[Sequence[StrawberrySchemaDirective]] = (),
     extend: bool = False,
 ):
@@ -115,6 +118,7 @@ def _process_type(
         is_interface=is_interface,
         interfaces=interfaces,
         description=description,
+        docstring=docstring,
         directives=directives,
         origin=cls,
         extend=extend,
@@ -207,6 +211,7 @@ def type(
                 exc = ObjectIsNotClassError.type
             raise exc(cls)
 
+        docstring = docstrings.get(cls)
         wrapped = _wrap_dataclass(cls)
         return _process_type(
             wrapped,
@@ -214,6 +219,7 @@ def type(
             is_input=is_input,
             is_interface=is_interface,
             description=description,
+            docstring=docstring,
             directives=directives,
             extend=extend,
         )

--- a/strawberry/schema/config.py
+++ b/strawberry/schema/config.py
@@ -9,6 +9,7 @@ from .name_converter import NameConverter
 class StrawberryConfig:
     auto_camel_case: InitVar[bool] = None  # type: ignore
     name_converter: NameConverter = field(default_factory=NameConverter)
+    description_from_docstrings: bool = False
 
     def __post_init__(
         self,

--- a/strawberry/types/types.py
+++ b/strawberry/types/types.py
@@ -15,6 +15,7 @@ from typing import (
 )
 
 from strawberry.type import StrawberryType, StrawberryTypeVar
+from strawberry.utils.docstrings import Docstring
 from strawberry.utils.typing import is_generic as is_type_generic
 
 
@@ -32,6 +33,7 @@ class TypeDefinition(StrawberryType):
     is_interface: bool
     origin: Type
     description: Optional[str]
+    docstring: Optional[Docstring]
     interfaces: List["TypeDefinition"]
     extend: bool
     directives: Optional[Sequence[StrawberrySchemaDirective]]
@@ -89,6 +91,7 @@ class TypeDefinition(StrawberryType):
             directives=self.directives,
             interfaces=self.interfaces,
             description=self.description,
+            docstring=self.docstring,
             extend=self.extend,
             is_type_of=self.is_type_of,
             _fields=fields,

--- a/strawberry/utils/docstrings.py
+++ b/strawberry/utils/docstrings.py
@@ -1,0 +1,53 @@
+from typing import Any, Optional
+
+import docstring_parser
+
+
+Docstring = docstring_parser.Docstring
+
+
+def get(obj: Any) -> Optional[Docstring]:
+    if obj is None or obj.__doc__ is None:
+        return None
+    return docstring_parser.parse(obj.__doc__)
+
+
+def type_description(docstring: Optional[Docstring]) -> Optional[str]:
+    if docstring is not None:
+        parts = []
+        if docstring.short_description:
+            parts.append(docstring.short_description)
+        if (
+            docstring.blank_after_short_description
+            and docstring.short_description
+            and docstring.long_description
+        ):
+            parts.append("")
+        if docstring.long_description:
+            parts.append(docstring.long_description)
+
+        # TODO: Expose other docstring bits (returns, raises, examples, etc)
+        # TODO: GraphQL expects descriptions to be formatted as Markdown,
+        # convertion may be needed (See pydoc-markdown)
+        return "\n".join(parts)
+    return None
+
+
+def func_description(docstring: Optional[Docstring]) -> Optional[str]:
+    return type_description(docstring)
+
+
+def arg_description(docstring: Optional[Docstring], name: str) -> Optional[str]:
+    if docstring is not None:
+        for param in docstring.params:
+            if param.args[0] == "param" and param.arg_name == name:
+                return param.description
+    return None
+
+
+def attribute_description(docstring: Optional[Docstring], name: str) -> Optional[str]:
+    if docstring is not None:
+        for param in docstring.params:
+            if param.args[0] == "attribute" and param.arg_name == name:
+                return param.description
+    return None

--- a/tests/schema/test_docstring.py
+++ b/tests/schema/test_docstring.py
@@ -1,0 +1,258 @@
+import textwrap
+from enum import Enum
+
+from graphql import DirectiveLocation
+
+import strawberry
+from strawberry.schema.config import StrawberryConfig
+
+
+@strawberry.directive(locations=[DirectiveLocation.FIELD])
+def replace(value: str, old_char: str, new_char: str):
+    """
+    Replaces a character in the string
+
+    Args:
+        value: String being edited
+        old_char: Character being removed
+        new_char: Character being added
+    """
+    return value.replace(old_char, new_char)
+
+
+@strawberry.enum
+class EnumType(Enum):
+    """
+    Enum type description
+
+    Attributes:
+        VANILLA: Vanilla is a spice derived from orchids of the genus Vanilla
+        STRAWBERRY: The garden strawberry is a widely grown species of the genus Fragaria
+        CHOCOLATE: Chocolate is a food product made from roasted and ground cacao pods
+    """
+
+    VANILLA = "vanilla"
+    STRAWBERRY = "strawberry"
+    CHOCOLATE = "chocolate"
+
+
+@strawberry.interface
+class InterfaceType:
+    """
+    This is a graphQL interface type
+
+    Attributes:
+        var_a (int): A fields that doesn't need a resolver
+        var_b (int): A complex field with a resolver
+    """
+
+    var_a: int
+
+    @strawberry.field
+    def var_b(self, arg_1: int = 1, arg_2: str = 2) -> str:
+        """
+        A complex field with a resolver and args
+
+        Args:
+            arg_1 (int): Something
+            arg_2 (str): Another thing
+        """
+        return ""
+
+
+@strawberry.type
+class ObjectType(InterfaceType):
+    """
+    This is a graphQL object type
+
+    Attributes:
+        var_a (int): A field that doesn't need a resolver
+        var_b (int): A complex field with a resolver
+        var_c (str): Something to differentiate ObjectType from InterfaceType
+    """
+
+    var_c: EnumType
+
+
+@strawberry.input
+class InputType:
+    """
+    This is a graphQL input type
+
+    Description has many lines.
+    Many, many lines
+
+    Attributes:
+        var_a (int): Something
+    """
+
+    var_a: int
+
+
+@strawberry.type
+class Query:
+    """
+    Main entrypoint to the GraphQL reads
+
+    Attributes:
+        object: A GraphQL object
+    """
+
+    object: ObjectType
+
+
+@strawberry.type
+class Mutation:
+    """
+    Main entrypoint to the GraphQL updates
+
+    Attributes:
+        set_object: A GraphQL object
+    """
+
+    @strawberry.field
+    def set_object(new_data: InputType, undocumented: str) -> str:
+        """
+        Update the object
+
+        Args:
+            new_data: New data
+            x-undocumented: This fields won't have a GraphQL description
+        """
+        return ""
+
+
+def test_docstrings_enabled():
+    schema = strawberry.Schema(
+        query=Query,
+        mutation=Mutation,
+        directives=[replace],
+        config=StrawberryConfig(description_from_docstrings=True),
+    )
+
+    expected = '''
+        """Replaces a character in the string"""
+        directive @replace(
+          """Character being removed"""
+          oldChar: String!
+
+          """Character being added"""
+          newChar: String!
+        ) on FIELD
+
+        """Enum type description"""
+        enum EnumType {
+          """Vanilla is a spice derived from orchids of the genus Vanilla"""
+          VANILLA
+
+          """The garden strawberry is a widely grown species of the genus Fragaria"""
+          STRAWBERRY
+
+          """Chocolate is a food product made from roasted and ground cacao pods"""
+          CHOCOLATE
+        }
+
+        """
+        This is a graphQL input type
+
+        Description has many lines.
+        Many, many lines
+        """
+        input InputType {
+          """Something"""
+          varA: Int!
+        }
+
+        """This is a graphQL interface type"""
+        interface InterfaceType {
+          """A fields that doesn't need a resolver"""
+          varA: Int!
+
+          """A complex field with a resolver and args"""
+          varB(
+            """Something"""
+            arg1: Int! = 1
+
+            """Another thing"""
+            arg2: String! = "2"
+          ): String!
+        }
+
+        """Main entrypoint to the GraphQL updates"""
+        type Mutation {
+          """Update the object"""
+          setObject(
+            """New data"""
+            newData: InputType!
+            undocumented: String!
+          ): String!
+        }
+
+        """This is a graphQL object type"""
+        type ObjectType implements InterfaceType {
+          """A field that doesn't need a resolver"""
+          varA: Int!
+
+          """A complex field with a resolver and args"""
+          varB(
+            """Something"""
+            arg1: Int! = 1
+
+            """Another thing"""
+            arg2: String! = "2"
+          ): String!
+
+          """Something to differentiate ObjectType from InterfaceType"""
+          varC: EnumType!
+        }
+
+        """Main entrypoint to the GraphQL reads"""
+        type Query {
+          """A GraphQL object"""
+          object: ObjectType!
+        }
+    '''
+    assert str(schema) == textwrap.dedent(expected).strip()
+
+
+def test_docstrings_disabled():
+    schema = strawberry.Schema(
+        query=Query,
+        mutation=Mutation,
+        directives=[replace],
+        config=StrawberryConfig(description_from_docstrings=False),
+    )
+
+    expected = """
+        directive @replace(oldChar: String!, newChar: String!) on FIELD
+
+        enum EnumType {
+          VANILLA
+          STRAWBERRY
+          CHOCOLATE
+        }
+
+        input InputType {
+          varA: Int!
+        }
+
+        interface InterfaceType {
+          varA: Int!
+          varB(arg1: Int! = 1, arg2: String! = "2"): String!
+        }
+
+        type Mutation {
+          setObject(newData: InputType!, undocumented: String!): String!
+        }
+
+        type ObjectType implements InterfaceType {
+          varA: Int!
+          varB(arg1: Int! = 1, arg2: String! = "2"): String!
+          varC: EnumType!
+        }
+
+        type Query {
+          object: ObjectType!
+        }
+    """
+    assert str(schema) == textwrap.dedent(expected).strip()


### PR DESCRIPTION
The most "pythonic" way of adding documentation to classes/functions is using docstrings, and it is well supported by all kinds of tools.

This PR modified Strawberry to support it too, as discussed on #653

This PR superseeds #1644

## Description

- In order to maintain backwards compatibility and avoid leaking implementation details, this feature needs to be enabled with `StrawberryConfig(description_from_docstrings=True)`
- Docstrings are parsed with [docstring_parser](https://github.com/rr-/docstring_parser/tree/master/docstring_parser), which allows inferring documentation for each resolver argument / enum value / dataclass field

## Example

Here is an example of using docstrings in types and fields:

```
@strawberry.enum
class EnumType(Enum):
    """
    Example enum

    Attributes:
        FOO: Some description
        BAR: Another description
    """

    FOO = "foo"
    BAR = "bar"

@strawberry.type
class Query:
    """
    The main GraphQL type

    Attributes:
        enum: A dataclass field
    """
    enum: EnumType = EnumType.BAR

    @strawberry.field
    def resolver(self, arg1: enum, arg2: int) -> int:
        """
        A GraphQL field with a resolver and arguments

        Params:
            arg1: An enum argument
            arg2: An int argument
        """
        return 1
```

It produces this GraphQL schema:

```
"""Example enum"""
enum EnumType {
  """Some description"""
  FOO

  """Another description"""
  BAR
}

"""The main GraphQL type"""
type Query {
  """A dataclass field"""
  enum: EnumType!

  """A GraphQL field with a resolver and arguments"""
  resolver(
    """An enum argument"""
    arg1: EnumType!

    """An int argument"""
    arg2: Int!
  ): Int!
}
```

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

* #653

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (TODO)
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
