### PR TITLE
Add python_type on GraphQLEnum

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+This release adds a `python_type` to the codegen `GraphQLEnum` class
+to allow access to the original python enum when generating code

--- a/strawberry/codegen/query_codegen.py
+++ b/strawberry/codegen/query_codegen.py
@@ -595,6 +595,10 @@ class QueryCodegen:
         return graphql_scalar
 
     def _collect_enum(self, enum: EnumDefinition) -> GraphQLEnum:
-        graphql_enum = GraphQLEnum(enum.name, [value.name for value in enum.values])
+        graphql_enum = GraphQLEnum(
+            enum.name,
+            [value.name for value in enum.values],
+            python_type=enum.wrapped_cls,
+        )
         self._collect_type(graphql_enum)
         return graphql_enum

--- a/strawberry/codegen/types.py
+++ b/strawberry/codegen/types.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from enum import Enum
+from enum import EnumMeta
 from typing import List, Optional, Type, Union
 
 from typing_extensions import Literal
@@ -39,7 +39,7 @@ class GraphQLObjectType:
 class GraphQLEnum:
     name: str
     values: List[str]
-    python_type: Type[Enum]
+    python_type: EnumMeta
 
 
 @dataclass

--- a/strawberry/codegen/types.py
+++ b/strawberry/codegen/types.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import Enum
 from typing import List, Optional, Type, Union
 
 from typing_extensions import Literal
@@ -38,6 +39,7 @@ class GraphQLObjectType:
 class GraphQLEnum:
     name: str
     values: List[str]
+    python_type: Type[Enum]
 
 
 @dataclass


### PR DESCRIPTION
Another small improvement on the code, this PR adds a `python_type` on `GraphQLEnum`, so plugins generating code can access the original enum type :)