### PR TITLE
Parse variables when passed with query params

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+This release fixes an issue in the previous release where requests using query params did not support passing variable values. Variables passed by query params are now parsed from a string to a dictionary.

--- a/strawberry/aiohttp/handlers/http_handler.py
+++ b/strawberry/aiohttp/handlers/http_handler.py
@@ -8,7 +8,7 @@ from typing_extensions import Literal
 from aiohttp import web
 from strawberry.exceptions import MissingQueryError
 from strawberry.file_uploads.utils import replace_placeholders_with_files
-from strawberry.http import GraphQLRequestData, parse_request_data
+from strawberry.http import GraphQLRequestData, parse_query_params, parse_request_data
 from strawberry.schema import BaseSchema
 from strawberry.schema.exceptions import InvalidOperationTypeError
 from strawberry.types.graphql import OperationType
@@ -43,7 +43,11 @@ class HTTPHandler:
     async def get(self, request: web.Request) -> web.StreamResponse:
         if request.query:
             try:
-                request_data = parse_request_data(request.query)
+                query_params = {
+                    key: request.query.getone(key) for key in set(request.query.keys())
+                }
+                query_data = parse_query_params(query_params)
+                request_data = parse_request_data(query_data)
             except MissingQueryError:
                 raise web.HTTPBadRequest(reason="No GraphQL query found in the request")
 

--- a/strawberry/asgi/handlers/http_handler.py
+++ b/strawberry/asgi/handlers/http_handler.py
@@ -9,7 +9,7 @@ from starlette.types import Receive, Scope, Send
 from strawberry.asgi.utils import get_graphiql_html
 from strawberry.exceptions import MissingQueryError
 from strawberry.file_uploads.utils import replace_placeholders_with_files
-from strawberry.http import parse_request_data
+from strawberry.http import parse_query_params, parse_request_data
 from strawberry.schema import BaseSchema
 from strawberry.schema.exceptions import InvalidOperationTypeError
 from strawberry.types.graphql import OperationType
@@ -79,7 +79,7 @@ class HTTPHandler:
 
         if method == "GET":
             if request.query_params:
-                data = request.query_params._dict
+                data = parse_query_params(request.query_params._dict)
             elif self.should_render_graphiql(request):
                 return self.get_graphiql_response()
             else:

--- a/strawberry/chalice/views.py
+++ b/strawberry/chalice/views.py
@@ -3,7 +3,12 @@ from typing import Dict, List, Union
 from chalice.app import BadRequestError, Request, Response
 from strawberry.chalice.graphiql import render_graphiql_page
 from strawberry.exceptions import MissingQueryError
-from strawberry.http import GraphQLHTTPResponse, parse_request_data, process_result
+from strawberry.http import (
+    GraphQLHTTPResponse,
+    parse_query_params,
+    parse_request_data,
+    process_result,
+)
 from strawberry.schema import BaseSchema
 from strawberry.types import ExecutionResult
 
@@ -93,7 +98,7 @@ class GraphQLView:
                     http_status_code=400,
                 )
         elif request.method == "GET" and request.query_params:
-            data = request.query_params
+            data = parse_query_params(request.query_params)
 
         elif request.method == "GET" and self.should_render_graphiql(
             self.graphiql, request

--- a/strawberry/django/views.py
+++ b/strawberry/django/views.py
@@ -21,6 +21,7 @@ from strawberry.file_uploads.utils import replace_placeholders_with_files
 from strawberry.http import (
     GraphQLHTTPResponse,
     GraphQLRequestData,
+    parse_query_params,
     parse_request_data,
     process_result,
 )
@@ -74,7 +75,7 @@ class BaseView(View):
 
             return data
         elif request.method.lower() == "get" and request.META.get("QUERY_STRING"):
-            return request.GET
+            return parse_query_params(request.GET.copy())
 
         return json.loads(request.body)
 

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -15,7 +15,12 @@ from strawberry.asgi.utils import get_graphiql_html
 from strawberry.exceptions import InvalidCustomContext, MissingQueryError
 from strawberry.fastapi.handlers import GraphQLTransportWSHandler, GraphQLWSHandler
 from strawberry.file_uploads.utils import replace_placeholders_with_files
-from strawberry.http import GraphQLHTTPResponse, parse_request_data, process_result
+from strawberry.http import (
+    GraphQLHTTPResponse,
+    parse_query_params,
+    parse_request_data,
+    process_result,
+)
 from strawberry.schema import BaseSchema
 from strawberry.schema.exceptions import InvalidOperationTypeError
 from strawberry.subscriptions import GRAPHQL_TRANSPORT_WS_PROTOCOL, GRAPHQL_WS_PROTOCOL
@@ -147,10 +152,11 @@ class GraphQLRouter(APIRouter):
             actual_response: Response
 
             if request.query_params:
+                query_data = parse_query_params(request.query_params._dict)
                 return await self.execute_request(
                     request=request,
                     response=response,
-                    data=request.query_params._dict,
+                    data=query_data,
                     context=context,
                     root_value=root_value,
                 )

--- a/strawberry/flask/views.py
+++ b/strawberry/flask/views.py
@@ -6,7 +6,12 @@ from flask.views import View
 from strawberry.exceptions import MissingQueryError
 from strawberry.file_uploads.utils import replace_placeholders_with_files
 from strawberry.flask.graphiql import render_graphiql_page, should_render_graphiql
-from strawberry.http import GraphQLHTTPResponse, parse_request_data, process_result
+from strawberry.http import (
+    GraphQLHTTPResponse,
+    parse_query_params,
+    parse_request_data,
+    process_result,
+)
 from strawberry.schema.base import BaseSchema
 from strawberry.schema.exceptions import InvalidOperationTypeError
 from strawberry.types import ExecutionResult
@@ -50,7 +55,7 @@ class GraphQLView(View):
 
             data = replace_placeholders_with_files(operations, files_map, request.files)
         elif method == "GET" and request.args:
-            data = request.args.to_dict()
+            data = parse_query_params(request.args.to_dict())
         elif method == "GET" and should_render_graphiql(self.graphiql, request):
             template = render_graphiql_page()
 

--- a/strawberry/http.py
+++ b/strawberry/http.py
@@ -1,3 +1,4 @@
+import json
 from dataclasses import dataclass
 from typing import Any, Dict, List, Mapping, Optional
 
@@ -31,6 +32,13 @@ class GraphQLRequestData:
     query: str
     variables: Optional[Dict[str, Any]]
     operation_name: Optional[str]
+
+
+def parse_query_params(params: Dict[str, str]) -> Dict[str, Any]:
+    if "variables" in params:
+        params["variables"] = json.loads(params["variables"])
+
+    return params
 
 
 def parse_request_data(data: Mapping) -> GraphQLRequestData:

--- a/strawberry/sanic/views.py
+++ b/strawberry/sanic/views.py
@@ -12,6 +12,7 @@ from strawberry.file_uploads.utils import replace_placeholders_with_files
 from strawberry.http import (
     GraphQLHTTPResponse,
     GraphQLRequestData,
+    parse_query_params,
     parse_request_data,
     process_result,
 )
@@ -73,12 +74,14 @@ class GraphQLView(HTTPMethodView):
 
     async def get(self, request: Request) -> HTTPResponse:
         if request.args:
-            # Sanic uses urllib to parse
-            # This returns a list of values for each variable name
-            # Enforcing only one value
-            data = {
+            # Sanic request.args uses urllib.parse.parse_qs
+            # returns a dictionary where the keys are the unique variable names
+            # and the values are a list of values for each variable name
+            # Enforcing using the first value
+            query_data = {
                 variable_name: value[0] for variable_name, value in request.args.items()
             }
+            data = parse_query_params(query_data)
 
             try:
                 request_data = parse_request_data(data)

--- a/tests/aiohttp/test_query_params.py
+++ b/tests/aiohttp/test_query_params.py
@@ -1,4 +1,4 @@
-async def test_no_graphiql_no_query(aiohttp_app_client):
+async def test_no_query(aiohttp_app_client):
     params = {
         "variables": """
             query {
@@ -11,7 +11,7 @@ async def test_no_graphiql_no_query(aiohttp_app_client):
     assert response.status == 400
 
 
-async def test_no_graphiql_get_with_query_params(aiohttp_app_client):
+async def test_get_with_query_params(aiohttp_app_client):
     query = {
         "query": """
             query {
@@ -24,6 +24,18 @@ async def test_no_graphiql_get_with_query_params(aiohttp_app_client):
     data = await response.json()
     assert response.status == 200
     assert data["data"]["hello"] == "Hello world"
+
+
+async def test_can_pass_variables_with_query_params(aiohttp_app_client):
+    query = {
+        "query": "query Hello($name: String!) { hello(name: $name) }",
+        "variables": '{"name": "James"}',
+    }
+
+    response = await aiohttp_app_client.get("/graphql", params=query)
+    data = await response.json()
+    assert response.status == 200
+    assert data["data"]["hello"] == "Hello James"
 
 
 async def test_post_fails_with_query_params(aiohttp_app_client):

--- a/tests/aiohttp/test_query_params.py
+++ b/tests/aiohttp/test_query_params.py
@@ -1,11 +1,5 @@
 async def test_no_query(aiohttp_app_client):
-    params = {
-        "variables": """
-            query {
-                hello
-            }
-        """
-    }
+    params = {"variables": '{"name": "James"}'}
 
     response = await aiohttp_app_client.get("/graphql", params=params)
     assert response.status == 400

--- a/tests/asgi/test_query_params.py
+++ b/tests/asgi/test_query_params.py
@@ -2,7 +2,7 @@ from starlette import status
 
 
 def test_no_query(test_client):
-    response = test_client.get("/graphql", params={"variables": "{ hello }"})
+    response = test_client.get("/graphql", params={"variables": '{"name": "James"}'})
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 

--- a/tests/asgi/test_query_params.py
+++ b/tests/asgi/test_query_params.py
@@ -1,19 +1,30 @@
 from starlette import status
 
 
-def test_no_graphiql_no_query(test_client_no_graphiql):
-    response = test_client_no_graphiql.get(
-        "/graphql", params={"variables": "{ hello }"}
-    )
+def test_no_query(test_client):
+    response = test_client.get("/graphql", params={"variables": "{ hello }"})
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_no_graphiql_get_with_query_params(test_client_no_graphiql):
-    response = test_client_no_graphiql.get("/graphql", params={"query": "{ hello }"})
+def test_get_with_query_params(test_client):
+    response = test_client.get("/graphql", params={"query": "{ hello }"})
 
     assert response.status_code == status.HTTP_200_OK
     assert response.json() == {"data": {"hello": "Hello world"}}
+
+
+def test_can_pass_variables_with_query_params(test_client):
+    response = test_client.get(
+        "/graphql",
+        params={
+            "query": "query Hello($name: String!) { hello(name: $name) }",
+            "variables": '{"name": "James"}',
+        },
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {"data": {"hello": "Hello James"}}
 
 
 def test_post_fails_with_query_params(test_client):

--- a/tests/chalice/app.py
+++ b/tests/chalice/app.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import strawberry
 from chalice import Chalice  # type: ignore
 from strawberry.chalice.views import GraphQLView
@@ -11,6 +13,10 @@ class Query:
     @strawberry.field
     def greetings(self) -> str:
         return "hello"
+
+    @strawberry.field
+    def hello(self, name: Optional[str] = None) -> str:
+        return f"Hello {name or 'world'}"
 
 
 @strawberry.type

--- a/tests/fastapi/test_query_params.py
+++ b/tests/fastapi/test_query_params.py
@@ -19,7 +19,7 @@ def test_no_graphiql_no_query():
     app.include_router(graphql_app, prefix="/graphql")
 
     test_client = TestClient(app)
-    response = test_client.get("/graphql", params={"variables": "{ abc }"})
+    response = test_client.get("/graphql", params={"variables": '{"name": "James"}'})
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 

--- a/tests/fastapi/test_query_params.py
+++ b/tests/fastapi/test_query_params.py
@@ -24,67 +24,40 @@ def test_no_graphiql_no_query():
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_no_graphiql_get_with_query_params():
-    @strawberry.type
-    class Query:
-        @strawberry.field
-        def abc(self) -> str:
-            return "abc"
-
-    app = FastAPI()
-    schema = strawberry.Schema(query=Query)
-    graphql_app = GraphQLRouter(schema, graphiql=False)
-    app.include_router(graphql_app, prefix="/graphql")
-
-    test_client = TestClient(app)
-    response = test_client.get("/graphql", params={"query": "{ abc }"})
+def test_get_with_query_params(test_client):
+    response = test_client.get("/graphql", params={"query": "{ hello }"})
 
     assert response.status_code == status.HTTP_200_OK
-    assert response.json() == {"data": {"abc": "abc"}}
+    assert response.json() == {"data": {"hello": "Hello world"}}
 
 
-def test_post_fails_with_query_params():
-    @strawberry.type
-    class Query:
-        @strawberry.field
-        def abc(self) -> str:
-            return "abc"
+def test_can_pass_variables_with_query_params(test_client):
+    response = test_client.get(
+        "/graphql",
+        params={
+            "query": "query Hello($name: String!) { hello(name: $name) }",
+            "variables": '{"name": "James"}',
+        },
+    )
 
-    app = FastAPI()
-    schema = strawberry.Schema(query=Query)
-    graphql_app = GraphQLRouter(schema)
-    app.include_router(graphql_app, prefix="/graphql")
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {"data": {"hello": "Hello James"}}
 
-    test_client = TestClient(app)
+
+def test_post_fails_with_query_params(test_client):
     response = test_client.post("/graphql", params={"query": "{ abc }"})
 
     assert response.status_code == status.HTTP_415_UNSUPPORTED_MEDIA_TYPE
 
 
-def test_does_not_allow_mutation():
-    @strawberry.type
-    class Query:
-        abc: str
-
-    @strawberry.type
-    class Mutation:
-        @strawberry.mutation
-        def abc(self) -> str:
-            return "abc"
-
-    app = FastAPI()
-    schema = strawberry.Schema(query=Query, mutation=Mutation)
-    graphql_app = GraphQLRouter(schema)
-    app.include_router(graphql_app, prefix="/graphql")
-
-    test_client = TestClient(app)
+def test_does_not_allow_mutation(test_client):
     response = test_client.get("/graphql", params={"query": "mutation { abc }"})
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.text == "mutations are not allowed when using GET"
 
 
-def test_fails_if_allow_queries_via_get_false():
+def test_fails_if_allow_queries_via_get_false(test_client):
     @strawberry.type
     class Query:
         abc: str

--- a/tests/flask/app.py
+++ b/tests/flask/app.py
@@ -13,7 +13,9 @@ def create_app(**kwargs):
 
     @strawberry.type
     class Query:
-        hello: str = "strawberry"
+        @strawberry.field
+        def hello(self, name: typing.Optional[str] = None) -> str:
+            return f"Hello {name or 'world'}"
 
     @strawberry.type
     class Mutation:

--- a/tests/flask/test_query_params.py
+++ b/tests/flask/test_query_params.py
@@ -9,13 +9,7 @@ def test_no_graphiql_empty_get(flask_client_no_graphiql):
 
 
 def test_no_query(flask_client):
-    params = {
-        "variables": """
-            query {
-                hello
-            }
-        """
-    }
+    params = {"variables": '{"name": "James"}'}
 
     response = flask_client.get("/graphql", query_string=params)
 

--- a/tests/flask/test_query_params.py
+++ b/tests/flask/test_query_params.py
@@ -8,7 +8,7 @@ def test_no_graphiql_empty_get(flask_client_no_graphiql):
     assert response.status_code == 415
 
 
-def test_no_graphiql_no_query(flask_client_no_graphiql):
+def test_no_query(flask_client):
     params = {
         "variables": """
             query {
@@ -17,12 +17,12 @@ def test_no_graphiql_no_query(flask_client_no_graphiql):
         """
     }
 
-    response = flask_client_no_graphiql.get("/graphql", query_string=params)
+    response = flask_client.get("/graphql", query_string=params)
 
     assert response.status_code == 400
 
 
-def test_no_graphiql_get_with_query_params(flask_client_no_graphiql):
+def test_get_with_query_params(flask_client):
     params = {
         "query": """
             query {
@@ -31,14 +31,27 @@ def test_no_graphiql_get_with_query_params(flask_client_no_graphiql):
         """
     }
 
-    response = flask_client_no_graphiql.get("/graphql", query_string=params)
+    response = flask_client.get("/graphql", query_string=params)
     data = json.loads(response.data.decode())
 
     assert response.status_code == 200
-    assert data["data"]["hello"] == "strawberry"
+    assert data["data"]["hello"] == "Hello world"
 
 
-def test_no_graphiql_post_fails_with_query_params(flask_client):
+def test_can_pass_variables_with_query_params(flask_client):
+    params = {
+        "query": "query Hello($name: String!) { hello(name: $name) }",
+        "variables": '{"name": "James"}',
+    }
+
+    response = flask_client.get("/graphql", query_string=params)
+    data = json.loads(response.data.decode())
+
+    assert response.status_code == 200
+    assert data["data"]["hello"] == "Hello James"
+
+
+def test_post_fails_with_query_params(flask_client):
     params = {
         "query": """
             query {

--- a/tests/flask/test_view.py
+++ b/tests/flask/test_view.py
@@ -21,7 +21,20 @@ def test_graphql_query(flask_client):
     data = json.loads(response.data.decode())
 
     assert response.status_code == 200
-    assert data["data"]["hello"] == "strawberry"
+    assert data["data"]["hello"] == "Hello world"
+
+
+def test_can_pass_variables(flask_client):
+    query = {
+        "query": "query Hello($name: String!) { hello(name: $name) }",
+        "variables": {"name": "James"},
+    }
+
+    response = flask_client.get("/graphql", json=query)
+    data = json.loads(response.data.decode())
+
+    assert response.status_code == 200
+    assert data["data"]["hello"] == "Hello James"
 
 
 def test_fails_when_request_body_has_invalid_json(flask_client):

--- a/tests/sanic/app.py
+++ b/tests/sanic/app.py
@@ -14,7 +14,9 @@ def create_app(**kwargs):
 
     @strawberry.type
     class Query:
-        hello: str = "strawberry"
+        @strawberry.field
+        def hello(self, name: typing.Optional[str] = None) -> str:
+            return f"Hello {name or 'world'}"
 
     @strawberry.type
     class Mutation:

--- a/tests/sanic/test_query_params.py
+++ b/tests/sanic/test_query_params.py
@@ -5,11 +5,7 @@ def test_no_graphiql_empty_get(sanic_client_no_graphiql):
 
 
 def test_no_query(sanic_client):
-    params = {
-        "variables": """
-            hello
-        """
-    }
+    params = {"variables": '{"name": "James"}'}
 
     request, response = sanic_client.test_client.get("/graphql", params=params)
     assert response.status == 400
@@ -33,7 +29,7 @@ def test_get_with_query_params(sanic_client):
 def test_can_pass_variables_with_query_params(sanic_client):
     params = {
         "query": "query Hello($name: String!) { hello(name: $name) }",
-        "variables": {"name": "James"},
+        "variables": '{"name": "James"}',
     }
 
     request, response = sanic_client.test_client.get("/graphql", params=params)

--- a/tests/sanic/test_query_params.py
+++ b/tests/sanic/test_query_params.py
@@ -4,20 +4,18 @@ def test_no_graphiql_empty_get(sanic_client_no_graphiql):
     assert response.status == 404
 
 
-def test_no_graphiql_no_query(sanic_client_no_graphiql):
+def test_no_query(sanic_client):
     params = {
         "variables": """
             hello
         """
     }
 
-    request, response = sanic_client_no_graphiql.test_client.get(
-        "/graphql", params=params
-    )
+    request, response = sanic_client.test_client.get("/graphql", params=params)
     assert response.status == 400
 
 
-def test_no_graphiql_get_with_query_params(sanic_client_no_graphiql):
+def test_get_with_query_params(sanic_client):
     params = {
         "query": """
             query {
@@ -26,12 +24,22 @@ def test_no_graphiql_get_with_query_params(sanic_client_no_graphiql):
         """
     }
 
-    request, response = sanic_client_no_graphiql.test_client.get(
-        "/graphql", params=params
-    )
+    request, response = sanic_client.test_client.get("/graphql", params=params)
     data = response.json
     assert response.status == 200
-    assert data["data"]["hello"] == "strawberry"
+    assert data["data"]["hello"] == "Hello world"
+
+
+def test_can_pass_variables_with_query_params(sanic_client):
+    params = {
+        "query": "query Hello($name: String!) { hello(name: $name) }",
+        "variables": {"name": "James"},
+    }
+
+    request, response = sanic_client.test_client.get("/graphql", params=params)
+    data = response.json
+    assert response.status == 200
+    assert data["data"]["hello"] == "Hello James"
 
 
 def test_post_fails_with_query_params(sanic_client):

--- a/tests/sanic/test_view.py
+++ b/tests/sanic/test_view.py
@@ -21,7 +21,19 @@ def test_graphql_query(sanic_client):
     request, response = sanic_client.test_client.post("/graphql", json=query)
     data = response.json
     assert response.status == 200
-    assert data["data"]["hello"] == "strawberry"
+    assert data["data"]["hello"] == "Hello world"
+
+
+def test_can_pass_variables(sanic_client):
+    query = {
+        "query": "query Hello($name: String!) { hello(name: $name) }",
+        "variables": {"name": "James"},
+    }
+
+    request, response = sanic_client.test_client.post("/graphql", json=query)
+    data = response.json
+    assert response.status == 200
+    assert data["data"]["hello"] == "Hello James"
 
 
 def test_graphiql_view(sanic_client):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

When query params were being parsed, `variables` was a `str`, but the execute method was expecting a `Dict[str, Any]`.
Changed so that if query params have a `variables` key, it is parsed from a JSON string to a dictionary.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #1818 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
