### PR TITLE
Fix first directive argument from being cut off

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,19 +1,45 @@
 Release type: minor
 
-This release Closes [#1666] by improving the injection of reserved arguments
-for resolvers and directives through use of an annotation-based approach which
-adds support for:
+This release changes how we declare the `info` argument in resolvers and the
+`value` argument in directives.
 
-1. Defining a directive value argument using a `DirectiveValue`
-annotation.
-2. Defining the resolve/directive `info` argument using the `Info` annotation
+Previously we'd use the name of the argument to determine its value. Now we use
+the type annotation of the argument to determine its value.
 
-**Deprecated:** Declaration of value and info arguments by relying on name-based
-matching without annotations.
-
-# Examples
+Here's an example of how the old syntax works:
 
 ```python
+def some_resolver(info) -> str:
+    return info.context.get("some_key", "default")
+
+@strawberry.type
+class Example:
+    a_field: str = strawberry.resolver(some_resolver)
+```
+
+and here's an example of how the new syntax works:
+
+```python
+from strawberry.types import Info
+
+def some_resolver(info: Info) -> str:
+    return info.context.get("some_key", "default")
+
+@strawberry.type
+class Example:
+    a_field: str = strawberry.resolver(some_resolver)
+```
+
+This means that you can now use a different name for the `info` argument in your
+resolver and the `value` argument in your directive.
+
+Here's an example that uses a custom name for both the value and the info
+parameter in directives:
+
+```python
+from strawberry.types import Info
+from strawberry.directive import DirectiveLocation, DirectiveValue
+
 @strawberry.type
 class Cake:
     frosting: Optional[str] = None
@@ -39,4 +65,5 @@ def add_frosting(value: str, v: DirectiveValue[Cake], my_info: Info):
     return v
 ```
 
-[#1666]: (https://github.com/strawberry-graphql/strawberry/issues/1666)
+**Note:** the old way of passing arguments by name is deprecated and will be
+removed in future releases of Strawberry.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,42 @@
+Release type: minor
+
+This release Closes [#1666] by improving the injection of reserved arguments
+for resolvers and directives through use of an annotation-based approach which
+adds support for:
+
+1. Defining a directive value argument using a `DirectiveValue`
+annotation.
+2. Defining the resolve/directive `info` argument using the `Info` annotation
+
+**Deprecated:** Declaration of value and info arguments by relying on name-based
+matching without annotations.
+
+# Examples
+
+```python
+@strawberry.type
+class Cake:
+    frosting: Optional[str] = None
+    flavor: str = "Chocolate"
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def cake(self) -> Cake:
+        return Cake()
+
+@strawberry.directive(
+    locations=[DirectiveLocation.FIELD],
+    description="Add frosting with ``value`` to a cake.",
+)
+def add_frosting(value: str, v: DirectiveValue[Cake], my_info: Info):
+    # Arbitrary argument name when using `DirectiveValue` is supported!
+    assert isinstance(v, Cake)
+    if value in my_info.context["allergies"]:  # Info can now be accessed from directives!
+        raise AllergyError("You are allergic to this frosting!")
+    else:
+        v.frosting = value  # Value can now be used as a GraphQL argument name!
+    return v
+```
+
+[#1666]: (https://github.com/strawberry-graphql/strawberry/issues/1666)

--- a/docs/types/resolvers.md
+++ b/docs/types/resolvers.md
@@ -84,12 +84,11 @@ very small resolvers.
 
 <Note>
 
-The _self_ argument is a bit special here, when executing a GraphQL
-query, in case of resolvers defined with a decorator, the _self_ argument
-corresponds to the _root_ value that field. In this example the _root_ value
-is the value `Query` type, which is usually `None`. You can change the _root_
-value when calling the `execute` method on a `Schema`. More on _root_ values
-below.
+The _self_ argument is a bit special here, when executing a GraphQL query, in
+case of resolvers defined with a decorator, the _self_ argument corresponds to
+the _root_ value that field. In this example the _root_ value is the value
+`Query` type, which is usually `None`. You can change the _root_ value when
+calling the `execute` method on a `Schema`. More on _root_ values below.
 
 </Note>
 
@@ -126,7 +125,9 @@ type Query {
 
 ### Optional arguments
 
-Optional or nullable arguments can be expressed using `Optional`. If you need to differentiate between `null` (maps to `None` in Python) and no arguments being passed, you can use `UNSET`:
+Optional or nullable arguments can be expressed using `Optional`. If you need to
+differentiate between `null` (maps to `None` in Python) and no arguments being
+passed, you can use `UNSET`:
 
 ```python+schema
 from typing import Optional
@@ -222,7 +223,9 @@ class User:
 ## Accessing execution information
 
 Sometimes it is useful to access the information for the current execution
-context. To do so you can provide the `info` parameter to resolvers, like this:
+context. Strawberry allows to declare a parameter of type `Info` that will be
+automatically passed to the resolver. This parameter containes the information
+for the current execution context.
 
 ```python
 import strawberry
@@ -237,6 +240,13 @@ class User:
     last_name: str
     full_name: str = strawberry.field(resolver=full_name)
 ```
+
+<Tip>
+
+You don't have to call this parameter `info`, its name can be anything.
+Strawberry uses the type to pass the correct value to the resolver.
+
+</Tip>
 
 ### API
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,9 @@ DJANGO_SETTINGS_MODULE = "tests.django.django_settings"
 testpaths = ["tests/"]
 markers = ["django", "starlette"]
 asyncio_mode = "auto"
+filterwarnings = [
+    "ignore::DeprecationWarning:strawberry.*.resolver"
+]
 
 [tool.autopub]
 git-username = "Botberry"

--- a/strawberry/directive.py
+++ b/strawberry/directive.py
@@ -13,7 +13,6 @@ from strawberry.arguments import StrawberryArgument
 from strawberry.field import StrawberryField
 from strawberry.types.fields.resolver import (
     INFO_PARAMSPEC,
-    ROOT_PARAMSPEC,
     ReservedType,
     StrawberryResolver,
 )
@@ -46,7 +45,6 @@ class StrawberryDirectiveResolver(StrawberryResolver[T]):
 
     RESERVED_PARAMSPEC = (
         INFO_PARAMSPEC,
-        ROOT_PARAMSPEC,
         VALUE_PARAMSPEC,
     )
 

--- a/strawberry/directive.py
+++ b/strawberry/directive.py
@@ -2,15 +2,21 @@ from __future__ import annotations
 
 import dataclasses
 import inspect
-import sys
-from itertools import islice
 from typing import Any, Callable, List, Optional, TypeVar
+
+from backports.cached_property import cached_property
+from typing_extensions import Annotated
 
 from graphql import DirectiveLocation
 
-from strawberry.annotation import StrawberryAnnotation
 from strawberry.arguments import StrawberryArgument
 from strawberry.field import StrawberryField
+from strawberry.types.fields.resolver import (
+    INFO_PARAMSPEC,
+    ROOT_PARAMSPEC,
+    ReservedType,
+    StrawberryResolver,
+)
 
 
 def directive_field(name: str) -> Any:
@@ -20,43 +26,47 @@ def directive_field(name: str) -> Any:
     )
 
 
+T = TypeVar("T")
+
+
+class StrawberryDirectiveValue:
+    ...
+
+
+DirectiveValue = Annotated[T, StrawberryDirectiveValue()]
+DirectiveValue.__doc__ = (
+    """Represents the ``value`` argument for a GraphQL query directive."""
+)
+
+
+VALUE_PARAMSPEC = ReservedType(name="value", type=StrawberryDirectiveValue)
+"""Registers `DirectiveValue[...]` annotated arguments as reserved."""
+
+
+class StrawberryDirectiveResolver(StrawberryResolver[T]):
+
+    RESERVED_PARAMSPEC = (
+        INFO_PARAMSPEC,
+        ROOT_PARAMSPEC,
+        VALUE_PARAMSPEC,
+    )
+
+    @cached_property
+    def value_parameter(self) -> Optional[inspect.Parameter]:
+        return self.reserved_parameters.get(VALUE_PARAMSPEC)
+
+
 @dataclasses.dataclass
 class StrawberryDirective:
     python_name: str
     graphql_name: Optional[str]
-    resolver: Callable
+    resolver: StrawberryDirectiveResolver
     locations: List[DirectiveLocation]
     description: Optional[str] = None
 
     @property
     def arguments(self) -> List[StrawberryArgument]:
-        annotations = self.resolver.__annotations__
-        annotations = dict(islice(annotations.items(), 1, None))
-        annotations.pop("return", None)
-
-        parameters = inspect.signature(self.resolver).parameters
-
-        module = sys.modules[self.resolver.__module__]
-        annotation_namespace = module.__dict__
-        arguments = []
-        for arg_name, annotation in annotations.items():
-            parameter = parameters[arg_name]
-
-            argument = StrawberryArgument(
-                python_name=arg_name,
-                graphql_name=None,
-                type_annotation=StrawberryAnnotation(
-                    annotation=annotation, namespace=annotation_namespace
-                ),
-                default=parameter.default,
-            )
-
-            arguments.append(argument)
-
-        return arguments
-
-
-T = TypeVar("T")
+        return self.resolver.arguments
 
 
 def directive(
@@ -71,7 +81,7 @@ def directive(
             graphql_name=name,
             locations=locations,
             description=description,
-            resolver=f,
+            resolver=StrawberryDirectiveResolver(f),
         )
 
     return _wrap

--- a/strawberry/directive.py
+++ b/strawberry/directive.py
@@ -38,9 +38,8 @@ DirectiveValue.__doc__ = (
     """Represents the ``value`` argument for a GraphQL query directive."""
 )
 
-
+# Registers `DirectiveValue[...]` annotated arguments as reserved
 VALUE_PARAMSPEC = ReservedType(name="value", type=StrawberryDirectiveValue)
-"""Registers `DirectiveValue[...]` annotated arguments as reserved."""
 
 
 class StrawberryDirectiveResolver(StrawberryResolver[T]):

--- a/strawberry/extensions/base_extension.py
+++ b/strawberry/extensions/base_extension.py
@@ -1,6 +1,8 @@
 from typing import Any, Dict
 
-from strawberry.types import ExecutionContext, Info
+from graphql import GraphQLResolveInfo
+
+from strawberry.types import ExecutionContext
 from strawberry.utils.await_maybe import AwaitableOrValue
 
 
@@ -35,7 +37,7 @@ class Extension:
         """This method is called after the executing step"""
 
     def resolve(
-        self, _next, root, info: Info, *args, **kwargs
+        self, _next, root, info: GraphQLResolveInfo, *args, **kwargs
     ) -> AwaitableOrValue[object]:
         return _next(root, info, *args, **kwargs)
 

--- a/strawberry/extensions/directives.py
+++ b/strawberry/extensions/directives.py
@@ -63,6 +63,7 @@ def process_directive(
     strawberry_directive = schema.get_directive_by_name(directive_name)
     assert strawberry_directive is not None, f"Directive {directive_name} not found"
 
+    # TODO: support converting lists
     arguments = {
         argument.name.value: argument.value.value  # type: ignore
         for argument in directive.arguments

--- a/strawberry/extensions/directives.py
+++ b/strawberry/extensions/directives.py
@@ -1,5 +1,8 @@
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Dict, Tuple
 
+from graphql import DirectiveNode
+
+from strawberry.directive import StrawberryDirective
 from strawberry.extensions import Extension
 from strawberry.types import Info
 from strawberry.utils.await_maybe import AwaitableOrValue, await_maybe
@@ -16,56 +19,60 @@ class DirectivesExtension(Extension):
     async def resolve(
         self, _next, root, info: Info, *args, **kwargs
     ) -> AwaitableOrValue[Any]:
-        result = await await_maybe(_next(root, info, *args, **kwargs))
+        value = await await_maybe(_next(root, info, *args, **kwargs))
 
         for directive in info.field_nodes[0].directives:
-            directive_name = directive.name.value
-
-            if directive_name in SPECIFIED_DIRECTIVES:
+            if directive.name.value in SPECIFIED_DIRECTIVES:
                 continue
-
-            # TODO: support converting lists
-            arguments = {
-                argument.name.value: argument.value.value  # type: ignore
-                for argument in directive.arguments
-            }
-
-            schema: Schema = info.schema._strawberry_schema  # type: ignore
-            strawberry_directive = schema.get_directive_by_name(directive_name)
-            assert (
-                strawberry_directive is not None
-            ), f"Directive {directive_name} not found"
-
-            result = await await_maybe(
-                strawberry_directive.resolver(result, **arguments)
+            strawberry_directive, arguments = process_directive(
+                directive, value, root, info
             )
+            value = await await_maybe(strawberry_directive.resolver(**arguments))
 
-        return result
+        return value
 
 
 class DirectivesExtensionSync(Extension):
-    # TODO: we might need the graphql info here
     def resolve(self, _next, root, info, *args, **kwargs) -> AwaitableOrValue[Any]:
-        result = _next(root, info, *args, **kwargs)
+        value = _next(root, info, *args, **kwargs)
 
         for directive in info.field_nodes[0].directives:
-            directive_name = directive.name.value
-
-            if directive_name in SPECIFIED_DIRECTIVES:
+            if directive.name.value in SPECIFIED_DIRECTIVES:
                 continue
+            strawberry_directive, arguments = process_directive(
+                directive, value, root, info
+            )
+            value = strawberry_directive.resolver(**arguments)
 
-            # TODO: support converting lists
-            arguments = {
-                argument.name.value: argument.value.value
-                for argument in directive.arguments
-            }
+        return value
 
-            schema: Schema = info.schema._strawberry_schema
-            strawberry_directive = schema.get_directive_by_name(directive_name)
-            assert (
-                strawberry_directive is not None
-            ), f"Directive {directive_name} not found"
 
-            result = strawberry_directive.resolver(result, **arguments)
+def process_directive(
+    directive: DirectiveNode,
+    value: Any,
+    root: Any,
+    info: Info,
+) -> Tuple[StrawberryDirective, Dict[str, Any]]:
+    """Get a `StrawberryDirective` from ``directive` and prepare its arguments."""
+    directive_name = directive.name.value
+    schema: Schema = info.schema._strawberry_schema  # type: ignore
 
-        return result
+    strawberry_directive = schema.get_directive_by_name(directive_name)
+    assert strawberry_directive is not None, f"Directive {directive_name} not found"
+
+    arguments = {
+        argument.name.value: argument.value.value  # type: ignore
+        for argument in directive.arguments
+    }
+    resolver = strawberry_directive.resolver
+
+    info_parameter = resolver.info_parameter
+    root_parameter = resolver.root_parameter
+    value_parameter = resolver.value_parameter
+    if info_parameter:
+        arguments[info_parameter.name] = info
+    if root_parameter:
+        arguments[root_parameter.name] = root
+    if value_parameter:
+        arguments[value_parameter.name] = value
+    return strawberry_directive, arguments

--- a/strawberry/extensions/directives.py
+++ b/strawberry/extensions/directives.py
@@ -25,9 +25,7 @@ class DirectivesExtension(Extension):
         for directive in info.field_nodes[0].directives:
             if directive.name.value in SPECIFIED_DIRECTIVES:
                 continue
-            strawberry_directive, arguments = process_directive(
-                directive, value, root, info
-            )
+            strawberry_directive, arguments = process_directive(directive, value, info)
             value = await await_maybe(strawberry_directive.resolver(**arguments))
 
         return value
@@ -42,9 +40,7 @@ class DirectivesExtensionSync(Extension):
         for directive in info.field_nodes[0].directives:
             if directive.name.value in SPECIFIED_DIRECTIVES:
                 continue
-            strawberry_directive, arguments = process_directive(
-                directive, value, root, info
-            )
+            strawberry_directive, arguments = process_directive(directive, value, info)
             value = strawberry_directive.resolver(**arguments)
 
         return value
@@ -53,7 +49,6 @@ class DirectivesExtensionSync(Extension):
 def process_directive(
     directive: DirectiveNode,
     value: Any,
-    root: Any,
     info: GraphQLResolveInfo,
 ) -> Tuple[StrawberryDirective, Dict[str, Any]]:
     """Get a `StrawberryDirective` from ``directive` and prepare its arguments."""
@@ -71,7 +66,6 @@ def process_directive(
     resolver = strawberry_directive.resolver
 
     info_parameter = resolver.info_parameter
-    root_parameter = resolver.root_parameter
     value_parameter = resolver.value_parameter
     if info_parameter:
         field: StrawberryField = schema.get_field_for_type(  # type: ignore
@@ -79,8 +73,6 @@ def process_directive(
             type_name=info.parent_type.name,
         )
         arguments[info_parameter.name] = Info(_raw_info=info, _field=field)
-    if root_parameter:
-        arguments[root_parameter.name] = root
     if value_parameter:
         arguments[value_parameter.name] = value
     return strawberry_directive, arguments

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -399,14 +399,16 @@ class GraphQLCoreConverter:
             args = []
 
             if field.base_resolver:
-                if field.base_resolver.has_self_arg:
+                if field.base_resolver.self_parameter:
                     args.append(source)
 
-                if field.base_resolver.has_root_arg:
-                    kwargs["root"] = source
+                root_parameter = field.base_resolver.root_parameter
+                if root_parameter:
+                    kwargs[root_parameter.name] = source
 
-                if field.base_resolver.has_info_arg:
-                    kwargs["info"] = info
+                info_parameter = field.base_resolver.info_parameter
+                if info_parameter:
+                    kwargs[info_parameter.name] = info
 
             return args, kwargs
 

--- a/strawberry/types/fields/resolver.py
+++ b/strawberry/types/fields/resolver.py
@@ -4,7 +4,6 @@ import builtins
 import inspect
 import sys
 import warnings
-from functools import lru_cache
 from inspect import isasyncgenfunction, iscoroutinefunction
 from typing import (  # type: ignore[attr-defined]
     Any,
@@ -122,8 +121,6 @@ INFO_PARAMSPEC = ReservedType("info", Info)
 
 T = TypeVar("T")
 
-cached_signature = lru_cache(maxsize=250)(inspect.signature)
-
 
 class StrawberryResolver(Generic[T]):
 
@@ -162,7 +159,7 @@ class StrawberryResolver(Generic[T]):
 
     @cached_property
     def signature(self) -> inspect.Signature:
-        return cached_signature(self._unbound_wrapped_func)
+        return inspect.signature(self._unbound_wrapped_func)
 
     @cached_property
     def reserved_parameters(

--- a/strawberry/types/fields/resolver.py
+++ b/strawberry/types/fields/resolver.py
@@ -3,24 +3,125 @@ from __future__ import annotations as _
 import builtins
 import inspect
 import sys
+import warnings
+from functools import lru_cache
 from inspect import isasyncgenfunction, iscoroutinefunction
-from typing import Callable, Dict, Generic, List, Mapping, Optional, TypeVar, Union
+from typing import (  # type: ignore[attr-defined]
+    Any,
+    Callable,
+    Dict,
+    Generic,
+    List,
+    Mapping,
+    NamedTuple,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    _eval_type,
+)
 
 from backports.cached_property import cached_property
+from typing_extensions import Annotated, Protocol, get_args, get_origin
 
 from strawberry.annotation import StrawberryAnnotation
 from strawberry.arguments import StrawberryArgument
 from strawberry.exceptions import MissingArgumentsAnnotationsError
 from strawberry.type import StrawberryType
-from strawberry.utils.inspect import get_func_args
+from strawberry.types.info import Info
 
+
+class ReservedParameterSpecification(Protocol):
+    def find(
+        self, parameters: Tuple[inspect.Parameter, ...], resolver: StrawberryResolver
+    ) -> Optional[inspect.Parameter]:
+        """Finds the reserved parameter from ``parameters``."""
+
+
+class ReservedName(NamedTuple):
+    name: str
+
+    def find(
+        self, parameters: Tuple[inspect.Parameter, ...], _: StrawberryResolver
+    ) -> Optional[inspect.Parameter]:
+        return next((p for p in parameters if p.name == self.name), None)
+
+
+class ReservedNameBoundParameter(NamedTuple):
+    name: str
+
+    def find(
+        self, parameters: Tuple[inspect.Parameter, ...], _: StrawberryResolver
+    ) -> Optional[inspect.Parameter]:
+        if parameters:  # Add compatibility for resolvers with no arguments
+            first_parameter = parameters[0]
+            return first_parameter if first_parameter.name == self.name else None
+        else:
+            return None
+
+
+class ReservedType(NamedTuple):
+    """Define a reserved type by name or by type.
+
+    To preserve backwards-comaptibility, if an annotation was defined but does not match
+    :attr:`type`, then the name is used as a fallback.
+    """
+
+    name: str
+    type: Type
+
+    def find(
+        self, parameters: Tuple[inspect.Parameter, ...], resolver: StrawberryResolver
+    ) -> Optional[inspect.Parameter]:
+        for parameter in parameters:
+            resolved_annotation = _eval_type(
+                parameter.annotation, resolver._namespace, None
+            )
+            if self.is_reserved_type(resolved_annotation):
+                return parameter
+
+        # Fallback to matching by name
+        reserved_name = ReservedName(name=self.name).find(parameters, resolver)
+        if reserved_name:
+            warning = DeprecationWarning(
+                f"Argument name-based matching of '{self.name}' is deprecated and will "
+                "be removed in v1.0. Ensure that reserved arguments are annotated "
+                "their respective types (i.e. use value: 'DirectiveValue[str]' instead "
+                "of 'value: str' and 'info: Info' instead of a plain 'info')."
+            )
+            warnings.warn(warning)
+            return reserved_name
+        else:
+            return None
+
+    def is_reserved_type(self, other: Type) -> bool:
+        if get_origin(other) is Annotated:
+            # Handle annotated arguments such as Private[str] and DirectiveValue[str]
+            return any(isinstance(argument, self.type) for argument in get_args(other))
+        else:
+            # Handle both concrete and generic types (i.e Info, and Info[Any, Any])
+            return other is self.type or get_origin(other) is self.type
+
+
+SELF_PARAMSPEC = ReservedNameBoundParameter("self")
+CLS_PARAMSPEC = ReservedNameBoundParameter("cls")
+ROOT_PARAMSPEC = ReservedName("root")
+INFO_PARAMSPEC = ReservedType("info", Info)
 
 T = TypeVar("T")
 
+cached_signature = lru_cache(maxsize=250)(inspect.signature)
+
 
 class StrawberryResolver(Generic[T]):
-    # TODO: Move to StrawberryArgument? StrawberryResolver ClassVar?
-    _SPECIAL_ARGS = {"root", "info", "self", "cls"}
+
+    RESERVED_PARAMSPEC: Tuple[ReservedParameterSpecification, ...] = (
+        SELF_PARAMSPEC,
+        CLS_PARAMSPEC,
+        ROOT_PARAMSPEC,
+        INFO_PARAMSPEC,
+    )
 
     def __init__(
         self,
@@ -44,70 +145,53 @@ class StrawberryResolver(Generic[T]):
         return self.wrapped_func(*args, **kwargs)
 
     @cached_property
-    def annotations(self) -> Dict[str, object]:
-        """Annotations for the resolver.
+    def signature(self) -> inspect.Signature:
+        return cached_signature(self._unbound_wrapped_func)
 
-        Does not include special args defined in _SPECIAL_ARGS (e.g. self, root, info)
-        """
-        annotations = self._unbound_wrapped_func.__annotations__
-
-        annotations = {
-            name: annotation
-            for name, annotation in annotations.items()
-            if name not in self._SPECIAL_ARGS
-        }
-
-        return annotations
+    @cached_property
+    def reserved_parameters(
+        self,
+    ) -> Dict[ReservedParameterSpecification, Optional[inspect.Parameter]]:
+        """Mapping of reserved parameter specification to parameter."""
+        parameters = tuple(self.signature.parameters.values())
+        return {spec: spec.find(parameters, self) for spec in self.RESERVED_PARAMSPEC}
 
     @cached_property
     def arguments(self) -> List[StrawberryArgument]:
-        parameters = inspect.signature(self._unbound_wrapped_func).parameters
-        function_arguments = set(parameters) - self._SPECIAL_ARGS
+        """Resolver arguments exposed in the GraphQL Schema."""
+        parameters = self.signature.parameters.values()
+        reserved_parameters = tuple(self.reserved_parameters.values())
 
-        arguments = self.annotations.copy()
-        arguments.pop("return", None)  # Discard return annotation to get just arguments
-
-        arguments_missing_annotations = function_arguments - set(arguments)
-
-        if any(arguments_missing_annotations):
-            raise MissingArgumentsAnnotationsError(
-                field_name=self.name,
-                arguments=arguments_missing_annotations,
-            )
-
-        module = sys.modules[self._module]
-        annotation_namespace = module.__dict__
-        strawberry_arguments = []
-        for arg_name, annotation in arguments.items():
-            parameter = parameters[arg_name]
-
-            argument = StrawberryArgument(
-                python_name=arg_name,
-                graphql_name=None,
-                type_annotation=StrawberryAnnotation(
-                    annotation=annotation, namespace=annotation_namespace
-                ),
-                default=parameter.default,
-            )
-
-            strawberry_arguments.append(argument)
-
-        return strawberry_arguments
+        missing_annotations = set()
+        arguments = []
+        for param in filter(lambda p: p not in reserved_parameters, parameters):
+            if param.annotation is inspect.Signature.empty:
+                missing_annotations.add(param.name)
+            else:
+                argument = StrawberryArgument(
+                    python_name=param.name,
+                    graphql_name=None,
+                    type_annotation=StrawberryAnnotation(
+                        annotation=param.annotation, namespace=self._namespace
+                    ),
+                    default=param.default,
+                )
+                arguments.append(argument)
+        if missing_annotations:
+            raise MissingArgumentsAnnotationsError(self.name, missing_annotations)
+        return arguments
 
     @cached_property
-    def has_info_arg(self) -> bool:
-        args = get_func_args(self._unbound_wrapped_func)
-        return "info" in args
+    def info_parameter(self) -> Optional[inspect.Parameter]:
+        return self.reserved_parameters.get(INFO_PARAMSPEC)
 
     @cached_property
-    def has_root_arg(self) -> bool:
-        args = get_func_args(self._unbound_wrapped_func)
-        return "root" in args
+    def root_parameter(self) -> Optional[inspect.Parameter]:
+        return self.reserved_parameters.get(ROOT_PARAMSPEC)
 
     @cached_property
-    def has_self_arg(self) -> bool:
-        args = get_func_args(self._unbound_wrapped_func)
-        return args and args[0] == "self"
+    def self_parameter(self) -> Optional[inspect.Parameter]:
+        return self.reserved_parameters.get(SELF_PARAMSPEC)
 
     @cached_property
     def name(self) -> str:
@@ -116,17 +200,13 @@ class StrawberryResolver(Generic[T]):
 
     @cached_property
     def type_annotation(self) -> Optional[StrawberryAnnotation]:
-        try:
-            return_annotation = self.annotations["return"]
-        except KeyError:
-            # No return annotation at all (as opposed to `-> None`)
+        return_annotation = self.signature.return_annotation
+        if return_annotation is inspect.Signature.empty:
             return None
-
-        module = sys.modules[self._module]
-        type_annotation = StrawberryAnnotation(
-            annotation=return_annotation, namespace=module.__dict__
-        )
-
+        else:
+            type_annotation = StrawberryAnnotation(
+                annotation=return_annotation, namespace=self._namespace
+            )
         return type_annotation
 
     @property
@@ -163,8 +243,8 @@ class StrawberryResolver(Generic[T]):
         )
 
     @cached_property
-    def _module(self) -> str:
-        return self._unbound_wrapped_func.__module__
+    def _namespace(self) -> Dict[str, Any]:
+        return sys.modules[self._unbound_wrapped_func.__module__].__dict__
 
     @cached_property
     def _unbound_wrapped_func(self) -> Callable[..., T]:

--- a/strawberry/types/fields/resolver.py
+++ b/strawberry/types/fields/resolver.py
@@ -180,7 +180,8 @@ class StrawberryResolver(Generic[T]):
 
         missing_annotations = set()
         arguments = []
-        for param in filter(lambda p: p not in reserved_parameters, parameters):
+        user_parameters = (p for p in parameters if p not in reserved_parameters)
+        for param in user_parameters:
             annotation = self._resolved_annotations.get(param, param.annotation)
             if annotation is inspect.Signature.empty:
                 missing_annotations.add(param.name)

--- a/strawberry/types/fields/resolver.py
+++ b/strawberry/types/fields/resolver.py
@@ -164,7 +164,7 @@ class StrawberryResolver(Generic[T]):
     def arguments(self) -> List[StrawberryArgument]:
         """Resolver arguments exposed in the GraphQL Schema."""
         parameters = self.signature.parameters.values()
-        reserved_parameters = tuple(self.reserved_parameters.values())
+        reserved_parameters = set(self.reserved_parameters.values())
 
         missing_annotations = set()
         arguments = []

--- a/strawberry/types/fields/resolver.py
+++ b/strawberry/types/fields/resolver.py
@@ -10,6 +10,7 @@ from typing import (  # type: ignore[attr-defined]
     Any,
     Callable,
     Dict,
+    ForwardRef,
     Generic,
     List,
     Mapping,
@@ -75,8 +76,11 @@ class ReservedType(NamedTuple):
         self, parameters: Tuple[inspect.Parameter, ...], resolver: StrawberryResolver
     ) -> Optional[inspect.Parameter]:
         for parameter in parameters:
+            annotation = parameter.annotation
             resolved_annotation = _eval_type(
-                parameter.annotation, resolver._namespace, None
+                ForwardRef(annotation) if isinstance(annotation, str) else annotation,
+                resolver._namespace,
+                None,
             )
             if self.is_reserved_type(resolved_annotation):
                 return parameter

--- a/tests/schema/test_directives.py
+++ b/tests/schema/test_directives.py
@@ -114,6 +114,32 @@ def test_can_declare_directives():
     assert schema.as_str() == textwrap.dedent(expected_schema).strip()
 
 
+def test_directive_arguments_without_value_param():
+    """regression test for https://github.com/strawberry-graphql/strawberry/issues/1666"""
+    @strawberry.type
+    class Query:
+        cake: str = "victoria sponge"
+
+    @strawberry.directive(
+        locations=[DirectiveLocation.FIELD], description="Don't actually like cake? try ice cream instead"
+    )
+    def ice_cream(flavor: str):
+        return f'{flavor} ice cream'
+
+    schema = strawberry.Schema(query=Query, directives=[ice_cream])
+
+    expected_schema = '''
+    """Don't actually like cake? try ice cream instead"""
+    directive @iceCream(flavor: String!) on FIELD
+
+    type Query {
+      cake: String!
+    }
+    '''
+
+    assert schema.as_str() == textwrap.dedent(expected_schema).strip()
+
+
 def test_runs_directives():
     @strawberry.type
     class Person:

--- a/tests/schema/test_directives.py
+++ b/tests/schema/test_directives.py
@@ -1,12 +1,14 @@
 import textwrap
-from typing import List
+from enum import Enum
+from typing import Dict, List, Optional
 
 import pytest
 
 import strawberry
-from strawberry.directive import DirectiveLocation
+from strawberry.directive import DirectiveLocation, DirectiveValue
 from strawberry.extensions import Extension
 from strawberry.schema.config import StrawberryConfig
+from strawberry.types.info import Info
 from strawberry.utils.await_maybe import await_maybe
 
 
@@ -30,7 +32,11 @@ def test_supports_default_directives():
     }"""
 
     schema = strawberry.Schema(query=Query)
-    result = schema.execute_sync(query, variable_values={"includePoints": False})
+    result = schema.execute_sync(
+        query,
+        variable_values={"includePoints": False},
+        context_value={"username": "foo"},
+    )
 
     assert not result.errors
     assert result.data["person"] == {"name": "Jess"}
@@ -115,16 +121,21 @@ def test_can_declare_directives():
 
 
 def test_directive_arguments_without_value_param():
-    """regression test for https://github.com/strawberry-graphql/strawberry/issues/1666"""
+    """Regression test for Strawberry Issue #1666.
+
+    https://github.com/strawberry-graphql/strawberry/issues/1666
+    """
+
     @strawberry.type
     class Query:
         cake: str = "victoria sponge"
 
     @strawberry.directive(
-        locations=[DirectiveLocation.FIELD], description="Don't actually like cake? try ice cream instead"
+        locations=[DirectiveLocation.FIELD],
+        description="Don't actually like cake? try ice cream instead",
     )
     def ice_cream(flavor: str):
-        return f'{flavor} ice cream'
+        return f"{flavor} ice cream"
 
     schema = strawberry.Schema(query=Query, directives=[ice_cream])
 
@@ -138,6 +149,11 @@ def test_directive_arguments_without_value_param():
     '''
 
     assert schema.as_str() == textwrap.dedent(expected_schema).strip()
+
+    query = 'query { cake @iceCream(flavor: "strawberry") }'
+    result = schema.execute_sync(query, root_value=Query())
+
+    assert result.data == {"cake": "strawberry ice cream"}
 
 
 def test_runs_directives():
@@ -371,3 +387,184 @@ async def test_runs_directives_with_extensions_async():
     assert not result.errors
     assert result.data
     assert result.data["person"]["name"] == "JESS"
+
+
+@pytest.fixture
+def info_directive_schema() -> strawberry.Schema:
+    """Returns a schema with directive that validates if info is recieved."""
+
+    @strawberry.enum
+    class Locale(Enum):
+        EN: str = "EN"
+        NL: str = "NL"
+
+    greetings: Dict[Locale, str] = {
+        Locale.EN: "Hello {username}",
+        Locale.NL: "Hallo {username}",
+    }
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def greetingTemplate(self, locale: Locale = Locale.EN) -> str:
+            return greetings[locale]
+
+    @strawberry.directive(
+        locations=[DirectiveLocation.FIELD],
+        description="Interpolate string on the server from context data",
+    )
+    def interpolate(value: str, info: Info):
+        try:
+            return value.format(**info.context["userdata"])
+        except KeyError:
+            return value
+
+    return strawberry.Schema(query=Query, directives=[interpolate])
+
+
+def test_info_directive_schema(info_directive_schema: strawberry.Schema):
+
+    expected_schema = '''
+    """Interpolate string on the server from context data"""
+    directive @interpolate on FIELD
+
+    enum Locale {
+      EN
+      NL
+    }
+
+    type Query {
+      greetingTemplate(locale: Locale! = EN): String!
+    }
+    '''
+
+    assert textwrap.dedent(expected_schema).strip() == str(info_directive_schema)
+
+
+def test_info_directive(info_directive_schema: strawberry.Schema):
+    query = "query { greetingTemplate @interpolate }"
+    result = info_directive_schema.execute_sync(
+        query, context_value={"userdata": {"username": "Foo"}}
+    )
+    assert result.data == {"greetingTemplate": "Hello Foo"}
+
+
+@pytest.mark.asyncio
+async def test_info_directive_async(info_directive_schema: strawberry.Schema):
+    query = "query { greetingTemplate @interpolate }"
+    result = await info_directive_schema.execute(
+        query, context_value={"userdata": {"username": "Foo"}}
+    )
+    assert result.data == {"greetingTemplate": "Hello Foo"}
+
+
+def test_directive_value():
+    """Tests if directive value is detected by type instead of by arg-name `value`."""
+
+    @strawberry.type
+    class Cake:
+        frosting: Optional[str] = None
+        flavor: str = "Chocolate"
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def cake(self) -> Cake:
+            return Cake()
+
+    @strawberry.directive(
+        locations=[DirectiveLocation.FIELD],
+        description="Add frostring with ``flavor`` to a cake.",
+    )
+    def add_frosting(flavor: str, v: DirectiveValue[Cake], value: str):
+        assert isinstance(v, Cake)
+        assert value == "foo"  # Check if value can be used as an argument
+        v.frosting = flavor
+        return v
+
+    schema = strawberry.Schema(query=Query, directives=[add_frosting])
+    result = schema.execute_sync(
+        """query {
+            cake @addFrosting(flavor: "Vanilla", value: "foo") {
+                frosting
+                flavor
+            }
+        }
+        """
+    )
+    assert result.data == {"cake": {"frosting": "Vanilla", "flavor": "Chocolate"}}
+
+
+# Defined in module scope to allow the FowardRef to be resolvable with eval
+@strawberry.directive(
+    locations=[DirectiveLocation.FIELD],
+    description="Add frostring with ``flavor`` to a cake.",
+)
+def add_frosting(flavor: str, v: DirectiveValue["Cake"], value: str):
+    assert isinstance(v, Cake)
+    assert value == "foo"
+    v.frosting = flavor
+    return v
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def cake(self) -> "Cake":
+        return Cake()
+
+
+@strawberry.type
+class Cake:
+    frosting: Optional[str] = None
+    flavor: str = "Chocolate"
+
+
+def test_directive_value_forward_ref():
+    """Tests if directive value by type works with PEP-563."""
+    schema = strawberry.Schema(query=Query, directives=[add_frosting])
+    result = schema.execute_sync(
+        """query {
+            cake @addFrosting(flavor: "Vanilla", value: "foo") {
+                frosting
+                flavor
+            }
+        }
+        """
+    )
+    assert result.data == {"cake": {"frosting": "Vanilla", "flavor": "Chocolate"}}
+
+
+def test_name_first_directive_value():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def greeting(self) -> str:
+            return "Hi"
+
+    @strawberry.directive(locations=[DirectiveLocation.FIELD])
+    def personalize_greeting(name: str, v: DirectiveValue[str]):
+        assert v == "Hi"
+        return f"{v} {name}"
+
+    schema = strawberry.Schema(Query, directives=[personalize_greeting])
+    result = schema.execute_sync('{ greeting @personalizeGreeting(name: "Bar")}')
+
+    assert result.data is not None
+    assert not result.errors
+    assert result.data["greeting"] == "Hi Bar"
+
+
+def test_named_based_directive_value_is_deprecated():
+
+    with pytest.deprecated_call(match=r"Argument name-based matching of 'value'"):
+
+        @strawberry.type
+        class Query:
+            hello: str = "hello"
+
+        @strawberry.directive(locations=[DirectiveLocation.FIELD])
+        def deprecated_value(value):
+            ...
+
+        strawberry.Schema(query=Query, directives=[deprecated_value])

--- a/tests/schema/test_directives.py
+++ b/tests/schema/test_directives.py
@@ -409,12 +409,16 @@ def info_directive_schema() -> strawberry.Schema:
         def greetingTemplate(self, locale: Locale = Locale.EN) -> str:
             return greetings[locale]
 
+    field = Query._type_definition.fields[0]  # type: ignore
+
     @strawberry.directive(
         locations=[DirectiveLocation.FIELD],
         description="Interpolate string on the server from context data",
     )
     def interpolate(value: str, info: Info):
         try:
+            assert isinstance(info, Info)
+            assert info._field is field
             return value.format(**info.context["userdata"])
         except KeyError:
             return value

--- a/tests/schema/test_directives.py
+++ b/tests/schema/test_directives.py
@@ -543,12 +543,12 @@ def test_name_first_directive_value():
             return "Hi"
 
     @strawberry.directive(locations=[DirectiveLocation.FIELD])
-    def personalize_greeting(name: str, v: DirectiveValue[str]):
+    def personalize_greeting(value: str, v: DirectiveValue[str]):
         assert v == "Hi"
-        return f"{v} {name}"
+        return f"{v} {value}"
 
     schema = strawberry.Schema(Query, directives=[personalize_greeting])
-    result = schema.execute_sync('{ greeting @personalizeGreeting(name: "Bar")}')
+    result = schema.execute_sync('{ greeting @personalizeGreeting(value: "Bar")}')
 
     assert result.data is not None
     assert not result.errors

--- a/tests/schema/test_resolvers.py
+++ b/tests/schema/test_resolvers.py
@@ -1,10 +1,11 @@
 # type: ignore
 import typing
-from typing import List, Type, TypeVar
+from typing import Any, List, Type, TypeVar
 
 import pytest
 
 import strawberry
+from strawberry.types.info import Info
 
 
 def test_resolver():
@@ -173,10 +174,10 @@ def test_optional_info_and_root_params():
 
 
 def test_only_info_function_resolvers():
-    def function_resolver(info) -> str:
+    def function_resolver(info: Info) -> str:
         return f"I'm a function resolver for {info.field_name}"
 
-    def function_resolver_with_params(info, x: str) -> str:
+    def function_resolver_with_params(info: Info, x: str) -> str:
         return f"I'm {x} for {info.field_name}"
 
     @strawberry.type
@@ -378,3 +379,53 @@ def test_typed_resolver_factory():
 
     assert not result.errors
     assert result.data == {"aType": {"some": 1}}
+
+
+def name_based_info(info, icon: str) -> str:
+    return f"I'm a resolver for {icon} {info.field_name}"
+
+
+def type_based_info(info: Info, icon: str) -> str:
+    return f"I'm a resolver for {icon} {info.field_name}"
+
+
+def generic_type_based_info(icon: str, info: Info[Any, Any]) -> str:
+    return f"I'm a resolver for {icon} {info.field_name}"
+
+
+def arbitrarily_named_info(icon: str, info_argument: Info) -> str:
+    return f"I'm a resolver for {icon} {info_argument.field_name}"
+
+
+@pytest.mark.parametrize(
+    "resolver",
+    (
+        pytest.param(name_based_info),
+        pytest.param(type_based_info),
+        pytest.param(generic_type_based_info),
+        pytest.param(arbitrarily_named_info),
+    ),
+)
+def test_info_argument(resolver):
+    @strawberry.type
+    class ResolverGreeting:
+        hello: str = strawberry.field(resolver=resolver)
+
+    schema = strawberry.Schema(query=ResolverGreeting)
+    result = schema.execute_sync('{ hello(icon: "🍓") }')
+
+    assert not result.errors
+    assert result.data["hello"] == "I'm a resolver for 🍓 hello"
+
+
+def test_name_based_info_is_deprecated():
+
+    with pytest.deprecated_call(match=r"Argument name-based matching of 'info'"):
+
+        @strawberry.type
+        class Query:
+            @strawberry.field
+            def foo(info: Any) -> str:
+                ...
+
+        strawberry.Schema(query=Query)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This PR Closes [#1666] by improving the injection of reserved
arguments by providing an opt-in functionality to match reserved
arguments by type-annotations. The functionality is added to
`StrawberryResolver`s which is then reused in `StrawberryDirectives`s
via a new `StrawberryDirectiveResolver` class. Additionally, A new
`DirectiveValue` `Annotated` type is defined to allow more flexibility
when defining directive resolvers. To ensure backwards-compatibility, a
fallback to argument name-based matching for reserved parameters is used
for `info` and `value` arguments. Overally, the new `ReservedType`
specification allows arbitrary names for `info` and `value` arguments,
provided that they are annotated as `<my_info_name>: Info` and
`<my_value_name>: DirectiveValue[Any]` respectively.

The new injection functionality is enabled by a
`ReservedParameterSpecification` `Protocol` which is used to define
various types of reserved parameters. Each specification is responsible
for iterating over the `parameters` of the wrapped resolver to `find`
its targeted reserved parameter. This information is then stored in a
mapping of specification to reserved parameter. Later, this mapping is
used to determine which reserved keyword argument(s) to pass to the
resolver during execution.

Summary of Changes:
- Improve reserved argument injection for resolvers by providing an
  opt-in functionality to match reserved arguments by type-annotations.
- Re-use filtering logic of `StrawberryResolver` by defining a
  specialized `StrawberryDirectiveResolver` class
- Support passing `info` and `root` to a `StrawberryDirective`
- Deprecate use of bare `info` and `value` arguments to resolvers
- Allow definition of arbitrarily named keyword arguments to represent
  `info`, and `value` reserved arguments
- Modify @magicmark's failing test to check if a directive without value
  argument correctly recieves its arguments
- Add test to verify new reserved argument injection logic

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

* Issue #1666 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

[#1666]: https://github.com/strawberry-graphql/strawberry/issues/1666