### PR TITLE
New Lazy to replace LazyType and fix typing issues

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+Release type: minor
+
+New `Lazy` that will replace `LazyType` in the future. It is aliased to
+`LazyType` at runtime, but static type checkers (e.g. pyright) see them as
+`Annotated`. That means that using it will prevent typing issues and also
+make those same static type checkers to properly type them.

--- a/strawberry/__init__.py
+++ b/strawberry/__init__.py
@@ -5,7 +5,7 @@ from .custom_scalar import scalar
 from .directive import directive, directive_field
 from .enum import enum, enum_value
 from .field import field
-from .lazy_type import LazyType
+from .lazy_type import Lazy, LazyType
 from .mutation import mutation, subscription
 from .object_type import input, interface, type
 from .permission import BasePermission
@@ -22,6 +22,7 @@ __all__ = [
     "experimental",
     "ID",
     "UNSET",
+    "Lazy",
     "LazyType",
     "Private",
     "Schema",

--- a/strawberry/ext/mypy_plugin.py
+++ b/strawberry/ext/mypy_plugin.py
@@ -880,7 +880,10 @@ class StrawberryPlugin(Plugin):
         )
 
     def _is_strawberry_lazy_type(self, fullname: str) -> bool:
-        return fullname == "strawberry.lazy_type.LazyType"
+        return fullname in [
+            "strawberry.lazy_type.LazyType",
+            "strawberry.lazy_type.Lazy",
+        ]
 
     def _is_strawberry_decorator(self, fullname: str) -> bool:
         if any(

--- a/strawberry/lazy_type.py
+++ b/strawberry/lazy_type.py
@@ -41,7 +41,7 @@ class LazyType(Generic[TypeName, Module]):
         return None
 
 
-if TYPE_CHECKING:  # pragma: nocover
+if TYPE_CHECKING:  # pragma: no cover
     # Static types like pyright expects a type to be passed to generic classes, which
     # means that if we pass a string it will say the type is unknown, and if we import
     # the module they will say a module can't be used in place of a type.

--- a/strawberry/lazy_type.py
+++ b/strawberry/lazy_type.py
@@ -1,7 +1,9 @@
 import importlib
 import inspect
 from dataclasses import dataclass
-from typing import Generic, Optional, Type, TypeVar
+from typing import TYPE_CHECKING, Generic, Optional, Type, TypeVar
+
+from typing_extensions import Annotated
 
 
 TypeName = TypeVar("TypeName")
@@ -37,3 +39,14 @@ class LazyType(Generic[TypeName, Module]):
 
     def __call__(self):  # pragma: no cover
         return None
+
+
+if TYPE_CHECKING:  # pragma: nocover
+    # Static types like pyright expects a type to be passed to generic classes, which
+    # means that if we pass a string it will say the type is unknown, and if we import
+    # the module they will say a module can't be used in place of a type.
+    # This will tricky it into thinking that LazyType is Annotated, not only avoiding
+    # the issue but also statically typing it correctly.
+    Lazy = Annotated
+else:
+    Lazy = LazyType

--- a/tests/mypy/test_lazy_type.yml
+++ b/tests/mypy/test_lazy_type.yml
@@ -1,0 +1,21 @@
+- case: test_unset
+  main: |
+    from typing import TYPE_CHECKING
+    import strawberry
+    from strawberry.lazy_type import Lazy
+
+
+    @strawberry.type
+    class SomeType:
+        some_var: Lazy[str, "strawberry.scalars"]
+
+
+    obj = SomeType(
+        some_var="foobar",
+    )
+
+    reveal_type(SomeType.some_var)
+    reveal_type(obj.some_var)
+  out: |
+    main:15: note: Revealed type is "builtins.str"
+    main:16: note: Revealed type is "builtins.str"

--- a/tests/pyright/test_lazy_type.py
+++ b/tests/pyright/test_lazy_type.py
@@ -1,0 +1,45 @@
+from .utils import Result, requires_pyright, run_pyright, skip_on_windows
+
+
+pytestmark = [skip_on_windows, requires_pyright]
+
+
+CODE = """
+from typing import TYPE_CHECKING
+import strawberry
+from strawberry.lazy_type import Lazy
+
+if TYPE_CHECKING:
+    from strawberry.scalars import JSON
+
+
+@strawberry.type
+class SomeType:
+    json: Lazy["JSON", "strawberry.scalars"]
+
+
+obj = SomeType(
+    json=JSON({"foo": "bar"}),
+)
+
+reveal_type(SomeType.json)
+reveal_type(obj.json)
+"""
+
+
+def test_pyright():
+    results = run_pyright(CODE)
+    assert results == [
+        Result(
+            type="information",
+            message='Type of "SomeType.json" is "JSON"',
+            line=19,
+            column=13,
+        ),
+        Result(
+            type="information",
+            message='Type of "obj.json" is "JSON"',
+            line=20,
+            column=13,
+        ),
+    ]


### PR DESCRIPTION
An attempt to solve typing issues with `LazyType`.

Currently there's a major issue with `LazyType` that requires you to always have to `# type:ignore` because of the module path. It also makes the final attribute expects a `LazyType` instance instead of the real type that we want to use.

This exposes a single `Lazy` that should be used in place of `LazyType`. For type checkers (i.e. inside a `if TYPE_CHECKING`), it is aliased as an `Annotated` because it will make it behave exactly the way we want. At runtime it is aliased to the `LazyType` itself.

At first I actually defined `if TYPE_CHECKING: LazyType = Annotated` and `else: class LazyType(Generic[...])):`, but it messes with the typing of schema parsers and other places of the lib. Then I thought that exposing a simple `Lazy` would be better, but I'm not sure what you all think (cc @patrick91 @BryceBeagle )

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fix #388
* Fix #1177