### PR TITLE
Rename `custom_getter` variable in nested scope for FastAPI router to reflect purpose

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Rename internal variable `custom_getter` in FastAPI router implementation.

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -88,7 +88,9 @@ class GraphQLRouter(APIRouter):
         sig = sig.replace(
             parameters=[
                 *list(sig.parameters.values())[1:],
-                sig.parameters["custom_context"].replace(default=Depends(custom_getter)),
+                sig.parameters["custom_context"].replace(
+                    default=Depends(custom_getter)
+                ),
             ],
         )
         # there is an ongoing issue with types and .__signature__ applied to Callables:

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -55,7 +55,7 @@ class GraphQLRouter(APIRouter):
         custom_getter: Callable[..., Optional[CustomContext]]
     ) -> Callable[..., CustomContext]:
         def dependency(
-            custom_getter: Optional[CustomContext],
+            custom_context: Optional[CustomContext],
             background_tasks: BackgroundTasks,
             request: Request = None,
             response: Response = None,
@@ -66,17 +66,17 @@ class GraphQLRouter(APIRouter):
                 "background_tasks": background_tasks,
                 "response": response,
             }
-            if isinstance(custom_getter, BaseContext):
-                custom_getter.request = request or ws
-                custom_getter.background_tasks = background_tasks
-                custom_getter.response = response
-                return custom_getter
-            elif isinstance(custom_getter, dict):
+            if isinstance(custom_context, BaseContext):
+                custom_context.request = request or ws
+                custom_context.background_tasks = background_tasks
+                custom_context.response = response
+                return custom_context
+            elif isinstance(custom_context, dict):
                 return {
                     **default_context,
-                    **custom_getter,
+                    **custom_context,
                 }
-            elif custom_getter is None:
+            elif custom_context is None:
                 return default_context
             else:
                 raise InvalidCustomContext()
@@ -88,7 +88,7 @@ class GraphQLRouter(APIRouter):
         sig = sig.replace(
             parameters=[
                 *list(sig.parameters.values())[1:],
-                sig.parameters["custom_getter"].replace(default=Depends(custom_getter)),
+                sig.parameters["custom_context"].replace(default=Depends(custom_getter)),
             ],
         )
         # there is an ongoing issue with types and .__signature__ applied to Callables:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

With the FastAPI router, the custom *context getter* function is called `custom_getter`, but in the internal implementation there is an internal variable for the *context* that is also called `custom_getter`. This PR changes the name of the internal variable to reduce confusion and remove the possibility of accidental name-conflict.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes. -> covered by existing tests
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
