### PR TITLE
Bug in JSONScalar example

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,7 @@
+Release type: minor
+
+There was a bug with the JSON custom scalar example.
+
+This release fixes the example and adds JSON scalar type into `strawberry.scalars`.
+
+The same happens with `Base64`: We now have Base16, Base32 and Base64 into `strawberry.scalars`

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -19,4 +19,3 @@ class Example:
     c: Base64
     d: JSON
 ```
-

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,22 @@
 Release type: minor
 
-There was a bug with the JSON custom scalar example.
+This release adds the following scalar types:
 
-This release fixes the example and adds JSON scalar type into `strawberry.scalars`.
+- `JSON`
+- `Base16`
+- `Base32`
+- `Base64`
 
-The same happens with `Base64`: We now have Base16, Base32 and Base64 into `strawberry.scalars`
+they can be used like so:
+
+```python
+from strawberry.scalar import Base16, Base32, Base64, JSON
+
+@strawberry.type
+class Example:
+    a: Base16
+    b: Base32
+    c: Base64
+    d: JSON
+```
+

--- a/docs/types/scalars.md
+++ b/docs/types/scalars.md
@@ -119,6 +119,7 @@ assert results.data  == {"base64": "aGk="}
 ```
 
 <Note>
+
 The `Base16`, `Base32` and `Base64` scalar types are available in `strawberry.scalars`
 
 ```python
@@ -171,6 +172,7 @@ query ExampleDataQuery {
 ```
 
 <Note>
+
 The `JSON` scalar type is available in `strawberry.scalars`
 
 ```python

--- a/docs/types/scalars.md
+++ b/docs/types/scalars.md
@@ -118,6 +118,15 @@ result = schema.execute_sync("{ base64 }")
 assert results.data  == {"base64": "aGk="}
 ```
 
+<Note>
+The `Base16`, `Base32` and `Base64` scalar types are available in `strawberry.scalars`
+
+```python
+from strawberry.scalars import Base16, Base32, Base64
+```
+
+</Note>
+
 ## Example JSONScalar
 
 ```python
@@ -126,11 +135,11 @@ from typing import Any, NewType
 
 import strawberry
 
-JSONScalar = strawberry.scalar(
-    NewType("JSONScalar", Any),
+JSON = strawberry.scalar(
+    NewType("JSON", object),
+    description="The `JSON` scalar type represents JSON values as specified by ECMA-404",
     serialize=lambda v: v,
     parse_value=lambda v: v,
-    description="The JSONScalar scalar type represents a generic GraphQL scalar value that can be built from: List, Object, String, Number, Boolean or Null"
 )
 
 ```
@@ -141,7 +150,7 @@ Usage:
 @strawberry.type
 class Query:
     @strawberry.field
-    def data(self, info) -> JSONScalar:
+    def data(self, info) -> JSON:
         return {"hello": {"a": 1}, "someNumbers": [1, 2, 3]}
 
 ```
@@ -160,6 +169,15 @@ query ExampleDataQuery {
   }
 }
 ```
+
+<Note>
+The `JSON` scalar type is available in `strawberry.scalars`
+
+```python
+from strawberry.scalars import JSON
+```
+
+</Note>
 
 ## Overriding built in scalars
 

--- a/docs/types/scalars.md
+++ b/docs/types/scalars.md
@@ -129,8 +129,8 @@ import strawberry
 JSONScalar = strawberry.scalar(
     NewType("JSONScalar", Any),
     serialize=lambda v: v,
-    parse_value=lambda v: json.loads(v),
-    description="The GenericScalar scalar type represents a generic GraphQL scalar value that could be: List or Object."
+    parse_value=lambda v: v,
+    description="The JSONScalar scalar type represents a generic GraphQL scalar value that can be built from: List, Object, String, Number, Boolean or Null"
 )
 
 ```

--- a/strawberry/custom_scalar.py
+++ b/strawberry/custom_scalar.py
@@ -16,6 +16,7 @@ def identity(x):
 class ScalarDefinition(StrawberryType):
     name: str
     description: Optional[str]
+    specified_by_url: Optional[str]
     serialize: Optional[Callable]
     parse_value: Optional[Callable]
     parse_literal: Optional[Callable]
@@ -47,11 +48,12 @@ class ScalarWrapper:
 def _process_scalar(
     cls,
     *,
-    name: str = None,
-    description: str = None,
-    serialize: Callable = None,
-    parse_value: Callable = None,
-    parse_literal: Callable = None
+    name: Optional[str] = None,
+    description: Optional[str] = None,
+    specified_by_url: Optional[str] = None,
+    serialize: Optional[Callable] = None,
+    parse_value: Optional[Callable] = None,
+    parse_literal: Optional[Callable] = None,
 ):
 
     name = name or to_camel_case(cls.__name__)
@@ -60,6 +62,7 @@ def _process_scalar(
     wrapper._scalar_definition = ScalarDefinition(
         name=name,
         description=description,
+        specified_by_url=specified_by_url,
         serialize=serialize,
         parse_literal=parse_literal,
         parse_value=parse_value,
@@ -72,10 +75,11 @@ def scalar(
     cls=None,
     *,
     name: str = None,
-    description: str = None,
+    description: Optional[str] = None,
+    specified_by_url: Optional[str] = None,
     serialize: Callable = identity,
     parse_value: Optional[Callable] = None,
-    parse_literal: Optional[Callable] = None
+    parse_literal: Optional[Callable] = None,
 ):
     """Annotates a class or type as a GraphQL custom scalar.
 
@@ -111,6 +115,7 @@ def scalar(
             cls,
             name=name,
             description=description,
+            specified_by_url=specified_by_url,
             serialize=serialize,
             parse_value=parse_value,
             parse_literal=parse_literal,

--- a/strawberry/scalars.py
+++ b/strawberry/scalars.py
@@ -1,9 +1,47 @@
+import base64
 from typing import Any, Dict, NewType, Union
 
-from .custom_scalar import ScalarDefinition, ScalarWrapper
+from .custom_scalar import ScalarDefinition, ScalarWrapper, scalar
 
 
 ID = NewType("ID", str)
+
+JSON = scalar(
+    NewType("JSON", object),  # mypy doesn't like `NewType("name", Any)`
+    description="The `JSON` scalar type represents JSON values as specified by"
+    " [ECMA-404](http://www.ecma-international.org"
+    "/publications/files/ECMA-ST/ECMA-404.pdf).",
+    specified_by_url="http://www.ecma-international.org"
+    "/publications/files/ECMA-ST/ECMA-404.pdf",
+    serialize=lambda v: v,
+    parse_value=lambda v: v,
+)
+
+Base16 = scalar(
+    NewType("Base16", bytes),
+    description="Represents binary data as Base16-encoded (hexadecimal) strings.",
+    specified_by_url="https://datatracker.ietf.org/doc/html/rfc4648.html#section-8",
+    serialize=lambda v: base64.b16encode(v).decode("utf-8"),
+    parse_value=lambda v: base64.b16decode(v.encode("utf-8"), casefold=True),
+)
+
+Base32 = scalar(
+    NewType("Base32", bytes),
+    description="Represents binary data as Base32-encoded strings,"
+    " using the standard alphabet.",
+    specified_by_url=("https://datatracker.ietf.org/doc/html/rfc4648.html#section-6"),
+    serialize=lambda v: base64.b32encode(v).decode("utf-8"),
+    parse_value=lambda v: base64.b32decode(v.encode("utf-8"), casefold=True),
+)
+
+Base64 = scalar(
+    NewType("Base64", bytes),
+    description="Represents binary data as Base64-encoded strings,"
+    " using the standard alphabet.",
+    specified_by_url="https://datatracker.ietf.org/doc/html/rfc4648.html#section-4",
+    serialize=lambda v: base64.b64encode(v).decode("utf-8"),
+    parse_value=lambda v: base64.b64decode(v.encode("utf-8")),
+)
 
 
 def is_scalar(

--- a/strawberry/scalars.py
+++ b/strawberry/scalars.py
@@ -40,8 +40,9 @@ Base32 = scalar(
 
 Base64 = scalar(
     NewType("Base64", bytes),
-    description="Represents binary data as Base64-encoded strings,"
-    " using the standard alphabet.",
+    description=(
+        "Represents binary data as Base64-encoded strings, using the standard alphabet."
+    ),
     specified_by_url="https://datatracker.ietf.org/doc/html/rfc4648.html#section-4",
     serialize=lambda v: base64.b64encode(v).decode("utf-8"),
     parse_value=lambda v: base64.b64decode(v.encode("utf-8")),

--- a/strawberry/scalars.py
+++ b/strawberry/scalars.py
@@ -8,11 +8,14 @@ ID = NewType("ID", str)
 
 JSON = scalar(
     NewType("JSON", object),  # mypy doesn't like `NewType("name", Any)`
-    description="The `JSON` scalar type represents JSON values as specified by"
-    " [ECMA-404](http://www.ecma-international.org"
-    "/publications/files/ECMA-ST/ECMA-404.pdf).",
-    specified_by_url="http://www.ecma-international.org"
-    "/publications/files/ECMA-ST/ECMA-404.pdf",
+    description=(
+        "The `JSON` scalar type represents JSON values as specified by "
+        "[ECMA-404]"
+        "(http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf)."
+    ),
+    specified_by_url=(
+        "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf"
+    ),
     serialize=lambda v: v,
     parse_value=lambda v: v,
 )

--- a/strawberry/scalars.py
+++ b/strawberry/scalars.py
@@ -30,8 +30,9 @@ Base16 = scalar(
 
 Base32 = scalar(
     NewType("Base32", bytes),
-    description="Represents binary data as Base32-encoded strings,"
-    " using the standard alphabet.",
+    description=(
+        "Represents binary data as Base32-encoded strings, using the standard alphabet."
+    ),
     specified_by_url=("https://datatracker.ietf.org/doc/html/rfc4648.html#section-6"),
     serialize=lambda v: base64.b32encode(v).decode("utf-8"),
     parse_value=lambda v: base64.b32decode(v.encode("utf-8"), casefold=True),

--- a/strawberry/schema/types/scalar.py
+++ b/strawberry/schema/types/scalar.py
@@ -22,6 +22,7 @@ def _make_scalar_type(definition: ScalarDefinition) -> GraphQLScalarType:
     return GraphQLScalarType(
         name=definition.name,
         description=definition.description,
+        specified_by_url=definition.specified_by_url,
         serialize=definition.serialize,
         parse_value=definition.parse_value,
         parse_literal=definition.parse_literal,
@@ -32,6 +33,7 @@ def _make_scalar_definition(scalar_type: GraphQLScalarType) -> ScalarDefinition:
     return ScalarDefinition(
         name=scalar_type.name,
         description=scalar_type.name,
+        specified_by_url=scalar_type.specified_by_url,
         serialize=scalar_type.serialize,
         parse_literal=scalar_type.parse_literal,
         parse_value=scalar_type.parse_value,

--- a/tests/schema/test_scalars.py
+++ b/tests/schema/test_scalars.py
@@ -114,22 +114,21 @@ def test_json():
 
     schema = strawberry.Schema(query=Query)
 
-    assert (
-        str(schema)
-        == dedent(
-            '''
-            """
-            The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
-            """
-            scalar JSON @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
+    expected_schema = dedent(
+        '''
+        """
+        The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+        """
+        scalar JSON @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
 
-            type Query {
-            echoJson(data: JSON!): JSON!
-            echoJsonNullable(data: JSON): JSON
-            }
-            '''  # noqa: E501
-        ).strip()
-    )
+        type Query {
+          echoJson(data: JSON!): JSON!
+          echoJsonNullable(data: JSON): JSON
+        }
+        '''  # noqa: E501
+    ).strip()
+
+    assert str(schema) == expected_schema
 
     result = schema.execute_sync(
         """

--- a/tests/schema/test_scalars.py
+++ b/tests/schema/test_scalars.py
@@ -118,16 +118,16 @@ def test_json():
         str(schema)
         == dedent(
             '''
-        """
-        The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
-        """
-        scalar JSON @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
+            """
+            The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+            """
+            scalar JSON @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
 
-        type Query {
-          echoJson(data: JSON!): JSON!
-          echoJsonNullable(data: JSON): JSON
-        }
-    '''  # noqa: E501
+            type Query {
+            echoJson(data: JSON!): JSON!
+            echoJsonNullable(data: JSON): JSON
+            }
+            '''  # noqa: E501
         ).strip()
     )
 


### PR DESCRIPTION
There was a bug in the JSONScalar example: `parse_value` takes a data structure (dicts/lists/primitives) instead of a JSON string, therefore `json.loads` is not necessary.

This PR started as a simple fix to the documentation, however @patrick91 suggested that we also added it into strawberry sources and tests, which I have done.

While at it, I did the same for the `Base64` example -- Which I unfolded into `Base16`, `Base32` and `Base64`

Finally, I also added support for the `specified_by_url` in scalars

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Checklist

- [x] My change requires a change to the documentation.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
