### PR TITLE
Allow `AsyncIterable` and `AsyncIterator` return annotation for Subscriptions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+Allow use of `AsyncIterator` and `AsyncIterable` generics to annotate return
+type of subscription resolvers.

--- a/strawberry/annotation.py
+++ b/strawberry/annotation.py
@@ -1,11 +1,10 @@
 import sys
 import typing
-from collections.abc import AsyncGenerator as AsyncGenerator_abc
+from collections import abc
 from enum import Enum
 from typing import (  # type: ignore[attr-defined]
     TYPE_CHECKING,
     Any,
-    AsyncGenerator as AsyncGenerator_typing,
     Dict,
     Optional,
     TypeVar,
@@ -38,6 +37,17 @@ if TYPE_CHECKING:
     from strawberry.union import StrawberryUnion
 
 
+ASYNC_TYPES = (
+    abc.AsyncGenerator,
+    abc.AsyncIterable,
+    abc.AsyncIterator,
+    typing.AsyncContextManager,
+    typing.AsyncGenerator,
+    typing.AsyncIterable,
+    typing.AsyncIterator,
+)
+
+
 class StrawberryAnnotation:
     def __init__(
         self, annotation: Union[object, str], *, namespace: Optional[Dict] = None
@@ -59,8 +69,8 @@ class StrawberryAnnotation:
             annotation = self.annotation
 
         evaled_type = _eval_type(annotation, self.namespace, None)
-        if self._is_async_generator(evaled_type):
-            evaled_type = self._strip_async_generator(evaled_type)
+        if self._is_async_type(evaled_type):
+            evaled_type = self._strip_async_type(evaled_type)
         if self._is_lazy_type(evaled_type):
             return evaled_type
 
@@ -150,14 +160,9 @@ class StrawberryAnnotation:
         return union
 
     @classmethod
-    def _is_async_generator(cls, annotation: type) -> bool:
+    def _is_async_type(cls, annotation: type) -> bool:
         origin = getattr(annotation, "__origin__", None)
-        if origin is AsyncGenerator_abc:
-            return True
-        if origin is AsyncGenerator_typing:
-            # deprecated in Python 3.9 and above
-            return True
-        return False
+        return origin in ASYNC_TYPES
 
     @classmethod
     def _is_enum(cls, annotation: Any) -> bool:
@@ -246,7 +251,7 @@ class StrawberryAnnotation:
         return annotation_origin is typing.Union
 
     @classmethod
-    def _strip_async_generator(cls, annotation) -> type:
+    def _strip_async_type(cls, annotation) -> type:
         return annotation.__args__[0]
 
     @classmethod

--- a/tests/schema/test_subscription.py
+++ b/tests/schema/test_subscription.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+import sys
 import typing
 
 import pytest
@@ -49,3 +52,47 @@ async def test_subscription_with_arguments():
 
     assert not result.errors
     assert result.data["example"] == "Hi Nina"
+
+
+requires_builtin_generics = pytest.mark.skipif(
+    sys.version_info < (3, 9),
+    reason="built-in generic annotations where added in python 3.9",
+)
+
+
+@pytest.mark.parametrize(
+    "return_annotation",
+    (
+        "typing.AsyncGenerator[str, None]",
+        "typing.AsyncIterable[str]",
+        "typing.AsyncIterator[str]",
+        pytest.param("abc.AsyncIterator[str]", marks=requires_builtin_generics),
+        pytest.param("abc.AsyncGenerator[str, None]", marks=requires_builtin_generics),
+        pytest.param("abc.AsyncIterable[str]", marks=requires_builtin_generics),
+    ),
+)
+@pytest.mark.asyncio
+async def test_subscription_return_typing_annotations(return_annotation: str):
+    async def async_resolver():
+        yield "Hi"
+
+    async_resolver.__annotations__["return"] = return_annotation
+
+    @strawberry.type
+    class Query:
+        x: str = "Hello"
+
+    @strawberry.type
+    class Subscription:
+
+        example = strawberry.subscription(resolver=async_resolver)
+
+    schema = strawberry.Schema(query=Query, subscription=Subscription)
+
+    query = "subscription { example }"
+
+    sub = await schema.subscribe(query)
+    result = await sub.__anext__()
+
+    assert not result.errors
+    assert result.data["example"] == "Hi"

--- a/tests/schema/test_subscription.py
+++ b/tests/schema/test_subscription.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 import typing
+from collections import abc  # noqa: F401
 
 import pytest
 
@@ -72,7 +73,7 @@ requires_builtin_generics = pytest.mark.skipif(
     ),
 )
 @pytest.mark.asyncio
-async def test_subscription_return_typing_annotations(return_annotation: str):
+async def test_subscription_return_annotations(return_annotation: str):
     async def async_resolver():
         yield "Hi"
 

--- a/tests/schema/test_subscription.py
+++ b/tests/schema/test_subscription.py
@@ -57,7 +57,7 @@ async def test_subscription_with_arguments():
 
 requires_builtin_generics = pytest.mark.skipif(
     sys.version_info < (3, 9),
-    reason="built-in generic annotations where added in python 3.9",
+    reason="built-in generic annotations were added in python 3.9",
 )
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This PR Closes [#1769] by modifying the `_is_async_generator`
classmethod in `StrawberryAnnotation` to check for the additional
type-hints that are now specified by the module constant `ASYNC_TYPES`.
This makes it possible to annotate subscription resolvers with the
`AsyncIterable` and `AsyncIterator` generics.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

- Issue [#1769]

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).


[#1769]: https://github.com/strawberry-graphql/strawberry/issues/1769
