### PR TITLE
Compiled resolvers proof of concept

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,42 @@
+Release type: minor
+
+This release Closes [#1666] by improving the injection of reserved arguments
+for resolvers and directives through use of an annotation-based approach which
+adds support for:
+
+1. Defining a directive value argument using a `DirectiveValue`
+annotation.
+2. Defining the resolve/directive `info` argument using the `Info` annotation
+
+**Deprecated:** Declaration of value and info arguments by relying on name-based
+matching without annotations.
+
+# Examples
+
+```python
+@strawberry.type
+class Cake:
+    frosting: Optional[str] = None
+    flavor: str = "Chocolate"
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def cake(self) -> Cake:
+        return Cake()
+
+@strawberry.directive(
+    locations=[DirectiveLocation.FIELD],
+    description="Add frosting with ``value`` to a cake.",
+)
+def add_frosting(value: str, v: DirectiveValue[Cake], my_info: Info):
+    # Arbitrary argument name when using `DirectiveValue` is supported!
+    assert isinstance(v, Cake)
+    if value in my_info.context["allergies"]:  # Info can now be accessed from directives!
+        raise AllergyError("You are allergic to this frosting!")
+    else:
+        v.frosting = value  # Value can now be used as a GraphQL argument name!
+    return v
+```
+
+[#1666]: (https://github.com/strawberry-graphql/strawberry/issues/1666)

--- a/strawberry/directive.py
+++ b/strawberry/directive.py
@@ -2,53 +2,63 @@ from __future__ import annotations
 
 import dataclasses
 import inspect
-import sys
-from itertools import islice
 from typing import Callable, List, Optional, TypeVar
+
+from backports.cached_property import cached_property
+from typing_extensions import Annotated
 
 from graphql import DirectiveLocation
 
-from strawberry.annotation import StrawberryAnnotation
 from strawberry.arguments import StrawberryArgument
+from strawberry.types.fields.resolver import (
+    INFO_PARAMSPEC,
+    ROOT_PARAMSPEC,
+    ReservedType,
+    StrawberryResolver,
+)
+
+
+T = TypeVar("T")
+
+
+class StrawberryDirectiveValue:
+    ...
+
+
+DirectiveValue = Annotated[T, StrawberryDirectiveValue()]
+DirectiveValue.__doc__ = (
+    """Represents the ``value`` argument for a GraphQL query directive."""
+)
+
+
+VALUE_PARAMSPEC = ReservedType(name="value", type=StrawberryDirectiveValue)
+"""Registers `DirectiveValue[...]` annotated arguments as reserved."""
+
+
+class StrawberryDirectiveResolver(StrawberryResolver[T]):
+
+    RESERVED_PARAMSPEC = (
+        INFO_PARAMSPEC,
+        ROOT_PARAMSPEC,
+        VALUE_PARAMSPEC,
+    )
+
+    @cached_property
+    def value_parameter(self) -> Optional[inspect.Parameter]:
+        return self.reserved_parameters.get(VALUE_PARAMSPEC)
 
 
 @dataclasses.dataclass
 class StrawberryDirective:
     python_name: str
     graphql_name: Optional[str]
-    resolver: Callable
+    resolver: StrawberryDirectiveResolver
     locations: List[DirectiveLocation]
     description: Optional[str] = None
 
     @property
     def arguments(self) -> List[StrawberryArgument]:
-        annotations = self.resolver.__annotations__
-        annotations = dict(islice(annotations.items(), 1, None))
-        annotations.pop("return", None)
-
-        parameters = inspect.signature(self.resolver).parameters
-
-        module = sys.modules[self.resolver.__module__]
-        annotation_namespace = module.__dict__
-        arguments = []
-        for arg_name, annotation in annotations.items():
-            parameter = parameters[arg_name]
-
-            argument = StrawberryArgument(
-                python_name=arg_name,
-                graphql_name=None,
-                type_annotation=StrawberryAnnotation(
-                    annotation=annotation, namespace=annotation_namespace
-                ),
-                default=parameter.default,
-            )
-
-            arguments.append(argument)
-
-        return arguments
-
-
-T = TypeVar("T")
+        return self.resolver.arguments
 
 
 def directive(
@@ -63,7 +73,7 @@ def directive(
             graphql_name=name,
             locations=locations,
             description=description,
-            resolver=f,
+            resolver=StrawberryDirectiveResolver(f),
         )
 
     return _wrap

--- a/strawberry/extensions/directives.py
+++ b/strawberry/extensions/directives.py
@@ -1,5 +1,8 @@
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Dict, Tuple
 
+from graphql import DirectiveNode
+
+from strawberry.directive import StrawberryDirective
 from strawberry.extensions import Extension
 from strawberry.types import Info
 from strawberry.utils.await_maybe import AwaitableOrValue, await_maybe
@@ -16,56 +19,60 @@ class DirectivesExtension(Extension):
     async def resolve(
         self, _next, root, info: Info, *args, **kwargs
     ) -> AwaitableOrValue[Any]:
-        result = await await_maybe(_next(root, info, *args, **kwargs))
+        value = await await_maybe(_next(root, info, *args, **kwargs))
 
         for directive in info.field_nodes[0].directives:
-            directive_name = directive.name.value
-
-            if directive_name in SPECIFIED_DIRECTIVES:
+            if directive.name.value in SPECIFIED_DIRECTIVES:
                 continue
-
-            # TODO: support converting lists
-            arguments = {
-                argument.name.value: argument.value.value  # type: ignore
-                for argument in directive.arguments
-            }
-
-            schema: Schema = info.schema._strawberry_schema  # type: ignore
-            strawberry_directive = schema.get_directive_by_name(directive_name)
-            assert (
-                strawberry_directive is not None
-            ), f"Directive {directive_name} not found"
-
-            result = await await_maybe(
-                strawberry_directive.resolver(result, **arguments)
+            strawberry_directive, arguments = process_directive(
+                directive, value, root, info
             )
+            value = await await_maybe(strawberry_directive.resolver(**arguments))
 
-        return result
+        return value
 
 
 class DirectivesExtensionSync(Extension):
-    # TODO: we might need the graphql info here
     def resolve(self, _next, root, info, *args, **kwargs) -> AwaitableOrValue[Any]:
-        result = _next(root, info, *args, **kwargs)
+        value = _next(root, info, *args, **kwargs)
 
         for directive in info.field_nodes[0].directives:
-            directive_name = directive.name.value
-
-            if directive_name in SPECIFIED_DIRECTIVES:
+            if directive.name.value in SPECIFIED_DIRECTIVES:
                 continue
+            strawberry_directive, arguments = process_directive(
+                directive, value, root, info
+            )
+            value = strawberry_directive.resolver(**arguments)
 
-            # TODO: support converting lists
-            arguments = {
-                argument.name.value: argument.value.value
-                for argument in directive.arguments
-            }
+        return value
 
-            schema: Schema = info.schema._strawberry_schema
-            strawberry_directive = schema.get_directive_by_name(directive_name)
-            assert (
-                strawberry_directive is not None
-            ), f"Directive {directive_name} not found"
 
-            result = strawberry_directive.resolver(result, **arguments)
+def process_directive(
+    directive: DirectiveNode,
+    value: Any,
+    root: Any,
+    info: Info,
+) -> Tuple[StrawberryDirective, Dict[str, Any]]:
+    """Get a `StrawberryDirective` from ``directive` and prepare its arguments."""
+    directive_name = directive.name.value
+    schema: Schema = info.schema._strawberry_schema  # type: ignore
 
-        return result
+    strawberry_directive = schema.get_directive_by_name(directive_name)
+    assert strawberry_directive is not None, f"Directive {directive_name} not found"
+
+    arguments = {
+        argument.name.value: argument.value.value  # type: ignore
+        for argument in directive.arguments
+    }
+    resolver = strawberry_directive.resolver
+
+    info_parameter = resolver.info_parameter
+    root_parameter = resolver.root_parameter
+    value_parameter = resolver.value_parameter
+    if info_parameter:
+        arguments[info_parameter.name] = info
+    if root_parameter:
+        arguments[root_parameter.name] = root
+    if value_parameter:
+        arguments[value_parameter.name] = value
+    return strawberry_directive, arguments

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -341,14 +341,16 @@ class GraphQLCoreConverter:
             args = []
 
             if field.base_resolver:
-                if field.base_resolver.has_self_arg:
+                if field.base_resolver.self_parameter:
                     args.append(source)
 
-                if field.base_resolver.has_root_arg:
-                    kwargs["root"] = source
+                root_parameter = field.base_resolver.root_parameter
+                if root_parameter:
+                    kwargs[root_parameter.name] = source
 
-                if field.base_resolver.has_info_arg:
-                    kwargs["info"] = info
+                info_parameter = field.base_resolver.info_parameter
+                if info_parameter:
+                    kwargs[info_parameter.name] = info
 
             return args, kwargs
 

--- a/strawberry/types/fields/resolver.py
+++ b/strawberry/types/fields/resolver.py
@@ -3,24 +3,125 @@ from __future__ import annotations as _
 import builtins
 import inspect
 import sys
+import warnings
+from functools import lru_cache
 from inspect import isasyncgenfunction, iscoroutinefunction
-from typing import Callable, Dict, Generic, List, Mapping, Optional, TypeVar, Union
+from typing import (  # type: ignore[attr-defined]
+    Any,
+    Callable,
+    Dict,
+    Generic,
+    List,
+    Mapping,
+    NamedTuple,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    _eval_type,
+)
 
 from backports.cached_property import cached_property
+from typing_extensions import Annotated, Protocol, get_args, get_origin
 
 from strawberry.annotation import StrawberryAnnotation
 from strawberry.arguments import StrawberryArgument
 from strawberry.exceptions import MissingArgumentsAnnotationsError
 from strawberry.type import StrawberryType
-from strawberry.utils.inspect import get_func_args
+from strawberry.types.info import Info
 
+
+class ReservedParameterSpecification(Protocol):
+    def find(
+        self, parameters: Tuple[inspect.Parameter, ...], resolver: StrawberryResolver
+    ) -> Optional[inspect.Parameter]:
+        """Finds the reserved parameter from ``parameters``."""
+
+
+class ReservedName(NamedTuple):
+    name: str
+
+    def find(
+        self, parameters: Tuple[inspect.Parameter, ...], _: StrawberryResolver
+    ) -> Optional[inspect.Parameter]:
+        return next((p for p in parameters if p.name == self.name), None)
+
+
+class ReservedNameBoundParameter(NamedTuple):
+    name: str
+
+    def find(
+        self, parameters: Tuple[inspect.Parameter, ...], _: StrawberryResolver
+    ) -> Optional[inspect.Parameter]:
+        if parameters:  # Add compatibility for resolvers with no arguments
+            first_parameter = parameters[0]
+            return first_parameter if first_parameter.name == self.name else None
+        else:
+            return None
+
+
+class ReservedType(NamedTuple):
+    """Define a reserved type by name or by type.
+
+    To preserve backwards-comaptibility, if an annotation was defined but does not match
+    :attr:`type`, then the name is used as a fallback.
+    """
+
+    name: str
+    type: Type
+
+    def find(
+        self, parameters: Tuple[inspect.Parameter, ...], resolver: StrawberryResolver
+    ) -> Optional[inspect.Parameter]:
+        for parameter in parameters:
+            resolved_annotation = _eval_type(
+                parameter.annotation, resolver._namespace, None
+            )
+            if self.is_reserved_type(resolved_annotation):
+                return parameter
+
+        # Fallback to matching by name
+        reserved_name = ReservedName(name=self.name).find(parameters, resolver)
+        if reserved_name:
+            warning = DeprecationWarning(
+                f"Argument name-based matching of '{self.name}' is deprecated and will "
+                "be removed in v1.0. Ensure that reserved arguments are annotated "
+                "their respective types (i.e. use value: 'DirectiveValue[str]' instead "
+                "of 'value: str' and 'info: Info' instead of a plain 'info')."
+            )
+            warnings.warn(warning)
+            return reserved_name
+        else:
+            return None
+
+    def is_reserved_type(self, other: Type) -> bool:
+        if get_origin(other) is Annotated:
+            # Handle annotated arguments such as Private[str] and DirectiveValue[str]
+            return any(isinstance(argument, self.type) for argument in get_args(other))
+        else:
+            # Handle both concrete and generic types (i.e Info, and Info[Any, Any])
+            return other is self.type or get_origin(other) is self.type
+
+
+SELF_PARAMSPEC = ReservedNameBoundParameter("self")
+CLS_PARAMSPEC = ReservedNameBoundParameter("cls")
+ROOT_PARAMSPEC = ReservedName("root")
+INFO_PARAMSPEC = ReservedType("info", Info)
 
 T = TypeVar("T")
 
+cached_signature = lru_cache(maxsize=250)(inspect.signature)
+
 
 class StrawberryResolver(Generic[T]):
-    # TODO: Move to StrawberryArgument? StrawberryResolver ClassVar?
-    _SPECIAL_ARGS = {"root", "info", "self", "cls"}
+
+    RESERVED_PARAMSPEC: Tuple[ReservedParameterSpecification, ...] = (
+        SELF_PARAMSPEC,
+        CLS_PARAMSPEC,
+        ROOT_PARAMSPEC,
+        INFO_PARAMSPEC,
+    )
 
     def __init__(
         self,
@@ -44,70 +145,53 @@ class StrawberryResolver(Generic[T]):
         return self.wrapped_func(*args, **kwargs)
 
     @cached_property
-    def annotations(self) -> Dict[str, object]:
-        """Annotations for the resolver.
+    def signature(self) -> inspect.Signature:
+        return cached_signature(self._unbound_wrapped_func)
 
-        Does not include special args defined in _SPECIAL_ARGS (e.g. self, root, info)
-        """
-        annotations = self._unbound_wrapped_func.__annotations__
-
-        annotations = {
-            name: annotation
-            for name, annotation in annotations.items()
-            if name not in self._SPECIAL_ARGS
-        }
-
-        return annotations
+    @cached_property
+    def reserved_parameters(
+        self,
+    ) -> Dict[ReservedParameterSpecification, Optional[inspect.Parameter]]:
+        """Mapping of reserved parameter specification to parameter."""
+        parameters = tuple(self.signature.parameters.values())
+        return {spec: spec.find(parameters, self) for spec in self.RESERVED_PARAMSPEC}
 
     @cached_property
     def arguments(self) -> List[StrawberryArgument]:
-        parameters = inspect.signature(self._unbound_wrapped_func).parameters
-        function_arguments = set(parameters) - self._SPECIAL_ARGS
+        """Resolver arguments exposed in the GraphQL Schema."""
+        parameters = self.signature.parameters.values()
+        reserved_parameters = tuple(self.reserved_parameters.values())
 
-        arguments = self.annotations.copy()
-        arguments.pop("return", None)  # Discard return annotation to get just arguments
-
-        arguments_missing_annotations = function_arguments - set(arguments)
-
-        if any(arguments_missing_annotations):
-            raise MissingArgumentsAnnotationsError(
-                field_name=self.name,
-                arguments=arguments_missing_annotations,
-            )
-
-        module = sys.modules[self._module]
-        annotation_namespace = module.__dict__
-        strawberry_arguments = []
-        for arg_name, annotation in arguments.items():
-            parameter = parameters[arg_name]
-
-            argument = StrawberryArgument(
-                python_name=arg_name,
-                graphql_name=None,
-                type_annotation=StrawberryAnnotation(
-                    annotation=annotation, namespace=annotation_namespace
-                ),
-                default=parameter.default,
-            )
-
-            strawberry_arguments.append(argument)
-
-        return strawberry_arguments
+        missing_annotations = set()
+        arguments = []
+        for param in filter(lambda p: p not in reserved_parameters, parameters):
+            if param.annotation is inspect.Signature.empty:
+                missing_annotations.add(param.name)
+            else:
+                argument = StrawberryArgument(
+                    python_name=param.name,
+                    graphql_name=None,
+                    type_annotation=StrawberryAnnotation(
+                        annotation=param.annotation, namespace=self._namespace
+                    ),
+                    default=param.default,
+                )
+                arguments.append(argument)
+        if missing_annotations:
+            raise MissingArgumentsAnnotationsError(self.name, missing_annotations)
+        return arguments
 
     @cached_property
-    def has_info_arg(self) -> bool:
-        args = get_func_args(self._unbound_wrapped_func)
-        return "info" in args
+    def info_parameter(self) -> Optional[inspect.Parameter]:
+        return self.reserved_parameters.get(INFO_PARAMSPEC)
 
     @cached_property
-    def has_root_arg(self) -> bool:
-        args = get_func_args(self._unbound_wrapped_func)
-        return "root" in args
+    def root_parameter(self) -> Optional[inspect.Parameter]:
+        return self.reserved_parameters.get(ROOT_PARAMSPEC)
 
     @cached_property
-    def has_self_arg(self) -> bool:
-        args = get_func_args(self._unbound_wrapped_func)
-        return args and args[0] == "self"
+    def self_parameter(self) -> Optional[inspect.Parameter]:
+        return self.reserved_parameters.get(SELF_PARAMSPEC)
 
     @cached_property
     def name(self) -> str:
@@ -116,17 +200,13 @@ class StrawberryResolver(Generic[T]):
 
     @cached_property
     def type_annotation(self) -> Optional[StrawberryAnnotation]:
-        try:
-            return_annotation = self.annotations["return"]
-        except KeyError:
-            # No return annotation at all (as opposed to `-> None`)
+        return_annotation = self.signature.return_annotation
+        if return_annotation is inspect.Signature.empty:
             return None
-
-        module = sys.modules[self._module]
-        type_annotation = StrawberryAnnotation(
-            annotation=return_annotation, namespace=module.__dict__
-        )
-
+        else:
+            type_annotation = StrawberryAnnotation(
+                annotation=return_annotation, namespace=self._namespace
+            )
         return type_annotation
 
     @property
@@ -163,8 +243,8 @@ class StrawberryResolver(Generic[T]):
         )
 
     @cached_property
-    def _module(self) -> str:
-        return self._unbound_wrapped_func.__module__
+    def _namespace(self) -> Dict[str, Any]:
+        return sys.modules[self._unbound_wrapped_func.__module__].__dict__
 
     @cached_property
     def _unbound_wrapped_func(self) -> Callable[..., T]:

--- a/tests/schema/test_directives.py
+++ b/tests/schema/test_directives.py
@@ -114,6 +114,32 @@ def test_can_declare_directives():
     assert schema.as_str() == textwrap.dedent(expected_schema).strip()
 
 
+def test_directive_arguments_without_value_param():
+    """regression test for https://github.com/strawberry-graphql/strawberry/issues/1666"""
+    @strawberry.type
+    class Query:
+        cake: str = "victoria sponge"
+
+    @strawberry.directive(
+        locations=[DirectiveLocation.FIELD], description="Don't actually like cake? try ice cream instead"
+    )
+    def ice_cream(flavor: str):
+        return f'{flavor} ice cream'
+
+    schema = strawberry.Schema(query=Query, directives=[ice_cream])
+
+    expected_schema = '''
+    """Don't actually like cake? try ice cream instead"""
+    directive @iceCream(flavor: String!) on FIELD
+
+    type Query {
+      cake: String!
+    }
+    '''
+
+    assert schema.as_str() == textwrap.dedent(expected_schema).strip()
+
+
 def test_runs_directives():
     @strawberry.type
     class Person:

--- a/tests/schema/test_directives.py
+++ b/tests/schema/test_directives.py
@@ -1,12 +1,14 @@
 import textwrap
-from typing import List
+from enum import Enum
+from typing import Dict, List, Optional
 
 import pytest
 
 import strawberry
-from strawberry.directive import DirectiveLocation
+from strawberry.directive import DirectiveLocation, DirectiveValue
 from strawberry.extensions import Extension
 from strawberry.schema.config import StrawberryConfig
+from strawberry.types.info import Info
 from strawberry.utils.await_maybe import await_maybe
 
 
@@ -30,7 +32,11 @@ def test_supports_default_directives():
     }"""
 
     schema = strawberry.Schema(query=Query)
-    result = schema.execute_sync(query, variable_values={"includePoints": False})
+    result = schema.execute_sync(
+        query,
+        variable_values={"includePoints": False},
+        context_value={"username": "foo"},
+    )
 
     assert not result.errors
     assert result.data["person"] == {"name": "Jess"}
@@ -115,16 +121,21 @@ def test_can_declare_directives():
 
 
 def test_directive_arguments_without_value_param():
-    """regression test for https://github.com/strawberry-graphql/strawberry/issues/1666"""
+    """Regression test for Strawberry Issue #1666.
+
+    https://github.com/strawberry-graphql/strawberry/issues/1666
+    """
+
     @strawberry.type
     class Query:
         cake: str = "victoria sponge"
 
     @strawberry.directive(
-        locations=[DirectiveLocation.FIELD], description="Don't actually like cake? try ice cream instead"
+        locations=[DirectiveLocation.FIELD],
+        description="Don't actually like cake? try ice cream instead",
     )
     def ice_cream(flavor: str):
-        return f'{flavor} ice cream'
+        return f"{flavor} ice cream"
 
     schema = strawberry.Schema(query=Query, directives=[ice_cream])
 
@@ -138,6 +149,11 @@ def test_directive_arguments_without_value_param():
     '''
 
     assert schema.as_str() == textwrap.dedent(expected_schema).strip()
+
+    query = 'query { cake @iceCream(flavor: "strawberry") }'
+    result = schema.execute_sync(query, root_value=Query())
+
+    assert result.data == {"cake": "strawberry ice cream"}
 
 
 def test_runs_directives():
@@ -371,3 +387,184 @@ async def test_runs_directives_with_extensions_async():
     assert not result.errors
     assert result.data
     assert result.data["person"]["name"] == "JESS"
+
+
+@pytest.fixture
+def info_directive_schema() -> strawberry.Schema:
+    """Returns a schema with directive that validates if info is recieved."""
+
+    @strawberry.enum
+    class Locale(Enum):
+        EN: str = "EN"
+        NL: str = "NL"
+
+    greetings: Dict[Locale, str] = {
+        Locale.EN: "Hello {username}",
+        Locale.NL: "Hallo {username}",
+    }
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def greetingTemplate(self, locale: Locale = Locale.EN) -> str:
+            return greetings[locale]
+
+    @strawberry.directive(
+        locations=[DirectiveLocation.FIELD],
+        description="Interpolate string on the server from context data",
+    )
+    def interpolate(value: str, info: Info):
+        try:
+            return value.format(**info.context["userdata"])
+        except KeyError:
+            return value
+
+    return strawberry.Schema(query=Query, directives=[interpolate])
+
+
+def test_info_directive_schema(info_directive_schema: strawberry.Schema):
+
+    expected_schema = '''
+    """Interpolate string on the server from context data"""
+    directive @interpolate on FIELD
+
+    enum Locale {
+      EN
+      NL
+    }
+
+    type Query {
+      greetingTemplate(locale: Locale! = EN): String!
+    }
+    '''
+
+    assert textwrap.dedent(expected_schema).strip() == str(info_directive_schema)
+
+
+def test_info_directive(info_directive_schema: strawberry.Schema):
+    query = "query { greetingTemplate @interpolate }"
+    result = info_directive_schema.execute_sync(
+        query, context_value={"userdata": {"username": "Foo"}}
+    )
+    assert result.data == {"greetingTemplate": "Hello Foo"}
+
+
+@pytest.mark.asyncio
+async def test_info_directive_async(info_directive_schema: strawberry.Schema):
+    query = "query { greetingTemplate @interpolate }"
+    result = await info_directive_schema.execute(
+        query, context_value={"userdata": {"username": "Foo"}}
+    )
+    assert result.data == {"greetingTemplate": "Hello Foo"}
+
+
+def test_directive_value():
+    """Tests if directive value is detected by type instead of by arg-name `value`."""
+
+    @strawberry.type
+    class Cake:
+        frosting: Optional[str] = None
+        flavor: str = "Chocolate"
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def cake(self) -> Cake:
+            return Cake()
+
+    @strawberry.directive(
+        locations=[DirectiveLocation.FIELD],
+        description="Add frostring with ``flavor`` to a cake.",
+    )
+    def add_frosting(flavor: str, v: DirectiveValue[Cake], value: str):
+        assert isinstance(v, Cake)
+        assert value == "foo"  # Check if value can be used as an argument
+        v.frosting = flavor
+        return v
+
+    schema = strawberry.Schema(query=Query, directives=[add_frosting])
+    result = schema.execute_sync(
+        """query {
+            cake @addFrosting(flavor: "Vanilla", value: "foo") {
+                frosting
+                flavor
+            }
+        }
+        """
+    )
+    assert result.data == {"cake": {"frosting": "Vanilla", "flavor": "Chocolate"}}
+
+
+# Defined in module scope to allow the FowardRef to be resolvable with eval
+@strawberry.directive(
+    locations=[DirectiveLocation.FIELD],
+    description="Add frostring with ``flavor`` to a cake.",
+)
+def add_frosting(flavor: str, v: DirectiveValue["Cake"], value: str):
+    assert isinstance(v, Cake)
+    assert value == "foo"
+    v.frosting = flavor
+    return v
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def cake(self) -> "Cake":
+        return Cake()
+
+
+@strawberry.type
+class Cake:
+    frosting: Optional[str] = None
+    flavor: str = "Chocolate"
+
+
+def test_directive_value_forward_ref():
+    """Tests if directive value by type works with PEP-563."""
+    schema = strawberry.Schema(query=Query, directives=[add_frosting])
+    result = schema.execute_sync(
+        """query {
+            cake @addFrosting(flavor: "Vanilla", value: "foo") {
+                frosting
+                flavor
+            }
+        }
+        """
+    )
+    assert result.data == {"cake": {"frosting": "Vanilla", "flavor": "Chocolate"}}
+
+
+def test_name_first_directive_value():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def greeting(self) -> str:
+            return "Hi"
+
+    @strawberry.directive(locations=[DirectiveLocation.FIELD])
+    def personalize_greeting(name: str, v: DirectiveValue[str]):
+        assert v == "Hi"
+        return f"{v} {name}"
+
+    schema = strawberry.Schema(Query, directives=[personalize_greeting])
+    result = schema.execute_sync('{ greeting @personalizeGreeting(name: "Bar")}')
+
+    assert result.data is not None
+    assert not result.errors
+    assert result.data["greeting"] == "Hi Bar"
+
+
+def test_named_based_directive_value_is_deprecated():
+
+    with pytest.deprecated_call(match=r"Argument name-based matching of 'value'"):
+
+        @strawberry.type
+        class Query:
+            hello: str = "hello"
+
+        @strawberry.directive(locations=[DirectiveLocation.FIELD])
+        def deprecated_value(value):
+            ...
+
+        strawberry.Schema(query=Query, directives=[deprecated_value])

--- a/tests/schema/test_directives.py
+++ b/tests/schema/test_directives.py
@@ -543,12 +543,12 @@ def test_name_first_directive_value():
             return "Hi"
 
     @strawberry.directive(locations=[DirectiveLocation.FIELD])
-    def personalize_greeting(name: str, v: DirectiveValue[str]):
+    def personalize_greeting(value: str, v: DirectiveValue[str]):
         assert v == "Hi"
-        return f"{v} {name}"
+        return f"{v} {value}"
 
     schema = strawberry.Schema(Query, directives=[personalize_greeting])
-    result = schema.execute_sync('{ greeting @personalizeGreeting(name: "Bar")}')
+    result = schema.execute_sync('{ greeting @personalizeGreeting(value: "Bar")}')
 
     assert result.data is not None
     assert not result.errors

--- a/tests/schema/test_resolvers.py
+++ b/tests/schema/test_resolvers.py
@@ -1,10 +1,11 @@
 # type: ignore
 import typing
-from typing import List
+from typing import Any, List
 
 import pytest
 
 import strawberry
+from strawberry.types.info import Info
 
 
 def test_resolver():
@@ -173,10 +174,10 @@ def test_optional_info_and_root_params():
 
 
 def test_only_info_function_resolvers():
-    def function_resolver(info) -> str:
+    def function_resolver(info: Info) -> str:
         return f"I'm a function resolver for {info.field_name}"
 
-    def function_resolver_with_params(info, x: str) -> str:
+    def function_resolver_with_params(info: Info, x: str) -> str:
         return f"I'm {x} for {info.field_name}"
 
     @strawberry.type
@@ -349,3 +350,53 @@ def test_can_use_source_as_argument_name():
 
     assert not result.errors
     assert result.data["hello"] == "I'm a resolver for 🍓"
+
+
+def name_based_info(info, icon: str) -> str:
+    return f"I'm a resolver for {icon} {info.field_name}"
+
+
+def type_based_info(info: Info, icon: str) -> str:
+    return f"I'm a resolver for {icon} {info.field_name}"
+
+
+def generic_type_based_info(icon: str, info: Info[Any, Any]) -> str:
+    return f"I'm a resolver for {icon} {info.field_name}"
+
+
+def arbitrarily_named_info(icon: str, info_argument: Info) -> str:
+    return f"I'm a resolver for {icon} {info_argument.field_name}"
+
+
+@pytest.mark.parametrize(
+    "resolver",
+    (
+        pytest.param(name_based_info),
+        pytest.param(type_based_info),
+        pytest.param(generic_type_based_info),
+        pytest.param(arbitrarily_named_info),
+    ),
+)
+def test_info_argument(resolver):
+    @strawberry.type
+    class ResolverGreeting:
+        hello: str = strawberry.field(resolver=resolver)
+
+    schema = strawberry.Schema(query=ResolverGreeting)
+    result = schema.execute_sync('{ hello(icon: "🍓") }')
+
+    assert not result.errors
+    assert result.data["hello"] == "I'm a resolver for 🍓 hello"
+
+
+def test_name_based_info_is_deprecated():
+
+    with pytest.deprecated_call(match=r"Argument name-based matching of 'info'"):
+
+        @strawberry.type
+        class Query:
+            @strawberry.field
+            def foo(info: Any) -> str:
+                ...
+
+        strawberry.Schema(query=Query)


### PR DESCRIPTION
Attempt to improves performance by compiling resolver functions to prevent
conditional look-up of arguments. In the future, this implementation could be
extended to also compile scalar converters, as their type is known ahead of
time. Therefore, dynamic look-up from the scalar registry can be avoided.