### PR TITLE
Add tests showing wrong argument types

### DIFF
--- a/tests/schema/test_arguments.py
+++ b/tests/schema/test_arguments.py
@@ -1,10 +1,15 @@
+import datetime
 from textwrap import dedent
-from typing import Optional
+from typing import List, Optional, Tuple
+
+import pytest
 
 from typing_extensions import Annotated
 
 import strawberry
 from strawberry.arguments import UNSET, is_unset
+from strawberry.schema.config import StrawberryConfig
+from strawberry.types.info import Info
 
 
 def test_argument_descriptions():
@@ -167,3 +172,142 @@ def test_optional_input_field_unset():
     )
     assert not result.errors
     assert result.data == {"hello": "Hi there"}
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        (
+            """
+            query {
+                typenames(date: "2022-02-22") {
+                    arg
+                    info
+                }
+            }
+            """,
+            None,
+        ),
+        (
+            """
+            query($date: Date!) {
+                typenames(date: $date) {
+                    arg
+                    info
+                }
+            }
+            """,
+            {"date": "2022-02-22"},
+        ),
+    ],
+    ids=["argument", "variable"],
+)
+def test_argument_type_date(query: List[Tuple[str, Optional[dict]]]):
+    """
+    Ensure that accessing a date both via resolver argument and
+    `Info` dictionary gives a `date` object. Also make sure that
+    it makes no difference if passing that value directly as
+    part of the `query` or using the `variable_values` dictionary.
+    """
+    import datetime
+
+    @strawberry.type
+    class TypeNames:
+        arg: str
+        info: str
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def typenames(self, info: Info, date: datetime.date) -> TypeNames:
+            [selected_field] = info.selected_fields
+            return TypeNames(
+                arg=type(date).__name__,
+                info=type(selected_field.arguments["date"]).__name__,
+            )
+
+    schema = strawberry.Schema(query=Query)
+
+    result = schema.execute_sync(*query)
+    assert not result.errors
+    assert result.data["typenames"]["arg"] == "date"
+    assert result.data["typenames"]["info"] == "date"
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        (
+            """
+            query {
+                typenames(obj: { date: "2022-02-22" }) {
+                    obj
+                    obj__date
+                    info__obj
+                    info__obj__date
+                }
+            }
+            """,
+            None,
+        ),
+        (
+            """
+            query($obj: Obj!) {
+                typenames(obj: $obj) {
+                    obj
+                    obj__date
+                    info__obj
+                    info__obj__date
+                }
+            }
+            """,
+            {"obj": {"date": "2022-02-22"}},
+        ),
+    ],
+    ids=["argument", "variable"],
+)
+def test_argument_type_dataclass(query: List[Tuple[str, Optional[dict]]]):
+    """
+    Ensure that accessing a dataclass both via resolver argument and
+    `Info` dictionary gives the proper object. Also make sure that
+    it makes no difference if passing that value directly as
+    part of the `query` or using the `variable_values` dictionary.
+    """
+
+    @strawberry.input
+    class Obj:
+        date: Optional[datetime.date] = None
+
+    @strawberry.type
+    class TypeNames:
+        obj: str
+        obj__date: str
+        info__obj: str
+        info__obj__date: str
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def typenames(self, info: Info, obj: Optional[Obj] = None) -> TypeNames:
+            [field] = info.selected_fields
+            info__obj = field.arguments["obj"]
+            info__obj__date = (
+                info__obj.date if isinstance(info__obj, Obj) else info__obj["date"]
+            )
+            return TypeNames(
+                obj=type(obj).__name__,
+                obj__date=type(obj.date).__name__,
+                info__obj=type(info__obj).__name__,
+                info__obj__date=type(info__obj__date).__name__,
+            )
+
+    config = StrawberryConfig(auto_camel_case=False)
+    schema = strawberry.Schema(query=Query, config=config)
+
+    result = schema.execute_sync(*query)
+
+    assert not result.errors
+    assert result.data["typenames"]["obj"] == "Obj"
+    assert result.data["typenames"]["obj__date"] == "date"
+    assert result.data["typenames"]["info__obj"] == "Obj"
+    assert result.data["typenames"]["info__obj__date"] == "date"


### PR DESCRIPTION
It should not make a difference wether passing arguments as part of the
`query` or via the `variable_values` dictionary. Also dataclasses should
be parsed from dictionaries when specified as argument type.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This PR is WiP and currently just adds the tests showing the wrong behavior.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [X] New tests
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #1662

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
- [X] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
