### PR TITLE
Fix aiohttp bare function warnings

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+This release fixed a false positive deprecation warning related to our AIOHTTP class based view.

--- a/strawberry/aiohttp/views.py
+++ b/strawberry/aiohttp/views.py
@@ -90,4 +90,4 @@ class GraphQLView:
 
 # Mark the view as coroutine so that AIOHTTP does not confuse it with a deprecated bare
 # handler function.
-GraphQLView._is_coroutine = asyncio.coroutines._is_coroutine
+GraphQLView._is_coroutine = asyncio.coroutines._is_coroutine  # type: ignore[attr-defined] # noqa: E501

--- a/strawberry/aiohttp/views.py
+++ b/strawberry/aiohttp/views.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import timedelta
 
 from aiohttp import web
@@ -85,3 +86,8 @@ class GraphQLView:
         self, request: web.Request, result: ExecutionResult
     ) -> GraphQLHTTPResponse:
         return process_result(result)
+
+
+# Mark the view as coroutine so that AIOHTTP does not confuse it with a deprecated bare
+# handler function.
+GraphQLView._is_coroutine = asyncio.coroutines._is_coroutine

--- a/strawberry/aiohttp/views.py
+++ b/strawberry/aiohttp/views.py
@@ -14,6 +14,10 @@ from strawberry.types import ExecutionResult
 
 
 class GraphQLView:
+    # Mark the view as coroutine so that AIOHTTP does not confuse it with a deprecated
+    # bare handler function.
+    _is_coroutine = asyncio.coroutines._is_coroutine  # type: ignore[attr-defined]
+
     graphql_transport_ws_handler_class = GraphQLTransportWSHandler
     graphql_ws_handler_class = GraphQLWSHandler
     http_handler_class = HTTPHandler
@@ -86,8 +90,3 @@ class GraphQLView:
         self, request: web.Request, result: ExecutionResult
     ) -> GraphQLHTTPResponse:
         return process_result(result)
-
-
-# Mark the view as coroutine so that AIOHTTP does not confuse it with a deprecated bare
-# handler function.
-GraphQLView._is_coroutine = asyncio.coroutines._is_coroutine  # type: ignore[attr-defined] # noqa: E501


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Before these changes our aiohttp tests used to yield 53 `Bare functions are deprecated, use async ones` deprecation warnings. They were false positives. Our aiohttp views `__call__` method is async, however, aiohttp uses `asyncio.iscoroutinefunction` which does not recognize that. That's known bug the aiohttp devs decided should be fixed in python itself. This PR fixes the iscoroutinefunction check with a trick I learned from the Django docs (https://docs.djangoproject.com/en/4.0/topics/async/#async-views).

Related upstream issues:
https://github.com/aio-libs/aiohttp/issues/1993#issuecomment-419431628
https://bugs.python.org/issue38225

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
