### PR TITLE
fix(newtypes): Fix pydantic conversions of newtypes within a list

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,8 @@ Release type: patch
 
 Fixes a bug when converting pydantic models with NewTypes in a List.
 This no longers causes an exception.
- ```{python}
+
+ ```python
 from typing import List, NewType
 from pydantic import BaseModel
 import strawberry

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,20 @@
+Release type: patch
+
+Fixes a bug when converting pydantic models with NewTypes in a List.
+This no longers causes an exception.
+ ```{python}
+from typing import List, NewType
+from pydantic import BaseModel
+import strawberry
+
+password = NewType("password", str)
+
+class User(BaseModel):
+    passwords: List[password]
+
+
+@strawberry.experimental.pydantic.type(User)
+class UserType:
+    passwords: strawberry.auto
+
+ ```

--- a/strawberry/experimental/pydantic/exceptions.py
+++ b/strawberry/experimental/pydantic/exceptions.py
@@ -19,7 +19,7 @@ class UnsupportedTypeError(Exception):
 
 
 class UnregisteredTypeException(Exception):
-    def __init__(self, type: BaseModel):
+    def __init__(self, type: Type[BaseModel]):
         message = (
             f"Cannot find a Strawberry Type for {type} did you forget to register it?"
         )

--- a/strawberry/experimental/pydantic/fields.py
+++ b/strawberry/experimental/pydantic/fields.py
@@ -1,11 +1,15 @@
+import builtins
 from decimal import Decimal
 from typing import Any, List, Optional, Type
 from uuid import UUID
 
 import pydantic
+from pydantic import BaseModel
 from pydantic.typing import is_new_type, new_type_supertype
+from typing_extensions import Literal
 
-from .exceptions import UnsupportedTypeError
+from ...types.types import TypeDefinition
+from .exceptions import UnregisteredTypeException, UnsupportedTypeError
 
 
 ATTR_TO_TYPE_MAP = {
@@ -79,3 +83,42 @@ def get_basic_type(type_) -> Type[Any]:
         return new_type_supertype(type_)
 
     return type_
+
+
+def replace_pydantic_types(type_: Any, is_input: bool):
+    if isinstance(type_, type):
+        if issubclass(type_, BaseModel):
+            attr = "_strawberry_input_type" if is_input else "_strawberry_type"
+            if hasattr(type_, attr):
+                return getattr(type_, attr)
+            else:
+                raise UnregisteredTypeException(type_)
+    return type_
+
+
+def replace_types_recursively(type_: Any, is_input: bool) -> Any:
+    """Runs the conversions recursively into the arguments of generic types if any"""
+    basic_type = get_basic_type(type_)
+    replaced_type = replace_pydantic_types(basic_type, is_input)
+
+    origin = getattr(type_, "__origin__", None)
+    if origin is Literal:
+        # Literal does not have types in its __args__ so we return early
+        return replaced_type
+    if hasattr(replaced_type, "__args__"):
+        replaced_type = replaced_type.copy_with(
+            tuple(
+                replace_types_recursively(t, is_input=is_input)
+                for t in replaced_type.__args__
+            )
+        )
+        if isinstance(replaced_type, TypeDefinition):
+            # TODO: Not sure if this is necessary. No coverage in tests
+            # TODO: Unnecessary with StrawberryObject
+            replaced_type = builtins.type(
+                replaced_type.name,
+                (),
+                {"_type_definition": replaced_type},
+            )
+
+    return replaced_type

--- a/strawberry/experimental/pydantic/fields.py
+++ b/strawberry/experimental/pydantic/fields.py
@@ -8,8 +8,11 @@ from pydantic import BaseModel
 from pydantic.typing import is_new_type, new_type_supertype
 from typing_extensions import Literal
 
-from ...types.types import TypeDefinition
-from .exceptions import UnregisteredTypeException, UnsupportedTypeError
+from strawberry.experimental.pydantic.exceptions import (
+    UnregisteredTypeException,
+    UnsupportedTypeError,
+)
+from strawberry.types.types import TypeDefinition
 
 
 ATTR_TO_TYPE_MAP = {
@@ -86,6 +89,8 @@ def get_basic_type(type_) -> Type[Any]:
 
 
 def replace_pydantic_types(type_: Any, is_input: bool):
+    # NewType is a function <= python 3.9. Therefore isinstance guard is needed otherwise
+    # to ignore NewType instances. Otherwise, issubclass will except
     if isinstance(type_, type):
         if issubclass(type_, BaseModel):
             attr = "_strawberry_input_type" if is_input else "_strawberry_type"

--- a/strawberry/experimental/pydantic/object_type.py
+++ b/strawberry/experimental/pydantic/object_type.py
@@ -26,6 +26,7 @@ from strawberry.experimental.pydantic.conversion import (
     convert_pydantic_model_to_strawberry_class,
     convert_strawberry_class_to_pydantic_model,
 )
+from strawberry.experimental.pydantic.exceptions import MissingFieldsListError
 from strawberry.experimental.pydantic.fields import replace_types_recursively
 from strawberry.experimental.pydantic.utils import (
     DataclassCreationFields,
@@ -38,8 +39,6 @@ from strawberry.field import StrawberryField
 from strawberry.object_type import _process_type, _wrap_dataclass
 from strawberry.schema_directive import StrawberrySchemaDirective
 from strawberry.types.type_resolver import _get_fields
-
-from .exceptions import MissingFieldsListError
 
 
 def get_type_for_field(field: ModelField, is_input: bool):

--- a/strawberry/experimental/pydantic/object_type.py
+++ b/strawberry/experimental/pydantic/object_type.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import builtins
 import dataclasses
 import warnings
 from functools import partial
@@ -17,9 +16,7 @@ from typing import (
     cast,
 )
 
-from pydantic import BaseModel
 from pydantic.fields import ModelField
-from typing_extensions import Literal
 
 from graphql import GraphQLResolveInfo
 
@@ -29,7 +26,7 @@ from strawberry.experimental.pydantic.conversion import (
     convert_pydantic_model_to_strawberry_class,
     convert_strawberry_class_to_pydantic_model,
 )
-from strawberry.experimental.pydantic.fields import get_basic_type
+from strawberry.experimental.pydantic.fields import replace_types_recursively
 from strawberry.experimental.pydantic.utils import (
     DataclassCreationFields,
     ensure_all_auto_fields_in_pydantic,
@@ -41,47 +38,13 @@ from strawberry.field import StrawberryField
 from strawberry.object_type import _process_type, _wrap_dataclass
 from strawberry.schema_directive import StrawberrySchemaDirective
 from strawberry.types.type_resolver import _get_fields
-from strawberry.types.types import TypeDefinition
 
-from .exceptions import MissingFieldsListError, UnregisteredTypeException
-
-
-def replace_pydantic_types(type_: Any, is_input: bool):
-    origin = getattr(type_, "__origin__", None)
-    if origin is Literal:
-        # Literal does not have types in its __args__ so we return early
-        return type_
-    if hasattr(type_, "__args__"):
-        replaced_type = type_.copy_with(
-            tuple(replace_pydantic_types(t, is_input) for t in type_.__args__)
-        )
-
-        if isinstance(replaced_type, TypeDefinition):
-            # TODO: Not sure if this is necessary. No coverage in tests
-            # TODO: Unnecessary with StrawberryObject
-
-            replaced_type = builtins.type(
-                replaced_type.name,
-                (),
-                {"_type_definition": replaced_type},
-            )
-
-        return replaced_type
-
-    if issubclass(type_, BaseModel):
-        attr = "_strawberry_input_type" if is_input else "_strawberry_type"
-        if hasattr(type_, attr):
-            return getattr(type_, attr)
-        else:
-            raise UnregisteredTypeException(type_)
-
-    return type_
+from .exceptions import MissingFieldsListError
 
 
 def get_type_for_field(field: ModelField, is_input: bool):
     outer_type = field.outer_type_
-    basic_type = get_basic_type(outer_type)
-    replaced_type = replace_pydantic_types(basic_type, is_input)
+    replaced_type = replace_types_recursively(outer_type, is_input)
 
     if not field.required:
         return Optional[replaced_type]

--- a/tests/experimental/pydantic/test_conversion.py
+++ b/tests/experimental/pydantic/test_conversion.py
@@ -812,17 +812,20 @@ def test_can_convert_pydantic_type_to_strawberry_newtype():
     class User(BaseModel):
         age: int
         password: Optional[Password]
+        passwords: List[Password]
 
     @strawberry.experimental.pydantic.type(User)
     class UserType:
         age: strawberry.auto
         password: strawberry.auto
+        passwords: strawberry.auto
 
-    origin_user = User(age=1, password="abc")
+    origin_user = User(age=1, password="abc", passwords=["hunter2"])
     user = UserType.from_pydantic(origin_user)
 
     assert user.age == 1
     assert user.password == "abc"
+    assert user.passwords == ["hunter2"]
 
 
 def test_sort_creation_fields():

--- a/tests/experimental/pydantic/test_conversion.py
+++ b/tests/experimental/pydantic/test_conversion.py
@@ -812,19 +812,35 @@ def test_can_convert_pydantic_type_to_strawberry_newtype():
     class User(BaseModel):
         age: int
         password: Optional[Password]
-        passwords: List[Password]
 
     @strawberry.experimental.pydantic.type(User)
     class UserType:
         age: strawberry.auto
         password: strawberry.auto
-        passwords: strawberry.auto
 
-    origin_user = User(age=1, password="abc", passwords=["hunter2"])
+    origin_user = User(age=1, password="abc")
     user = UserType.from_pydantic(origin_user)
 
     assert user.age == 1
     assert user.password == "abc"
+
+
+def test_can_convert_pydantic_type_to_strawberry_newtype_list():
+    Password = NewType("Password", str)
+
+    class User(BaseModel):
+        age: int
+        passwords: List[Password]
+
+    @strawberry.experimental.pydantic.type(User)
+    class UserType:
+        age: strawberry.auto
+        passwords: strawberry.auto
+
+    origin_user = User(age=1, passwords=["hunter2"])
+    user = UserType.from_pydantic(origin_user)
+
+    assert user.age == 1
     assert user.passwords == ["hunter2"]
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Fixes a bug when converting pydantic models with NewTypes in a List.
This no longers causes an exception.
 ```{python}
from typing import List, NewType
from pydantic import BaseModel
import strawberry

password = NewType("password", str)

class User(BaseModel):
    passwords: List[password]


@strawberry.experimental.pydantic.type(User)
class UserType:
    passwords: strawberry.auto

 ```

would cause strawberry to except.
## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation



## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
