### PR TITLE
Support "void" functions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,8 +13,10 @@ class Mutation:
     @strawberry.field
     def do_something(self, arg: int) -> None:
         return
+```
 results in this schema:
 ```grapqhl
 type Mutation {
     doSomething(arg: Int!): Void
 }
+```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,8 +15,7 @@ and will always send `null` in the response
             return
 ```
 results in this schema:
-```
-   type Mutation {
-       doSomething(arg: Int!): Void
-    }
-```
+```grapqhl
+type Mutation {
+    doSomething(arg: Int!): Void
+}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,22 @@
+Release type: minor
+
+Support "void" functions
+
+It is now possible to have a resolver that returns "None". Strawberry will automatically assign the new `Void` scalar in the schema
+and will always send `null` in the response
+
+## Exampe
+
+```
+    @strawberry.type
+    class Mutation:
+        @strawberry.field
+        def do_something(self, arg: int) -> None:
+            return
+```
+results in this schema:
+```
+   type Mutation {
+       doSomething(arg: Int!): Void
+    }
+```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,13 +7,12 @@ and will always send `null` in the response
 
 ## Exampe
 
-```
-    @strawberry.type
-    class Mutation:
-        @strawberry.field
-        def do_something(self, arg: int) -> None:
-            return
-```
+```python
+@strawberry.type
+class Mutation:
+    @strawberry.field
+    def do_something(self, arg: int) -> None:
+        return
 results in this schema:
 ```grapqhl
 type Mutation {

--- a/docs/general/mutations.md
+++ b/docs/general/mutations.md
@@ -77,5 +77,7 @@ type Mutation {
 ```
 
 <Note>
+
 Mutations with void-result go against [GQL best practices](https://graphql-rules.com/rules/mutation-payload)
+
 </Note>

--- a/docs/general/mutations.md
+++ b/docs/general/mutations.md
@@ -57,3 +57,25 @@ example we might want to return an error if the book already exists.
 You can checkout our documentation on
 [dealing with errors](/docs/guides/errors#expected-errors) to learn how to return a
 union of types from a mutation.
+
+## Mutations without returned data
+
+It is also possible to write a mutation that doesn't return anything.
+
+This is mapped to a `Void` GraphQL scalar, and always returns `null`
+
+```python+schema
+@strawberry.type
+class Mutation:
+    @strawberry.mutation
+    def restart() -> None:
+        print(f'Restarting the server')
+---
+type Mutation {
+  restart: Void
+}
+```
+
+<Note>
+Mutations with void-result go against [GQL best practices](https://graphql-rules.com/rules/mutation-payload)
+</Note>

--- a/docs/types/scalars.md
+++ b/docs/types/scalars.md
@@ -37,6 +37,7 @@ There are several built-in scalars, and you can define custom scalars too.
 - `Time`, an ISO-8601 encoded [time](https://docs.python.org/3/library/datetime.html#time-objects)
 - `Decimal`, a [Decimal](https://docs.python.org/3/library/decimal.html#decimal.Decimal) value serialized as a string
 - `UUID`, a [UUID](https://docs.python.org/3/library/uuid.html#uuid.UUID) value serialized as a string
+- `Void`, always null, maps to Python’s `None`
 
 Fields can return built-in scalars by using the Python equivalent:
 
@@ -56,6 +57,7 @@ class Product:
     same_day_shipping_before: datetime.time
     created_at: datetime.datetime
     price: decimal.Decimal
+    void: None
 ---
 type Product {
   id: UUID!
@@ -66,6 +68,7 @@ type Product {
   sameDayShippingBefore: Time!
   createdAt: DateTime!
   price: Decimal!
+  void: Void
 }
 ```
 

--- a/strawberry/annotation.py
+++ b/strawberry/annotation.py
@@ -59,8 +59,6 @@ class StrawberryAnnotation:
             annotation = self.annotation
 
         evaled_type = _eval_type(annotation, self.namespace, None)
-        if evaled_type is None:
-            raise ValueError("Annotation cannot be plain None type")
         if self._is_async_generator(evaled_type):
             evaled_type = self._strip_async_generator(evaled_type)
         if self._is_lazy_type(evaled_type):

--- a/strawberry/schema/types/base_scalars.py
+++ b/strawberry/schema/types/base_scalars.py
@@ -67,3 +67,17 @@ UUID = scalar(
     serialize=str,
     parse_value=wrap_parser(uuid.UUID, "UUID"),
 )
+
+
+def _verify_void(x) -> None:
+    if x is not None:
+        raise ValueError(f"Expected 'None', got '{x}'")
+
+
+Void = scalar(
+    type(None),
+    name="Void",
+    serialize=_verify_void,
+    parse_value=_verify_void,
+    description="Represents NULL values",
+)

--- a/strawberry/schema/types/scalar.py
+++ b/strawberry/schema/types/scalar.py
@@ -40,6 +40,8 @@ def _make_scalar_definition(scalar_type: GraphQLScalarType) -> ScalarDefinition:
 
 
 DEFAULT_SCALAR_REGISTRY: Dict[object, ScalarDefinition] = {
+    type(None): base_scalars.Void._scalar_definition,
+    None: base_scalars.Void._scalar_definition,
     str: _make_scalar_definition(GraphQLString),
     int: _make_scalar_definition(GraphQLInt),
     float: _make_scalar_definition(GraphQLFloat),

--- a/tests/types/resolving/test_literals.py
+++ b/tests/types/resolving/test_literals.py
@@ -1,7 +1,5 @@
 from typing import Optional, Union
 
-import pytest
-
 from strawberry.annotation import StrawberryAnnotation
 
 
@@ -35,8 +33,10 @@ def test_str():
 
 def test_none():
     annotation = StrawberryAnnotation(None)
-    with pytest.raises(ValueError, match="Annotation cannot be plain None type"):
-        annotation.resolve()
+    annotation.resolve()
+
+    annotation = StrawberryAnnotation(type(None))
+    annotation.resolve()
 
     annotation = StrawberryAnnotation(Optional[int])
     annotation.resolve()


### PR DESCRIPTION
## Description

It might not be a best practice, but sometimes a mutation resolver just doesn't need to return anything.

Having a resolver that returns `None` is currently an error in strawberry.

This PR adds the scalar "Void" and uses it automatically when the type is `None` (or `NoneType`, which can be confusing :roll_eyes:)

This scalar mimics the `Void` type provided by [GraphQL Scalars](https://www.graphql-scalars.dev/docs/scalars/void)

## Example:

```
    @strawberry.type
    class Mutation:
        @strawberry.field
        def do_something(self, arg: int) -> None:
            return
```
results in this schema:
```
   type Mutation {
       doSomething(arg: Int!): Void
    }
```
---

## Changes:
- Added a new `Void` scalar, and registered it to handle `None` and `NoneType`
- Allow `None` type annotations
- Merge `from_optional` and `from_non_optional` into `from_maybe_optional`
- Add a special case for NoneType, to avoid wrapping it into `GraphQLNonNull`

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
