### PR TITLE
Add extremely basic support for unpacking in union

### DIFF
--- a/tests/mypy/test_union.yml
+++ b/tests/mypy/test_union.yml
@@ -76,3 +76,37 @@
     main:16: note: Revealed type is "builtins.object"
     main:17: note: Revealed type is "Union[main.User, main.Error]"
     main:20: note: Revealed type is "main.User"
+
+- case: test_union_unpacking
+  main: |
+    import strawberry
+
+    @strawberry.type
+    class User:
+        name: str
+
+    @strawberry.type
+    class Error:
+        message: str
+
+    @strawberry.type
+    class AnotherError:
+        message: str
+
+    UserErrors = (
+        Error,
+        AnotherError,
+    )
+
+    Response = strawberry.union(types=(User, *UserErrors), name="Response")
+
+    a: Response
+    reveal_type(Response)
+    reveal_type(a)
+
+    a = User("abc")
+    reveal_type(a)
+  out: |
+    main:23: note: Revealed type is "builtins.object"
+    main:24: note: Revealed type is "Union[main.User, Any]"
+    main:27: note: Revealed type is "main.User"


### PR DESCRIPTION
Closes https://github.com/strawberry-graphql/strawberry/issues/1828

This PR add support for the following code in mypy:


```python
UserErrors = (
    Error,
    AnotherError,
)

Response = strawberry.union(types=(User, *UserErrors), name="Response")
```

unfortunately the support is not ideal as response now is typed as:

```
note: Revealed type is "Union[main.User, Any]"
```

which is not ideal, I'll spend a bit more time trying to see if I can find the value of the unpacked variable. If I can find a solution quickly enough I'll merge this since it prevents mypy from crashing at least.