### PR TITLE
Add support for query params for all integrations

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,8 @@
+Release type: minor
+
+This release adds support in all our integration for queries via GET requests.
+This behavior is enabled by default, but you can disable it by passing
+`allow_queries_via_get=False` to the constructor of the integration of your
+choice.
+
+For security reason only queries are allowed via `GET` requests.

--- a/docs/integrations/aiohttp.md
+++ b/docs/integrations/aiohttp.md
@@ -4,8 +4,8 @@ title: AIOHTTP
 
 # AIOHTTP
 
-Strawberry comes with a basic AIOHTTP integration. It provides a view that you can
-use to serve your GraphQL schema:
+Strawberry comes with a basic AIOHTTP integration. It provides a view that you
+can use to serve your GraphQL schema:
 
 ```python
 import strawberry
@@ -30,11 +30,15 @@ app.router.add_route("*", "/graphql", GraphQLView(schema=schema))
 The `GraphQLView` accepts two options at the moment:
 
 - `schema`: mandatory, the schema created by `strawberry.Schema`.
-- `graphiql`: optional, defaults to `True`, whether to enable the GraphiQL interface.
+- `graphiql`: optional, defaults to `True`, whether to enable the GraphiQL
+  interface.
+- `allow_queries_via_get`: optional, defaults to `True`, whether to enable
+  queries via `GET` requests
 
 ## Extending the view
 
-The base `GraphQLView` class can be extended by overriding the following methods:
+The base `GraphQLView` class can be extended by overriding the following
+methods:
 
 - `async get_context(self, request: aiohttp.web.Request, response: aiohttp.web.StreamResponse) -> object`
 - `async get_root_value(self, request: aiohttp.web.Request) -> object`
@@ -42,9 +46,9 @@ The base `GraphQLView` class can be extended by overriding the following methods
 
 ## get_context
 
-By overriding `GraphQLView.get_context` you can provide a custom context object for
-your resolvers. You can return anything here; by default GraphQLView returns a
-dictionary with the request.
+By overriding `GraphQLView.get_context` you can provide a custom context object
+for your resolvers. You can return anything here; by default GraphQLView returns
+a dictionary with the request.
 
 ```python
 import strawberry
@@ -68,12 +72,14 @@ class Query:
 Here we are returning a custom context dictionary that contains only one item
 called `"example"`.
 
-Then we can use the context in a resolver. In this case the resolver will return `1`.
+Then we can use the context in a resolver. In this case the resolver will return
+`1`.
 
 ## get_root_value
 
-By overriding `GraphQLView.get_root_value` you can provide a custom root value for your
-schema. This is probably not used a lot but it might be useful in certain situations.
+By overriding `GraphQLView.get_root_value` you can provide a custom root value
+for your schema. This is probably not used a lot but it might be useful in
+certain situations.
 
 Here's an example:
 
@@ -93,17 +99,17 @@ class Query:
     name: str
 ```
 
-Here we configure a Query where requesting the `name` field will return `"Patrick"`
-through the custom root value.
+Here we configure a Query where requesting the `name` field will return
+`"Patrick"` through the custom root value.
 
 ## process_result
 
-By overriding `GraphQLView.process_result` you can customize and/or process results
-before they are sent to a client. This can be useful for logging errors, or even hiding
-them (for example to hide internal exceptions).
+By overriding `GraphQLView.process_result` you can customize and/or process
+results before they are sent to a client. This can be useful for logging errors,
+or even hiding them (for example to hide internal exceptions).
 
-It needs to return an object of `GraphQLHTTPResponse` and accepts the request and
-execution result.
+It needs to return an object of `GraphQLHTTPResponse` and accepts the request
+and execution result.
 
 ```python
 from aiohttp import web

--- a/docs/integrations/aiohttp.md
+++ b/docs/integrations/aiohttp.md
@@ -15,7 +15,9 @@ from strawberry.aiohttp.views import GraphQLView
 
 @strawberry.type
 class Query:
-    pass
+    @strawberry.field
+    def hello(self, name: str = "World") -> str:
+        return f"Hello, {name}!"
 
 
 schema = strawberry.Schema(query=Query)

--- a/docs/integrations/asgi.md
+++ b/docs/integrations/asgi.md
@@ -5,8 +5,8 @@ title: ASGI
 # ASGI
 
 Strawberry comes with a basic ASGI integration. It provides an app that you can
-use to serve your GraphQL schema. Before using Strawberry's ASGI support make sure
-you install all the required dependencies by running:
+use to serve your GraphQL schema. Before using Strawberry's ASGI support make
+sure you install all the required dependencies by running:
 
 ```
 pip install 'strawberry-graphql[asgi]'
@@ -23,16 +23,19 @@ from api.schema import schema
 app = GraphQL(schema)
 ```
 
-Every ASGI server will accept this `app` instance to start the server.
-For example if you're using [uvicorn](https://pypi.org/project/uvicorn/) you run the app with `uvicorn server:app`
+Every ASGI server will accept this `app` instance to start the server. For
+example if you're using [uvicorn](https://pypi.org/project/uvicorn/) you run the
+app with `uvicorn server:app`
 
 ## Options
 
 The `GraphQL` app accepts two options at the moment:
 
-- schema: mandatory, the schema created by `strawberry.Schema`.
-- graphiql: optional, defaults to `True`, whether to enable the GraphiQL
+- `schema`: mandatory, the schema created by `strawberry.Schema`.
+- `graphiql`: optional, defaults to `True`, whether to enable the GraphiQL
   interface.
+- `allow_queries_via_get`: optional, defaults to `True`, whether to enable
+  queries via `GET` requests
 
 ## Extending the view
 
@@ -69,10 +72,12 @@ case.
 
 ### Setting response headers
 
-It is possible to use `get_context` to set response headers. A common use case might be cookie-based user authentication,
-where your login mutation resolver needs to set a cookie on the response.
+It is possible to use `get_context` to set response headers. A common use case
+might be cookie-based user authentication, where your login mutation resolver
+needs to set a cookie on the response.
 
-This is possible by updating the response object contained inside the context of the `Info` object.
+This is possible by updating the response object contained inside the context of
+the `Info` object.
 
 ```python
 @strawberry.type
@@ -86,7 +91,8 @@ class Mutation:
 
 ### Setting background tasks
 
-Similarly, [background tasks](https://www.starlette.io/background/) can be set on the response via the context:
+Similarly, [background tasks](https://www.starlette.io/background/) can be set
+on the response via the context:
 
 ```python
 from starlette.background import BackgroundTask

--- a/docs/integrations/django.md
+++ b/docs/integrations/django.md
@@ -4,7 +4,8 @@ title: Django
 
 # Django
 
-Strawberry comes with a basic [Django integration](https://github.com/strawberry-graphql/strawberry-graphql-django).
+Strawberry comes with a basic
+[Django integration](https://github.com/strawberry-graphql/strawberry-graphql-django).
 It provides a view that you can use to serve your GraphQL schema:
 
 ```python
@@ -24,19 +25,21 @@ project, this is needed to provide the template for the GraphiQL interface.
 
 ## Options
 
-The `GraphQLView` accepts five options at the moment:
+The `GraphQLView` accepts the following arguments:
 
 - `schema`: mandatory, the schema created by `strawberry.Schema`.
 - `graphiql`: optional, defaults to `True`, whether to enable the GraphiQL
   interface.
-- `subscriptions_enabled`: optional boolean paramenter enabling subscriptions
-  in the GraphiQL interface, defaults to `False`.
+- `allow_queries_via_get`: optional, defaults to `True`, whether to enable
+  queries via `GET` requests
+- `subscriptions_enabled`: optional boolean paramenter enabling subscriptions in
+  the GraphiQL interface, defaults to `False`.
 - `json_encoder`: optional JSON encoder, defaults to `DjangoJSONEncoder`, will
   be used to serialize the data.
-- `json_dumps_params`: optional dictionary of keyword arguments to pass to
-  the `json.dumps` call used to generate the response. To get the most compact
-  JSON representation, you should specify `{"separators": (",", ":")}`,
-  defaults to `None`.
+- `json_dumps_params`: optional dictionary of keyword arguments to pass to the
+  `json.dumps` call used to generate the response. To get the most compact JSON
+  representation, you should specify `{"separators": (",", ":")}`, defaults to
+  `None`.
 
 ## Extending the view
 
@@ -153,11 +156,21 @@ project, this is needed to provide the template for the GraphiQL interface.
 
 ## Options
 
-The `AsyncGraphQLView` accepts two options at the moment:
+The `AsyncGraphQLView` accepts the following arguments:
 
-- schema: mandatory, the schema created by `strawberry.Schema`.
-- graphiql: optional, defaults to `True`, whether to enable the GraphiQL
+- `schema`: mandatory, the schema created by `strawberry.Schema`.
+- `graphiql`: optional, defaults to `True`, whether to enable the GraphiQL
   interface.
+- `allow_queries_via_get`: optional, defaults to `True`, whether to enable
+  queries via `GET` requests
+- `subscriptions_enabled`: optional boolean paramenter enabling subscriptions in
+  the GraphiQL interface, defaults to `False`.
+- `json_encoder`: optional JSON encoder, defaults to `DjangoJSONEncoder`, will
+  be used to serialize the data.
+- `json_dumps_params`: optional dictionary of keyword arguments to pass to the
+  `json.dumps` call used to generate the response. To get the most compact JSON
+  representation, you should specify `{"separators": (",", ":")}`, defaults to
+  `None`.
 
 ## Extending the view
 

--- a/docs/integrations/fastapi.md
+++ b/docs/integrations/fastapi.md
@@ -42,18 +42,20 @@ app.include_router(graphql_app, prefix="/graphql")
 
 The `GraphQLRouter` accepts the following options:
 
-- schema: mandatory, the schema created by `strawberry.Schema`.
-- graphiql: optional, defaults to `True`, whether to enable the GraphiQL
+- `schema`: mandatory, the schema created by `strawberry.Schema`.
+- `graphiql`: optional, defaults to `True`, whether to enable the GraphiQL
   interface.
-- context_getter: optional FastAPI dependency for providing custom context
+- `allow_queries_via_get`: optional, defaults to `True`, whether to enable
+  queries via `GET` requests
+- `context_getter`: optional FastAPI dependency for providing custom context
   value.
-- root_value_getter: optional FastAPI dependency for providing custom root
+- `root_value_getter`: optional FastAPI dependency for providing custom root
   value.
 
 ## context_getter
 
-The `context_getter` option allows you to provide a custom context object that can be
-used in your resolver. `context_getter` is a
+The `context_getter` option allows you to provide a custom context object that
+can be used in your resolver. `context_getter` is a
 [FastAPI dependency](https://fastapi.tiangolo.com/tutorial/dependencies/) and
 can inject other dependencies if you so wish.
 
@@ -62,13 +64,13 @@ There are two options at your disposal here:
 1. Define your custom context as a dictionary,
 2. Define your custom context as a class.
 
-If no context is supplied, then the default context returned is a dictionary containing
-the request, the response, and any background tasks.
+If no context is supplied, then the default context returned is a dictionary
+containing the request, the response, and any background tasks.
 
 However, you can define a class-based custom context inline with
 [FastAPI practice](https://fastapi.tiangolo.com/tutorial/dependencies/classes-as-dependencies/).
-If you choose to do this, you must ensure that your custom context class inherits from
-`BaseContext` or an `InvalidCustomContext` exception is raised.
+If you choose to do this, you must ensure that your custom context class
+inherits from `BaseContext` or an `InvalidCustomContext` exception is raised.
 
 For dictionary-based custom contexts, an example might look like the following.
 
@@ -114,8 +116,8 @@ called "custom*value", which is injected from `custom_context_dependency`. This
 value exists alongside `request`, `response`, and `background_tasks` in the
 `info.context` \_dictionary* and so it requires `['request']` indexing.
 
-Then we use the context in a resolver.
-The resolver will return "Hello John" in this case.
+Then we use the context in a resolver. The resolver will return "Hello John" in
+this case.
 
 For class-based custom contexts, an example might look like the following.
 
@@ -160,14 +162,14 @@ app = FastAPI()
 app.include_router(graphql_app, prefix="/graphql")
 ```
 
-In this case, we are returning a custom context class that inherits
-from BaseContext with fields `name` and `greeting`, which is also
-injected by `custom_context_dependency`. These custom values exist
-alongside `request`, `response`, and `background_tasks` in the
-`info.context` _class_ and so it requires `.request` indexing.
+In this case, we are returning a custom context class that inherits from
+BaseContext with fields `name` and `greeting`, which is also injected by
+`custom_context_dependency`. These custom values exist alongside `request`,
+`response`, and `background_tasks` in the `info.context` _class_ and so it
+requires `.request` indexing.
 
-Then we use the context in a resolver.
-The resolver will return “Hello John, you rock!” in this case.
+Then we use the context in a resolver. The resolver will return “Hello John, you
+rock!” in this case.
 
 ### Setting background tasks
 
@@ -209,12 +211,13 @@ app = FastAPI()
 app.include_router(graphql_app, prefix="/graphql")
 ```
 
-If using a custom context class, then background tasks should be stored within the class object as `.background_tasks`.
+If using a custom context class, then background tasks should be stored within
+the class object as `.background_tasks`.
 
 ## root_value_getter
 
-The `root_value_getter` option allows you to provide a custom root value for your
-schema. This is most likely a rare usecase but might be useful in certain
+The `root_value_getter` option allows you to provide a custom root value for
+your schema. This is most likely a rare usecase but might be useful in certain
 situations.
 
 Here's an example:
@@ -252,12 +255,12 @@ the field name we'll return "Patrick".
 
 ## process_result
 
-The `process_result` option allows you to customize and/or process results before they are sent
-to the clients. This can be useful for logging errors or hiding them (for example to
-hide internal exceptions).
+The `process_result` option allows you to customize and/or process results
+before they are sent to the clients. This can be useful for logging errors or
+hiding them (for example to hide internal exceptions).
 
-It needs to return a `GraphQLHTTPResponse` object and accepts the request
-and execution results.
+It needs to return a `GraphQLHTTPResponse` object and accepts the request and
+execution results.
 
 ```python
 from fastapi import Request

--- a/docs/integrations/flask.md
+++ b/docs/integrations/flask.md
@@ -24,9 +24,11 @@ app.add_url_rule(
 
 The `GraphQLView` accepts two options at the moment:
 
-- schema: mandatory, the schema created by `strawberry.Schema`.
-- graphiql: optional, defaults to `True`, whether to enable the GraphiQL
+- `schema`: mandatory, the schema created by `strawberry.Schema`.
+- `graphiql:` optional, defaults to `True`, whether to enable the GraphiQL
   interface.
+- `allow_queries_via_get`: optional, defaults to `True`, whether to enable
+  queries via `GET` requests
 
 ## Extending the view
 

--- a/docs/integrations/sanic.md
+++ b/docs/integrations/sanic.md
@@ -4,8 +4,8 @@ title: Sanic
 
 # Sanic
 
-Strawberry comes with a basic [Sanic](https://github.com/sanic-org/sanic) integration. It provides a view that you can
-use to serve your GraphQL schema:
+Strawberry comes with a basic [Sanic](https://github.com/sanic-org/sanic)
+integration. It provides a view that you can use to serve your GraphQL schema:
 
 ```python
 from strawberry.sanic.views import GraphQLView
@@ -27,16 +27,19 @@ The `GraphQLView` accepts two options at the moment:
 - `schema`: mandatory, the schema created by `strawberry.Schema`.
 - `graphiql`: optional, defaults to `True`, whether to enable the GraphiQL
   interface.
-- `json_encoder`: optional **JSON** encoder, defaults to `DjangoJSONEncoder`, will
-  be used to serialize the data.
-- `json_dumps_params`: optional dictionary of keyword arguments to pass to
-  the `json.dumps` call used to generate the response. To get the most compact
-  JSON representation, you should specify `{"separators": (",", ":")}`,
-  defaults to `None`.
+- `allow_queries_via_get`: optional, defaults to `True`, whether to enable
+  queries via `GET` requests
+- `json_encoder`: optional **JSON** encoder, defaults to `DjangoJSONEncoder`,
+  will be used to serialize the data.
+- `json_dumps_params`: optional dictionary of keyword arguments to pass to the
+  `json.dumps` call used to generate the response. To get the most compact JSON
+  representation, you should specify `{"separators": (",", ":")}`, defaults to
+  `None`.
 
 ## Extending the view
 
-The base `GraphQLView` class can be extended by overriding the following methods:
+The base `GraphQLView` class can be extended by overriding the following
+methods:
 
 - `async get_context(self) -> Any`
 - `get_root_value(self) -> Any`
@@ -44,9 +47,9 @@ The base `GraphQLView` class can be extended by overriding the following methods
 
 ## get_context
 
-By overriding `GraphQLView.get_context` you can provide a custom context object for
-your resolvers. You can return anything here; by default GraphQLView returns a
-dictionary with the request.
+By overriding `GraphQLView.get_context` you can provide a custom context object
+for your resolvers. You can return anything here; by default GraphQLView returns
+a dictionary with the request.
 
 ```python
 class MyGraphQLView(GraphQLView):
@@ -64,12 +67,14 @@ class Query:
 Here we are returning a custom context dictionary that contains only one item
 called `"example"`.
 
-Then we can use the context in a resolver. In this case the resolver will return `1`.
+Then we can use the context in a resolver. In this case the resolver will return
+`1`.
 
 ## get_root_value
 
-By overriding `GraphQLView.get_root_value` you can provide a custom root value for your
-schema. This is probably not used a lot but it might be useful in certain situations.
+By overriding `GraphQLView.get_root_value` you can provide a custom root value
+for your schema. This is probably not used a lot but it might be useful in
+certain situations.
 
 Here's an example:
 
@@ -84,16 +89,17 @@ class Query:
     name: str
 ```
 
-Here we configure a Query where requesting the `name` field will return `"Patrick"`
-through the custom root value.
+Here we configure a Query where requesting the `name` field will return
+`"Patrick"` through the custom root value.
 
 ## process_result
 
-By overriding `GraphQLView.process_result` you can customize and/or process results
-before they are sent to a client. This can be useful for logging errors, or even hiding
-them (for example to hide internal exceptions).
+By overriding `GraphQLView.process_result` you can customize and/or process
+results before they are sent to a client. This can be useful for logging errors,
+or even hiding them (for example to hide internal exceptions).
 
-It needs to return an object of `GraphQLHTTPResponse` and accepts the execution result.
+It needs to return an object of `GraphQLHTTPResponse` and accepts the execution
+result.
 
 ```python
 from strawberry.http import GraphQLHTTPResponse

--- a/strawberry/aiohttp/handlers/http_handler.py
+++ b/strawberry/aiohttp/handlers/http_handler.py
@@ -38,8 +38,8 @@ class HTTPHandler:
         if request.query:
             try:
                 request_data = parse_request_data(
-                    request.query
-                )  # type:ignore[arg-type]
+                    request.query  # type:ignore[arg-type]
+                )
             except MissingQueryError:
                 raise web.HTTPBadRequest(reason="No GraphQL query found in the request")
 

--- a/strawberry/aiohttp/handlers/http_handler.py
+++ b/strawberry/aiohttp/handlers/http_handler.py
@@ -100,8 +100,10 @@ class HTTPHandler:
 
         try:
             request_data = parse_request_data(data)
-        except MissingQueryError:
-            raise web.HTTPBadRequest(reason="No GraphQL query found in the request")
+        except MissingQueryError as e:
+            raise web.HTTPBadRequest(
+                reason="No GraphQL query found in the request"
+            ) from e
 
         return request_data
 
@@ -110,8 +112,10 @@ class HTTPHandler:
             return await self.parse_multipart_body(request)
         try:
             return await request.json()
-        except json.JSONDecodeError:
-            raise web.HTTPBadRequest(reason="Unable to parse request body as JSON")
+        except json.JSONDecodeError as e:
+            raise web.HTTPBadRequest(
+                reason="Unable to parse request body as JSON"
+            ) from e
 
     async def parse_multipart_body(self, request: web.Request) -> dict:
         reader = await request.multipart()

--- a/strawberry/aiohttp/handlers/http_handler.py
+++ b/strawberry/aiohttp/handlers/http_handler.py
@@ -72,7 +72,7 @@ class HTTPHandler:
         context = await self.get_context(request, response)
         root_value = await self.get_root_value(request)
 
-        allowed_operation_types = set(OperationType.from_http(method))
+        allowed_operation_types = OperationType.from_http(method)
 
         if not self.allow_queries_via_get and method == "GET":
             allowed_operation_types = allowed_operation_types - {OperationType.QUERY}

--- a/strawberry/aiohttp/handlers/http_handler.py
+++ b/strawberry/aiohttp/handlers/http_handler.py
@@ -83,7 +83,7 @@ class HTTPHandler:
                 root_value=root_value,
                 variable_values=request_data.variables,
                 context_value=context,
-                allowed_operation_types=list(allowed_operation_types),
+                allowed_operation_types=allowed_operation_types,
             )
         except InvalidOperationTypeError as e:
             raise web.HTTPBadRequest(

--- a/strawberry/aiohttp/handlers/http_handler.py
+++ b/strawberry/aiohttp/handlers/http_handler.py
@@ -37,7 +37,9 @@ class HTTPHandler:
     async def get(self, request: web.Request) -> web.StreamResponse:
         if request.query:
             try:
-                request_data = parse_request_data(request.query)
+                request_data = parse_request_data(
+                    request.query
+                )  # type:ignore[arg-type]
             except MissingQueryError:
                 raise web.HTTPBadRequest(reason="No GraphQL query found in the request")
 

--- a/strawberry/aiohttp/handlers/http_handler.py
+++ b/strawberry/aiohttp/handlers/http_handler.py
@@ -66,7 +66,7 @@ class HTTPHandler:
         self,
         request: web.Request,
         request_data: GraphQLRequestData,
-        method=Union[Literal["GET"], Literal["POST"]],
+        method: Union[Literal["GET"], Literal["POST"]],
     ) -> web.StreamResponse:
         response = web.Response()
         context = await self.get_context(request, response)

--- a/strawberry/aiohttp/views.py
+++ b/strawberry/aiohttp/views.py
@@ -26,6 +26,7 @@ class GraphQLView:
         self,
         schema: BaseSchema,
         graphiql: bool = True,
+        allow_queries_via_get: bool = True,
         keep_alive: bool = True,
         keep_alive_interval: float = 1,
         debug: bool = False,
@@ -34,6 +35,7 @@ class GraphQLView:
     ):
         self.schema = schema
         self.graphiql = graphiql
+        self.allow_queries_via_get = allow_queries_via_get
         self.keep_alive = keep_alive
         self.keep_alive_interval = keep_alive_interval
         self.debug = debug
@@ -72,6 +74,7 @@ class GraphQLView:
             return await self.http_handler_class(
                 schema=self.schema,
                 graphiql=self.graphiql,
+                allow_queries_via_get=self.allow_queries_via_get,
                 get_context=self.get_context,
                 get_root_value=self.get_root_value,
                 process_result=self.process_result,

--- a/strawberry/asgi/__init__.py
+++ b/strawberry/asgi/__init__.py
@@ -26,6 +26,7 @@ class GraphQL:
         self,
         schema: BaseSchema,
         graphiql: bool = True,
+        allow_queries_via_get: bool = True,
         keep_alive: bool = False,
         keep_alive_interval: float = 1,
         debug: bool = False,
@@ -34,6 +35,7 @@ class GraphQL:
     ) -> None:
         self.schema = schema
         self.graphiql = graphiql
+        self.allow_queries_via_get = allow_queries_via_get
         self.keep_alive = keep_alive
         self.keep_alive_interval = keep_alive_interval
         self.debug = debug
@@ -45,6 +47,7 @@ class GraphQL:
             await self.http_handler_class(
                 schema=self.schema,
                 graphiql=self.graphiql,
+                allow_queries_via_get=self.allow_queries_via_get,
                 debug=self.debug,
                 get_context=self.get_context,
                 get_root_value=self.get_root_value,

--- a/strawberry/asgi/handlers/http_handler.py
+++ b/strawberry/asgi/handlers/http_handler.py
@@ -162,7 +162,7 @@ class HTTPHandler:
     async def execute(
         self,
         query: str,
-        variables: Dict[str, Any] = None,
+        variables: Optional[Dict[str, Any]] = None,
         context: Any = None,
         operation_name: Optional[str] = None,
         root_value: Any = None,

--- a/strawberry/asgi/handlers/http_handler.py
+++ b/strawberry/asgi/handlers/http_handler.py
@@ -2,7 +2,6 @@ import json
 from typing import Any, Callable, Optional
 
 from starlette import status
-from starlette.datastructures import QueryParams
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse, PlainTextResponse, Response
 from starlette.types import Receive, Scope, Send

--- a/strawberry/asgi/handlers/http_handler.py
+++ b/strawberry/asgi/handlers/http_handler.py
@@ -73,7 +73,7 @@ class HTTPHandler:
     ) -> Response:
         if request.method == "GET":
             if request.query_params:
-                data = request.query_params
+                data = request.query_params._dict
             elif self.should_render_graphiql(request):
                 return self.get_graphiql_response()
             else:

--- a/strawberry/asgi/handlers/http_handler.py
+++ b/strawberry/asgi/handlers/http_handler.py
@@ -121,7 +121,7 @@ class HTTPHandler:
                 status_code=status.HTTP_400_BAD_REQUEST,
             )
 
-        allowed_operation_types = set(OperationType.from_http(method))
+        allowed_operation_types = OperationType.from_http(method)
 
         if not self.allow_queries_via_get and method == "GET":
             allowed_operation_types = allowed_operation_types - {OperationType.QUERY}

--- a/strawberry/chalice/views.py
+++ b/strawberry/chalice/views.py
@@ -1,3 +1,5 @@
+from typing import Dict, List, Union
+
 from chalice.app import BadRequestError, Request, Response
 from strawberry.chalice.graphiql import render_graphiql_page
 from strawberry.exceptions import MissingQueryError
@@ -19,8 +21,7 @@ class GraphQLView:
         Returns:
             The GraphiQL html page as a string
         """
-        result = render_graphiql_page()
-        return result
+        return render_graphiql_page()
 
     @staticmethod
     def should_render_graphiql(graphiql: bool, request: Request) -> bool:
@@ -34,22 +35,27 @@ class GraphQLView:
         """
         if not graphiql:
             return False
+
         return any(
             supported_header in request.headers.get("accept", "")
-            for supported_header in ("text/html", "*/*")
+            for supported_header in {"text/html", "*/*"}
         )
 
     @staticmethod
-    def error_response(message, error_code, http_status_code, headers=None) -> Response:
+    def error_response(
+        message: str,
+        error_code: str,
+        http_status_code: int,
+        headers: Dict[str, Union[str, List[str]]] = None,
+    ) -> Response:
         """
         A wrapper for error responses
         Returns:
         An errors response
         """
         body = {"Code": error_code, "Message": message}
-        response = Response(body=body, status_code=http_status_code, headers=headers)
 
-        return response
+        return Response(body=body, status_code=http_status_code, headers=headers)
 
     def execute_request(self, request: Request) -> Response:
         """
@@ -61,7 +67,7 @@ class GraphQLView:
             A chalice response
         """
 
-        if request.method not in ["POST", "GET"]:
+        if request.method not in {"POST", "GET"}:
             return self.error_response(
                 error_code="MethodNotAllowedError",
                 message="Unsupported method, must be of request type POST or GET",
@@ -74,8 +80,10 @@ class GraphQLView:
                 if not (isinstance(data, dict)):
                     return self.error_response(
                         error_code="BadRequestError",
-                        message="""Provide a valid graphql query
-                         in the body of your request""",
+                        message=(
+                            "Provide a valid graphql query "
+                            "in the body of your request"
+                        ),
                         http_status_code=400,
                     )
             except BadRequestError:

--- a/strawberry/chalice/views.py
+++ b/strawberry/chalice/views.py
@@ -90,9 +90,8 @@ class GraphQLView:
         elif request.method == "GET" and self.should_render_graphiql(
             self.graphiql, request
         ):
-            graphiql_page: str = self.render_graphiql()
             return Response(
-                body=graphiql_page,
+                body=self.render_graphiql(),
                 headers={"content-type": "text/html"},
                 status_code=200,
             )

--- a/strawberry/django/views.py
+++ b/strawberry/django/views.py
@@ -181,7 +181,7 @@ class GraphQLView(BaseView):
         root_value = self.get_root_value(request)
 
         method = request.method
-        allowed_operation_types = set(OperationType.from_http(method))
+        allowed_operation_types = OperationType.from_http(method)
 
         if not self.allow_queries_via_get and method == "GET":
             allowed_operation_types = allowed_operation_types - {OperationType.QUERY}
@@ -235,7 +235,7 @@ class AsyncGraphQLView(BaseView):
 
         method = request.method
 
-        allowed_operation_types = set(OperationType.from_http(method))
+        allowed_operation_types = OperationType.from_http(method)
 
         if not self.allow_queries_via_get and method == "GET":
             allowed_operation_types = allowed_operation_types - {OperationType.QUERY}

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -146,7 +146,7 @@ class GraphQLRouter(APIRouter):
                 return await self.execute_request(
                     request=request,
                     response=response,
-                    data=request.query_params,
+                    data=request.query_params._dict,
                     context=context,
                     root_value=root_value,
                 )
@@ -289,11 +289,11 @@ class GraphQLRouter(APIRouter):
         try:
             request_data = parse_request_data(data)
         except MissingQueryError:
-            actual_response = PlainTextResponse(
+            missing_query_response = PlainTextResponse(
                 "No GraphQL query found in the request",
                 status_code=status.HTTP_400_BAD_REQUEST,
             )
-            return self._merge_responses(response, actual_response)
+            return self._merge_responses(response, missing_query_response)
 
         result = await self.execute(
             request_data.query,
@@ -305,7 +305,7 @@ class GraphQLRouter(APIRouter):
 
         response_data = await self.process_result(request, result)
 
-        actual_response = JSONResponse(
+        actual_response: JSONResponse = JSONResponse(
             response_data,
             status_code=status.HTTP_200_OK,
         )

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -270,7 +270,7 @@ class GraphQLRouter(APIRouter):
     async def execute(
         self,
         query: str,
-        variables: Dict[str, Any] = None,
+        variables: Optional[Dict[str, Any]] = None,
         context: Any = None,
         operation_name: Optional[str] = None,
         root_value: Any = None,

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -306,7 +306,7 @@ class GraphQLRouter(APIRouter):
             return self._merge_responses(response, missing_query_response)
 
         method = request.method
-        allowed_operation_types = set(OperationType.from_http(method))
+        allowed_operation_types = OperationType.from_http(method)
 
         if not self.allow_queries_via_get and method == "GET":
             allowed_operation_types = allowed_operation_types - {OperationType.QUERY}

--- a/strawberry/flask/graphiql.py
+++ b/strawberry/flask/graphiql.py
@@ -2,7 +2,7 @@ from os.path import abspath, dirname, join
 from typing import Any
 
 
-def render_graphiql_page():
+def render_graphiql_page() -> str:
     dir_path = abspath(join(dirname(__file__), ".."))
     graphiql_html_file = f"{dir_path}/static/graphiql.html"
 

--- a/strawberry/flask/graphiql.py
+++ b/strawberry/flask/graphiql.py
@@ -1,4 +1,5 @@
 from os.path import abspath, dirname, join
+from typing import Any
 
 
 def render_graphiql_page():
@@ -11,3 +12,12 @@ def render_graphiql_page():
         html_string = f.read()
 
     return html_string.replace("{{ SUBSCRIPTION_ENABLED }}", "false")
+
+
+def should_render_graphiql(graphiql: bool, request: Any) -> bool:
+    if not graphiql:
+        return False
+    return any(
+        supported_header in request.environ.get("HTTP_ACCEPT", "")
+        for supported_header in ("text/html", "*/*")
+    )

--- a/strawberry/flask/views.py
+++ b/strawberry/flask/views.py
@@ -38,14 +38,14 @@ class GraphQLView(View):
         content_type = request.content_type or ""
 
         if "application/json" in content_type:
-            data = request.json
+            data: dict = request.json  # type:ignore[assignment]
         elif content_type.startswith("multipart/form-data"):
             operations = json.loads(request.form.get("operations", "{}"))
             files_map = json.loads(request.form.get("map", "{}"))
 
             data = replace_placeholders_with_files(operations, files_map, request.files)
         elif request.method == "GET" and request.args:
-            data = request.args
+            data = request.args.to_dict()
         elif request.method == "GET" and should_render_graphiql(self.graphiql, request):
             template = render_graphiql_page()
             return self.render_template(template=template)

--- a/strawberry/flask/views.py
+++ b/strawberry/flask/views.py
@@ -1,4 +1,5 @@
 import json
+from typing import Mapping
 
 from flask import Response, render_template_string, request
 from flask.views import View
@@ -25,19 +26,19 @@ class GraphQLView(View):
         self.graphiql = graphiql
         self.allow_queries_via_get = allow_queries_via_get
 
-    def get_root_value(self):
+    def get_root_value(self) -> object:
         return None
 
-    def get_context(self, response: Response):
+    def get_context(self, response: Response) -> Mapping[str, object]:
         return {"request": request, "response": response}
 
-    def render_template(self, template=None):
+    def render_template(self, template: str) -> str:
         return render_template_string(template)
 
     def process_result(self, result: ExecutionResult) -> GraphQLHTTPResponse:
         return process_result(result)
 
-    def dispatch_request(self):
+    def dispatch_request(self) -> Response:
         method = request.method
         content_type = request.content_type or ""
 
@@ -52,8 +53,8 @@ class GraphQLView(View):
             data = request.args.to_dict()
         elif method == "GET" and should_render_graphiql(self.graphiql, request):
             template = render_graphiql_page()
-            return self.render_template(template=template)
 
+            return self.render_template(template=template)
         else:
             return Response("Unsupported Media Type", 415)
 
@@ -65,7 +66,7 @@ class GraphQLView(View):
         response = Response(status=200, content_type="application/json")
         context = self.get_context(response)
 
-        allowed_operation_types = set(OperationType.from_http(method))
+        allowed_operation_types = OperationType.from_http(method)
 
         if not self.allow_queries_via_get and method == "GET":
             allowed_operation_types = allowed_operation_types - {OperationType.QUERY}

--- a/strawberry/http.py
+++ b/strawberry/http.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Mapping, Optional
 
 from typing_extensions import TypedDict
 
@@ -33,7 +33,7 @@ class GraphQLRequestData:
     operation_name: Optional[str]
 
 
-def parse_request_data(data: Dict) -> GraphQLRequestData:
+def parse_request_data(data: Mapping) -> GraphQLRequestData:
     if "query" not in data:
         raise MissingQueryError()
 

--- a/strawberry/sanic/graphiql.py
+++ b/strawberry/sanic/graphiql.py
@@ -1,5 +1,7 @@
 from os.path import abspath, dirname, join
 
+from sanic.request import Request
+
 
 def render_graphiql_page() -> str:
     dir_path = abspath(join(dirname(__file__), ".."))
@@ -11,3 +13,12 @@ def render_graphiql_page() -> str:
         html_string = f.read()
 
     return html_string.replace("{{ SUBSCRIPTION_ENABLED }}", "false")
+
+
+def should_render_graphiql(graphiql: bool, request: Request) -> bool:
+    if not graphiql:
+        return False
+    return any(
+        supported_header in request.headers.get("accept", "")
+        for supported_header in ("text/html", "*/*")
+    )

--- a/strawberry/sanic/views.py
+++ b/strawberry/sanic/views.py
@@ -136,7 +136,7 @@ class GraphQLView(HTTPMethodView):
                 context_value=context,
                 root_value=root_value,
                 operation_name=request_data.operation_name,
-                allowed_operation_types=list(allowed_operation_types),
+                allowed_operation_types=allowed_operation_types,
             )
         except InvalidOperationTypeError as e:
             raise ServerError(

--- a/strawberry/sanic/views.py
+++ b/strawberry/sanic/views.py
@@ -13,12 +13,11 @@ from strawberry.http import (
     parse_request_data,
     process_result,
 )
+from strawberry.sanic.context import StrawberrySanicContext
+from strawberry.sanic.graphiql import render_graphiql_page, should_render_graphiql
+from strawberry.sanic.utils import convert_request_to_files_dict
+from strawberry.schema import BaseSchema
 from strawberry.types import ExecutionResult
-
-from ..schema import BaseSchema
-from .context import StrawberrySanicContext
-from .graphiql import render_graphiql_page
-from .utils import convert_request_to_files_dict
 
 
 class GraphQLView(HTTPMethodView):
@@ -85,7 +84,7 @@ class GraphQLView(HTTPMethodView):
                 request=request, request_data=request_data
             )
 
-        elif self.graphiql:
+        elif should_render_graphiql(self.graphiql, request):
             template = render_graphiql_page()
             return self.render_template(template=template)
 
@@ -153,13 +152,5 @@ class GraphQLView(HTTPMethodView):
                 raise SanicException(
                     status_code=400, message="File(s) missing in form data"
                 )
-        elif request.args:
-            # Sanic uses urllib to parse
-            # This returns a list of values for each variable name
-            # Enforcing only one value
-            data = {
-                variable_name: value[0] for variable_name, value in request.args.items()
-            }
-            return data
 
         raise ServerError("Unsupported Media Type", status_code=415)

--- a/strawberry/sanic/views.py
+++ b/strawberry/sanic/views.py
@@ -124,7 +124,7 @@ class GraphQLView(HTTPMethodView):
         context = await self.get_context(request)
         root_value = self.get_root_value()
 
-        allowed_operation_types = set(OperationType.from_http(method))
+        allowed_operation_types = OperationType.from_http(method)
 
         if not self.allow_queries_via_get and method == "GET":
             allowed_operation_types = allowed_operation_types - {OperationType.QUERY}

--- a/strawberry/schema/base.py
+++ b/strawberry/schema/base.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 from functools import lru_cache
-from typing import Any, Dict, List, Optional, Sequence, Union
+from typing import Any, Dict, Iterable, List, Optional, Union
 
 from typing_extensions import Protocol
 
@@ -29,7 +29,7 @@ class BaseSchema(Protocol):
         context_value: Optional[Any] = None,
         root_value: Optional[Any] = None,
         operation_name: Optional[str] = None,
-        allowed_operation_types: Optional[Sequence[OperationType]] = None,
+        allowed_operation_types: Optional[Iterable[OperationType]] = None,
     ) -> ExecutionResult:
         raise NotImplementedError
 
@@ -41,7 +41,7 @@ class BaseSchema(Protocol):
         context_value: Optional[Any] = None,
         root_value: Optional[Any] = None,
         operation_name: Optional[str] = None,
-        allowed_operation_types: Optional[Sequence[OperationType]] = None,
+        allowed_operation_types: Optional[Iterable[OperationType]] = None,
     ) -> ExecutionResult:
         raise NotImplementedError
 

--- a/strawberry/schema/base.py
+++ b/strawberry/schema/base.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 from functools import lru_cache
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Sequence, Union
 
 from typing_extensions import Protocol
 
@@ -10,6 +10,7 @@ from strawberry.custom_scalar import ScalarDefinition
 from strawberry.directive import StrawberryDirective
 from strawberry.enum import EnumDefinition
 from strawberry.types import ExecutionContext, ExecutionResult
+from strawberry.types.graphql import OperationType
 from strawberry.types.types import TypeDefinition
 from strawberry.union import StrawberryUnion
 from strawberry.utils.logging import StrawberryLogger
@@ -28,6 +29,7 @@ class BaseSchema(Protocol):
         context_value: Optional[Any] = None,
         root_value: Optional[Any] = None,
         operation_name: Optional[str] = None,
+        allowed_operation_types: Optional[Sequence[OperationType]] = None,
     ) -> ExecutionResult:
         raise NotImplementedError
 
@@ -39,6 +41,7 @@ class BaseSchema(Protocol):
         context_value: Optional[Any] = None,
         root_value: Optional[Any] = None,
         operation_name: Optional[str] = None,
+        allowed_operation_types: Optional[Sequence[OperationType]] = None,
     ) -> ExecutionResult:
         raise NotImplementedError
 

--- a/strawberry/schema/exceptions.py
+++ b/strawberry/schema/exceptions.py
@@ -1,0 +1,6 @@
+from strawberry.types.graphql import OperationType
+
+
+class InvalidOperationTypeError(Exception):
+    def __init__(self, operation_type: OperationType):
+        self.operation_type = operation_type

--- a/strawberry/schema/exceptions.py
+++ b/strawberry/schema/exceptions.py
@@ -4,3 +4,12 @@ from strawberry.types.graphql import OperationType
 class InvalidOperationTypeError(Exception):
     def __init__(self, operation_type: OperationType):
         self.operation_type = operation_type
+
+    def as_http_error_reason(self, method: str) -> str:
+        operation_type = {
+            OperationType.QUERY: "queries",
+            OperationType.MUTATION: "mutations",
+            OperationType.SUBSCRIPTION: "subscriptions",
+        }[self.operation_type]
+
+        return f"{operation_type} are not allowed when using {method}"

--- a/strawberry/schema/execute.py
+++ b/strawberry/schema/execute.py
@@ -16,6 +16,9 @@ from graphql.validation import ASTValidationRule, validate
 from strawberry.extensions import Extension
 from strawberry.extensions.runner import ExtensionsRunner
 from strawberry.types import ExecutionContext, ExecutionResult
+from strawberry.types.graphql import OperationType
+
+from .exceptions import InvalidOperationTypeError
 
 
 def parse_document(query: str) -> DocumentNode:
@@ -49,6 +52,8 @@ def _run_validation(execution_context: ExecutionContext) -> None:
 async def execute(
     schema: GraphQLSchema,
     query: str,
+    *,
+    allowed_operation_types: Sequence[OperationType],
     extensions: Sequence[Union[Type[Extension], Extension]],
     execution_context: ExecutionContext,
     execution_context_class: Optional[Type[GraphQLExecutionContext]] = None,
@@ -66,6 +71,7 @@ async def execute(
             try:
                 if not execution_context.graphql_document:
                     execution_context.graphql_document = parse_document(query)
+
             except GraphQLError as error:
                 execution_context.errors = [error]
                 return ExecutionResult(
@@ -83,6 +89,9 @@ async def execute(
                     errors=[error],
                     extensions=await extensions_runner.get_extensions_results(),
                 )
+
+        if execution_context.operation_type not in allowed_operation_types:
+            raise InvalidOperationTypeError(execution_context.operation_type)
 
         async with extensions_runner.validation():
             _run_validation(execution_context)
@@ -122,6 +131,8 @@ async def execute(
 def execute_sync(
     schema: GraphQLSchema,
     query: str,
+    *,
+    allowed_operation_types: Sequence[OperationType],
     extensions: Sequence[Union[Type[Extension], Extension]],
     execution_context: ExecutionContext,
     execution_context_class: Optional[Type[GraphQLExecutionContext]] = None,
@@ -139,6 +150,7 @@ def execute_sync(
             try:
                 if not execution_context.graphql_document:
                     execution_context.graphql_document = parse_document(query)
+
             except GraphQLError as error:
                 execution_context.errors = [error]
                 return ExecutionResult(
@@ -156,6 +168,9 @@ def execute_sync(
                     errors=[error],
                     extensions=extensions_runner.get_extensions_results_sync(),
                 )
+
+        if execution_context.operation_type not in allowed_operation_types:
+            raise InvalidOperationTypeError(execution_context.operation_type)
 
         with extensions_runner.validation():
             _run_validation(execution_context)

--- a/strawberry/schema/execute.py
+++ b/strawberry/schema/execute.py
@@ -1,6 +1,16 @@
 from asyncio import ensure_future
 from inspect import isawaitable
-from typing import Awaitable, List, Optional, Sequence, Tuple, Type, Union, cast
+from typing import (
+    Awaitable,
+    Iterable,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    Union,
+    cast,
+)
 
 from graphql import (
     ExecutionContext as GraphQLExecutionContext,
@@ -53,7 +63,7 @@ async def execute(
     schema: GraphQLSchema,
     query: str,
     *,
-    allowed_operation_types: Sequence[OperationType],
+    allowed_operation_types: Iterable[OperationType],
     extensions: Sequence[Union[Type[Extension], Extension]],
     execution_context: ExecutionContext,
     execution_context_class: Optional[Type[GraphQLExecutionContext]] = None,
@@ -132,7 +142,7 @@ def execute_sync(
     schema: GraphQLSchema,
     query: str,
     *,
-    allowed_operation_types: Sequence[OperationType],
+    allowed_operation_types: Iterable[OperationType],
     extensions: Sequence[Union[Type[Extension], Extension]],
     execution_context: ExecutionContext,
     execution_context_class: Optional[Type[GraphQLExecutionContext]] = None,

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -25,6 +25,7 @@ from strawberry.field import StrawberryField
 from strawberry.schema.schema_converter import GraphQLCoreConverter
 from strawberry.schema.types.scalar import DEFAULT_SCALAR_REGISTRY
 from strawberry.types import ExecutionContext, ExecutionResult
+from strawberry.types.graphql import OperationType
 from strawberry.types.types import TypeDefinition
 from strawberry.union import StrawberryUnion
 
@@ -32,6 +33,13 @@ from ..printer import print_schema
 from .base import BaseSchema
 from .config import StrawberryConfig
 from .execute import execute, execute_sync
+
+
+DEFAULT_ALLOWED_OPERATION_TYPES = (
+    OperationType.QUERY,
+    OperationType.MUTATION,
+    OperationType.SUBSCRIPTION,
+)
 
 
 class Schema(BaseSchema):
@@ -157,7 +165,11 @@ class Schema(BaseSchema):
         context_value: Optional[Any] = None,
         root_value: Optional[Any] = None,
         operation_name: Optional[str] = None,
+        allowed_operation_types: Optional[Sequence[OperationType]] = None,
     ) -> ExecutionResult:
+        if allowed_operation_types is None:
+            allowed_operation_types = DEFAULT_ALLOWED_OPERATION_TYPES
+
         # Create execution context
         execution_context = ExecutionContext(
             query=query,
@@ -174,6 +186,7 @@ class Schema(BaseSchema):
             extensions=list(self.extensions) + [DirectivesExtension],
             execution_context_class=self.execution_context_class,
             execution_context=execution_context,
+            allowed_operation_types=allowed_operation_types,
         )
 
         if result.errors:
@@ -188,7 +201,11 @@ class Schema(BaseSchema):
         context_value: Optional[Any] = None,
         root_value: Optional[Any] = None,
         operation_name: Optional[str] = None,
+        allowed_operation_types: Optional[Sequence[OperationType]] = None,
     ) -> ExecutionResult:
+        if allowed_operation_types is None:
+            allowed_operation_types = DEFAULT_ALLOWED_OPERATION_TYPES
+
         execution_context = ExecutionContext(
             query=query,
             schema=self,
@@ -204,6 +221,7 @@ class Schema(BaseSchema):
             extensions=list(self.extensions) + [DirectivesExtensionSync],
             execution_context_class=self.execution_context_class,
             execution_context=execution_context,
+            allowed_operation_types=allowed_operation_types,
         )
 
         if result.errors:

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -1,5 +1,5 @@
 from functools import lru_cache
-from typing import Any, Dict, Optional, Sequence, Type, Union
+from typing import Any, Dict, Iterable, Optional, Sequence, Type, Union
 
 from graphql import (
     ExecutionContext as GraphQLExecutionContext,
@@ -165,7 +165,7 @@ class Schema(BaseSchema):
         context_value: Optional[Any] = None,
         root_value: Optional[Any] = None,
         operation_name: Optional[str] = None,
-        allowed_operation_types: Optional[Sequence[OperationType]] = None,
+        allowed_operation_types: Optional[Iterable[OperationType]] = None,
     ) -> ExecutionResult:
         if allowed_operation_types is None:
             allowed_operation_types = DEFAULT_ALLOWED_OPERATION_TYPES
@@ -201,7 +201,7 @@ class Schema(BaseSchema):
         context_value: Optional[Any] = None,
         root_value: Optional[Any] = None,
         operation_name: Optional[str] = None,
-        allowed_operation_types: Optional[Sequence[OperationType]] = None,
+        allowed_operation_types: Optional[Iterable[OperationType]] = None,
     ) -> ExecutionResult:
         if allowed_operation_types is None:
             allowed_operation_types = DEFAULT_ALLOWED_OPERATION_TYPES

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -35,11 +35,11 @@ from .config import StrawberryConfig
 from .execute import execute, execute_sync
 
 
-DEFAULT_ALLOWED_OPERATION_TYPES = (
+DEFAULT_ALLOWED_OPERATION_TYPES = {
     OperationType.QUERY,
     OperationType.MUTATION,
     OperationType.SUBSCRIPTION,
-)
+}
 
 
 class Schema(BaseSchema):

--- a/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
@@ -8,7 +8,6 @@ from graphql import (
     ExecutionResult as GraphQLExecutionResult,
     GraphQLError,
     GraphQLSyntaxError,
-    OperationType,
     parse,
 )
 from graphql.error.graphql_error import format_error as format_graphql_error
@@ -26,6 +25,7 @@ from strawberry.subscriptions.protocols.graphql_transport_ws.types import (
     SubscribeMessage,
     SubscribeMessagePayload,
 )
+from strawberry.types.graphql import OperationType
 from strawberry.utils.debug import pretty_print_graphql_operation
 from strawberry.utils.operation import get_operation_type
 

--- a/strawberry/types/execution.py
+++ b/strawberry/types/execution.py
@@ -1,7 +1,5 @@
 import dataclasses
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, cast
-
-from typing_extensions import Literal
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type
 
 from graphql import (
     ASTValidationRule,
@@ -13,12 +11,11 @@ from graphql.language import DocumentNode, OperationDefinitionNode
 
 from strawberry.utils.operation import get_first_operation, get_operation_type
 
+from .graphql import OperationType
+
 
 if TYPE_CHECKING:
     from strawberry.schema import Schema
-
-
-GraphqlOperationTypes = Literal["QUERY", "MUTATION", "SUBSCRIPTION"]
 
 
 @dataclasses.dataclass
@@ -59,14 +56,12 @@ class ExecutionContext:
         return definition.name.value
 
     @property
-    def operation_type(self) -> GraphqlOperationTypes:
+    def operation_type(self) -> OperationType:
         graphql_document = self.graphql_document
         if not graphql_document:
             raise RuntimeError("No GraphQL document available")
 
-        operation_type = get_operation_type(graphql_document, self.operation_name)
-
-        return cast(GraphqlOperationTypes, operation_type.name)
+        return get_operation_type(graphql_document, self.operation_name)
 
     def _get_first_operation(self) -> Optional[OperationDefinitionNode]:
         graphql_document = self.graphql_document

--- a/strawberry/types/graphql.py
+++ b/strawberry/types/graphql.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import enum
-from typing import Tuple
+from typing import Set
 
 
 class OperationType(enum.Enum):
@@ -10,15 +10,15 @@ class OperationType(enum.Enum):
     SUBSCRIPTION = "subscription"
 
     @staticmethod
-    def from_http(method: str) -> Tuple[OperationType, ...]:
+    def from_http(method: str) -> Set[OperationType]:
         if method == "GET":
-            return (OperationType.QUERY,)
+            return {OperationType.QUERY}
 
         if method == "POST":
-            return (
+            return {
                 OperationType.QUERY,
                 OperationType.MUTATION,
                 OperationType.SUBSCRIPTION,
-            )
+            }
 
         raise ValueError(f"Unsupported HTTP method: {method}")  # pragma: no cover

--- a/strawberry/types/graphql.py
+++ b/strawberry/types/graphql.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import enum
+from typing import Tuple
+
+
+class OperationType(enum.Enum):
+    QUERY = "query"
+    MUTATION = "mutation"
+    SUBSCRIPTION = "subscription"
+
+    @staticmethod
+    def from_http(method: str) -> Tuple[OperationType, ...]:
+        if method == "GET":
+            return (OperationType.QUERY,)
+
+        if method == "POST":
+            return (
+                OperationType.QUERY,
+                OperationType.MUTATION,
+                OperationType.SUBSCRIPTION,
+            )
+
+        raise ValueError(f"Unsupported HTTP method: {method}")  # pragma: no cover

--- a/strawberry/utils/operation.py
+++ b/strawberry/utils/operation.py
@@ -1,6 +1,8 @@
 from typing import Optional, cast
 
-from graphql.language import DocumentNode, OperationDefinitionNode, OperationType
+from graphql.language import DocumentNode, OperationDefinitionNode
+
+from strawberry.types.graphql import OperationType
 
 
 def get_first_operation(
@@ -30,4 +32,4 @@ def get_operation_type(
     if not definition:
         raise RuntimeError("Can't get GraphQL operation type")
 
-    return definition.operation
+    return OperationType(definition.operation.value)

--- a/tests/aiohttp/conftest.py
+++ b/tests/aiohttp/conftest.py
@@ -13,6 +13,13 @@ async def aiohttp_app_client(event_loop, aiohttp_client):
     return await aiohttp_client(app)
 
 
+@pytest_asyncio.fixture
+async def aiohttp_app_client_no_get(event_loop, aiohttp_client):
+    app = create_app(graphiql=True, allow_queries_via_get=False)
+    event_loop.set_debug(True)
+    return await aiohttp_client(app)
+
+
 @pytest.fixture
 def graphql_client(aiohttp_app_client):
     yield GraphQLTestClient(aiohttp_app_client)

--- a/tests/aiohttp/test_query_params.py
+++ b/tests/aiohttp/test_query_params.py
@@ -38,3 +38,19 @@ async def test_post_fails_with_query_params(aiohttp_app_client):
     response = await aiohttp_app_client.post("/graphql", params=query)
 
     assert response.status == 400
+
+
+async def test_does_not_allow_mutation(aiohttp_app_client):
+    query = {
+        "query": """
+            mutation {
+                hello
+            }
+        """
+    }
+
+    response = await aiohttp_app_client.get("/graphql", params=query)
+    assert response.status == 400
+
+    data = await response.text()
+    assert data == "400: mutations are not allowed when using GET"

--- a/tests/aiohttp/test_query_params.py
+++ b/tests/aiohttp/test_query_params.py
@@ -26,7 +26,7 @@ async def test_no_graphiql_get_with_query_params(aiohttp_app_client):
     assert data["data"]["hello"] == "strawberry"
 
 
-async def test_post_with_query_params(aiohttp_app_client):
+async def test_post_fails_with_query_params(aiohttp_app_client):
     query = {
         "query": """
             query {
@@ -36,6 +36,5 @@ async def test_post_with_query_params(aiohttp_app_client):
     }
 
     response = await aiohttp_app_client.post("/graphql", params=query)
-    data = await response.json()
-    assert response.status == 200
-    assert data["data"]["hello"] == "strawberry"
+
+    assert response.status == 400

--- a/tests/aiohttp/test_query_params.py
+++ b/tests/aiohttp/test_query_params.py
@@ -23,7 +23,7 @@ async def test_no_graphiql_get_with_query_params(aiohttp_app_client):
     response = await aiohttp_app_client.get("/graphql", params=query)
     data = await response.json()
     assert response.status == 200
-    assert data["data"]["hello"] == "strawberry"
+    assert data["data"]["hello"] == "Hello world"
 
 
 async def test_post_fails_with_query_params(aiohttp_app_client):
@@ -54,3 +54,18 @@ async def test_does_not_allow_mutation(aiohttp_app_client):
 
     data = await response.text()
     assert data == "400: mutations are not allowed when using GET"
+
+
+async def test_fails_if_allow_queries_via_get_false(aiohttp_app_client_no_get):
+    query = {
+        "query": """
+            query {
+                hello
+            }
+        """
+    }
+
+    response = await aiohttp_app_client_no_get.get("/graphql", params=query)
+    assert response.status == 400
+    data = await response.text()
+    assert data == "400: queries are not allowed when using GET"

--- a/tests/aiohttp/test_query_params.py
+++ b/tests/aiohttp/test_query_params.py
@@ -1,0 +1,41 @@
+async def test_no_graphiql_no_query(aiohttp_app_client):
+    params = {
+        "variables": """
+            query {
+                hello
+            }
+        """
+    }
+
+    response = await aiohttp_app_client.get("/graphql", params=params)
+    assert response.status == 400
+
+
+async def test_no_graphiql_get_with_query_params(aiohttp_app_client):
+    query = {
+        "query": """
+            query {
+                hello
+            }
+        """
+    }
+
+    response = await aiohttp_app_client.get("/graphql", params=query)
+    data = await response.json()
+    assert response.status == 200
+    assert data["data"]["hello"] == "strawberry"
+
+
+async def test_post_with_query_params(aiohttp_app_client):
+    query = {
+        "query": """
+            query {
+                hello
+            }
+        """
+    }
+
+    response = await aiohttp_app_client.post("/graphql", params=query)
+    data = await response.json()
+    assert response.status == 200
+    assert data["data"]["hello"] == "strawberry"

--- a/tests/asgi/conftest.py
+++ b/tests/asgi/conftest.py
@@ -25,5 +25,11 @@ def test_client_no_graphiql():
 
 
 @pytest.fixture
+def test_client_no_get():
+    app = create_app(allow_queries_via_get=False)
+    return TestClient(app)
+
+
+@pytest.fixture
 def graphql_client(test_client):
     yield GraphQLTestClient(test_client)

--- a/tests/asgi/test_query_params.py
+++ b/tests/asgi/test_query_params.py
@@ -1,0 +1,23 @@
+from starlette import status
+
+
+def test_no_graphiql_no_query(test_client_no_graphiql):
+    response = test_client_no_graphiql.get(
+        "/graphql", params={"variables": "{ hello }"}
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_no_graphiql_get_with_query_params(test_client_no_graphiql):
+    response = test_client_no_graphiql.get("/graphql", params={"query": "{ hello }"})
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {"data": {"hello": "Hello world"}}
+
+
+def test_no_graphiql_post_with_query_params(test_client):
+    response = test_client.post("/graphql", params={"query": "{ hello }"})
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {"data": {"hello": "Hello world"}}

--- a/tests/asgi/test_query_params.py
+++ b/tests/asgi/test_query_params.py
@@ -16,7 +16,13 @@ def test_no_graphiql_get_with_query_params(test_client_no_graphiql):
     assert response.json() == {"data": {"hello": "Hello world"}}
 
 
-def test_no_graphiql_post_fails_with_query_params(test_client):
+def test_post_fails_with_query_params(test_client):
     response = test_client.post("/graphql", params={"query": "{ hello }"})
 
     assert response.status_code == status.HTTP_415_UNSUPPORTED_MEDIA_TYPE
+
+
+def test_fails_mutation_using_get(test_client):
+    response = test_client.get("/graphql", params={"query": "mutation { hello }"})
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/tests/asgi/test_query_params.py
+++ b/tests/asgi/test_query_params.py
@@ -26,3 +26,11 @@ def test_fails_mutation_using_get(test_client):
     response = test_client.get("/graphql", params={"query": "mutation { hello }"})
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.text == "mutations are not allowed when using GET"
+
+
+def test_fails_query_using_params_when_disabled(test_client_no_get):
+    response = test_client_no_get.get("/graphql", params={"query": "{ hello }"})
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.text == "queries are not allowed when using GET"

--- a/tests/asgi/test_query_params.py
+++ b/tests/asgi/test_query_params.py
@@ -16,8 +16,7 @@ def test_no_graphiql_get_with_query_params(test_client_no_graphiql):
     assert response.json() == {"data": {"hello": "Hello world"}}
 
 
-def test_no_graphiql_post_with_query_params(test_client):
+def test_no_graphiql_post_fails_with_query_params(test_client):
     response = test_client.post("/graphql", params={"query": "{ hello }"})
 
-    assert response.status_code == status.HTTP_200_OK
-    assert response.json() == {"data": {"hello": "Hello world"}}
+    assert response.status_code == status.HTTP_415_UNSUPPORTED_MEDIA_TYPE

--- a/tests/chalice/app.py
+++ b/tests/chalice/app.py
@@ -1,6 +1,5 @@
 import strawberry
 from chalice import Chalice  # type: ignore
-from chalice.app import Request
 from strawberry.chalice.views import GraphQLView
 
 
@@ -23,6 +22,7 @@ class Mutation:
 
 schema = strawberry.Schema(query=Query, mutation=Mutation)
 view = GraphQLView(schema=schema, render_graphiql=True)
+view_no_graphiql = GraphQLView(schema=schema, render_graphiql=False)
 
 
 @app.route("/")
@@ -32,6 +32,11 @@ def index():
 
 @app.route("/graphql", methods=["GET", "POST"], content_types=["application/json"])
 def handle_graphql():
-    request: Request = app.current_request
-    result = view.execute_request(request)
-    return result
+    return view.execute_request(app.current_request)
+
+
+@app.route(
+    "/graphql-no-graphiql", methods=["GET", "POST"], content_types=["application/json"]
+)
+def handle_graphql_without_graphiql():
+    return view_no_graphiql.execute_request(app.current_request)

--- a/tests/chalice/app.py
+++ b/tests/chalice/app.py
@@ -36,7 +36,9 @@ def handle_graphql():
 
 
 @app.route(
-    "/graphql-no-graphiql", methods=["GET", "POST"], content_types=["application/json"]
+    "/graphql-no-graphiql",
+    methods=["GET", "POST", "PUT"],
+    content_types=["application/json"],
 )
 def handle_graphql_without_graphiql():
     return view_no_graphiql.execute_request(app.current_request)

--- a/tests/chalice/test_views.py
+++ b/tests/chalice/test_views.py
@@ -129,9 +129,15 @@ def test_graphiql_query_unsupported_method():
         headers = {"Accept": "application/json", "Content-Type": "application/json"}
 
         query = {"query": "query GreetMe {greetings}"}
-        response = client.http.put("/graphql", headers=headers, body=json.dumps(query))
+        response = client.http.put(
+            "/graphql-no-graphiql", headers=headers, body=json.dumps(query)
+        )
 
         assert response.status_code == 405
+        assert (
+            response.json_body["Message"]
+            == "Unsupported method, must be of request type POST or GET"
+        )
 
 
 @pytest.mark.parametrize("header_value", ["text/html", "*/*"])

--- a/tests/chalice/test_views.py
+++ b/tests/chalice/test_views.py
@@ -1,9 +1,10 @@
 import json
-from http import HTTPStatus
 
 import pytest
 
-from chalice.test import Client, HTTPResponse
+from werkzeug.urls import url_encode, url_unparse
+
+from chalice.test import Client
 
 from .app import app
 
@@ -11,7 +12,7 @@ from .app import app
 def test_chalice_server_index_route_returns():
     with Client(app) as client:
         response = client.http.get("/")
-        assert response.status_code == HTTPStatus.OK
+        assert response.status_code == 200
         assert response.json_body == {"strawberry": "cake"}
 
 
@@ -20,30 +21,24 @@ def test_graphiql_view_is_returned_if_accept_is_html_or_accept_all(header_value)
     with Client(app) as client:
         headers = {"Accept": header_value}
         response = client.http.get("/graphql", headers=headers)
-        assert response.status_code == HTTPStatus.OK
+
+        assert response.status_code == 200
         assert "GraphiQL" in str(response.body)
 
 
 def test_graphiql_view_is_not_returned_if_accept_headers_is_none():
     with Client(app) as client:
         response = client.http.get("/graphql", headers=None)
-        assert response.status_code == HTTPStatus.OK
-        assert response_is_of_error_type(response)
 
-
-def response_is_of_error_type(response: HTTPResponse) -> bool:
-    if "errors" in response.json_body.keys():
-        if response.status_code == HTTPStatus.OK:
-            return True
-    return False
+        assert response.status_code == 415
 
 
 def test_get_graphql_view_with_json_accept_type_is_rejected():
     with Client(app) as client:
         headers = {"Accept": "application/json"}
         response = client.http.get("/graphql", headers=headers)
-        assert response.status_code == HTTPStatus.OK
-        assert response_is_of_error_type(response)
+
+        assert response.status_code == 415
 
 
 def test_malformed_unparsable_json_query_returns_error():
@@ -53,7 +48,8 @@ def test_malformed_unparsable_json_query_returns_error():
         # The query key in the json dict is missing
         query = "I am a malformed query"
         response = client.http.post("/graphql", headers=headers, body=json.dumps(query))
-        assert response_is_of_error_type(response)
+
+        assert response.status_code == 400
 
 
 # These tests are checking that graphql is getting routed through the endpoint
@@ -65,8 +61,8 @@ def test_graphiql_query():
 
         query = {"query": "query GreetMe {greetings}"}
         response = client.http.post("/graphql", headers=headers, body=json.dumps(query))
-        assert response.status_code == HTTPStatus.OK
-        assert not response_is_of_error_type(response)
+
+        assert response.status_code == 200
         assert "hello" == response.json_body["data"]["greetings"]
 
 
@@ -75,22 +71,38 @@ def test_graphiql_mutation():
         headers = {"Accept": "application/json", "Content-Type": "application/json"}
         query = {"query": """mutation EchoMutation { echo(stringToEcho: "mark")} """}
         response = client.http.post("/graphql", headers=headers, body=json.dumps(query))
-        assert response.status_code == HTTPStatus.OK
+
+        assert response.status_code == 200
         assert "mark" == response.json_body["data"]["echo"]
 
 
-def test_graphiql_query_with_malformed_json_gives_http_ok_and_bad_request_message():
+def test_graphiql_query_with_malformed_json_returns_bad_request():
     with Client(app) as client:
         headers = {"Accept": "application/json", "Content-Type": "application/json"}
 
         response = client.http.post("/graphql", headers=headers, body="{invalidjson")
-        assert response.status_code == HTTPStatus.OK
-        assert response_is_of_error_type(response)
+
+        assert response.status_code == 400
 
 
 def test_graphiql_query_with_no_request_body():
     with Client(app) as client:
         headers = {"Accept": "application/json"}
         response = client.http.post("/graphql", headers=headers, body="")
-        assert response.status_code == HTTPStatus.OK
-        assert response_is_of_error_type(response)
+
+        assert response.status_code == 415
+
+
+def test_graphiql_query_with_query_params():
+    with Client(app) as client:
+        params = {
+            "query": """
+                query GreetMe {
+                    greetings
+                }
+            """
+        }
+        query_url = url_unparse(("", "", "/graphql", url_encode(params), ""))
+        response = client.http.get(query_url)
+
+        assert response.status_code == 200

--- a/tests/django/app/schema.py
+++ b/tests/django/app/schema.py
@@ -18,6 +18,10 @@ class FolderInput:
 @strawberry.type
 class Mutation:
     @strawberry.mutation
+    def hello(self) -> str:
+        return "strawberry"
+
+    @strawberry.mutation
     def read_text(self, text_file: Upload) -> str:
         return text_file.read().decode()
 

--- a/tests/django/test_async_view.py
+++ b/tests/django/test_async_view.py
@@ -89,7 +89,7 @@ async def test_async_graphql_get_query_using_params():
     assert data["data"]["helloAsync"] == "async strawberry"
 
 
-async def test_async_graphql_post_query_using_params():
+async def test_async_graphql_post_query_fails_using_params():
     params = {"query": "{ helloAsync }"}
 
     factory = RequestFactory()
@@ -99,10 +99,10 @@ async def test_async_graphql_post_query_using_params():
         content_type="application/x-www-form-urlencoded"
     )
 
-    response = await AsyncGraphQLView.as_view(schema=schema)(request)
-    data = json.loads(response.content.decode())
+    with pytest.raises(SuspiciousOperation) as e:
+        await AsyncGraphQLView.as_view(schema=schema)(request)
 
-    assert data["data"]["helloAsync"] == "async strawberry"
+    assert e.value.args == ("No GraphQL query found in the request",)
 
 
 @pytest.mark.parametrize("method", ["DELETE", "HEAD", "PUT", "PATCH"])

--- a/tests/django/test_async_view.py
+++ b/tests/django/test_async_view.py
@@ -5,7 +5,7 @@ import pytest
 from asgiref.sync import sync_to_async
 
 import django
-from django.core.exceptions import SuspiciousOperation
+from django.core.exceptions import BadRequest, SuspiciousOperation
 from django.test.client import RequestFactory
 from django.utils.http import urlencode
 
@@ -39,7 +39,7 @@ class Query:
 
         get_name = sync_to_async(_get_name)
 
-        return await get_name()  # type: ignore
+        return await get_name()
 
 
 schema = strawberry.Schema(query=Query)
@@ -99,10 +99,38 @@ async def test_async_graphql_post_query_fails_using_params():
         content_type="application/x-www-form-urlencoded"
     )
 
-    with pytest.raises(SuspiciousOperation) as e:
+    with pytest.raises(
+        SuspiciousOperation, match="No GraphQL query found in the request"
+    ):
         await AsyncGraphQLView.as_view(schema=schema)(request)
 
-    assert e.value.args == ("No GraphQL query found in the request",)
+
+async def test_async_graphql_get_does_not_allow_mutation():
+    params = {"query": "mutation { hello }"}
+
+    factory = RequestFactory()
+    request = factory.get(
+        "/graphql",
+        data=params,
+    )
+
+    with pytest.raises(BadRequest, match="mutations are not allowed when using GET"):
+        await AsyncGraphQLView.as_view(schema=schema)(request)
+
+
+async def test_async_graphql_get_does_get_when_disabled():
+    params = {"query": "{ helloAsync }"}
+
+    factory = RequestFactory()
+    request = factory.get(
+        "/graphql",
+        data=params,
+    )
+
+    with pytest.raises(BadRequest, match="queries are not allowed when using GET"):
+        await AsyncGraphQLView.as_view(schema=schema, allow_queries_via_get=False)(
+            request
+        )
 
 
 @pytest.mark.parametrize("method", ["DELETE", "HEAD", "PUT", "PATCH"])
@@ -123,10 +151,10 @@ async def test_fails_when_not_sending_query():
 
     request = factory.post("/graphql/")
 
-    with pytest.raises(SuspiciousOperation) as e:
+    with pytest.raises(
+        SuspiciousOperation, match="No GraphQL query found in the request"
+    ):
         await AsyncGraphQLView.as_view(schema=schema)(request)
-
-    assert e.value.args == ("No GraphQL query found in the request",)
 
 
 async def test_fails_when_request_body_has_invalid_json():
@@ -136,10 +164,10 @@ async def test_fails_when_request_body_has_invalid_json():
         "/graphql/", "definitely-not-json-string", content_type="application/json"
     )
 
-    with pytest.raises(SuspiciousOperation) as e:
+    with pytest.raises(
+        SuspiciousOperation, match="Unable to parse request body as JSON"
+    ):
         await AsyncGraphQLView.as_view(schema=schema, graphiql=False)(request)
-
-    assert e.value.args == ("Unable to parse request body as JSON",)
 
 
 @pytest.mark.django_db

--- a/tests/django/test_views.py
+++ b/tests/django/test_views.py
@@ -6,6 +6,7 @@ import pytest
 from django.core.exceptions import SuspiciousOperation
 from django.http import Http404
 from django.test.client import RequestFactory
+from django.utils.http import urlencode
 
 import strawberry
 from strawberry.django.views import GraphQLView as BaseGraphQLView
@@ -133,6 +134,37 @@ def test_graphql_query():
     data = json.loads(response.content.decode())
 
     assert response["content-type"] == "application/json"
+    assert data["data"]["hello"] == "strawberry"
+
+
+def test_graphql_get_query_using_params():
+    params = {"query": "{ hello }"}
+
+    factory = RequestFactory()
+    request = factory.get(
+        "/graphql",
+        data=params,
+    )
+
+    response = GraphQLView.as_view(schema=schema)(request)
+    data = json.loads(response.content.decode())
+
+    assert data["data"]["hello"] == "strawberry"
+
+
+def test_graphql_post_query_using_params():
+    params = {"query": "{ hello }"}
+
+    factory = RequestFactory()
+    request = factory.post(
+        "/graphql",
+        **{"QUERY_STRING": urlencode(params, doseq=True)},
+        content_type="application/x-www-form-urlencoded"
+    )
+
+    response = GraphQLView.as_view(schema=schema)(request)
+    data = json.loads(response.content.decode())
+
     assert data["data"]["hello"] == "strawberry"
 
 

--- a/tests/django/test_views.py
+++ b/tests/django/test_views.py
@@ -152,7 +152,7 @@ def test_graphql_get_query_using_params():
     assert data["data"]["hello"] == "strawberry"
 
 
-def test_graphql_post_query_using_params():
+def test_graphql_post_query_fails_using_params():
     params = {"query": "{ hello }"}
 
     factory = RequestFactory()
@@ -162,10 +162,10 @@ def test_graphql_post_query_using_params():
         content_type="application/x-www-form-urlencoded"
     )
 
-    response = GraphQLView.as_view(schema=schema)(request)
-    data = json.loads(response.content.decode())
+    with pytest.raises(SuspiciousOperation) as e:
+        GraphQLView.as_view(schema=schema)(request)
 
-    assert data["data"]["hello"] == "strawberry"
+    assert e.value.args == ("No GraphQL query found in the request",)
 
 
 @pytest.mark.django_db

--- a/tests/fastapi/test_query_params.py
+++ b/tests/fastapi/test_query_params.py
@@ -43,7 +43,7 @@ def test_no_graphiql_get_with_query_params():
     assert response.json() == {"data": {"abc": "abc"}}
 
 
-def test_post_with_query_params():
+def test_post_fails_with_query_params():
     @strawberry.type
     class Query:
         @strawberry.field
@@ -58,5 +58,4 @@ def test_post_with_query_params():
     test_client = TestClient(app)
     response = test_client.post("/graphql", params={"query": "{ abc }"})
 
-    assert response.status_code == status.HTTP_200_OK
-    assert response.json() == {"data": {"abc": "abc"}}
+    assert response.status_code == status.HTTP_415_UNSUPPORTED_MEDIA_TYPE

--- a/tests/fastapi/test_query_params.py
+++ b/tests/fastapi/test_query_params.py
@@ -1,0 +1,62 @@
+from starlette import status
+from starlette.testclient import TestClient
+
+import strawberry
+from fastapi import FastAPI
+from strawberry.fastapi import GraphQLRouter
+
+
+def test_no_graphiql_no_query():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def abc(self) -> str:
+            return "abc"
+
+    app = FastAPI()
+    schema = strawberry.Schema(query=Query)
+    graphql_app = GraphQLRouter(schema, graphiql=False)
+    app.include_router(graphql_app, prefix="/graphql")
+
+    test_client = TestClient(app)
+    response = test_client.get("/graphql", params={"variables": "{ abc }"})
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_no_graphiql_get_with_query_params():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def abc(self) -> str:
+            return "abc"
+
+    app = FastAPI()
+    schema = strawberry.Schema(query=Query)
+    graphql_app = GraphQLRouter(schema, graphiql=False)
+    app.include_router(graphql_app, prefix="/graphql")
+
+    test_client = TestClient(app)
+    response = test_client.get("/graphql", params={"query": "{ abc }"})
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {"data": {"abc": "abc"}}
+
+
+def test_post_with_query_params():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def abc(self) -> str:
+            return "abc"
+
+    app = FastAPI()
+    schema = strawberry.Schema(query=Query)
+    graphql_app = GraphQLRouter(schema)
+    app.include_router(graphql_app, prefix="/graphql")
+
+    test_client = TestClient(app)
+    response = test_client.post("/graphql", params={"query": "{ abc }"})
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {"data": {"abc": "abc"}}

--- a/tests/fastapi/test_query_params.py
+++ b/tests/fastapi/test_query_params.py
@@ -59,3 +59,49 @@ def test_post_fails_with_query_params():
     response = test_client.post("/graphql", params={"query": "{ abc }"})
 
     assert response.status_code == status.HTTP_415_UNSUPPORTED_MEDIA_TYPE
+
+
+def test_does_not_allow_mutation():
+    @strawberry.type
+    class Query:
+        abc: str
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        def abc(self) -> str:
+            return "abc"
+
+    app = FastAPI()
+    schema = strawberry.Schema(query=Query, mutation=Mutation)
+    graphql_app = GraphQLRouter(schema)
+    app.include_router(graphql_app, prefix="/graphql")
+
+    test_client = TestClient(app)
+    response = test_client.get("/graphql", params={"query": "mutation { abc }"})
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.text == "mutations are not allowed when using GET"
+
+
+def test_fails_if_allow_queries_via_get_false():
+    @strawberry.type
+    class Query:
+        abc: str
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        def abc(self) -> str:
+            return "abc"
+
+    app = FastAPI()
+    schema = strawberry.Schema(query=Query, mutation=Mutation)
+    graphql_app = GraphQLRouter(schema, allow_queries_via_get=False)
+    app.include_router(graphql_app, prefix="/graphql")
+
+    test_client = TestClient(app)
+    response = test_client.get("/graphql", params={"query": "{ abc }"})
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.text == "queries are not allowed when using GET"

--- a/tests/fastapi/test_view.py
+++ b/tests/fastapi/test_view.py
@@ -19,7 +19,7 @@ def test_renders_graphiql(test_client):
 def test_renders_graphiql_disabled(test_client_no_graphiql):
     response = test_client_no_graphiql.get("/graphql")
 
-    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
 def test_turning_off_graphql_ws():

--- a/tests/flask/app.py
+++ b/tests/flask/app.py
@@ -18,6 +18,10 @@ def create_app(**kwargs):
     @strawberry.type
     class Mutation:
         @strawberry.mutation
+        def hello(self) -> str:
+            return "strawberry"
+
+        @strawberry.mutation
         def read_text(self, text_file: Upload) -> str:
             return text_file.read().decode()
 

--- a/tests/flask/conftest.py
+++ b/tests/flask/conftest.py
@@ -13,3 +13,9 @@ def flask_client():
 def flask_client_no_graphiql():
     with create_app(graphiql=False).test_client() as client:
         yield client
+
+
+@pytest.fixture
+def flask_client_no_get():
+    with create_app(allow_queries_via_get=False).test_client() as client:
+        yield client

--- a/tests/flask/conftest.py
+++ b/tests/flask/conftest.py
@@ -7,3 +7,9 @@ from .app import create_app
 def flask_client():
     with create_app().test_client() as client:
         yield client
+
+
+@pytest.fixture
+def flask_client_no_graphiql():
+    with create_app(graphiql=False).test_client() as client:
+        yield client

--- a/tests/flask/test_query_params.py
+++ b/tests/flask/test_query_params.py
@@ -1,7 +1,5 @@
 import json
 
-from werkzeug.urls import url_encode, url_unparse
-
 
 def test_no_graphiql_empty_get(flask_client_no_graphiql):
 
@@ -19,8 +17,7 @@ def test_no_graphiql_no_query(flask_client_no_graphiql):
         """
     }
 
-    query_url = url_unparse(("", "", "/graphql", url_encode(params), ""))
-    response = flask_client_no_graphiql.get(query_url)
+    response = flask_client_no_graphiql.get("/graphql", query_string=params)
 
     assert response.status_code == 400
 
@@ -34,8 +31,7 @@ def test_no_graphiql_get_with_query_params(flask_client_no_graphiql):
         """
     }
 
-    query_url = url_unparse(("", "", "/graphql", url_encode(params), ""))
-    response = flask_client_no_graphiql.get(query_url)
+    response = flask_client_no_graphiql.get("/graphql", query_string=params)
     data = json.loads(response.data.decode())
 
     assert response.status_code == 200
@@ -51,7 +47,6 @@ def test_no_graphiql_post_fails_with_query_params(flask_client):
         """
     }
 
-    query_url = url_unparse(("", "", "/graphql", url_encode(params), ""))
-    response = flask_client.post(query_url)
+    response = flask_client.post("/graphql", query_string=params)
 
     assert response.status_code == 415

--- a/tests/flask/test_query_params.py
+++ b/tests/flask/test_query_params.py
@@ -42,7 +42,7 @@ def test_no_graphiql_get_with_query_params(flask_client_no_graphiql):
     assert data["data"]["hello"] == "strawberry"
 
 
-def test_no_graphiql_post_with_query_params(flask_client):
+def test_no_graphiql_post_fails_with_query_params(flask_client):
     params = {
         "query": """
             query {
@@ -52,8 +52,6 @@ def test_no_graphiql_post_with_query_params(flask_client):
     }
 
     query_url = url_unparse(("", "", "/graphql", url_encode(params), ""))
-    response = flask_client.get(query_url)
-    data = json.loads(response.data.decode())
+    response = flask_client.post(query_url)
 
-    assert response.status_code == 200
-    assert data["data"]["hello"] == "strawberry"
+    assert response.status_code == 415

--- a/tests/flask/test_query_params.py
+++ b/tests/flask/test_query_params.py
@@ -50,3 +50,33 @@ def test_no_graphiql_post_fails_with_query_params(flask_client):
     response = flask_client.post("/graphql", query_string=params)
 
     assert response.status_code == 415
+
+
+def test_does_not_allow_mutation(flask_client):
+    query = {
+        "query": """
+            mutation {
+                hello
+            }
+        """
+    }
+
+    response = flask_client.get("/graphql", query_string=query)
+
+    assert response.status_code == 400
+    assert "mutations are not allowed when using GET" in response.text
+
+
+def test_fails_if_allow_queries_via_get_false(flask_client_no_get):
+    query = {
+        "query": """
+            query {
+                hello
+            }
+        """
+    }
+
+    response = flask_client_no_get.get("/graphql", query_string=query)
+
+    assert response.status_code == 400
+    assert "queries are not allowed when using GET" in response.text

--- a/tests/flask/test_query_params.py
+++ b/tests/flask/test_query_params.py
@@ -1,0 +1,59 @@
+import json
+
+from werkzeug.urls import url_encode, url_unparse
+
+
+def test_no_graphiql_empty_get(flask_client_no_graphiql):
+
+    response = flask_client_no_graphiql.get("/graphql")
+
+    assert response.status_code == 415
+
+
+def test_no_graphiql_no_query(flask_client_no_graphiql):
+    params = {
+        "variables": """
+            query {
+                hello
+            }
+        """
+    }
+
+    query_url = url_unparse(("", "", "/graphql", url_encode(params), ""))
+    response = flask_client_no_graphiql.get(query_url)
+
+    assert response.status_code == 400
+
+
+def test_no_graphiql_get_with_query_params(flask_client_no_graphiql):
+    params = {
+        "query": """
+            query {
+                hello
+            }
+        """
+    }
+
+    query_url = url_unparse(("", "", "/graphql", url_encode(params), ""))
+    response = flask_client_no_graphiql.get(query_url)
+    data = json.loads(response.data.decode())
+
+    assert response.status_code == 200
+    assert data["data"]["hello"] == "strawberry"
+
+
+def test_no_graphiql_post_with_query_params(flask_client):
+    params = {
+        "query": """
+            query {
+                hello
+            }
+        """
+    }
+
+    query_url = url_unparse(("", "", "/graphql", url_encode(params), ""))
+    response = flask_client.get(query_url)
+    data = json.loads(response.data.decode())
+
+    assert response.status_code == 200
+    assert data["data"]["hello"] == "strawberry"

--- a/tests/flask/test_view.py
+++ b/tests/flask/test_view.py
@@ -48,7 +48,7 @@ def test_graphiql_disabled_view():
         client.environ_base["HTTP_ACCEPT"] = "text/html"
         response = client.get("/graphql")
 
-        assert response.status_code == 404
+        assert response.status_code == 415
 
 
 def test_custom_context():

--- a/tests/sanic/app.py
+++ b/tests/sanic/app.py
@@ -19,6 +19,10 @@ def create_app(**kwargs):
     @strawberry.type
     class Mutation:
         @strawberry.mutation
+        def hello(self) -> str:
+            return "strawberry"
+
+        @strawberry.mutation
         def read_text(self, text_file: Upload) -> str:
             return text_file.read().decode()
 
@@ -43,9 +47,6 @@ def create_app(**kwargs):
             return Query()
 
     app = Sanic(f"test_{int(random()*1000)}")
+    app.add_route(GraphQLView.as_view(schema=schema, **kwargs), "/graphql")
 
-    app.add_route(
-        GraphQLView.as_view(schema=schema, graphiql=kwargs.get("graphiql", True)),
-        "/graphql",
-    )
     return app

--- a/tests/sanic/conftest.py
+++ b/tests/sanic/conftest.py
@@ -6,3 +6,8 @@ from .app import create_app
 @pytest.fixture
 def sanic_client():
     yield create_app()
+
+
+@pytest.fixture
+def sanic_client_no_graphiql():
+    yield create_app(graphiql=False)

--- a/tests/sanic/conftest.py
+++ b/tests/sanic/conftest.py
@@ -11,3 +11,8 @@ def sanic_client():
 @pytest.fixture
 def sanic_client_no_graphiql():
     yield create_app(graphiql=False)
+
+
+@pytest.fixture
+def sanic_client_no_get():
+    yield create_app(allow_queries_via_get=False)

--- a/tests/sanic/test_query_params.py
+++ b/tests/sanic/test_query_params.py
@@ -46,3 +46,33 @@ def test_post_fails_with_query_params(sanic_client):
     request, response = sanic_client.test_client.post("/graphql", params=query)
 
     assert response.status == 415
+
+
+def test_does_not_allow_mutation(sanic_client):
+    query = {
+        "query": """
+            mutation {
+                hello
+            }
+        """
+    }
+
+    request, response = sanic_client.test_client.get("/graphql", params=query)
+
+    assert response.status == 400
+    assert "mutations are not allowed when using GET" in response.text
+
+
+def test_fails_if_allow_queries_via_get_false(sanic_client_no_get):
+    query = {
+        "query": """
+            query {
+                hello
+            }
+        """
+    }
+
+    request, response = sanic_client_no_get.test_client.get("/graphql", params=query)
+
+    assert response.status == 400
+    assert "queries are not allowed when using GET" in response.text

--- a/tests/sanic/test_query_params.py
+++ b/tests/sanic/test_query_params.py
@@ -1,0 +1,51 @@
+def test_no_graphiql_empty_get(sanic_client_no_graphiql):
+
+    request, response = sanic_client_no_graphiql.test_client.get("/graphql")
+    assert response.status == 404
+
+
+def test_no_graphiql_no_query(sanic_client_no_graphiql):
+    params = {
+        "variables": """
+            query {
+                hello
+            }
+        """
+    }
+
+    request, response = sanic_client_no_graphiql.test_client.post(
+        "/graphql", params=params
+    )
+    assert response.status == 400
+
+
+def test_no_graphiql_get_with_query_params(sanic_client_no_graphiql):
+    params = {
+        "query": """
+            query {
+                hello
+            }
+        """
+    }
+
+    request, response = sanic_client_no_graphiql.test_client.post(
+        "/graphql", params=params
+    )
+    data = response.json
+    assert response.status == 200
+    assert data["data"]["hello"] == "strawberry"
+
+
+def test_post_with_query_params(sanic_client):
+    query = {
+        "query": """
+            query {
+                hello
+            }
+        """
+    }
+
+    request, response = sanic_client.test_client.post("/graphql", params=query)
+    data = response.json
+    assert response.status == 200
+    assert data["data"]["hello"] == "strawberry"

--- a/tests/sanic/test_query_params.py
+++ b/tests/sanic/test_query_params.py
@@ -7,13 +7,11 @@ def test_no_graphiql_empty_get(sanic_client_no_graphiql):
 def test_no_graphiql_no_query(sanic_client_no_graphiql):
     params = {
         "variables": """
-            query {
-                hello
-            }
+            hello
         """
     }
 
-    request, response = sanic_client_no_graphiql.test_client.post(
+    request, response = sanic_client_no_graphiql.test_client.get(
         "/graphql", params=params
     )
     assert response.status == 400
@@ -28,7 +26,7 @@ def test_no_graphiql_get_with_query_params(sanic_client_no_graphiql):
         """
     }
 
-    request, response = sanic_client_no_graphiql.test_client.post(
+    request, response = sanic_client_no_graphiql.test_client.get(
         "/graphql", params=params
     )
     data = response.json
@@ -36,7 +34,7 @@ def test_no_graphiql_get_with_query_params(sanic_client_no_graphiql):
     assert data["data"]["hello"] == "strawberry"
 
 
-def test_post_with_query_params(sanic_client):
+def test_post_fails_with_query_params(sanic_client):
     query = {
         "query": """
             query {
@@ -46,6 +44,5 @@ def test_post_with_query_params(sanic_client):
     }
 
     request, response = sanic_client.test_client.post("/graphql", params=query)
-    data = response.json
-    assert response.status == 200
-    assert data["data"]["hello"] == "strawberry"
+
+    assert response.status == 415

--- a/tests/types/test_execution.py
+++ b/tests/types/test_execution.py
@@ -23,7 +23,7 @@ def test_execution_context_operation_name_and_type():
             execution_context = self.execution_context
 
             operation_name = execution_context.operation_name
-            operation_type = execution_context.operation_type
+            operation_type = execution_context.operation_type.value
 
     schema = strawberry.Schema(Query, extensions=[MyExtension])
 
@@ -31,14 +31,14 @@ def test_execution_context_operation_name_and_type():
     assert not result.errors
 
     assert operation_name is None
-    assert operation_type == "QUERY"
+    assert operation_type == "query"
 
     # Try again with an operation_name
     result = schema.execute_sync("query MyOperation { ping }")
     assert not result.errors
 
     assert operation_name == "MyOperation"
-    assert operation_type == "QUERY"
+    assert operation_type == "query"
 
     # Try again with an operation_name override
     result = schema.execute_sync(
@@ -51,7 +51,7 @@ def test_execution_context_operation_name_and_type():
     assert not result.errors
 
     assert operation_name == "MyOperation2"
-    assert operation_type == "QUERY"
+    assert operation_type == "query"
 
 
 def test_execution_context_operation_type_mutation():
@@ -66,7 +66,7 @@ def test_execution_context_operation_type_mutation():
             execution_context = self.execution_context
 
             operation_name = execution_context.operation_name
-            operation_type = execution_context.operation_type
+            operation_type = execution_context.operation_type.value
 
     @strawberry.type
     class Mutation:
@@ -80,14 +80,14 @@ def test_execution_context_operation_type_mutation():
     assert not result.errors
 
     assert operation_name is None
-    assert operation_type == "MUTATION"
+    assert operation_type == "mutation"
 
     # Try again with an operation_name
     result = schema.execute_sync("mutation MyMutation { myMutation }")
     assert not result.errors
 
     assert operation_name == "MyMutation"
-    assert operation_type == "MUTATION"
+    assert operation_type == "mutation"
 
     # Try again with an operation_name override
     result = schema.execute_sync(
@@ -100,10 +100,10 @@ def test_execution_context_operation_type_mutation():
     assert not result.errors
 
     assert operation_name == "MyMutation2"
-    assert operation_type == "MUTATION"
+    assert operation_type == "mutation"
 
 
-def test_execution_context_operation_name_and_type_with_fragmenets():
+def test_execution_context_operation_name_and_type_with_fragments():
     operation_name = None
     operation_type = None
 
@@ -115,7 +115,7 @@ def test_execution_context_operation_name_and_type_with_fragmenets():
             execution_context = self.execution_context
 
             operation_name = execution_context.operation_name
-            operation_type = execution_context.operation_type
+            operation_type = execution_context.operation_type.value
 
     schema = strawberry.Schema(Query, extensions=[MyExtension])
 
@@ -134,7 +134,7 @@ def test_execution_context_operation_name_and_type_with_fragmenets():
     assert not result.errors
 
     assert operation_name == "MyOperation"
-    assert operation_type == "QUERY"
+    assert operation_type == "query"
 
 
 def test_error_when_accessing_operation_type_before_parsing():


### PR DESCRIPTION
## Description

Support GraphQL operations via GET requests using query parameters.

If a GET request request contains query parameters, they are parsed and executed.
Otherwise, if GraphiQL should be rendered, then  GET request returns the rendered GraphiQL.

I have standardised the conditions when GraphiQL should be rendered.
This is now when GraphiQL is enabled and the Accept headers contain "text/html" or "\*/\*".

While making these changes I also came across some issues with the Chalice integration's error handling, so I have fixed that as part of this PR.


Potential snag points on this PR that I would like some discussion on:

- Handling query params for Sanic - Sanic uses `urllib` to parse query params, and returns a list for each variable, so I am only taking the first value - but there could be a better way to handle this.
- My changes resulted in changes to some of the responses for bad GET requests when GraphiQL is disabled, and there are still inconsistencies between integrations in the response codes returned (at the moment either a 400, 404 or 415). This could potentially be standardised across integrations.
- Documentation may be needed to describe the request formats Strawberry supports. This may be needed on an integration level as there are differences in the formats each supports, i.e. whether multipart form data is supported.
- In relation to the point above, should multipart form data support be added to integrations that support it where it is not there?
- Test coverage - there are a couple of files where I need to improve the coverage

I am going to look at adding the documentation and test coverage now - just wanted to get the PR out so the rest of the code can be critiqued.
There are quite a lot of changes in this, so would appreciate as many eyes as possible and a thorough review!


## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Closes #1584
* Closes #834

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation. _(not 100% sure if needed but could be good to add)_
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
