### PR TITLE
Add support for aliased fields in codegen

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+This release adds support for aliased fields when doing codegen.

--- a/strawberry/codegen/plugins/print_operation.py
+++ b/strawberry/codegen/plugins/print_operation.py
@@ -120,6 +120,9 @@ class PrintOperationPlugin(QueryCodegenPlugin):
             f"{self._print_directives(selection.directives)}"
         )
 
+        if selection.alias:
+            field = f"{selection.alias}: {field}"
+
         if selection.selections:
             return field + f" {{\n{self._print_selections(selection.selections)}\n}}"
 

--- a/strawberry/codegen/plugins/python.py
+++ b/strawberry/codegen/plugins/python.py
@@ -97,8 +97,12 @@ class PythonPlugin(QueryCodegenPlugin):
         return type_.name
 
     def _print_field(self, field: GraphQLField) -> str:
+        name = field.name
 
-        return f"{field.name}: {self._get_type_name(field.type)}"
+        if field.alias:
+            name = f"# alias for {field.name}\n{field.alias}"
+
+        return f"{name}: {self._get_type_name(field.type)}"
 
     def _print_enum_value(self, value: str) -> str:
         return f'{value} = "{value}"'

--- a/strawberry/codegen/plugins/typescript.py
+++ b/strawberry/codegen/plugins/typescript.py
@@ -63,8 +63,12 @@ class TypeScriptPlugin(QueryCodegenPlugin):
         return type_.name
 
     def _print_field(self, field: GraphQLField) -> str:
+        name = field.name
 
-        return f"{field.name}: {self._get_type_name(field.type)}"
+        if field.alias:
+            name = f"// alias for {field.name}\n{field.alias}"
+
+        return f"{name}: {self._get_type_name(field.type)}"
 
     def _print_enum_value(self, value: str) -> str:
         return f'{value} = "{value}",'

--- a/strawberry/codegen/types.py
+++ b/strawberry/codegen/types.py
@@ -26,6 +26,7 @@ class GraphQLUnion:
 @dataclass
 class GraphQLField:
     name: str
+    alias: Optional[str]
     type: GraphQLType
 
 
@@ -60,8 +61,8 @@ GraphQLType = Union[
 
 @dataclass
 class GraphQLFieldSelection:
-    # TODO: alias
     field: str
+    alias: Optional[str]
     selections: List[GraphQLSelection]
     directives: List[GraphQLDirective]
     arguments: List[GraphQLArgument]

--- a/tests/codegen/queries/alias.graphql
+++ b/tests/codegen/queries/alias.graphql
@@ -1,0 +1,8 @@
+query OperationName {
+  id
+  second_id: id
+  a_float: float
+  lazy {
+    lazy: something
+  }
+}

--- a/tests/codegen/snapshots/python/alias.py
+++ b/tests/codegen/snapshots/python/alias.py
@@ -1,0 +1,11 @@
+class OperationNameResultLazy:
+    # alias for something
+    lazy: bool
+
+class OperationNameResult:
+    id: str
+    # alias for id
+    second_id: str
+    # alias for float
+    a_float: float
+    lazy: OperationNameResultLazy

--- a/tests/codegen/snapshots/typescript/alias.ts
+++ b/tests/codegen/snapshots/typescript/alias.ts
@@ -1,0 +1,13 @@
+type OperationNameResultLazy = {
+    // alias for something
+    lazy: boolean
+}
+
+type OperationNameResult = {
+    id: string
+    // alias for id
+    second_id: string
+    // alias for float
+    a_float: number
+    lazy: OperationNameResultLazy
+}


### PR DESCRIPTION
This PR adds support for aliased fields in codegen:

```graphql
query OperationName {
  id
  second_id: id
  a_float: float
  lazy {
    lazy: something
  }
}
```