### PR TITLE
add failing test

### DIFF
--- a/tests/schema/test_directives.py
+++ b/tests/schema/test_directives.py
@@ -114,6 +114,32 @@ def test_can_declare_directives():
     assert schema.as_str() == textwrap.dedent(expected_schema).strip()
 
 
+def test_directive_arguments_without_value_param():
+    """regression test for https://github.com/strawberry-graphql/strawberry/issues/1666"""
+    @strawberry.type
+    class Query:
+        cake: str = "victoria sponge"
+
+    @strawberry.directive(
+        locations=[DirectiveLocation.FIELD], description="Don't actually like cake? try ice cream instead"
+    )
+    def ice_cream(flavor: str):
+        return f'{flavor} ice cream'
+
+    schema = strawberry.Schema(query=Query, directives=[ice_cream])
+
+    expected_schema = '''
+    """Don't actually like cake? try ice cream instead"""
+    directive @iceCream(flavor: String!) on FIELD
+
+    type Query {
+      cake: String!
+    }
+    '''
+
+    assert schema.as_str() == textwrap.dedent(expected_schema).strip()
+
+
 def test_runs_directives():
     @strawberry.type
     class Person:


### PR DESCRIPTION
!! wip, this PR is just the failing test for now !!

Fix https://github.com/strawberry-graphql/strawberry/issues/1666

## Description

Let's change it so that `@strawberry.directive` passes in the info argument based on its typing of the param (e.g. `foo: Info`), rather than current behaviour of assuming that the first arg is always `info`.

## Types of Changes

- [x] Core
- [x] Bugfix
- [x] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/strawberry-graphql/strawberry/issues/1666

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
