### PR TITLE
Move enum deserialization logic from convert_arguments to CustomGraph…

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Refactoring: Move enum deserialization logic from convert_arguments to CustomGraphQLEnumType

--- a/strawberry/arguments.py
+++ b/strawberry/arguments.py
@@ -135,10 +135,8 @@ def convert_argument(
     if is_scalar(type_, scalar_registry):
         return value
 
-    # Convert Enum fields to instances using the value. This is safe
-    # because graphql-core has already validated the input.
     if isinstance(type_, EnumDefinition):
-        return type_.wrapped_cls(value)
+        return value
 
     if isinstance(type_, LazyType):
         return convert_argument(value, type_.resolve_type(), scalar_registry, config)

--- a/tests/schema/test_enum.py
+++ b/tests/schema/test_enum.py
@@ -263,11 +263,16 @@ def test_enum_as_argument():
     assert str(schema) == expected
 
     query = "{ createFlavour(flavour: CHOCOLATE) }"
-
     result = schema.execute_sync(query)
-
     assert not result.errors
     assert result.data["createFlavour"] == "CHOCOLATE"
+
+    # Explicitly using `variable_values` now so that the enum is parsed using
+    # `CustomGraphQLEnumType.parse_value()` instead of `.parse_literal`
+    query = "query ($flavour: IceCreamFlavour!) { createFlavour(flavour: $flavour) }"
+    result = schema.execute_sync(query, variable_values={"flavour": "VANILLA"})
+    assert not result.errors
+    assert result.data["createFlavour"] == "VANILLA"
 
 
 def test_enum_as_default_argument():

--- a/tests/utils/test_arguments_converter.py
+++ b/tests/utils/test_arguments_converter.py
@@ -229,9 +229,9 @@ def test_nested_input_types():
     args = {
         "input": {
             "prNumber": 12,
-            "status": ReleaseFileStatus.OK.value,
+            "status": ReleaseFileStatus.OK,
             "releaseInfo": {
-                "changeType": ChangeType.MAJOR.value,
+                "changeType": ChangeType.MAJOR,
                 "changelog": "example",
             },
         }
@@ -261,7 +261,7 @@ def test_nested_input_types():
     args = {
         "input": {
             "prNumber": 12,
-            "status": ReleaseFileStatus.OK.value,
+            "status": ReleaseFileStatus.OK,
             "releaseInfo": None,
         }
     }


### PR DESCRIPTION
## Description

Apparently Python's GraphQL core enum isn't designed to work with Python Enums out of the box :man_facepalming:.

Instead, strawberry defines custom serialization/deserialization logic. However it is currently split in 2 places:
  - `CustomGraphQLEnumType` takes care of converting an enum object to it's value during _serialization_ (Which is later converted to its name by GraphQL Core)
  - `convert_arguments` converts the enum value back to the enum object during _deserialization_

This PR moves the deserialization step into `CustomGraphQLEnumType`, which has a few (minor) advantages:
- Both are kept together in source
- deserialization is automatically triggered in GraphQL-Core instead of being handled explicitly
  - (This makes it a little simpler to hack strawberry types for serialization/deserialization -- A thing I'm working on)

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.  (Not necessary)
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
