### PR TITLE
Add is_auto utility

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+Release type: minor
+
+Add `is_auto` utility for checking if a type is `strawberry.auto`,
+considering the possibility of it being a `StrawberryAnnotation` or
+even being used inside `Annotated`.

--- a/strawberry/auto.py
+++ b/strawberry/auto.py
@@ -1,6 +1,8 @@
-from typing import Any, ClassVar, Optional
+from typing import Any, ClassVar, Optional, Union, cast
 
 from typing_extensions import Annotated, Final, get_args, get_origin
+
+from strawberry.type import StrawberryType
 
 from .annotation import StrawberryAnnotation
 
@@ -25,14 +27,15 @@ class StrawberryAuto:
 auto: Final = Annotated[Any, StrawberryAuto()]
 
 
-def is_auto(type_):
+def is_auto(type_: Union[StrawberryAnnotation, StrawberryType, type]):
     if isinstance(type_, StrawberryAnnotation):
-        annotation = type_.annotation
-        if isinstance(annotation, str):
+        resolved = type_.annotation
+        if isinstance(resolved, str):
             namespace = type_.namespace
-            type_ = namespace and namespace.get(annotation)
-        else:
-            type_ = annotation
+            resolved = namespace and namespace.get(resolved)
+
+        if resolved is not None:
+            type_ = cast(type, resolved)
 
     if type_ is auto:
         return True

--- a/strawberry/auto.py
+++ b/strawberry/auto.py
@@ -1,6 +1,8 @@
 from typing import Any, ClassVar, Optional
 
-from typing_extensions import Annotated, Final
+from typing_extensions import Annotated, Final, get_args, get_origin
+
+from .annotation import StrawberryAnnotation
 
 
 class StrawberryAuto:
@@ -21,3 +23,24 @@ class StrawberryAuto:
 
 
 auto: Final = Annotated[Any, StrawberryAuto()]
+
+
+def is_auto(type_):
+    if isinstance(type_, StrawberryAnnotation):
+        annotation = type_.annotation
+        if isinstance(annotation, str):
+            namespace = type_.namespace
+            type_ = namespace and namespace.get(annotation)
+        else:
+            type_ = annotation
+
+    if type_ is auto:
+        return True
+
+    # Support uses of Annotated[auto, something()]
+    if get_origin(type_) is Annotated:
+        args = get_args(type_)
+        if args[0] is Any:
+            return any(isinstance(arg, StrawberryAuto) for arg in args[1:])
+
+    return False

--- a/strawberry/auto.py
+++ b/strawberry/auto.py
@@ -1,4 +1,6 @@
-from typing import Any, ClassVar, Optional, Union, cast
+from __future__ import annotations
+
+from typing import Any, Optional, Union, cast
 
 from typing_extensions import Annotated, Final, get_args, get_origin
 
@@ -7,16 +9,58 @@ from strawberry.type import StrawberryType
 from .annotation import StrawberryAnnotation
 
 
-class StrawberryAuto:
-    _instance: ClassVar[Optional["StrawberryAuto"]] = None
+class StrawberryAutoMeta(type):
+    """Metaclass for StrawberryAuto.
 
-    def __new__(cls, *args, **kwargs):
-        if cls._instance is not None:
-            return cls._instance
+    This is used to make sure StrawberryAuto is a singleton and also to
+    override the behavior of `isinstance` so that it consider the following
+    cases:
 
-        cls._instance = super().__new__(cls, *args, **kwargs)
+        >> isinstance(StrawberryAuto(), StrawberryAuto)
+        True
+        >> isinstance(StrawberryAnnotation(StrawberryAuto()), StrawberryAuto)
+        True
+        >> isinstance(Annotated[StrawberryAuto(), object()), StrawberryAuto)
+        True
+
+    """
+
+    def __init__(self, *args, **kwargs):
+        self._instance: Optional[StrawberryAuto] = None
+        super().__init__(*args, **kwargs)
+
+    def __call__(cls, *args, **kwargs):
+        if cls._instance is None:
+            cls._instance = super().__call__(*args, **kwargs)
+
         return cls._instance
 
+    def __instancecheck__(
+        self,
+        instance: Union[StrawberryAuto, StrawberryAnnotation, StrawberryType, type],
+    ):
+        if isinstance(instance, StrawberryAnnotation):
+            resolved = instance.annotation
+            if isinstance(resolved, str):
+                namespace = instance.namespace
+                resolved = namespace and namespace.get(resolved)
+
+            if resolved is not None:
+                instance = cast(type, resolved)
+
+        if instance is auto:
+            return True
+
+        # Support uses of Annotated[auto, something()]
+        if get_origin(instance) is Annotated:
+            args = get_args(instance)
+            if args[0] is Any:
+                return any(isinstance(arg, StrawberryAuto) for arg in args[1:])
+
+        return False
+
+
+class StrawberryAuto(metaclass=StrawberryAutoMeta):
     def __str__(self):
         return "auto"
 
@@ -25,25 +69,3 @@ class StrawberryAuto:
 
 
 auto: Final = Annotated[Any, StrawberryAuto()]
-
-
-def is_auto(type_: Union[StrawberryAnnotation, StrawberryType, type]):
-    if isinstance(type_, StrawberryAnnotation):
-        resolved = type_.annotation
-        if isinstance(resolved, str):
-            namespace = type_.namespace
-            resolved = namespace and namespace.get(resolved)
-
-        if resolved is not None:
-            type_ = cast(type, resolved)
-
-    if type_ is auto:
-        return True
-
-    # Support uses of Annotated[auto, something()]
-    if get_origin(type_) is Annotated:
-        args = get_args(type_)
-        if args[0] is Any:
-            return any(isinstance(arg, StrawberryAuto) for arg in args[1:])
-
-    return False

--- a/strawberry/experimental/pydantic/error_type.py
+++ b/strawberry/experimental/pydantic/error_type.py
@@ -5,7 +5,7 @@ from typing import Any, List, Optional, Sequence, Tuple, Type, cast
 from pydantic import BaseModel
 from pydantic.fields import ModelField
 
-from strawberry.auto import is_auto
+from strawberry.auto import StrawberryAuto
 from strawberry.experimental.pydantic.utils import (
     get_private_fields,
     get_strawberry_type_from_model,
@@ -68,7 +68,11 @@ def error_type(
 
         existing_fields = getattr(cls, "__annotations__", {})
         fields_set = fields_set.union(
-            set(name for name, typ in existing_fields.items() if is_auto(typ))
+            set(
+                name
+                for name, type_ in existing_fields.items()
+                if isinstance(type_, StrawberryAuto)
+            )
         )
 
         if all_fields:
@@ -105,7 +109,7 @@ def error_type(
                     field,
                 )
                 for field in extra_fields + private_fields
-                if not is_auto(field.type)
+                if not isinstance(field.type, StrawberryAuto)
             )
         )
 

--- a/strawberry/experimental/pydantic/error_type.py
+++ b/strawberry/experimental/pydantic/error_type.py
@@ -5,7 +5,7 @@ from typing import Any, List, Optional, Sequence, Tuple, Type, cast
 from pydantic import BaseModel
 from pydantic.fields import ModelField
 
-import strawberry
+from strawberry.auto import is_auto
 from strawberry.experimental.pydantic.utils import (
     get_private_fields,
     get_strawberry_type_from_model,
@@ -68,7 +68,7 @@ def error_type(
 
         existing_fields = getattr(cls, "__annotations__", {})
         fields_set = fields_set.union(
-            set(name for name, typ in existing_fields.items() if typ == strawberry.auto)
+            set(name for name, typ in existing_fields.items() if is_auto(typ))
         )
 
         if all_fields:
@@ -105,7 +105,7 @@ def error_type(
                     field,
                 )
                 for field in extra_fields + private_fields
-                if field.type != strawberry.auto
+                if not is_auto(field.type)
             )
         )
 

--- a/strawberry/experimental/pydantic/object_type.py
+++ b/strawberry/experimental/pydantic/object_type.py
@@ -24,7 +24,7 @@ from typing_extensions import Literal
 from graphql import GraphQLResolveInfo
 
 from strawberry.arguments import UNSET
-from strawberry.auto import is_auto
+from strawberry.auto import StrawberryAuto
 from strawberry.experimental.pydantic.conversion import (
     convert_pydantic_model_to_strawberry_class,
     convert_strawberry_class_to_pydantic_model,
@@ -175,7 +175,11 @@ def type(
         # these are the fields that were marked with strawberry.auto and
         # should copy their type from the pydantic model
         auto_fields_set = original_fields_set.union(
-            set(name for name, typ in existing_fields.items() if is_auto(typ))
+            set(
+                name
+                for name, type_ in existing_fields.items()
+                if isinstance(type_, StrawberryAuto)
+            )
         )
 
         if all_fields:

--- a/strawberry/experimental/pydantic/object_type.py
+++ b/strawberry/experimental/pydantic/object_type.py
@@ -23,8 +23,8 @@ from typing_extensions import Literal
 
 from graphql import GraphQLResolveInfo
 
-import strawberry
 from strawberry.arguments import UNSET
+from strawberry.auto import is_auto
 from strawberry.experimental.pydantic.conversion import (
     convert_pydantic_model_to_strawberry_class,
     convert_strawberry_class_to_pydantic_model,
@@ -175,7 +175,7 @@ def type(
         # these are the fields that were marked with strawberry.auto and
         # should copy their type from the pydantic model
         auto_fields_set = original_fields_set.union(
-            set(name for name, typ in existing_fields.items() if typ == strawberry.auto)
+            set(name for name, typ in existing_fields.items() if is_auto(typ))
         )
 
         if all_fields:

--- a/tests/test_auto.py
+++ b/tests/test_auto.py
@@ -3,7 +3,7 @@ from typing import Any, cast
 from typing_extensions import Annotated, get_args
 
 from strawberry.annotation import StrawberryAnnotation
-from strawberry.auto import StrawberryAuto, auto, is_auto
+from strawberry.auto import StrawberryAuto, auto
 
 
 def test_singleton():
@@ -18,19 +18,27 @@ def test_annotated():
     assert get_args(new_annotated) == (Any, StrawberryAuto(), some_obj)
 
 
-def test_is_auto():
-    assert is_auto(auto) is True
-    assert is_auto(object) is False
-    assert is_auto(cast(Any, object())) is False
+def test_str():
+    assert str(StrawberryAuto()) == "auto"
 
 
-def test_is_auto_with_annotation():
+def test_repr():
+    assert repr(StrawberryAuto()) == "<auto>"
+
+
+def test_isinstance():
+    assert isinstance(auto, StrawberryAuto)
+    assert not isinstance(object, StrawberryAuto)
+    assert not isinstance(cast(Any, object()), StrawberryAuto)
+
+
+def test_isinstance_with_annotation():
     annotation = StrawberryAnnotation(auto)
-    assert is_auto(annotation) is True
+    assert isinstance(annotation, StrawberryAuto)
     str_annotation = StrawberryAnnotation("auto", namespace=globals())
-    assert is_auto(str_annotation) is True
+    assert isinstance(str_annotation, StrawberryAuto)
 
 
-def test_is_auto_with_annotated():
-    assert is_auto(Annotated[auto, object()]) is True
-    assert is_auto(Annotated[str, auto]) is False
+def test_isinstance_with_annotated():
+    assert isinstance(Annotated[auto, object()], StrawberryAuto)
+    assert not isinstance(Annotated[str, auto], StrawberryAuto)

--- a/tests/test_auto.py
+++ b/tests/test_auto.py
@@ -2,7 +2,8 @@ from typing import Any
 
 from typing_extensions import Annotated, get_args
 
-from strawberry.auto import StrawberryAuto, auto
+from strawberry.annotation import StrawberryAnnotation
+from strawberry.auto import StrawberryAuto, auto, is_auto
 
 
 def test_singleton():
@@ -15,3 +16,21 @@ def test_annotated():
     some_obj = object()
     new_annotated = Annotated[auto, some_obj]
     assert get_args(new_annotated) == (Any, StrawberryAuto(), some_obj)
+
+
+def test_is_auto():
+    assert is_auto(auto) is True
+    assert is_auto(object) is False
+    assert is_auto(object()) is False
+
+
+def test_is_auto_with_annotation():
+    annotation = StrawberryAnnotation(auto)
+    assert is_auto(annotation) is True
+    str_annotation = StrawberryAnnotation("auto", namespace=globals())
+    assert is_auto(str_annotation) is True
+
+
+def test_is_auto_with_annotated():
+    assert is_auto(Annotated[auto, object()]) is True
+    assert is_auto(Annotated[str, auto]) is False

--- a/tests/test_auto.py
+++ b/tests/test_auto.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, cast
 
 from typing_extensions import Annotated, get_args
 
@@ -21,7 +21,7 @@ def test_annotated():
 def test_is_auto():
     assert is_auto(auto) is True
     assert is_auto(object) is False
-    assert is_auto(object()) is False
+    assert is_auto(cast(Any, object())) is False
 
 
 def test_is_auto_with_annotation():


### PR DESCRIPTION
Add `is_auto` utility for checking if a type is `strawberry.auto`,
considering the possibility of it being a `StrawberryAnnotation` or
even being used inside `Annotated`.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
