### PR TITLE
Omit exceptions from DataLoader.load/load_many return type annotation

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+Release type: patch
+
+The return type annotation for `DataLoader.load` and `load_many` no longer
+includes any exceptions directly returned by the `load_fn`. The ability to
+handle errors by returning them as elements from `load_fn` is now documented too.

--- a/docs/guides/dataloaders.md
+++ b/docs/guides/dataloaders.md
@@ -109,13 +109,13 @@ async def load_users(keys: List[int]) -> List[Union[User, ValueError]]:
 loader = DataLoader(load_fn=load_users)
 ```
 
-For this loader, a uses like `await loader.load(1)` will return `User(id=1)`, while
-`await loader.load(3)` will raise `ValueError("not found")`.
+For this loader, calls like `await loader.load(1)` will return `User(id=1)`,
+while `await loader.load(3)` will raise `ValueError("not found")`.
 
 It's important that the `load_users` function returns exception values within
 the list for each incorrect key. A call with `keys == [1, 3]` returns
 `[User(id=1), ValueError("not found")]`, and doesn't raise the `ValueError`
-directly. If the `load_users` function raises an exception, even a call with an
+directly. If the `load_users` function raises an exception, even `load`s with an
 otherwise valid key, like `await loader.load(1)`, will raise that exception.
 
 ## Usage with GraphQL

--- a/docs/guides/dataloaders.md
+++ b/docs/guides/dataloaders.md
@@ -81,6 +81,43 @@ cases we can use the `load_many` method.
 [user_a, user_b, user_c] = await loader.load_many([1, 2, 3])
 ```
 
+### Errors
+
+An error associated with a particular key can be indicated by including an
+exception value in the corresponding position in the returned list. This
+exception will be thrown by the `load` call for that key. With the same `User`
+class from above:
+
+```python
+from typing import List, Union
+from strawberry.dataloader import DataLoader
+
+users_database = {
+    1: User(id=1),
+    2: User(id=2),
+}
+
+async def load_users(keys: List[int]) -> List[Union[User, ValueError]]:
+    def lookup(key: int) -> Union[User, ValueError]:
+       if user := users_database.get(key):
+           return user
+
+       return ValueError("not found")
+
+    return [lookup(key) for key in keys]
+
+loader = DataLoader(load_fn=load_users)
+```
+
+For this loader, a uses like `await loader.load(1)` will return `User(id=1)`, while
+`await loader.load(3)` will raise `ValueError("not found")`.
+
+It's important that the `load_users` function returns exception values within
+the list for each incorrect key. A call with `keys == [1, 3]` returns
+`[User(id=1), ValueError("not found")]`, and doesn't raise the `ValueError`
+directly. If the `load_users` function raises an exception, even a call with an
+otherwise valid key, like `await loader.load(1)`, will raise that exception.
+
 ## Usage with GraphQL
 
 Let's see an example of how you can use DataLoaders with GraphQL:

--- a/strawberry/dataloader.py
+++ b/strawberry/dataloader.py
@@ -52,7 +52,7 @@ class DataLoader(Generic[K, T]):
 
     @overload
     def __init__(
-        self: "DataLoader[K, T]",
+        self,
         # any BaseException is rethrown in 'load', so should be excluded from the T type
         load_fn: Callable[[List[K]], Awaitable[Sequence[Union[T, BaseException]]]],
         max_batch_size: Optional[int] = None,

--- a/tests/mypy/test_dataloaders.yml
+++ b/tests/mypy/test_dataloaders.yml
@@ -26,7 +26,7 @@
     async def load(keys: List[int]) -> List[str]:
         return [str(k) for k in keys]
 
-    loader = DataLoader[int, str](load)
+    loader = DataLoader(load)
 
     reveal_type(loader)
 
@@ -37,3 +37,45 @@
   out: |
     main:10: note: Revealed type is "strawberry.dataloader.DataLoader[builtins.int*, builtins.str*]"
     main:15: note: Revealed type is "builtins.str*"
+
+- case: test_dataloader_exception
+  main: |
+    from typing import List, Union
+
+    from strawberry.dataloader import DataLoader
+
+    async def load(keys: List[int]) -> List[Union[str, ValueError, TypeError]]:
+        return [ValueError("x") for k in keys]
+
+    loader = DataLoader(load)
+
+    reveal_type(loader)
+
+    async def run() -> None:
+      user = await loader.load(1)
+
+      reveal_type(user)
+  out: |
+    main:10: note: Revealed type is "strawberry.dataloader.DataLoader[builtins.int*, builtins.str*]"
+    main:15: note: Revealed type is "builtins.str*"
+
+- case: test_dataloader_optional
+  main: |
+    from typing import List, Optional
+
+    from strawberry.dataloader import DataLoader
+
+    async def load(keys: List[int]) -> List[Optional[str]]:
+        return [None for k in keys]
+
+    loader = DataLoader(load)
+
+    reveal_type(loader)
+
+    async def run() -> None:
+      user = await loader.load(1)
+
+      reveal_type(user)
+  out: |
+    main:10: note: Revealed type is "strawberry.dataloader.DataLoader[builtins.int*, Union[builtins.str, None]]"
+    main:15: note: Revealed type is "Union[builtins.str, None]"


### PR DESCRIPTION

## Description

Per the proposal in #1736, this adjusts the type hints on `DataLoader.__init__` so that the `T` type variable never includes exceptions that are re-raised by `load`/`load_many`. In particular, when the `load_fn` is explicitly annotated to return a type like `list[Union[SomeModel, ValueError]]`, the type variable is inferred to `T  = SomeModel`, and thus the return value of `load` is `SomeModel`, as desired.

This requires some somewhat subtle `@overload`s to ensure that using a completely unannotated `load_fn` is handled appropriately. Fortunately there's an existing mypy test covering that, and this PR adds mypy tests for `Union[]`s with exception, and without (`Optional`).

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #1736

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
