### PR TITLE
Make `strawberry.Private` compatible with PEP-563

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,41 @@
+Release type: patch
+
+Add support for postponed evaluation of annotations
+([PEP-563](https://www.python.org/dev/peps/pep-0563/)) to `strawberry.Private`
+annotated fields.
+
+## Example
+
+This release fixes Issue #1586 using schema-conversion time filtering of
+`strawberry.Private` fields for PEP-563. This means the following is now
+supported:
+
+```python
+
+@strawberry.type
+class Query:
+    foo: "strawberry.Private[int]"
+```
+
+Forward references are supported as well:
+
+```python
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+@strawberry.type
+class Query:
+    private_foo: strawberry.Private[SensitiveData]
+
+    @strawberry.field
+    def foo(self) -> int:
+        return self.private_foo.visible
+
+@dataclass
+class SensitiveData:
+
+    visible: int
+    not_visible int
+```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,7 +11,6 @@ This release fixes Issue #1586 using schema-conversion time filtering of
 supported:
 
 ```python
-
 @strawberry.type
 class Query:
     foo: "strawberry.Private[int]"
@@ -20,7 +19,6 @@ class Query:
 Forward references are supported as well:
 
 ```python
-
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -35,7 +33,6 @@ class Query:
 
 @dataclass
 class SensitiveData:
-
     visible: int
     not_visible int
 ```

--- a/strawberry/exceptions.py
+++ b/strawberry/exceptions.py
@@ -131,6 +131,15 @@ class UnsupportedTypeError(Exception):
         super().__init__(message)
 
 
+class UnresolvedFieldTypeError(Exception):
+    def __init__(self, field_name: str):
+        message = (
+            f"Could not resolve the type of '{field_name}'. Check that the class is "
+            "accessible from the global module scope."
+        )
+        super().__init__(message)
+
+
 class MissingFieldAnnotationError(Exception):
     def __init__(self, field_name: str):
         message = (

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -18,6 +18,7 @@ from typing import (
     overload,
 )
 
+import sentinel
 from backports.cached_property import cached_property
 from typing_extensions import Literal
 
@@ -38,6 +39,8 @@ if TYPE_CHECKING:
 
 
 _RESOLVER_TYPE = Union[StrawberryResolver, Callable, staticmethod, classmethod]
+
+UNRESOLVED = sentinel.create("UNRESOLVED")
 
 
 class StrawberryField(dataclasses.Field):
@@ -212,7 +215,7 @@ class StrawberryField(dataclasses.Field):
 
             return self.type_annotation.resolve()
         except NameError:
-            return None  # type: ignore
+            return UNRESOLVED
 
     @type.setter
     def type(self, type_: Any) -> None:

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -40,11 +40,7 @@ if TYPE_CHECKING:
 _RESOLVER_TYPE = Union[StrawberryResolver, Callable, staticmethod, classmethod]
 
 
-class UnresolvedType(type):
-    pass
-
-
-UNRESOLVED = UnresolvedType()
+UNRESOLVED = object()
 
 
 class StrawberryField(dataclasses.Field):
@@ -199,7 +195,7 @@ class StrawberryField(dataclasses.Field):
         _ = resolver.arguments
 
     @property  # type: ignore
-    def type(self) -> Union[StrawberryType, type]:  # type: ignore
+    def type(self) -> Union[StrawberryType, type, Literal[UNRESOLVED]]:  # type: ignore
         # We are catching NameError because dataclasses tries to fetch the type
         # of the field from the class before the class is fully defined.
         # This triggers a NameError error when using forward references because

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -18,7 +18,6 @@ from typing import (
     overload,
 )
 
-import sentinel
 from backports.cached_property import cached_property
 from typing_extensions import Literal
 
@@ -40,7 +39,12 @@ if TYPE_CHECKING:
 
 _RESOLVER_TYPE = Union[StrawberryResolver, Callable, staticmethod, classmethod]
 
-UNRESOLVED = sentinel.create("UNRESOLVED")
+
+class UnresolvedType(type):
+    pass
+
+
+UNRESOLVED = UnresolvedType()
 
 
 class StrawberryField(dataclasses.Field):

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -195,6 +195,7 @@ class GraphQLCoreConverter:
             TypeError: If the type of a field in ``fields`` is `UNRESOLVED`
         """
         thunk_mapping = {}
+
         for f in fields:
             if f.type is UNRESOLVED:
                 raise TypeError(

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -183,6 +183,14 @@ class GraphQLCoreConverter:
         name_converter: Callable[[StrawberryField], str],
         field_converter: Callable[[StrawberryField], FieldType],
     ) -> Dict[str, FieldType]:
+        """Create a GraphQL core `ThunkMapping` mapping of field names to field types.
+
+        This method filters out remaining `strawberry.Private` annotated fields that
+        could not be filtered during the initialization of a `TypeDefinition` due to
+        postponed type-hint evaluation (PEP-563). Performing this filtering now (at
+        schema conversion time) ensures that all types to be included in the schema
+        should have already been resolved.
+        """
         return {
             name_converter(f): field_converter(f)
             for f in fields

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -200,9 +200,9 @@ class GraphQLCoreConverter:
         for f in fields:
             if f.type is UNRESOLVED:
                 raise UnresolvedFieldTypeError(f.name)
-            else:
-                if not is_private(f.type):
-                    thunk_mapping[name_converter(f)] = field_converter(f)
+
+            if not is_private(f.type):
+                thunk_mapping[name_converter(f)] = field_converter(f)
         return thunk_mapping
 
     def get_graphql_fields(

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -42,6 +42,7 @@ from strawberry.enum import EnumDefinition, EnumValue
 from strawberry.exceptions import (
     MissingTypesForGenericError,
     ScalarAlreadyRegisteredError,
+    UnresolvedFieldTypeError,
 )
 from strawberry.field import UNRESOLVED, StrawberryField
 from strawberry.lazy_type import LazyType
@@ -198,10 +199,7 @@ class GraphQLCoreConverter:
 
         for f in fields:
             if f.type is UNRESOLVED:
-                raise TypeError(
-                    f"Could not resolve the type of '{f.name}'. Check that the class "
-                    "is accessible from the global module scope."
-                )
+                raise UnresolvedFieldTypeError(f.name)
             else:
                 if not is_private(f.type):
                     thunk_mapping[name_converter(f)] = field_converter(f)

--- a/tests/schema/test_private_field.py
+++ b/tests/schema/test_private_field.py
@@ -1,4 +1,3 @@
-from logging import root
 import pytest
 
 import strawberry

--- a/tests/schema/test_private_field.py
+++ b/tests/schema/test_private_field.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass
+
 import pytest
 
 import strawberry
@@ -57,27 +59,55 @@ def test_private_field_access_in_resolver():
     }
 
 
+@strawberry.type
+class Query:
+    not_seen: "strawberry.Private[SensitiveData]"
+
+    @strawberry.field
+    def accessible_info(self) -> str:
+        return self.not_seen.info
+
+
+@dataclass
+class SensitiveData:
+    value: int
+    info: str
+
+
 def test_private_field_with_str_annotations():
     """Check compatibility of strawberry.Private with annotations as string."""
-
-    from dataclasses import dataclass
-
-    @strawberry.type
-    class Query:
-        not_seen: "strawberry.Private[SensitiveData]"
-
-        @strawberry.field
-        def accesible_info(self) -> str:
-            return self.not_seen.info
-
-    @dataclass
-    class SensitiveData:
-        value: int
-        info: str
 
     schema = strawberry.Schema(query=Query)
 
     result = schema.execute_sync(
-        "query { accesibleInfo }", root_value=Query(not_seen=SensitiveData(1, "foo"))
+        "query { accessibleInfo }",
+        root_value=Query(not_seen=SensitiveData(1, "foo")),
     )
-    assert result.data == {"accesibleInfo": "foo"}
+    assert result.data == {"accessibleInfo": "foo"}
+
+    # Check if querying `notSeen` raises error and no data is returned
+    assert "notSeen" not in str(schema)
+    failed_result = schema.execute_sync(
+        "query { notSeen }", root_value=Query(not_seen=SensitiveData(1, "foo"))
+    )
+    assert failed_result.data is None
+
+
+def test_private_field_defined_outside_module_scope():
+    """Check compatibility of strawberry.Private when defined outside module scope."""
+
+    @strawberry.type
+    class LocallyScopedQuery:
+        not_seen: "strawberry.Private[LocallyScopedSensitiveData]"
+
+        @strawberry.field
+        def accessible_info(self) -> str:
+            return self.not_seen.info
+
+    @dataclass
+    class LocallyScopedSensitiveData:
+        value: int
+        info: str
+
+    schema = strawberry.Schema(query=LocallyScopedQuery)
+    assert "notSeen" not in str(schema)

--- a/tests/schema/test_private_field.py
+++ b/tests/schema/test_private_field.py
@@ -109,5 +109,8 @@ def test_private_field_defined_outside_module_scope():
         value: int
         info: str
 
-    schema = strawberry.Schema(query=LocallyScopedQuery)
-    assert "notSeen" not in str(schema)
+    with pytest.raises(TypeError, match=r"Could not resolve the type of 'not_seen'."):
+        schema = strawberry.Schema(query=LocallyScopedQuery)
+
+        # If schema-conversion does not raise, check if private field is visible
+        assert "notSeen" not in str(schema)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This commit Closes #1586 by checking for private fields at schema
conversion time. As per [PEP-563], in the future Python annotations will
no longer be evaluated at definition time. As reported by Issue #1586,
this means that `strawberry.Private` is incompatible with postponed
evaluation as the check for a private field requires an evaluated
type-hint annotation to work.

By checking for private fields at schema conversion time, it is
guaranteed that all fields that should be included in the schema are
resolvable using an eval. This ensures that the current approach for
defining private fields can be left intact.

The current filtering for fields annotated with `strawberry.Private` in
`types.type_resolver.py` are left intact to not needlessly instantiate
`StrawberryField` objects when `strawberry.Private` is resolvable.

Summary of Changes:
- Added check for private fields at schema-conversion time
- Added test to check that postponed evaluation with
  `strawberry.Private` functions correctly
- Reduced code duplication in schema_converter.py

[PEP-563]: https://www.python.org/dev/peps/pep-0563/

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

Issue #1586

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
