### PR TITLE
Add support for passing names to field in schema directives

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,27 @@
+Release type: minor
+
+This release adds support for passing a custom name to schema directives fields,
+by using `strawberry.directive_field`.
+
+```python
+import strawberry
+
+@strawberry.schema_directive(locations=[Location.FIELD_DEFINITION])
+class Sensitive:
+    reason: str = strawberry.directive_field(name="as")
+    real_age_2: str = strawberry.directive_field(name="real_age")
+
+@strawberry.type
+class Query:
+    first_name: str = strawberry.field(
+        directives=[Sensitive(reason="GDPR", real_age_2="42")]
+    )
+```
+
+should return:
+
+```graphql
+type Query {
+    firstName: String! @sensitive(as: "GDPR", real_age: "42")
+}
+```

--- a/docs/types/schema-directives.md
+++ b/docs/types/schema-directives.md
@@ -46,6 +46,16 @@ type User @keys(fields: "id") {
 }
 ```
 
+## Overriding field names
+
+You can use `strawberry.directive_field` to override the name of a field:
+
+```python
+@strawberry.schema_directive(locations=[Location.OBJECT])
+class Keys:
+    fields: str = strawberry.directive_field(name="as")
+```
+
 ## Locations
 
 Schema directives can be applied to many different parts of a schema. Here's the

--- a/strawberry/__init__.py
+++ b/strawberry/__init__.py
@@ -2,7 +2,7 @@ from . import experimental, federation
 from .arguments import argument
 from .auto import auto
 from .custom_scalar import scalar
-from .directive import directive
+from .directive import directive, directive_field
 from .enum import enum, enum_value
 from .field import field
 from .lazy_type import LazyType
@@ -27,6 +27,7 @@ __all__ = [
     "Schema",
     "argument",
     "directive",
+    "directive_field",
     "schema_directive",
     "enum",
     "enum_value",

--- a/strawberry/directive.py
+++ b/strawberry/directive.py
@@ -10,6 +10,14 @@ from graphql import DirectiveLocation
 
 from strawberry.annotation import StrawberryAnnotation
 from strawberry.arguments import StrawberryArgument
+from strawberry.field import StrawberryField
+
+
+def directive_field(name: str) -> StrawberryField:
+    return StrawberryField(
+        python_name=None,
+        graphql_name=name,
+    )
 
 
 @dataclasses.dataclass

--- a/strawberry/federation/schema.py
+++ b/strawberry/federation/schema.py
@@ -128,7 +128,7 @@ def _get_entity_type(type_map: TypeMap):
 
 
 def _is_key(directive: Any) -> bool:
-    return directive.wrap is Key.wrap  # type: ignore
+    return isinstance(directive, Key)
 
 
 def _has_federation_keys(

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -24,7 +24,6 @@ from typing_extensions import Literal
 from strawberry.annotation import StrawberryAnnotation
 from strawberry.arguments import StrawberryArgument
 from strawberry.exceptions import InvalidDefaultFactoryError, InvalidFieldArgument
-from strawberry.schema_directive import StrawberrySchemaDirective
 from strawberry.type import StrawberryType
 from strawberry.types.info import Info
 from strawberry.union import StrawberryUnion
@@ -35,6 +34,8 @@ from .types.fields.resolver import StrawberryResolver
 
 
 if TYPE_CHECKING:
+    from strawberry.schema_directive import StrawberrySchemaDirective
+
     from .object_type import TypeDefinition
 
 
@@ -60,7 +61,7 @@ class StrawberryField(dataclasses.Field):
         default: object = UNSET,
         default_factory: Union[Callable[[], Any], object] = UNSET,
         deprecation_reason: Optional[str] = None,
-        directives: Sequence[StrawberrySchemaDirective] = (),
+        directives: Sequence["StrawberrySchemaDirective"] = (),
     ):
         # basic fields are fields with no provided resolver
         is_basic_field = not base_resolver
@@ -321,7 +322,7 @@ def field(
     deprecation_reason: Optional[str] = None,
     default: Any = UNSET,
     default_factory: Union[Callable, object] = UNSET,
-    directives: Optional[Sequence[StrawberrySchemaDirective]] = (),
+    directives: Optional[Sequence["StrawberrySchemaDirective"]] = (),
 ) -> T:
     ...
 
@@ -337,7 +338,7 @@ def field(
     deprecation_reason: Optional[str] = None,
     default: Any = UNSET,
     default_factory: Union[Callable, object] = UNSET,
-    directives: Optional[Sequence[StrawberrySchemaDirective]] = (),
+    directives: Optional[Sequence["StrawberrySchemaDirective"]] = (),
 ) -> Any:
     ...
 
@@ -353,7 +354,7 @@ def field(
     deprecation_reason: Optional[str] = None,
     default: Any = UNSET,
     default_factory: Union[Callable, object] = UNSET,
-    directives: Optional[Sequence[StrawberrySchemaDirective]] = (),
+    directives: Optional[Sequence["StrawberrySchemaDirective"]] = (),
 ) -> StrawberryField:
     ...
 

--- a/strawberry/object_type.py
+++ b/strawberry/object_type.py
@@ -1,9 +1,17 @@
 import dataclasses
 import inspect
 import types
-from typing import Callable, List, Optional, Sequence, Type, TypeVar, cast, overload
-
-from strawberry.schema_directive import StrawberrySchemaDirective
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    List,
+    Optional,
+    Sequence,
+    Type,
+    TypeVar,
+    cast,
+    overload,
+)
 
 from .exceptions import (
     MissingFieldAnnotationError,
@@ -15,6 +23,10 @@ from .types.type_resolver import _get_fields
 from .types.types import TypeDefinition
 from .utils.str_converters import to_camel_case
 from .utils.typing import __dataclass_transform__
+
+
+if TYPE_CHECKING:
+    from strawberry.schema_directive import StrawberrySchemaDirective
 
 
 def _get_interfaces(cls: Type) -> List[TypeDefinition]:
@@ -100,7 +112,7 @@ def _process_type(
     is_input: bool = False,
     is_interface: bool = False,
     description: Optional[str] = None,
-    directives: Optional[Sequence[StrawberrySchemaDirective]] = (),
+    directives: Optional[Sequence["StrawberrySchemaDirective"]] = (),
     extend: bool = False,
 ):
     name = name or to_camel_case(cls.__name__)
@@ -158,7 +170,7 @@ def type(
     is_input: bool = False,
     is_interface: bool = False,
     description: str = None,
-    directives: Optional[Sequence[StrawberrySchemaDirective]] = (),
+    directives: Optional[Sequence["StrawberrySchemaDirective"]] = (),
     extend: bool = False,
 ) -> T:
     ...
@@ -172,7 +184,7 @@ def type(
     is_input: bool = False,
     is_interface: bool = False,
     description: str = None,
-    directives: Optional[Sequence[StrawberrySchemaDirective]] = (),
+    directives: Optional[Sequence["StrawberrySchemaDirective"]] = (),
     extend: bool = False,
 ) -> Callable[[T], T]:
     ...
@@ -231,7 +243,7 @@ def input(
     *,
     name: str = None,
     description: str = None,
-    directives: Optional[Sequence[StrawberrySchemaDirective]] = (),
+    directives: Optional[Sequence["StrawberrySchemaDirective"]] = (),
 ) -> T:
     ...
 
@@ -242,7 +254,7 @@ def input(
     *,
     name: str = None,
     description: str = None,
-    directives: Optional[Sequence[StrawberrySchemaDirective]] = (),
+    directives: Optional[Sequence["StrawberrySchemaDirective"]] = (),
 ) -> Callable[[T], T]:
     ...
 
@@ -272,7 +284,7 @@ def interface(
     *,
     name: str = None,
     description: str = None,
-    directives: Optional[Sequence[StrawberrySchemaDirective]] = (),
+    directives: Optional[Sequence["StrawberrySchemaDirective"]] = (),
 ):
     """Annotates a class as a GraphQL Interface.
     Example usage:

--- a/strawberry/printer.py
+++ b/strawberry/printer.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from itertools import chain
-from typing import TYPE_CHECKING, Dict, Optional, cast
+from typing import TYPE_CHECKING, Any, Dict, Optional, cast
 
 from graphql.type import (
     is_enum_type,
@@ -26,7 +26,7 @@ from graphql.utilities.print_schema import (
 )
 
 from strawberry.field import StrawberryField
-from strawberry.schema_directive import Location, StrawberrySchemaDirective
+from strawberry.schema_directive import Location
 from strawberry.types.types import TypeDefinition
 
 
@@ -41,9 +41,7 @@ def print_schema_directive_params(params: Dict) -> str:
     return "(" + ", ".join(f'{name}: "{value}"' for name, value in params.items()) + ")"
 
 
-def print_schema_directive(
-    directive: StrawberrySchemaDirective, schema: BaseSchema
-) -> str:
+def print_schema_directive(directive: Any, schema: BaseSchema) -> str:
     name_converter = schema.config.name_converter
 
     params = {
@@ -65,7 +63,7 @@ def print_field_directives(field: Optional[StrawberryField], schema: BaseSchema)
         for directive in field.directives
         if any(
             location in [Location.FIELD_DEFINITION, Location.INPUT_FIELD_DEFINITION]
-            for location in directive.__strawberry_directive__.locations
+            for location in directive.__strawberry_directive__.locations  # type: ignore
         )
     )
 
@@ -126,7 +124,7 @@ def print_type_directives(type_, schema: BaseSchema) -> str:
         for directive in strawberry_type.directives or []
         if any(
             location in allowed_locations
-            for location in directive.__strawberry_directive__.locations
+            for location in directive.__strawberry_directive__.locations  # type: ignore
         )
     )
 

--- a/tests/test_printer/test_schema_directives.py
+++ b/tests/test_printer/test_schema_directives.py
@@ -2,6 +2,7 @@ import textwrap
 
 import strawberry
 from strawberry.printer import print_schema
+from strawberry.schema.config import StrawberryConfig
 from strawberry.schema_directive import Location
 
 
@@ -26,17 +27,21 @@ def test_print_simple_directive():
 
 
 def test_print_directive_with_name():
-    @strawberry.schema_directive(locations=[Location.FIELD_DEFINITION])
-    class SensitiveField:
+    @strawberry.schema_directive(
+        name="sensitive", locations=[Location.FIELD_DEFINITION]
+    )
+    class SensitiveDirective:
         reason: str
 
     @strawberry.type
     class Query:
-        first_name: str = strawberry.field(directives=[SensitiveField(reason="GDPR")])
+        first_name: str = strawberry.field(
+            directives=[SensitiveDirective(reason="GDPR")]
+        )
 
     expected_type = """
     type Query {
-      firstName: String! @sensitiveField(reason: "GDPR")
+      firstName: String! @sensitive(reason: "GDPR")
     }
     """
 
@@ -83,5 +88,51 @@ def test_directive_on_types():
     """
 
     schema = strawberry.Schema(query=Query)
+
+    assert print_schema(schema) == textwrap.dedent(expected_type).strip()
+
+
+def test_using_different_names_for_directive_field():
+    @strawberry.schema_directive(locations=[Location.FIELD_DEFINITION])
+    class Sensitive:
+        reason: str = strawberry.field(name="as")
+        real_age: str = strawberry.field()
+        real_age_2: str = strawberry.field(name="real_age")
+
+    @strawberry.type
+    class Query:
+        first_name: str = strawberry.field(
+            directives=[Sensitive(reason="GDPR", real_age="42", real_age_2="42")]
+        )
+
+    expected_type = """
+    type Query {
+      firstName: String! @sensitive(as: "GDPR", realAge: "42", real_age: "42")
+    }
+    """
+
+    schema = strawberry.Schema(query=Query)
+
+    assert print_schema(schema) == textwrap.dedent(expected_type).strip()
+
+
+def test_respects_schema_config_for_names():
+    @strawberry.schema_directive(locations=[Location.FIELD_DEFINITION])
+    class Sensitive:
+        real_age: str = strawberry.field()
+
+    @strawberry.type
+    class Query:
+        first_name: str = strawberry.field(directives=[Sensitive(real_age="42")])
+
+    expected_type = """
+    type Query {
+      first_name: String! @Sensitive(real_age: "42")
+    }
+    """
+
+    schema = strawberry.Schema(
+        query=Query, config=StrawberryConfig(auto_camel_case=False)
+    )
 
     assert print_schema(schema) == textwrap.dedent(expected_type).strip()

--- a/tests/test_printer/test_schema_directives.py
+++ b/tests/test_printer/test_schema_directives.py
@@ -95,9 +95,9 @@ def test_directive_on_types():
 def test_using_different_names_for_directive_field():
     @strawberry.schema_directive(locations=[Location.FIELD_DEFINITION])
     class Sensitive:
-        reason: str = strawberry.field(name="as")
-        real_age: str = strawberry.field()
-        real_age_2: str = strawberry.field(name="real_age")
+        reason: str = strawberry.directive_field(name="as")
+        real_age: str
+        real_age_2: str = strawberry.directive_field(name="real_age")
 
     @strawberry.type
     class Query:
@@ -119,7 +119,7 @@ def test_using_different_names_for_directive_field():
 def test_respects_schema_config_for_names():
     @strawberry.schema_directive(locations=[Location.FIELD_DEFINITION])
     class Sensitive:
-        real_age: str = strawberry.field()
+        real_age: str
 
     @strawberry.type
     class Query:


### PR DESCRIPTION
This PR add support for passing names to field of strawberry directives, it also tried the `__strawberry_xxx__` approach, this will be probably refactored, but I'll probably merge this soon as it blocks other PRs 😊

This works now:

```python
@strawberry.schema_directive(locations=[Location.FIELD_DEFINITION])
class Sensitive:
    reason: str = directive_field(name="as")
    real_age_2: str = directive_field(name="real_age")

@strawberry.type
class Query:
    first_name: str = strawberry.field(
        directives=[Sensitive(reason="GDPR", real_age_2="42")]
    )

expected_type = """
type Query {
    firstName: String! @sensitive(as: "GDPR", real_age: "42")
}
```

This is done by using `strawberry.directive_field` that uses StrawberryField, we might introduce a new type, but for now this will work 😊