### PR TITLE
Add activity dashboard in repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,3 +147,5 @@ pre-commit install
 
 The code in this project is licensed under MIT license. See [LICENSE](./LICENSE)
 for more information.
+
+![Recent Activity](https://images.repography.com/0/strawberry-graphql/strawberry/recent-activity/d751713988987e9331980363e24189ce.svg)


### PR DESCRIPTION
@strawberry-graphql/core a friend of mine made this project getting infographics for GitHub projects, this dashboard seems quite useful to have (hopefilly it will motivate me to merge more PRs :D), the only thing I'm not sure user of is the the trending topics, I'll ask what they are and if we can replace with something else, maybe a list of good first issues?

