### PR TITLE
Copy field deprecation, permission_classes, and directives in pydantic

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,21 @@
+Release type: patch
+
+Fix an issue where there was no clean way to mark a Pydantic field as deprecated, add permission classes, or add directives. Now you can use the short field syntax to do all three.
+
+```python
+import pydantic
+import strawberry
+
+class MyModel(pydantic.BaseModel):
+    age: int
+    name: str
+
+@strawberry.experimental.pydantic.type(MyModel)
+class MyType:
+    age: strawberry.auto
+    name: strawberry.auto = strawberry.field(
+        deprecation_reason="Because",
+        permission_classes=[MyPermission],
+        directives=[MyDirective],
+    )
+```

--- a/strawberry/experimental/pydantic/object_type.py
+++ b/strawberry/experimental/pydantic/object_type.py
@@ -110,6 +110,7 @@ def _build_dataclass_creation_fields(
         strawberry_field = existing_fields[field.name]
     else:
         # otherwise we build an appropriate strawberry field that resolves it
+        existing_field = existing_fields.get(field.name)
         strawberry_field = StrawberryField(
             python_name=field.name,
             graphql_name=field.alias
@@ -120,6 +121,13 @@ def _build_dataclass_creation_fields(
             default_factory=get_default_factory_for_field(field),
             type_annotation=type_annotation,
             description=field.field_info.description,
+            deprecation_reason=existing_field.deprecation_reason
+            if existing_field
+            else None,
+            permission_classes=existing_field.permission_classes
+            if existing_field
+            else (),
+            directives=existing_field.directives if existing_field else (),
         )
 
     return DataclassCreationFields(

--- a/strawberry/experimental/pydantic/object_type.py
+++ b/strawberry/experimental/pydantic/object_type.py
@@ -126,7 +126,7 @@ def _build_dataclass_creation_fields(
             else None,
             permission_classes=existing_field.permission_classes
             if existing_field
-            else (),
+            else [],
             directives=existing_field.directives if existing_field else (),
         )
 

--- a/strawberry/experimental/pydantic/object_type.py
+++ b/strawberry/experimental/pydantic/object_type.py
@@ -121,12 +121,12 @@ def _build_dataclass_creation_fields(
             default_factory=get_default_factory_for_field(field),
             type_annotation=type_annotation,
             description=field.field_info.description,
-            deprecation_reason=existing_field.deprecation_reason
-            if existing_field
-            else None,
-            permission_classes=existing_field.permission_classes
-            if existing_field
-            else [],
+            deprecation_reason=(
+                existing_field.deprecation_reason if existing_field else None
+            ),
+            permission_classes=(
+                existing_field.permission_classes if existing_field else []
+            ),
             directives=existing_field.directives if existing_field else (),
         )
 

--- a/tests/experimental/pydantic/test_basic.py
+++ b/tests/experimental/pydantic/test_basic.py
@@ -1,6 +1,6 @@
 import dataclasses
 from enum import Enum
-from typing import List, Optional, Union
+from typing import Any, List, Optional, Union
 
 import pytest
 
@@ -9,6 +9,7 @@ import pydantic
 import strawberry
 from strawberry.enum import EnumDefinition
 from strawberry.experimental.pydantic.exceptions import MissingFieldsListError
+from strawberry.schema_directive import Location
 from strawberry.type import StrawberryList, StrawberryOptional
 from strawberry.types.types import TypeDefinition
 from strawberry.union import StrawberryUnion
@@ -699,5 +700,98 @@ def test_type_with_aliased_pydantic_field_changed_type():
     assert field1.graphql_name == "age"
 
     assert field2.python_name == "password"
+    assert isinstance(field2.type, StrawberryOptional)
+    assert field2.type.of_type is str
+
+
+def test_deprecated_fields():
+    class User(pydantic.BaseModel):
+        age: int
+        password: Optional[str]
+        other: float
+
+    @strawberry.experimental.pydantic.type(User)
+    class UserType:
+        age: strawberry.auto = strawberry.field(deprecation_reason="Because")
+        password: strawberry.auto
+
+    definition: TypeDefinition = UserType._type_definition
+    assert definition.name == "UserType"
+
+    [field1, field2] = definition.fields
+
+    assert field1.python_name == "age"
+    assert field1.graphql_name is None
+    assert field1.type is int
+    assert field1.deprecation_reason == "Because"
+
+    assert field2.python_name == "password"
+    assert field2.graphql_name is None
+    assert isinstance(field2.type, StrawberryOptional)
+    assert field2.type.of_type is str
+
+
+def test_permission_classes():
+    class IsAuthenticated(strawberry.BasePermission):
+        message = "User is not authenticated"
+
+        def has_permission(
+            self, source: Any, info: strawberry.types.Info, **kwargs
+        ) -> bool:
+            return False
+
+    class User(pydantic.BaseModel):
+        age: int
+        password: Optional[str]
+        other: float
+
+    @strawberry.experimental.pydantic.type(User)
+    class UserType:
+        age: strawberry.auto = strawberry.field(permission_classes=[IsAuthenticated])
+        password: strawberry.auto
+
+    definition: TypeDefinition = UserType._type_definition
+    assert definition.name == "UserType"
+
+    [field1, field2] = definition.fields
+
+    assert field1.python_name == "age"
+    assert field1.graphql_name is None
+    assert field1.type is int
+    assert field1.permission_classes == [IsAuthenticated]
+
+    assert field2.python_name == "password"
+    assert field2.graphql_name is None
+    assert isinstance(field2.type, StrawberryOptional)
+    assert field2.type.of_type is str
+
+
+def test_field_directives():
+    @strawberry.schema_directive(locations=[Location.FIELD_DEFINITION])
+    class Sensitive:
+        reason: str
+
+    class User(pydantic.BaseModel):
+        age: int
+        password: Optional[str]
+        other: float
+
+    @strawberry.experimental.pydantic.type(User)
+    class UserType:
+        age: strawberry.auto = strawberry.field(directives=[Sensitive(reason="GDPR")])
+        password: strawberry.auto
+
+    definition: TypeDefinition = UserType._type_definition
+    assert definition.name == "UserType"
+
+    [field1, field2] = definition.fields
+
+    assert field1.python_name == "age"
+    assert field1.graphql_name is None
+    assert field1.type is int
+    assert field1.directives == [Sensitive(reason="GDPR")]
+
+    assert field2.python_name == "password"
+    assert field2.graphql_name is None
     assert isinstance(field2.type, StrawberryOptional)
     assert field2.type.of_type is str


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

Basically we weren't copying all of the possible field arguments over if you used the short field syntax, because we were checking for base_resolver. Now we copy over the metadata from the field definition into the generated type.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* fixes #1747

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
