### PR TITLE
Focus error handling when parsing `graphql_transport_ws` messages

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+Exeptions from handler functions in graphql_transport_ws are no longer
+incorrectly caught and classified as message parsing errors.

--- a/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
@@ -86,30 +86,35 @@ class BaseGraphQLTransportWSHandler(ABC):
             message_type = message.pop("type")
 
             if message_type == ConnectionInitMessage.type:
-                await self.handle_connection_init(ConnectionInitMessage(**message))
+                handler = self.handle_connection_init
+                handler_arg = ConnectionInitMessage(**message)
 
             elif message_type == PingMessage.type:
-                await self.handle_ping(PingMessage(**message))
+                handler = self.handle_ping
+                handler_arg = PingMessage(**message)
 
             elif message_type == PongMessage.type:
-                await self.handle_pong(PongMessage(**message))
+                handler = self.handle_pong
+                handler_arg = PongMessage(**message)
 
             elif message_type == SubscribeMessage.type:
+                handler = self.handle_subscribe
                 payload = SubscribeMessagePayload(**message.pop("payload"))
-                await self.handle_subscribe(
-                    SubscribeMessage(payload=payload, **message)
-                )
+                handler_arg = SubscribeMessage(payload=payload, **message)
 
             elif message_type == CompleteMessage.type:
-                await self.handle_complete(CompleteMessage(**message))
+                handler = self.handle_complete
+                handler_arg = CompleteMessage(**message)
 
             else:
-                error_message = f"Unknown message type: {message_type}"
-                await self.handle_invalid_message(error_message)
+                handler = self.handle_invalid_message
+                handler_arg = f"Unknown message type: {message_type}"
 
         except (KeyError, TypeError):
-            error_message = "Failed to parse message"
-            await self.handle_invalid_message(error_message)
+            handler = self.handle_invalid_message
+            handler_arg = "Failed to parse message"
+
+        await handler(handler_arg)
 
     async def handle_connection_init(self, message: ConnectionInitMessage) -> None:
         if self.connection_init_received:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Move the parsing and exception handling of incoming messages away from actually executing the handler
## Description

Any type errors or key errors that would occur within the message handlers themselves that weren't explicitly caught would percolate up to the message parsing handler and be classified as an invalid incoming message.  This would hide errors that occur during development or other unexpected errors.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #1762 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
