### PR TITLE
Unify single-response-requests with streaming requests on `graphql-transport-ws`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
       - id: check-toml
 
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
         exclude: ^tests/codegen/snapshots/python/

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,12 @@
+Release type: patch
+
+This release fixes a number of problems with single-result-operations over
+`graphql-transport-ws` protocol
+
+- operation **IDs** now share the same namespace as streaming operations
+  meaning that they cannot be reused while the others are in operation
+
+- single-result-operations now run as *tasks* meaning that messages related
+  to them can be overlapped with other messages on the websocket.
+
+- single-result-operations can be cancelled with the `complete` message.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,3 +10,7 @@ This release fixes a number of problems with single-result-operations over
   to them can be overlapped with other messages on the websocket.
 
 - single-result-operations can be cancelled with the `complete` message.
+
+- IDs for single result and streaming result operations are now released
+  once the operation is done, allowing them to be re-used later, as well as
+  freeing up resources related to previous requests.

--- a/strawberry/aiohttp/handlers/graphql_transport_ws_handler.py
+++ b/strawberry/aiohttp/handlers/graphql_transport_ws_handler.py
@@ -50,5 +50,6 @@ class GraphQLTransportWSHandler(BaseGraphQLTransportWSHandler):
         finally:
             for operation_id in list(self.subscriptions.keys()):
                 await self.cleanup_operation(operation_id)
+            await self.reap_completed_tasks()
 
         return self._ws

--- a/strawberry/asgi/handlers/graphql_transport_ws_handler.py
+++ b/strawberry/asgi/handlers/graphql_transport_ws_handler.py
@@ -56,3 +56,4 @@ class GraphQLTransportWSHandler(BaseGraphQLTransportWSHandler):
 
             for operation_id in list(self.subscriptions.keys()):
                 await self.cleanup_operation(operation_id)
+            await self.reap_completed_tasks()

--- a/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
@@ -2,7 +2,7 @@ import asyncio
 from abc import ABC, abstractmethod
 from contextlib import suppress
 from datetime import timedelta
-from typing import Any, AsyncGenerator, Callable, Dict, Optional
+from typing import Any, AsyncGenerator, Callable, Dict, List, Optional
 
 from graphql import (
     ExecutionResult as GraphQLExecutionResult,
@@ -43,8 +43,9 @@ class BaseGraphQLTransportWSHandler(ABC):
         self.connection_init_timeout_task: Optional[asyncio.Task] = None
         self.connection_init_received = False
         self.connection_acknowledged = False
-        self.subscriptions: Dict[str, AsyncGenerator] = {}
+        self.subscriptions: Dict[str, Optional[AsyncGenerator]] = {}
         self.tasks: Dict[str, asyncio.Task] = {}
+        self.completed_tasks: List[asyncio.Task] = []
 
     @abstractmethod
     async def get_context(self) -> Any:
@@ -117,6 +118,7 @@ class BaseGraphQLTransportWSHandler(ABC):
             handler_arg = "Failed to parse message"
 
         await handler(handler_arg)
+        await self.reap_completed_tasks()
 
     async def handle_connection_init(self, message: ConnectionInitMessage) -> None:
         if self.connection_init_received:
@@ -159,6 +161,11 @@ class BaseGraphQLTransportWSHandler(ABC):
             return await self.handle_single_result_operation(message)
 
     async def handle_single_result_operation(self, message: SubscribeMessage):
+        if message.id in self.subscriptions:
+            reason = f"Subscriber for {message.id} already exists"
+            await self.close(code=4409, reason=reason)
+            return
+
         if self.debug:  # pragma: no cover
             pretty_print_graphql_operation(
                 message.payload.operationName,
@@ -169,27 +176,39 @@ class BaseGraphQLTransportWSHandler(ABC):
         context = await self.get_context()
         root_value = await self.get_root_value()
 
-        result = await self.schema.execute(
-            query=message.payload.query,
-            variable_values=message.payload.variables,
-            context_value=context,
-            root_value=root_value,
-            operation_name=message.payload.operationName,
-        )
+        async def task_handler():
+            try:
+                result = await self.schema.execute(
+                    query=message.payload.query,
+                    variable_values=message.payload.variables,
+                    context_value=context,
+                    root_value=root_value,
+                    operation_name=message.payload.operationName,
+                )
 
-        if result.errors:
-            payload = [format_graphql_error(result.errors[0])]
-            await self.send_message(ErrorMessage(id=message.id, payload=payload))
-            self.schema.process_errors(result.errors)
-            return
+                if result.errors:
+                    payload = [format_graphql_error(result.errors[0])]
+                    await self.send_message(
+                        ErrorMessage(id=message.id, payload=payload)
+                    )
+                    self.schema.process_errors(result.errors)
+                    return
 
-        await self.send_message(
-            NextMessage(id=message.id, payload={"data": result.data})
-        )
-        await self.send_message(CompleteMessage(id=message.id))
+                await self.send_message(
+                    NextMessage(id=message.id, payload={"data": result.data})
+                )
+                await self.send_message(CompleteMessage(id=message.id))
+            finally:
+                self.subscriptions.pop(message.id, None)
+                task = self.tasks.pop(message.id, None)
+                if task is not None:
+                    self.completed.tasks.append(task)
+
+        self.subscriptions[message.id] = None
+        self.tasks[message.id] = asyncio.create_task(task_handler())
 
     async def handle_streaming_operation(self, message: SubscribeMessage) -> None:
-        if message.id in self.subscriptions.keys():
+        if message.id in self.subscriptions:
             reason = f"Subscriber for {message.id} already exists"
             await self.close(code=4409, reason=reason)
             return
@@ -266,10 +285,21 @@ class BaseGraphQLTransportWSHandler(ABC):
         await self.send_json(data)
 
     async def cleanup_operation(self, operation_id: str) -> None:
-        await self.subscriptions[operation_id].aclose()
-        del self.subscriptions[operation_id]
+        generator = self.subscriptions.pop(operation_id)
+        if generator is not None:
+            await generator.aclose()
 
-        self.tasks[operation_id].cancel()
-        with suppress(BaseException):
-            await self.tasks[operation_id]
-        del self.tasks[operation_id]
+        task = self.tasks.pop(operation_id, None)
+        if task:
+            task.cancel()
+            with suppress(BaseException):
+                await task
+
+    async def reap_completed_tasks(self) -> None:
+        """
+        Await tasks that have completed
+        """
+        tasks, self.completed_tasks = self.completed_tasks, []
+        for task in tasks:
+            with suppress(BaseException):
+                await task

--- a/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
@@ -243,8 +243,8 @@ class BaseGraphQLTransportWSHandler(ABC):
                 self.schema.process_errors([error])
                 return
 
-        except BaseException:
-            # cleanup
+        except BaseException:  # pragma: no cover
+            # cleanup in case of something really unexpected
             del self.subscriptions[operation_id]
             del self.tasks[operation_id]
             raise

--- a/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
@@ -201,60 +201,66 @@ class BaseGraphQLTransportWSHandler(ABC):
             return
 
         # Create task to handle this subscription, reserve the operation ID
-        handler = self.handle_async_results(result_source, message.id)
         self.subscriptions[message.id] = result_source
-        self.tasks[message.id] = asyncio.create_task(handler)
+        self.tasks[message.id] = asyncio.create_task(
+            self.operation_task(result_source, message.id)
+        )
 
-    async def handle_async_results(
-        self,
-        result_source: AsyncGenerator,
-        operation_id: str,
+    async def operation_task(
+        self, result_source: AsyncGenerator, operation_id: str
     ) -> None:
-        task = self.tasks[operation_id]
+        """
+        Operation task top level method.  Cleans up and de-registers the operation
+        once it is done.
+        """
         try:
-            try:
-                async for result in result_source:
-                    if result.errors:
-                        error_payload = [
-                            format_graphql_error(err) for err in result.errors
-                        ]
-                        error_message = ErrorMessage(
-                            id=operation_id, payload=error_payload
-                        )
-                        await self.send_message(error_message)
-                        self.schema.process_errors(result.errors)
-                        return
-                    else:
-                        next_payload = {"data": result.data}
-                        next_message = NextMessage(
-                            id=operation_id, payload=next_payload
-                        )
-                        await self.send_message(next_message)
-            except asyncio.CancelledError:
-                # CancelledErrors are expected during task cleanup.
-                return
-            except Exception as error:
-                # GraphQLErrors are handled by graphql-core and included in the
-                # ExecutionResult
-                error = GraphQLError(str(error), original_error=error)
-                error_payload = [format_graphql_error(error)]
-                error_message = ErrorMessage(id=operation_id, payload=error_payload)
-                await self.send_message(error_message)
-                self.schema.process_errors([error])
-                return
-
+            await self.handle_async_results(result_source, operation_id)
         except BaseException:  # pragma: no cover
             # cleanup in case of something really unexpected
             del self.subscriptions[operation_id]
             del self.tasks[operation_id]
             raise
         else:
-            # forget at the point of sending the CompleteMessage
+            # de-register the operation _before_ sending the `Complete` message
+            # to make the `operation_id` immediately available for re-use
             del self.subscriptions[operation_id]
             del self.tasks[operation_id]
             await self.send_message(CompleteMessage(id=operation_id))
         finally:
+            # add this task to a list to be reaped later
+            task = asyncio.current_task()
+            assert task is not None
             self.completed_tasks.append(task)
+
+    async def handle_async_results(
+        self,
+        result_source: AsyncGenerator,
+        operation_id: str,
+    ) -> None:
+        try:
+            async for result in result_source:
+                if result.errors:
+                    error_payload = [format_graphql_error(err) for err in result.errors]
+                    error_message = ErrorMessage(id=operation_id, payload=error_payload)
+                    await self.send_message(error_message)
+                    self.schema.process_errors(result.errors)
+                    return
+                else:
+                    next_payload = {"data": result.data}
+                    next_message = NextMessage(id=operation_id, payload=next_payload)
+                    await self.send_message(next_message)
+        except asyncio.CancelledError:
+            # CancelledErrors are expected during task cleanup.
+            return
+        except Exception as error:
+            # GraphQLErrors are handled by graphql-core and included in the
+            # ExecutionResult
+            error = GraphQLError(str(error), original_error=error)
+            error_payload = [format_graphql_error(error)]
+            error_message = ErrorMessage(id=operation_id, payload=error_payload)
+            await self.send_message(error_message)
+            self.schema.process_errors([error])
+            return
 
     async def handle_complete(self, message: CompleteMessage) -> None:
         await self.cleanup_operation(operation_id=message.id)

--- a/tests/aiohttp/schema.py
+++ b/tests/aiohttp/schema.py
@@ -50,6 +50,11 @@ class Query:
     def always_fail(self) -> typing.Optional[str]:
         return "Hey"
 
+    @strawberry.field
+    async def exception(self, message: str) -> str:
+        raise ValueError(message)
+        return message
+
 
 @strawberry.type
 class Mutation:

--- a/tests/aiohttp/schema.py
+++ b/tests/aiohttp/schema.py
@@ -41,6 +41,11 @@ class Query:
     def hello(self, name: typing.Optional[str] = None) -> str:
         return f"Hello {name or 'world'}"
 
+    @strawberry.field
+    async def async_hello(self, name: str, delay: float = 0) -> str:
+        await asyncio.sleep(delay)
+        return f"Hello {name or 'world'}"
+
     @strawberry.field(permission_classes=[AlwaysFailPermission])
     def always_fail(self) -> typing.Optional[str]:
         return "Hey"

--- a/tests/aiohttp/test_graphql_transport_ws.py
+++ b/tests/aiohttp/test_graphql_transport_ws.py
@@ -285,6 +285,55 @@ async def test_duplicated_operation_ids(aiohttp_client):
         assert data.extra == "Subscriber for sub1 already exists"
 
 
+async def test_reused_operation_ids(aiohttp_client):
+    app = create_app()
+    aiohttp_app_client = await aiohttp_client(app)
+
+    async with aiohttp_app_client.ws_connect(
+        "/graphql", protocols=[GRAPHQL_TRANSPORT_WS_PROTOCOL]
+    ) as ws:
+        await ws.send_json(ConnectionInitMessage().as_dict())
+
+        response = await ws.receive_json()
+        assert response == ConnectionAckMessage().as_dict()
+
+        await ws.send_json(
+            SubscribeMessage(
+                id="sub1",
+                payload=SubscribeMessagePayload(
+                    query='subscription { echo(message: "Hi") }'
+                ),
+            ).as_dict()
+        )
+
+        response = await ws.receive_json()
+        assert (
+            response
+            == NextMessage(id="sub1", payload={"data": {"echo": "Hi"}}).as_dict()
+        )
+
+        response = await ws.receive_json()
+        assert response == CompleteMessage(id="sub1").as_dict()
+
+        # now the ID should be free for re-use
+        await ws.send_json(
+            SubscribeMessage(
+                id="sub1",
+                payload=SubscribeMessagePayload(
+                    query='subscription { echo(message: "Hi") }'
+                ),
+            ).as_dict()
+        )
+
+        response = await ws.receive_json()
+        assert (
+            response
+            == NextMessage(id="sub1", payload={"data": {"echo": "Hi"}}).as_dict()
+        )
+        await ws.close()
+        assert ws.closed
+
+
 async def test_simple_subscription(aiohttp_client):
     app = create_app()
     aiohttp_app_client = await aiohttp_client(app)

--- a/tests/asgi/schema.py
+++ b/tests/asgi/schema.py
@@ -43,6 +43,11 @@ class Query:
     def hello(self, name: typing.Optional[str] = None) -> str:
         return f"Hello {name or 'world'}"
 
+    @strawberry.field
+    async def async_hello(self, name: str, delay: float = 0) -> str:
+        await asyncio.sleep(delay)
+        return f"Hello {name or 'world'}"
+
     @strawberry.field(permission_classes=[AlwaysFailPermission])
     def always_fail(self) -> Optional[str]:
         return "Hey"

--- a/tests/asgi/schema.py
+++ b/tests/asgi/schema.py
@@ -56,6 +56,11 @@ class Query:
     def root_name(root) -> str:
         return type(root).__name__
 
+    @strawberry.field
+    async def exception(self, message: str) -> str:
+        raise ValueError(message)
+        return message
+
 
 @strawberry.type
 class Mutation:

--- a/tests/asgi/test_graphql_transport_ws.py
+++ b/tests/asgi/test_graphql_transport_ws.py
@@ -438,6 +438,79 @@ def test_single_result_query_operation(test_client):
         assert response == CompleteMessage(id="sub1").as_dict()
 
 
+def test_single_result_query_operation_async(test_client):
+    with test_client.websocket_connect(
+        "/graphql", [GRAPHQL_TRANSPORT_WS_PROTOCOL]
+    ) as ws:
+        ws.send_json(ConnectionInitMessage().as_dict())
+
+        response = ws.receive_json()
+        assert response == ConnectionAckMessage().as_dict()
+
+        ws.send_json(
+            SubscribeMessage(
+                id="sub1",
+                payload=SubscribeMessagePayload(
+                    query='query { asyncHello(name: "Dolly", delay:0.01)}'
+                ),
+            ).as_dict()
+        )
+
+        response = ws.receive_json()
+        assert (
+            response
+            == NextMessage(
+                id="sub1", payload={"data": {"asyncHello": "Hello Dolly"}}
+            ).as_dict()
+        )
+
+        response = ws.receive_json()
+        assert response == CompleteMessage(id="sub1").as_dict()
+
+
+def test_single_result_query_operation_overlapped(test_client):
+    """
+    Test that two single result queries can be in flight at the same time
+    """
+    with test_client.websocket_connect(
+        "/graphql", [GRAPHQL_TRANSPORT_WS_PROTOCOL]
+    ) as ws:
+        ws.send_json(ConnectionInitMessage().as_dict())
+
+        response = ws.receive_json()
+        assert response == ConnectionAckMessage().as_dict()
+
+        # first query
+        ws.send_json(
+            SubscribeMessage(
+                id="sub1",
+                payload=SubscribeMessagePayload(
+                    query='query { asyncHello(name: "Dolly", delay:1)}'
+                ),
+            ).as_dict()
+        )
+        # second query
+        ws.send_json(
+            SubscribeMessage(
+                id="sub2",
+                payload=SubscribeMessagePayload(
+                    query='query { asyncHello(name: "Dolly", delay:0)}'
+                ),
+            ).as_dict()
+        )
+
+        # we expect the response to the second query to arrive first
+        response = ws.receive_json()
+        assert (
+            response
+            == NextMessage(
+                id="sub2", payload={"data": {"asyncHello": "Hello Dolly"}}
+            ).as_dict()
+        )
+        response = ws.receive_json()
+        assert response == CompleteMessage(id="sub2").as_dict()
+
+
 def test_single_result_mutation_operation(test_client):
     with test_client.websocket_connect(
         "/graphql", [GRAPHQL_TRANSPORT_WS_PROTOCOL]
@@ -553,3 +626,70 @@ def test_single_result_operation_error(test_client):
         assert response["id"] == "sub1"
         assert len(response["payload"]) == 1
         assert response["payload"][0]["message"] == "You are not authorized"
+
+
+def test_single_result_duplicate_ids_sub(test_client):
+    with test_client.websocket_connect(
+        "/graphql", [GRAPHQL_TRANSPORT_WS_PROTOCOL]
+    ) as ws:
+        ws.send_json(ConnectionInitMessage().as_dict())
+
+        response = ws.receive_json()
+        assert response == ConnectionAckMessage().as_dict()
+
+        # regular subscription
+        ws.send_json(
+            SubscribeMessage(
+                id="sub1",
+                payload=SubscribeMessagePayload(
+                    query='subscription { echo(message: "Hi", delay: 5) }'
+                ),
+            ).as_dict()
+        )
+        # single result subscription with duplicate id
+        ws.send_json(
+            SubscribeMessage(
+                id="sub1",
+                payload=SubscribeMessagePayload(
+                    query="query { hello }",
+                ),
+            ).as_dict()
+        )
+
+        data = ws.receive()
+        assert data["type"] == "websocket.close"
+        assert data["code"] == 4409
+
+
+def test_single_result_duplicate_ids_query(test_client):
+    with test_client.websocket_connect(
+        "/graphql", [GRAPHQL_TRANSPORT_WS_PROTOCOL]
+    ) as ws:
+        ws.send_json(ConnectionInitMessage().as_dict())
+
+        response = ws.receive_json()
+        assert response == ConnectionAckMessage().as_dict()
+
+        # single result subscription 1
+        ws.send_json(
+            SubscribeMessage(
+                id="sub1",
+                payload=SubscribeMessagePayload(
+                    query='query { asyncHello(name: "Hi", delay: 5) }'
+                ),
+            ).as_dict()
+        )
+        # single result subscription with duplicate id
+        ws.send_json(
+            SubscribeMessage(
+                id="sub1",
+                payload=SubscribeMessagePayload(
+                    query="query { hello }",
+                ),
+            ).as_dict()
+        )
+
+        # We expect the remote to close the socket due to duplicate ID in use
+        data = ws.receive()
+        assert data["type"] == "websocket.close"
+        assert data["code"] == 4409

--- a/tests/asgi/test_graphql_transport_ws.py
+++ b/tests/asgi/test_graphql_transport_ws.py
@@ -220,6 +220,50 @@ def test_duplicated_operation_ids(test_client):
         assert data["code"] == 4409
 
 
+def test_reused_operation_ids(test_client):
+    with test_client.websocket_connect(
+        "/graphql", [GRAPHQL_TRANSPORT_WS_PROTOCOL]
+    ) as ws:
+        ws.send_json(ConnectionInitMessage().as_dict())
+
+        response = ws.receive_json()
+        assert response == ConnectionAckMessage().as_dict()
+
+        ws.send_json(
+            SubscribeMessage(
+                id="sub1",
+                payload=SubscribeMessagePayload(
+                    query='subscription { echo(message: "Hi") }'
+                ),
+            ).as_dict()
+        )
+
+        response = ws.receive_json()
+        assert (
+            response
+            == NextMessage(id="sub1", payload={"data": {"echo": "Hi"}}).as_dict()
+        )
+
+        response = ws.receive_json()
+        assert response == CompleteMessage(id="sub1").as_dict()
+
+        # now the ID should be free for re-use
+        ws.send_json(
+            SubscribeMessage(
+                id="sub1",
+                payload=SubscribeMessagePayload(
+                    query='subscription { echo(message: "Hi") }'
+                ),
+            ).as_dict()
+        )
+
+        response = ws.receive_json()
+        assert (
+            response
+            == NextMessage(id="sub1", payload={"data": {"echo": "Hi"}}).as_dict()
+        )
+
+
 def test_simple_subscription(test_client):
     with test_client.websocket_connect("/", [GRAPHQL_TRANSPORT_WS_PROTOCOL]) as ws:
         ws.send_json(ConnectionInitMessage().as_dict())

--- a/tests/asgi/test_graphql_transport_ws.py
+++ b/tests/asgi/test_graphql_transport_ws.py
@@ -672,6 +672,32 @@ def test_single_result_operation_error(test_client):
         assert response["payload"][0]["message"] == "You are not authorized"
 
 
+def test_single_result_operation_exception(test_client):
+    with test_client.websocket_connect(
+        "/graphql", [GRAPHQL_TRANSPORT_WS_PROTOCOL]
+    ) as ws:
+        ws.send_json(ConnectionInitMessage().as_dict())
+
+        response = ws.receive_json()
+        assert response == ConnectionAckMessage().as_dict()
+
+        ws.send_json(
+            SubscribeMessage(
+                id="sub1",
+                payload=SubscribeMessagePayload(
+                    query='query { exception(message: "bummer") }',
+                ),
+            ).as_dict()
+        )
+
+        response = ws.receive_json()
+        assert response["type"] == ErrorMessage.type
+        assert response["id"] == "sub1"
+        assert len(response["payload"]) == 1
+        assert response["payload"][0].get("path") == ["exception"]
+        assert response["payload"][0]["message"] == "bummer"
+
+
 def test_single_result_duplicate_ids_sub(test_client):
     with test_client.websocket_connect(
         "/graphql", [GRAPHQL_TRANSPORT_WS_PROTOCOL]

--- a/tests/fastapi/schema.py
+++ b/tests/fastapi/schema.py
@@ -43,6 +43,11 @@ class Query:
     def hello(self, name: typing.Optional[str] = None) -> str:
         return f"Hello {name or 'world'}"
 
+    @strawberry.field
+    async def async_hello(self, name: str, delay: float = 0) -> str:
+        await asyncio.sleep(delay)
+        return f"Hello {name or 'world'}"
+
     @strawberry.field(permission_classes=[AlwaysFailPermission])
     def always_fail(self) -> Optional[str]:
         return "Hey"

--- a/tests/fastapi/schema.py
+++ b/tests/fastapi/schema.py
@@ -56,6 +56,11 @@ class Query:
     def root_name(root) -> str:
         return type(root).__name__
 
+    @strawberry.field
+    async def exception(self, message: str) -> str:
+        raise ValueError(message)
+        return message
+
 
 @strawberry.type
 class Mutation:

--- a/tests/fastapi/test_graphql_transport_ws.py
+++ b/tests/fastapi/test_graphql_transport_ws.py
@@ -245,6 +245,10 @@ def test_duplicated_operation_ids(test_client):
 
 
 def test_reused_operation_ids(test_client):
+    """
+    Test that an operation id can be re-used after it has been
+    previously used for a completed operation
+    """
     with test_client.websocket_connect(
         "/graphql", [GRAPHQL_TRANSPORT_WS_PROTOCOL]
     ) as ws:
@@ -253,6 +257,7 @@ def test_reused_operation_ids(test_client):
         response = ws.receive_json()
         assert response == ConnectionAckMessage().as_dict()
 
+        # Use sub1 as an id for an operation
         ws.send_json(
             SubscribeMessage(
                 id="sub1",
@@ -271,7 +276,8 @@ def test_reused_operation_ids(test_client):
         response = ws.receive_json()
         assert response == CompleteMessage(id="sub1").as_dict()
 
-        # now the ID should be free for re-use
+        # operation is now complete.  Create a new operation using
+        # the same ID
         ws.send_json(
             SubscribeMessage(
                 id="sub1",
@@ -519,6 +525,11 @@ def test_single_result_query_operation(test_client):
 
 
 def test_single_result_query_operation_async(test_client):
+    """
+    Test a single result query operation on an
+    `async` method in the schema, including an artificial
+    async delay
+    """
     with test_client.websocket_connect(
         "/graphql", [GRAPHQL_TRANSPORT_WS_PROTOCOL]
     ) as ws:
@@ -550,7 +561,10 @@ def test_single_result_query_operation_async(test_client):
 
 def test_single_result_query_operation_overlapped(test_client):
     """
-    Test that two single result queries can be in flight at the same time
+    Test that two single result queries can be in flight at the same time,
+    just like regular queries.  Start two queries with separate ids. The
+    first query has a delay, so we expect the response to the second
+    query to be delivered first.
     """
     with test_client.websocket_connect(
         "/graphql", [GRAPHQL_TRANSPORT_WS_PROTOCOL]
@@ -709,6 +723,10 @@ def test_single_result_operation_error(test_client):
 
 
 def test_single_result_operation_exception(test_client):
+    """
+    Test that single-result-operations which raise exceptions
+    behave in the same way as streaming operations
+    """
     with test_client.websocket_connect(
         "/graphql", [GRAPHQL_TRANSPORT_WS_PROTOCOL]
     ) as ws:
@@ -735,6 +753,12 @@ def test_single_result_operation_exception(test_client):
 
 
 def test_single_result_duplicate_ids_sub(test_client):
+    """
+    Test that single-result-operations and streaming operations
+    share the same ID namespace.  Start a regular subscription,
+    then issue a single-result operation with same ID and expect an
+    error due to already existing ID
+    """
     with test_client.websocket_connect(
         "/graphql", [GRAPHQL_TRANSPORT_WS_PROTOCOL]
     ) as ws:
@@ -768,6 +792,11 @@ def test_single_result_duplicate_ids_sub(test_client):
 
 
 def test_single_result_duplicate_ids_query(test_client):
+    """
+    Test that single-result-operations don't allow duplicate
+    IDs for two asynchronous queries.  Issue one async query
+    with delay, then another with same id.  Expect error.
+    """
     with test_client.websocket_connect(
         "/graphql", [GRAPHQL_TRANSPORT_WS_PROTOCOL]
     ) as ws:


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the title above. -->
(replaces closed #1739)

Various problems with single-response-requests existed as a result of their having a separate control
path from streaming requests.  Single-response-requests are really just special cases of streaming requests
that deliver __at most__ one `Next` message and need to behave as such.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

single-response-request are now handled as *tasks* and can be overlapped with other requests
on the same connection, can be cancelled, and share the same unique requests ID namespace.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #1731
* #1733
* #1734
* #1738

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
