### PR TITLE
Move console plugin to end

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+Release type: patch
+
+This release moves the console plugin for the codegen command
+to be last one, allowing to run code before writing files to
+disk.

--- a/strawberry/cli/commands/codegen.py
+++ b/strawberry/cli/commands/codegen.py
@@ -149,7 +149,7 @@ def codegen(
     console_plugin = _load_plugin(cli_plugin) if cli_plugin else ConsolePlugin
 
     plugins = _load_plugins(selected_plugins)
-    plugins.insert(0, console_plugin(query, output_dir, plugins))
+    plugins.append(console_plugin(query, output_dir, plugins))
 
     code_generator = QueryCodegen(schema_symbol, plugins=plugins)
     code_generator.run(query.read_text())


### PR DESCRIPTION
Not sure why I decided to put the console plugin as the first plugin, especially now that we can specify a new one it doesn't make a lot of sense.

Having it at the end allows other plugins to edit the content of the files (for example running black) before they are written on disk.