### PR TITLE
Support transport specific FastAPI `context_getters`

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+This release updates the FastAPI integration to support transport specific context getters.

--- a/docs/integrations/fastapi.md
+++ b/docs/integrations/fastapi.md
@@ -47,9 +47,15 @@ The `GraphQLRouter` accepts the following options:
   interface.
 - `allow_queries_via_get`: optional, defaults to `True`, whether to enable
   queries via `GET` requests
-- `context_getter`: optional FastAPI dependency for providing custom context
-  value.
-- `root_value_getter`: optional FastAPI dependency for providing custom root
+- `context_getter`: optional, default FastAPI dependency for providing custom
+  context value.
+- `http_get_context_getter`: optional, override `context_getter` for queries
+  executed via HTTP GET.
+- `http_post_context_getter`: optional, override `context_getter` for queries
+  executed via HTTP POST.
+- `ws_context_getter`: optional, override `context_getter` for queries executed
+  via WebSockets.
+- `root_value_getter`: optional, FastAPI dependency for providing custom root
   value.
 
 ## context_getter


### PR DESCRIPTION
## Description

This updates the FastAPI integration to support defining transport specific `context_getter`s. This is intended to solve #1821, but would be generally useful to anyone that has transport specific dependencies.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

* #1821

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
