### PR TITLE
Allow all types to `Schema(types=[...])`

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Allow all data types in `Schema(types=[...])`

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Optional, Sequence, Type, Union
 from graphql import (
     ExecutionContext as GraphQLExecutionContext,
     GraphQLNamedType,
+    GraphQLNonNull,
     GraphQLSchema,
     get_introspection_query,
     parse,
@@ -79,9 +80,13 @@ class Schema(BaseSchema):
 
         graphql_types = []
         for type_ in types:
-            graphql_type = self.schema_converter.from_type(type_)
-            if isinstance(graphql_type, GraphQLNamedType):
-                graphql_types.append(graphql_type)
+            graphql_type = self.schema_converter.from_maybe_optional(type_)
+            if isinstance(graphql_type, GraphQLNonNull):
+                graphql_type = graphql_type.of_type
+            assert isinstance(
+                graphql_type, GraphQLNamedType
+            ), f"{graphql_type} is not a named GraphQL Type"
+            graphql_types.append(graphql_type)
 
         self._schema = GraphQLSchema(
             query=query_type,

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, Optional, Sequence, Type, Union
 
 from graphql import (
     ExecutionContext as GraphQLExecutionContext,
+    GraphQLNamedType,
     GraphQLSchema,
     get_introspection_query,
     parse,
@@ -78,8 +79,9 @@ class Schema(BaseSchema):
 
         graphql_types = []
         for type_ in types:
-            graphql_type = self.schema_converter.from_object(type_._type_definition)
-            graphql_types.append(graphql_type)
+            graphql_type = self.schema_converter.from_type(type_)
+            if isinstance(graphql_type, GraphQLNamedType):
+                graphql_types.append(graphql_type)
 
         self._schema = GraphQLSchema(
             query=query_type,

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -83,9 +83,8 @@ class Schema(BaseSchema):
             graphql_type = self.schema_converter.from_maybe_optional(type_)
             if isinstance(graphql_type, GraphQLNonNull):
                 graphql_type = graphql_type.of_type
-            assert isinstance(
-                graphql_type, GraphQLNamedType
-            ), f"{graphql_type} is not a named GraphQL Type"
+            if not isinstance(graphql_type, GraphQLNamedType):
+                raise TypeError(f"{graphql_type} is not a named GraphQL Type")
             graphql_types.append(graphql_type)
 
         self._schema = GraphQLSchema(

--- a/tests/schema/test_basic.py
+++ b/tests/schema/test_basic.py
@@ -11,6 +11,7 @@ from strawberry.exceptions import (
     FieldWithResolverAndDefaultFactoryError,
     FieldWithResolverAndDefaultValueError,
 )
+from strawberry.scalars import Base64
 
 
 def test_raises_exception_with_unsupported_types():
@@ -493,3 +494,48 @@ def test_field_with_resolver_default_factory():
             @strawberry.field(default_factory=lambda: "Example C")
             def c(self) -> str:
                 return "I'm a resolver"
+
+
+def test_with_types():
+    # Ensures Schema(types=[...]) works with all data types
+    @strawberry.type
+    class Type:
+        foo: int
+
+    @strawberry.interface
+    class Interface:
+        foo: int
+
+    @strawberry.input
+    class Input:
+        foo: int
+
+    @strawberry.type
+    class Query:
+        foo: int
+
+    schema = strawberry.Schema(query=Query, types=[Type, Interface, Input, Base64])
+    expected = '''
+        """
+        Represents binary data as Base64-encoded strings, using the standard alphabet.
+        """
+        scalar Base64 @specifiedBy(url: "https://datatracker.ietf.org/doc/html/rfc4648.html#section-4")
+
+        input Input {
+          foo: Int!
+        }
+
+        interface Interface {
+          foo: Int!
+        }
+
+        type Query {
+          foo: Int!
+        }
+
+        type Type {
+          foo: Int!
+        }
+    '''  # noqa: E501
+
+    assert str(schema) == textwrap.dedent(expected).strip()

--- a/tests/schema/test_basic.py
+++ b/tests/schema/test_basic.py
@@ -13,6 +13,7 @@ from strawberry.exceptions import (
     FieldWithResolverAndDefaultValueError,
 )
 from strawberry.scalars import Base64
+from strawberry.type import StrawberryList
 
 
 def test_raises_exception_with_unsupported_types():
@@ -516,7 +517,7 @@ def test_with_types():
         foo: int
 
     schema = strawberry.Schema(
-        query=Query, types=[Type, Interface, Input, Base64, ID, str]
+        query=Query, types=[Type, Interface, Input, Base64, ID, str, int]
     )
     expected = '''
         """
@@ -542,3 +543,12 @@ def test_with_types():
     '''  # noqa: E501
 
     assert str(schema) == textwrap.dedent(expected).strip()
+
+
+def test_with_types_non_named():
+    @strawberry.type
+    class Query:
+        foo: int
+
+    with pytest.raises(AssertionError, match=r"\[Int!\] is not a named GraphQL Type"):
+        strawberry.Schema(query=Query, types=[StrawberryList(int)])

--- a/tests/schema/test_basic.py
+++ b/tests/schema/test_basic.py
@@ -550,5 +550,5 @@ def test_with_types_non_named():
     class Query:
         foo: int
 
-    with pytest.raises(AssertionError, match=r"\[Int!\] is not a named GraphQL Type"):
+    with pytest.raises(TypeError, match=r"\[Int!\] is not a named GraphQL Type"):
         strawberry.Schema(query=Query, types=[StrawberryList(int)])

--- a/tests/schema/test_basic.py
+++ b/tests/schema/test_basic.py
@@ -7,6 +7,7 @@ from typing import Optional
 import pytest
 
 import strawberry
+from strawberry import ID
 from strawberry.exceptions import (
     FieldWithResolverAndDefaultFactoryError,
     FieldWithResolverAndDefaultValueError,
@@ -514,7 +515,9 @@ def test_with_types():
     class Query:
         foo: int
 
-    schema = strawberry.Schema(query=Query, types=[Type, Interface, Input, Base64])
+    schema = strawberry.Schema(
+        query=Query, types=[Type, Interface, Input, Base64, ID, str]
+    )
     expected = '''
         """
         Represents binary data as Base64-encoded strings, using the standard alphabet.


### PR DESCRIPTION
## Description

I accidently found that Strawberry assumes all types specified in
Schema constructor are expected to be object types.

Because of this, setting `types=[InputType]` would cause the schema to contain `type InputType`
instead of `input InputType`, and everything crashed from there (Same for interfaces).

This change ensures all types are allowed :)

This is a minor fix and probably doesn't require a release

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
