### PR TITLE
Fix parsing Scalar Decimal values

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Correctly parse Decimal scalar types to avoid floating point errors

--- a/strawberry/schema/types/base_scalars.py
+++ b/strawberry/schema/types/base_scalars.py
@@ -23,7 +23,7 @@ def wrap_parser(parser: Callable, type_: str) -> Callable:
 
 def parse_decimal(value: str) -> decimal.Decimal:
     try:
-        return decimal.Decimal(value)
+        return decimal.Decimal(str(value))
     except decimal.DecimalException:
         raise GraphQLError(f'Value cannot represent a Decimal: "{value}".')
 

--- a/strawberry/schema/types/base_scalars.py
+++ b/strawberry/schema/types/base_scalars.py
@@ -21,7 +21,7 @@ def wrap_parser(parser: Callable, type_: str) -> Callable:
     return inner
 
 
-def parse_decimal(value: str) -> decimal.Decimal:
+def parse_decimal(value: object) -> decimal.Decimal:
     try:
         return decimal.Decimal(str(value))
     except decimal.DecimalException:

--- a/tests/schema/test_scalars.py
+++ b/tests/schema/test_scalars.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta, timezone
+from decimal import Decimal
 from textwrap import dedent
 from typing import Optional
 from uuid import UUID
@@ -383,3 +384,34 @@ def test_override_unknown_scalars():
 
     assert not result.errors
     assert result.data == {"duration": 10}
+
+
+def test_decimal():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def decimal(value: Decimal) -> Decimal:
+            return value
+
+    schema = strawberry.Schema(query=Query)
+
+    result = schema.execute_sync(
+        """
+        query {
+            floatDecimal: decimal(value: 3.14)
+            floatDecimal2: decimal(value: 3.14509999)
+            floatDecimal3: decimal(value: 0.000001)
+            stringDecimal: decimal(value: "3.14")
+            stringDecimal2: decimal(value: "3.1499999991")
+        }
+    """
+    )
+
+    assert not result.errors
+    assert result.data == {
+        "floatDecimal": "3.14",
+        "floatDecimal2": "3.14509999",
+        "floatDecimal3": "0.000001",
+        "stringDecimal": "3.14",
+        "stringDecimal2": "3.1499999991",
+    }


### PR DESCRIPTION
## Description

When we parse the Decimal scalar we need to make sure to cast it as a string otherwise Python will create a Decimal with floating errors.

For example, before this fix, the unit tests would fail with this:

```python
E       AssertionError: assert {'floatDecimal': '3.140000000000000124344978758017532527446746826171875',\n 'floatDecimal2': '3.145099989999999845480260773911140859127044677734375',\n 'floatDecimal3': '9.99999999999999954748111825886258685613938723690807819366455078125E-7',\n 'stringDecimal': '3.14',\n 'stringDecimal2': '3.1499999991'} == {'floatDecimal': '3.14',\n 'floatDecimal2': '3.00000114509999',\n 'floatDecimal3': '0.000001',\n 'stringDecimal': '3.14',\n 'stringDecimal2': '3.1499999991'}
E         Common items:
E         {'stringDecimal': '3.14', 'stringDecimal2': '3.1499999991'}
E         Differing items:
E         {'floatDecimal3': '9.99999999999999954748111825886258685613938723690807819366455078125E-7'} != {'floatDecimal3': '0.000001'}
E         {'floatDecimal': '3.140000000000000124344978758017532527446746826171875'} != {'floatDecimal': '3.14'}
E         {'floatDecimal2': '3.145099989999999845480260773911140859127044677734375'} != {'floatDecimal2': '3.14509999'}
E         Full diff:
E           {
E         -  'floatDecimal': '3.14',
E         -  'floatDecimal2': '3.14509999',
E         -  'floatDecimal3': '0.000001',
E         +  'floatDecimal': '3.140000000000000124344978758017532527446746826171875',
E         +  'floatDecimal2': '3.145099989999999845480260773911140859127044677734375',
E         +  'floatDecimal3': '9.99999999999999954748111825886258685613938723690807819366455078125E-7',
E            'stringDecimal': '3.14',
E            'stringDecimal2': '3.1499999991',
E           }
```

You can see that the `floatDecimal` all have imprecision errors. After the fix, the Decimal is created correctly (the constructor always receives a string as the documentation explains: https://docs.python.org/3/library/decimal.html

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Closes #1807

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
