### PR TITLE
Add hook functions, process_connection_payload()

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,26 @@
+Release type: minor
+
+Adding the possiblity to process `payload` sent with a websockets `connection_init` message,
+and provide a response payload included with the `connection_ack` message.  This can be useful for
+customized authentication and to provide general information to the client.
+
+## Example
+
+Here is how one might subclass the Router to provide a custom handler class.  This example
+uses the `GraphQLWSHandler`, but the `GraphQLTransportWSHandler` case is identical.
+
+```python
+from strawberry.fastapi import GraphQLRouter
+from strawberry.fastapi.handlers import GraphQLTransportWSHandler, GraphQLWSHandler
+class MyGraphQLWSHandler(GraphQLWSHandler):
+    async def process_connection_payload(self, payload):
+        if not payload or payload.get("name") == "bob":
+            await self.close(4400, "Bob is banned")
+            return
+        return {"hello": "Welcome to our server!"}
+
+class MyRouter(GraphQLRouter):
+    graphql_ws_handler_class = MyGraphQLWSHandler
+
+graphql_app = MyRouter(schema)
+```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,7 +14,7 @@ from strawberry.fastapi import GraphQLRouter
 from strawberry.fastapi.handlers import GraphQLTransportWSHandler, GraphQLWSHandler
 class MyGraphQLWSHandler(GraphQLWSHandler):
     async def process_connection_payload(self, payload):
-        if not payload or payload.get("name") == "bob":
+        if payload.get("name") == "bob":
             await self.close(4400, "Bob is banned")
             return
         return {"hello": "Welcome to our server!"}

--- a/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
@@ -111,8 +111,16 @@ class BaseGraphQLTransportWSHandler(ABC):
             return
 
         self.connection_init_received = True
-        await self.send_message(ConnectionAckMessage())
+        ack = ConnectionAckMessage()
+        payload = await self.process_connection_payload(message.payload)
+        if payload:
+            ack.payload = payload
+        await self.send_message(ack)
         self.connection_acknowledged = True
+
+    async def process_connection_payload(self,  payload: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+        """Can be overridden to validate connection payload and provide response payload"""
+        return None
 
     async def handle_ping(self, message: PingMessage) -> None:
         await self.send_message(PongMessage())

--- a/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
@@ -118,8 +118,12 @@ class BaseGraphQLTransportWSHandler(ABC):
         await self.send_message(ack)
         self.connection_acknowledged = True
 
-    async def process_connection_payload(self,  payload: Dict[str, Any]) -> Optional[Dict[str, Any]]:
-        """Can be overridden to validate connection payload and provide response payload"""
+    async def process_connection_payload(
+        self, payload: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]:
+        """
+        Can be overridden to validate connection payload and provide response payload
+        """
         return None
 
     async def handle_ping(self, message: PingMessage) -> None:

--- a/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
@@ -112,13 +112,13 @@ class BaseGraphQLTransportWSHandler(ABC):
 
         self.connection_init_received = True
         ack = ConnectionAckMessage()
-        payload = await self.process_connection_payload(message.payload)
+        payload = await self.process_connection_payload(message.payload or {})
         if payload:
             ack.payload = payload
         await self.send_message(ack)
         self.connection_acknowledged = True
 
-    async def process_connection_payload(self,  payload: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    async def process_connection_payload(self,  payload: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         """Can be overridden to validate connection payload and provide response payload"""
         return None
 

--- a/strawberry/subscriptions/protocols/graphql_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_ws/handlers.py
@@ -82,11 +82,18 @@ class BaseGraphQLWSHandler(ABC):
 
     async def handle_connection_init(self, message: OperationMessage) -> None:
         data: OperationMessage = {"type": GQL_CONNECTION_ACK}
+        payload = await self.process_connection_payload(message.get("payload"))
+        if payload:
+            data["payload"] = payload
         await self.send_json(data)
 
         if self.keep_alive:
             keep_alive_handler = self.handle_keep_alive()
             self.keep_alive_task = asyncio.create_task(keep_alive_handler)
+
+    async def process_connection_payload(self,  payload: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+        """Can be overridden to validate connection payload and provide response payload"""
+        return None
 
     async def handle_connection_terminate(self, message: OperationMessage) -> None:
         await self.close()

--- a/strawberry/subscriptions/protocols/graphql_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_ws/handlers.py
@@ -91,8 +91,12 @@ class BaseGraphQLWSHandler(ABC):
             keep_alive_handler = self.handle_keep_alive()
             self.keep_alive_task = asyncio.create_task(keep_alive_handler)
 
-    async def process_connection_payload(self,  payload: Dict[str, Any]) -> Optional[Dict[str, Any]]:
-        """Can be overridden to validate connection payload and provide response payload"""
+    async def process_connection_payload(
+        self, payload: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]:
+        """
+        Can be overridden to validate connection payload and provide response payload
+        """
         return None
 
     async def handle_connection_terminate(self, message: OperationMessage) -> None:

--- a/strawberry/subscriptions/protocols/graphql_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_ws/handlers.py
@@ -82,7 +82,7 @@ class BaseGraphQLWSHandler(ABC):
 
     async def handle_connection_init(self, message: OperationMessage) -> None:
         data: OperationMessage = {"type": GQL_CONNECTION_ACK}
-        payload = await self.process_connection_payload(message.get("payload"))
+        payload = await self.process_connection_payload(message.get("payload") or {})
         if payload:
             data["payload"] = payload
         await self.send_json(data)
@@ -91,7 +91,7 @@ class BaseGraphQLWSHandler(ABC):
             keep_alive_handler = self.handle_keep_alive()
             self.keep_alive_task = asyncio.create_task(keep_alive_handler)
 
-    async def process_connection_payload(self,  payload: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    async def process_connection_payload(self,  payload: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         """Can be overridden to validate connection payload and provide response payload"""
         return None
 


### PR DESCRIPTION
This PR adds a hook funciton in to the websocket handlers, `process_connection_payload()` which can
be customized to validate/proecss the payload sent with the `connection_init` message and
provide a payload to return with the `connection_ack` response.

This allows validation of conneciton payload, as well as to pro
## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

See discussion #1640
and issue #1702

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
