### PR TITLE
More codegen fixes

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+Release type: patch
+
+This release fixes a couple of more issues with codegen:
+
+1. Adds support for boolean values in input fields
+2. Changes how we unwrap types in order to add full support for LazyTypes, Optionals and Lists

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,3 +4,4 @@ This release fixes a couple of more issues with codegen:
 
 1. Adds support for boolean values in input fields
 2. Changes how we unwrap types in order to add full support for LazyTypes, Optionals and Lists
+3. Improve also how we generate types for unions, now we don't generate a Union type if the selection is for only one type

--- a/strawberry/codegen/plugins/print_operation.py
+++ b/strawberry/codegen/plugins/print_operation.py
@@ -5,6 +5,7 @@ from strawberry.codegen import CodegenFile, QueryCodegenPlugin
 from strawberry.codegen.types import (
     GraphQLArgument,
     GraphQLArgumentValue,
+    GraphQLBoolValue,
     GraphQLDirective,
     GraphQLEnumValue,
     GraphQLFieldSelection,
@@ -80,6 +81,9 @@ class PrintOperationPlugin(QueryCodegenPlugin):
 
         if isinstance(value, GraphQLEnumValue):
             return value.name
+
+        if isinstance(value, GraphQLBoolValue):
+            return str(value.value).lower()
 
         raise ValueError(f"not supported: {type(value)}")  # pragma: no cover
 

--- a/strawberry/codegen/query_codegen.py
+++ b/strawberry/codegen/query_codegen.py
@@ -8,6 +8,7 @@ from typing_extensions import Literal, Protocol
 
 from graphql import (
     ArgumentNode,
+    BooleanValueNode,
     DirectiveNode,
     DocumentNode,
     EnumValueNode,
@@ -51,6 +52,7 @@ from .exceptions import (
 from .types import (
     GraphQLArgument,
     GraphQLArgumentValue,
+    GraphQLBoolValue,
     GraphQLDirective,
     GraphQLEnum,
     GraphQLEnumValue,
@@ -216,6 +218,9 @@ class QueryCodegen:
 
         if isinstance(value, EnumValueNode):
             return GraphQLEnumValue(value.value)
+
+        if isinstance(value, BooleanValueNode):
+            return GraphQLBoolValue(value.value)
 
         raise ValueError(f"Unsupported type: {type(value)}")  # pragma: no cover
 

--- a/strawberry/codegen/query_codegen.py
+++ b/strawberry/codegen/query_codegen.py
@@ -448,30 +448,21 @@ class QueryCodegen:
         assert selected_field
 
         selected_field_type, wrapper = self._unwrap_type(selected_field.type)
+        name = capitalize_first(to_camel_case(selection.name.value))
+        class_name = f"{class_name}{(name)}"
 
-        print(wrapper)
+        field_type: GraphQLType
 
         if isinstance(selected_field_type, StrawberryUnion):
-            # TODO: remove duplication
-            name = capitalize_first(to_camel_case(selection.name.value))
-            class_name = f"{class_name}{name}"
-
-            sub_types = self._collect_types_using_fragments(
+            field_type = self._collect_types_with_inline_fragments(
                 selection, parent_type, class_name
             )
-
-            union = GraphQLUnion(class_name, sub_types)
-
-            self._collect_type(union)
-
-            return GraphQLField(selection.name.value, union)
+            return GraphQLField(selected_field.name, field_type)
 
         parent_type = cast(
             TypeDefinition, selected_field_type._type_definition  # type: ignore
         )
 
-        name = capitalize_first(to_camel_case(selection.name.value))
-        class_name = f"{class_name}{(name)}"
         field_type = self._collect_types(selection, parent_type, class_name)
 
         if wrapper:

--- a/strawberry/codegen/query_codegen.py
+++ b/strawberry/codegen/query_codegen.py
@@ -414,7 +414,9 @@ class QueryCodegen:
 
         return GraphQLField(field.name, field_type)
 
-    def _unwrap_type(self, type_: Union[type, StrawberryType]) -> StrawberryType:
+    def _unwrap_type(
+        self, type_: Union[type, StrawberryType]
+    ) -> Union[type, StrawberryType]:
         if isinstance(type_, StrawberryOptional):
             return self._unwrap_type(type_.of_type)
 

--- a/strawberry/codegen/types.py
+++ b/strawberry/codegen/types.py
@@ -90,6 +90,11 @@ class GraphQLEnumValue:
 
 
 @dataclass
+class GraphQLBoolValue:
+    value: bool
+
+
+@dataclass
 class GraphQLListValue:
     values: List[GraphQLArgumentValue]
 
@@ -105,6 +110,7 @@ GraphQLArgumentValue = Union[
     GraphQLVariableReference,
     GraphQLListValue,
     GraphQLEnumValue,
+    GraphQLBoolValue,
 ]
 
 

--- a/tests/codegen/queries/union_with_one_type.graphql
+++ b/tests/codegen/queries/union_with_one_type.graphql
@@ -1,0 +1,7 @@
+query OperationName {
+  union {
+    ... on Animal {
+      age
+    }
+  }
+}

--- a/tests/codegen/queries/with_directives.graphql
+++ b/tests/codegen/queries/with_directives.graphql
@@ -1,4 +1,4 @@
-query OperationName @owner(name: "Patrick", age: 30, items: [1, 2, 3], enum: NAME) {
+query OperationName @owner(name: "Patrick", age: 30, items: [1, 2, 3], enum: NAME, bool: true) {
   person {
     name @root
   }

--- a/tests/codegen/snapshots/python/union_with_one_type.py
+++ b/tests/codegen/snapshots/python/union_with_one_type.py
@@ -1,0 +1,5 @@
+class OperationNameResultUnionAnimal:
+    age: int
+
+class OperationNameResult:
+    union: OperationNameResultUnionAnimal

--- a/tests/codegen/snapshots/typescript/union_with_one_type.ts
+++ b/tests/codegen/snapshots/typescript/union_with_one_type.ts
@@ -1,0 +1,7 @@
+type OperationNameResultUnionAnimal = {
+    age: number
+}
+
+type OperationNameResult = {
+    union: OperationNameResultUnionAnimal
+}


### PR DESCRIPTION
This PR fixes:

- Improve how we unwrap types, now it is recursive so we don't have issues with Optional LazyTypes and so on 
- Add support for booleans
- Improve also how we generate types for unions, now we don't generate them if only one type is selected
