### PR TITLE
Allow to deprecate enums values

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,13 @@
+Release type: minor
+
+Added support for deprecating Enum values with `deprecation_reason` while using `strawberry.enum_value` instead of string definition.
+
+```python
+@strawberry.enum
+class IceCreamFlavour(Enum):
+    VANILLA = strawberry.enum_value("vanilla")
+    STRAWBERRY = strawberry.enum_value(
+        "strawberry", deprecation_reason="We ran out"
+    )
+    CHOCOLATE = "chocolate"
+```

--- a/docs/types/enums.md
+++ b/docs/types/enums.md
@@ -126,6 +126,20 @@ type.
 
 </Note>
 
+You can also deprecate enum value. To do so you need more verbose syntax using
+`strawberry.enum_value` and `deprecation_reason`. You can mix and match string
+and verbose syntax.
+
+```python
+@strawberry.enum
+class IceCreamFlavour(Enum):
+    VANILLA = strawberry.enum_value("vanilla")
+    STRAWBERRY = strawberry.enum_value(
+        "strawberry", deprecation_reason="We ran out"
+    )
+    CHOCOLATE = "chocolate"
+```
+
 <AdditionalResources
   title="Enums"
   spec="https://spec.graphql.org/June2018/#sec-Enums"

--- a/strawberry/__init__.py
+++ b/strawberry/__init__.py
@@ -3,7 +3,7 @@ from .arguments import argument
 from .auto import auto
 from .custom_scalar import scalar
 from .directive import directive
-from .enum import enum
+from .enum import enum, enum_value
 from .field import field
 from .lazy_type import LazyType
 from .mutation import mutation, subscription
@@ -27,6 +27,7 @@ __all__ = [
     "directive",
     "schema_directive",
     "enum",
+    "enum_value",
     "federation",
     "field",
     "input",

--- a/strawberry/enum.py
+++ b/strawberry/enum.py
@@ -74,9 +74,8 @@ def _process_enum(
             deprecation_reason = item_value.deprecation_reason
             item_value = item_value.value
 
-        values.append(
-            EnumValue(item_name, item_value, deprecation_reason=deprecation_reason)
-        )
+        value = EnumValue(item_name, item_value, deprecation_reason=deprecation_reason)
+        values.append(value)
 
     cls._enum_definition = EnumDefinition(  # type: ignore
         wrapped_cls=cls,

--- a/strawberry/enum.py
+++ b/strawberry/enum.py
@@ -11,6 +11,7 @@ from .exceptions import ObjectIsNotAnEnumError
 class EnumValue:
     name: str
     value: Any
+    deprecation_reason: Optional[str] = None
 
 
 @dataclasses.dataclass
@@ -34,6 +35,21 @@ class EnumDefinition(StrawberryType):
         return False
 
 
+@dataclasses.dataclass
+class EnumValueDefinition:
+    value: Any
+    deprecation_reason: Optional[str] = None
+
+
+def enum_value(
+    value: Any, deprecation_reason: Optional[str] = None
+) -> EnumValueDefinition:
+    return EnumValueDefinition(
+        value=value,
+        deprecation_reason=deprecation_reason,
+    )
+
+
 EnumType = TypeVar("EnumType", bound=EnumMeta)
 
 
@@ -48,7 +64,19 @@ def _process_enum(
 
     description = description
 
-    values = [EnumValue(item.name, item.value) for item in cls]  # type: ignore
+    values = []
+    for item in cls:  # type: ignore
+        item_value = item.value
+        item_name = item.name
+        deprecation_reason = None
+
+        if isinstance(item_value, EnumValueDefinition):
+            deprecation_reason = item_value.deprecation_reason
+            item_value = item_value.value
+
+        values.append(
+            EnumValue(item_name, item_value, deprecation_reason=deprecation_reason)
+        )
 
     cls._enum_definition = EnumDefinition(  # type: ignore
         wrapped_cls=cls,

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -117,7 +117,10 @@ class GraphQLCoreConverter:
         return graphql_enum
 
     def from_enum_value(self, enum_value: EnumValue) -> GraphQLEnumValue:
-        return GraphQLEnumValue(enum_value.value)
+        return GraphQLEnumValue(
+            enum_value.value,
+            deprecation_reason=enum_value.deprecation_reason,
+        )
 
     def from_directive(self, directive: StrawberryDirective) -> GraphQLDirective:
         graphql_arguments = {}

--- a/tests/enums/test_enum.py
+++ b/tests/enums/test_enum.py
@@ -67,3 +67,27 @@ def test_raises_error_when_using_enum_with_a_not_enum_class():
         @strawberry.enum
         class NormalClass:
             hello = "world"
+
+
+def test_can_deprecate_enum_values():
+    @strawberry.enum
+    class IceCreamFlavour(Enum):
+        VANILLA = strawberry.enum_value("vanilla")
+        STRAWBERRY = strawberry.enum_value(
+            "strawberry", deprecation_reason="We ran out"
+        )
+        CHOCOLATE = "chocolate"
+
+    definition = IceCreamFlavour._enum_definition
+
+    assert definition.values[0].name == "VANILLA"
+    assert definition.values[0].value == "vanilla"
+    assert definition.values[0].deprecation_reason is None
+
+    assert definition.values[1].name == "STRAWBERRY"
+    assert definition.values[1].value == "strawberry"
+    assert definition.values[1].deprecation_reason == "We ran out"
+
+    assert definition.values[2].name == "CHOCOLATE"
+    assert definition.values[2].value == "chocolate"
+    assert definition.values[2].deprecation_reason is None

--- a/tests/mypy/test_enum.yml
+++ b/tests/mypy/test_enum.yml
@@ -140,15 +140,18 @@
 - case: test_enum_with_deprecation_reason
   main: |
     from enum import Enum
+
     import strawberry
+
     class Flavour(Enum):
         VANILLA = strawberry.enum_value("vanilla")
         STRAWBERRY = strawberry.enum_value(
             "strawberry", deprecation_reason="We ran out"
         )
         CHOCOLATE = "chocolate"
+
     reveal_type(strawberry.enum(name="IceCreamFlavour")(Flavour))
     reveal_type(strawberry.enum(name="IceCreamFlavour")(Flavour).STRAWBERRY)
   out: |
-    main:9: note: Revealed type is "def (value: builtins.object) -> main.Flavour*"
-    main:10: note: Revealed type is "Literal[main.Flavour.STRAWBERRY]?"
+    main:12: note: Revealed type is "def (value: builtins.object) -> main.Flavour*"
+    main:13: note: Revealed type is "Literal[main.Flavour.STRAWBERRY]?"

--- a/tests/mypy/test_enum.yml
+++ b/tests/mypy/test_enum.yml
@@ -137,3 +137,18 @@
   out: |
     main:10: note: Revealed type is "def (value: builtins.object) -> main.Flavour*"
     main:11: note: Revealed type is "Literal[main.Flavour.VANILLA]?"
+- case: test_enum_with_deprecation_reason
+  main: |
+    from enum import Enum
+    import strawberry
+    class Flavour(Enum):
+        VANILLA = strawberry.enum_value("vanilla")
+        STRAWBERRY = strawberry.enum_value(
+            "strawberry", deprecation_reason="We ran out"
+        )
+        CHOCOLATE = "chocolate"
+    reveal_type(strawberry.enum(name="IceCreamFlavour")(Flavour))
+    reveal_type(strawberry.enum(name="IceCreamFlavour")(Flavour).STRAWBERRY)
+  out: |
+    main:9: note: Revealed type is "def (value: builtins.object) -> main.Flavour*"
+    main:10: note: Revealed type is "Literal[main.Flavour.STRAWBERRY]?"

--- a/tests/pyright/test_enum.py
+++ b/tests/pyright/test_enum.py
@@ -155,3 +155,40 @@ def test_enum_with_manual_decorator_and_name():
             column=13,
         ),
     ]
+
+
+CODE_WITH_DEPRECATION_REASON = """
+from enum import Enum
+import strawberry
+@strawberry.enum
+class IceCreamFlavour(Enum):
+    VANILLA = "vanilla"
+    STRAWBERRY = strawberry.enum_value(
+        "strawberry", deprecation_reason="We ran out"
+    )
+    CHOCOLATE = "chocolate"
+reveal_type(IceCreamFlavour)
+reveal_type(IceCreamFlavour.STRAWBERRY)
+"""
+
+
+def test_enum_deprecated():
+    results = run_pyright(CODE_WITH_DEPRECATION_REASON)
+
+    assert results == [
+        Result(
+            type="information",
+            message='Type of "IceCreamFlavour" is "Type[IceCreamFlavour]"',
+            line=11,
+            column=13,
+        ),
+        Result(
+            type="information",
+            message=(
+                'Type of "IceCreamFlavour.STRAWBERRY" is '
+                '"Literal[IceCreamFlavour.STRAWBERRY]"'
+            ),
+            line=12,
+            column=13,
+        ),
+    ]

--- a/tests/pyright/test_enum.py
+++ b/tests/pyright/test_enum.py
@@ -159,7 +159,9 @@ def test_enum_with_manual_decorator_and_name():
 
 CODE_WITH_DEPRECATION_REASON = """
 from enum import Enum
+
 import strawberry
+
 @strawberry.enum
 class IceCreamFlavour(Enum):
     VANILLA = "vanilla"
@@ -167,6 +169,7 @@ class IceCreamFlavour(Enum):
         "strawberry", deprecation_reason="We ran out"
     )
     CHOCOLATE = "chocolate"
+
 reveal_type(IceCreamFlavour)
 reveal_type(IceCreamFlavour.STRAWBERRY)
 """
@@ -179,7 +182,7 @@ def test_enum_deprecated():
         Result(
             type="information",
             message='Type of "IceCreamFlavour" is "Type[IceCreamFlavour]"',
-            line=11,
+            line=14,
             column=13,
         ),
         Result(
@@ -188,7 +191,7 @@ def test_enum_deprecated():
                 'Type of "IceCreamFlavour.STRAWBERRY" is '
                 '"Literal[IceCreamFlavour.STRAWBERRY]"'
             ),
-            line=12,
+            line=15,
             column=13,
         ),
     ]

--- a/tests/schema/test_enum.py
+++ b/tests/schema/test_enum.py
@@ -355,8 +355,9 @@ def test_enum_deprecated_value():
 
     query = """
     {
-        __type(name:"IceCreamFlavour") {
-            enumValues {
+        __type(name: "IceCreamFlavour") {
+            enumValues(includeDeprecated: true) {
+                name
                 isDeprecated
                 deprecationReason
             }
@@ -367,5 +368,9 @@ def test_enum_deprecated_value():
     result = schema.execute_sync(query)
 
     assert not result.errors
-    # deprecated value dissapears
-    assert len(result.data["__type"]["enumValues"]) == 2
+    assert result.data
+    assert result.data["__type"]["enumValues"] == [
+        {"deprecationReason": None, "isDeprecated": False, "name": "VANILLA"},
+        {"deprecationReason": "We ran out", "isDeprecated": True, "name": "STRAWBERRY"},
+        {"deprecationReason": None, "isDeprecated": False, "name": "CHOCOLATE"},
+    ]

--- a/tests/schema/test_enum.py
+++ b/tests/schema/test_enum.py
@@ -349,7 +349,7 @@ def test_enum_deprecated_value():
     class Query:
         @strawberry.field
         def best_flavour(self) -> IceCreamFlavour:
-            return "strawberry"  # type: ignore
+            return IceCreamFlavour.STRAWBERRY
 
     schema = strawberry.Schema(query=Query)
 

--- a/tests/schema/test_enum.py
+++ b/tests/schema/test_enum.py
@@ -343,7 +343,7 @@ def test_enum_deprecated_value():
         STRAWBERRY = strawberry.enum_value(
             "strawberry", deprecation_reason="We ran out"
         )
-        CHOCOLATE = "chocolate"
+        CHOCOLATE = strawberry.enum_value("chocolate")
 
     @strawberry.type
     class Query:
@@ -367,8 +367,5 @@ def test_enum_deprecated_value():
     result = schema.execute_sync(query)
 
     assert not result.errors
-    assert result.data["__type"]["enumValues"] == [
-        {"isDeprecated": False, "deprecationReason": None},
-        {"isDeprecated": True, "deprecationReason": "We ran out"},
-        {"isDeprecated": False, "deprecationReason": None},
-    ]
+    # deprecated value dissapears
+    assert len(result.data["__type"]["enumValues"]) == 2


### PR DESCRIPTION
## Description

We should be able to deprecate enum fields :) as per spec, GraphQL allows to deprecate enum values by passing a directive: https://spec.graphql.org/June2018/#sec-Enums

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

* Closes https://github.com/strawberry-graphql/strawberry/issues/537

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
