### PR TITLE
Issue #1731 - Allow `complete` messages for single-result-operations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
       - id: check-toml
 
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
         exclude: ^tests/codegen/snapshots/python/

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,4 @@
 Release type: patch
 
-This release fixes issue #1732, allowing a `graphql-transport-ws` client
+This release fixes issue #1731, allowing a `graphql-transport-ws` client
 to send `complete` messages for a *single result request*

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+This release fixes issue #1732, allowing a `graphql-transport-ws` client
+to send `complete` messages for a *single result request*

--- a/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
@@ -256,7 +256,10 @@ class BaseGraphQLTransportWSHandler(ABC):
         await self.send_message(CompleteMessage(id=operation_id))
 
     async def handle_complete(self, message: CompleteMessage) -> None:
-        await self.cleanup_operation(operation_id=message.id)
+        # Due to how complete messages can originate simultaneously from both sides, allow
+        # for complete messages for stale subscriptions to be ignored.
+        if message.id in self.subscriptions:
+            await self.cleanup_operation(operation_id=message.id)
 
     async def handle_invalid_message(self, error_message: str) -> None:
         await self.close(code=4400, reason=error_message)

--- a/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
@@ -256,8 +256,8 @@ class BaseGraphQLTransportWSHandler(ABC):
         await self.send_message(CompleteMessage(id=operation_id))
 
     async def handle_complete(self, message: CompleteMessage) -> None:
-        # Due to how complete messages can originate simultaneously from both sides, allow
-        # for complete messages for stale subscriptions to be ignored.
+        # Due to how complete messages can originate simultaneously from both sides,
+        # allow for complete messages for stale subscriptions to be ignored.
         if message.id in self.subscriptions:
             await self.cleanup_operation(operation_id=message.id)
 

--- a/tests/aiohttp/test_graphql_transport_ws.py
+++ b/tests/aiohttp/test_graphql_transport_ws.py
@@ -419,7 +419,7 @@ async def test_subscription_cancellation(aiohttp_client):
 
         response = await ws.receive_json()
         assert response == CompleteMessage(id="sub2").as_dict()
-        
+
         # Issue #1731
         # Check that a racing complete message to an already completed subscription
         # is ignored by server

--- a/tests/aiohttp/test_graphql_transport_ws.py
+++ b/tests/aiohttp/test_graphql_transport_ws.py
@@ -419,6 +419,11 @@ async def test_subscription_cancellation(aiohttp_client):
 
         response = await ws.receive_json()
         assert response == CompleteMessage(id="sub2").as_dict()
+        
+        # Issue #1731
+        # Check that a racing complete message to an already completed subscription
+        # is ignored by server
+        await ws.send_json(CompleteMessage(id="sub2").as_dict())
 
         await ws.send_json(CompleteMessage(id="sub1").as_dict())
 

--- a/tests/asgi/test_graphql_transport_ws.py
+++ b/tests/asgi/test_graphql_transport_ws.py
@@ -553,3 +553,61 @@ def test_single_result_operation_error(test_client):
         assert response["id"] == "sub1"
         assert len(response["payload"]) == 1
         assert response["payload"][0]["message"] == "You are not authorized"
+
+
+def test_single_result_complete(test_client):
+    """
+    #issue #1731 - Make sure we can `complete` a single result operation
+    """
+    with test_client.websocket_connect(
+        "/graphql", [GRAPHQL_TRANSPORT_WS_PROTOCOL]
+    ) as ws:
+        ws.send_json(ConnectionInitMessage().as_dict())
+
+        response = ws.receive_json()
+        assert response == ConnectionAckMessage().as_dict()
+
+        ws.send_json(
+            SubscribeMessage(
+                id="sub1",
+                payload=SubscribeMessagePayload(query="query { hello }"),
+            ).as_dict()
+        )
+        # complete it before getting a result
+        ws.send_json(CompleteMessage(id="sub1").as_dict())
+
+        # send another request, to make sure we get a response and
+        # the socket doesn't stay silent
+        ws.send_json(
+            SubscribeMessage(
+                id="sub2",
+                payload=SubscribeMessagePayload(query="query { hello }"),
+            ).as_dict()
+        )
+
+        # discard stale `next` or `complete` messages from sub1
+        # (in case our `complete` was too late)
+        response = ws.receive_json()
+        next1 = NextMessage(
+            id="sub1", payload={"data": {"hello": "Hello world"}}
+        ).as_dict()
+        comp1 = CompleteMessage(id="sub1").as_dict()
+        if response == next1:
+            response = ws.receive_json()
+        if response == comp1:
+            response = ws.receive_json()
+
+        assert (
+            response
+            == NextMessage(
+                id="sub2", payload={"data": {"hello": "Hello world"}}
+            ).as_dict()
+        )
+
+        # discard stale sub1 messages that may be arriving here
+        response = ws.receive_json()
+        if response == next1:
+            response = ws.receive_json()
+        if response == comp1:
+            response = ws.receive_json()
+        assert response == CompleteMessage(id="sub2").as_dict()

--- a/tests/asgi/test_graphql_transport_ws.py
+++ b/tests/asgi/test_graphql_transport_ws.py
@@ -332,6 +332,11 @@ def test_subscription_cancellation(test_client):
         response = ws.receive_json()
         assert response == CompleteMessage(id="sub2").as_dict()
 
+        # Issue #1731
+        # Check that a racing complete message to an already completed subscription
+        # is ignored by server
+        ws.send_json(CompleteMessage(id="sub2").as_dict())
+
         ws.send_json(CompleteMessage(id="sub1").as_dict())
 
         ws.send_json(

--- a/tests/asgi/test_graphql_transport_ws.py
+++ b/tests/asgi/test_graphql_transport_ws.py
@@ -332,11 +332,6 @@ def test_subscription_cancellation(test_client):
         response = ws.receive_json()
         assert response == CompleteMessage(id="sub2").as_dict()
 
-        # Issue #1731
-        # Check that a racing complete message to an already completed subscription
-        # is ignored by server
-        ws.send_json(CompleteMessage(id="sub2").as_dict())
-
         ws.send_json(CompleteMessage(id="sub1").as_dict())
 
         ws.send_json(
@@ -560,9 +555,66 @@ def test_single_result_operation_error(test_client):
         assert response["payload"][0]["message"] == "You are not authorized"
 
 
-def test_single_result_complete(test_client):
+def test_subscription_complete_race(test_client):
+    """Issue #1731
+    Test that sending a complete message after server
+    has already completed doesn't cause problems.
     """
-    #issue #1731 - Make sure we can `complete` a single result operation
+    with test_client.websocket_connect(
+        "/graphql", [GRAPHQL_TRANSPORT_WS_PROTOCOL]
+    ) as ws:
+        ws.send_json(ConnectionInitMessage().as_dict())
+
+        response = ws.receive_json()
+        assert response == ConnectionAckMessage().as_dict()
+
+        ws.send_json(
+            SubscribeMessage(
+                id="sub1",
+                payload=SubscribeMessagePayload(
+                    query="subscription { debug { numActiveResultHandlers } }",
+                ),
+            ).as_dict()
+        )
+
+        response = ws.receive_json()
+        assert (
+            response
+            == NextMessage(
+                id="sub1", payload={"data": {"debug": {"numActiveResultHandlers": 1}}}
+            ).as_dict()
+        )
+
+        response = ws.receive_json()
+        assert response == CompleteMessage(id="sub1").as_dict()
+
+        # Imagine that we didn'r receive the CompleteMessage from server and
+        # issue one of our own.  It should be ignored by the server.
+        # Verify this by making a new subscription
+        ws.send_json(CompleteMessage(id="sub1").as_dict())
+
+        # make a new subscription
+        ws.send_json(
+            SubscribeMessage(
+                id="sub2",
+                payload=SubscribeMessagePayload(
+                    query="subscription { debug { numActiveResultHandlers } }",
+                ),
+            ).as_dict()
+        )
+
+        response = ws.receive_json()
+        assert (
+            response
+            == NextMessage(
+                id="sub2", payload={"data": {"debug": {"numActiveResultHandlers": 1}}}
+            ).as_dict()
+        )
+
+
+def test_single_result_complete(test_client):
+    """Issue #1731
+    Make sure we can `complete` a single result operation
     """
     with test_client.websocket_connect(
         "/graphql", [GRAPHQL_TRANSPORT_WS_PROTOCOL]

--- a/tests/fastapi/test_graphql_transport_ws.py
+++ b/tests/fastapi/test_graphql_transport_ws.py
@@ -364,6 +364,11 @@ def test_subscription_cancellation(test_client):
         response = ws.receive_json()
         assert response == CompleteMessage(id="sub2").as_dict()
 
+        # Issue #1731
+        # Check that a racing complete message to an already completed subscription
+        # is ignored by server
+        ws.send_json(CompleteMessage(id="sub2").as_dict())
+
         ws.send_json(CompleteMessage(id="sub1").as_dict())
 
         ws.send_json(

--- a/tests/fastapi/test_graphql_transport_ws.py
+++ b/tests/fastapi/test_graphql_transport_ws.py
@@ -364,11 +364,6 @@ def test_subscription_cancellation(test_client):
         response = ws.receive_json()
         assert response == CompleteMessage(id="sub2").as_dict()
 
-        # Issue #1731
-        # Check that a racing complete message to an already completed subscription
-        # is ignored by server
-        ws.send_json(CompleteMessage(id="sub2").as_dict())
-
         ws.send_json(CompleteMessage(id="sub1").as_dict())
 
         ws.send_json(
@@ -596,9 +591,66 @@ def test_single_result_operation_error(test_client):
         assert response["payload"][0]["message"] == "You are not authorized"
 
 
-def test_single_result_complete(test_client):
+def test_subscription_complete_race(test_client):
+    """Issue #1731
+    Test that sending a complete message after server
+    has already completed doesn't cause problems.
     """
-    #issue #1731 - Make sure we can `complete` a single result operation
+    with test_client.websocket_connect(
+        "/graphql", [GRAPHQL_TRANSPORT_WS_PROTOCOL]
+    ) as ws:
+        ws.send_json(ConnectionInitMessage().as_dict())
+
+        response = ws.receive_json()
+        assert response == ConnectionAckMessage().as_dict()
+
+        ws.send_json(
+            SubscribeMessage(
+                id="sub1",
+                payload=SubscribeMessagePayload(
+                    query="subscription { debug { numActiveResultHandlers } }",
+                ),
+            ).as_dict()
+        )
+
+        response = ws.receive_json()
+        assert (
+            response
+            == NextMessage(
+                id="sub1", payload={"data": {"debug": {"numActiveResultHandlers": 1}}}
+            ).as_dict()
+        )
+
+        response = ws.receive_json()
+        assert response == CompleteMessage(id="sub1").as_dict()
+
+        # Imagine that we didn'r receive the CompleteMessage from server and
+        # issue one of our own.  It should be ignored by the server.
+        # Verify this by making a new subscription
+        ws.send_json(CompleteMessage(id="sub1").as_dict())
+
+        # make a new subscription
+        ws.send_json(
+            SubscribeMessage(
+                id="sub2",
+                payload=SubscribeMessagePayload(
+                    query="subscription { debug { numActiveResultHandlers } }",
+                ),
+            ).as_dict()
+        )
+
+        response = ws.receive_json()
+        assert (
+            response
+            == NextMessage(
+                id="sub2", payload={"data": {"debug": {"numActiveResultHandlers": 1}}}
+            ).as_dict()
+        )
+
+
+def test_single_result_complete(test_client):
+    """Issue #1731
+    Make sure we can `complete` a single result operation
     """
     with test_client.websocket_connect(
         "/graphql", [GRAPHQL_TRANSPORT_WS_PROTOCOL]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Single result operations must also accept `complete` messages. See #1731

## Description
Since single-result-operations don't put their IDs into the `self.subscriptions` dict, we need to ignore `complete`
messages that don't have an ID in that dict.
Previously such messages would cause a disconnect, because  `KeyError` was caught by ann exception handler intended
to catch malformed messages.

The PR doesn't attempt to actually cancel the single-request-operation.  Although the protocol specification says that a cancellation should be possible, a `complete` message may always come too late for that due to the non-synchronous bi-directional nature of the Websocket: The client may issue a `complete` message while a `next` and `complete` messages are in-flight from the server, and still receive them.  As such, a `complete` message can never guarantee that nothing more is ever received with that ID.

Actually cancelling the single request operation is an optional enhancement, for some future PR.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #1732

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
