### PR TITLE
invalid return type for AsyncGenerator (Documentation)

### DIFF
--- a/docs/general/subscriptions.md
+++ b/docs/general/subscriptions.md
@@ -43,7 +43,6 @@ argument is the actual type of the response, in most cases the second argument
 should be left as `None` (more about Generator typing [here](https://docs.python.org/3/library/typing.html#typing.AsyncGenerator)).
 </Note>
 
-
 We would send the following GraphQL document to our server to subscribe to this
 data stream:
 

--- a/docs/general/subscriptions.md
+++ b/docs/general/subscriptions.md
@@ -12,19 +12,20 @@ This is how you define a subscription-capable resolver:
 
 ```python
 import asyncio
+from typing import AsyncGenerator
 
 import strawberry
 
 @strawberry.type
 class Query:
     @strawberry.field
-    def hello() -> str:
+    def hello(self) -> str:
         return "world"
 
 @strawberry.type
 class Subscription:
     @strawberry.subscription
-    async def count(self, target: int = 100) -> int:
+    async def count(self, target: int = 100) -> AsyncGenerator[int, None]:
         for i in range(target):
             yield i
             await asyncio.sleep(0.5)
@@ -35,6 +36,13 @@ schema = strawberry.Schema(query=Query, subscription=Subscription)
 Like queries and mutations, subscriptions are defined in a class and passed to
 the Schema function. Here we create a rudimentary counting function which counts
 from 0 to the target sleeping between each loop iteration.
+
+<Note>
+The return type of `count` is `AsyncGenerator` where the first generic
+argument is the actual type of the response, in most cases the second argument
+should be left as `None` (more about Generator typing [here](https://docs.python.org/3/library/typing.html#typing.AsyncGenerator)).
+</Note>
+
 
 We would send the following GraphQL document to our server to subscribe to this
 data stream:


### PR DESCRIPTION



## Description

I fixed the typing for subscription AsyncGenerator in the Docs, as well as another small typo. Added short note about AsyncGenerator typing, with link to typing docs.

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
