### PR TITLE
Prevent creating TypeDefinition for Private fields

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,32 @@
+Release type: patch
+
+Allow use of implicit `Any` in `strawberry.Private` annotated Generic types.
+
+For example the following is now supported:
+
+```python
+from __future__ import annotations
+
+from typing import Generic, Sequence, TypeVar
+
+import strawberry
+
+
+T = TypeVar("T")
+
+
+@strawberry.type
+class Foo(Generic[T]):
+
+    private_field: strawberry.Private[Sequence]  # instead of Sequence[Any]
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def foo(self) -> Foo[str]:
+        return Foo(private_field=[1, 2, 3])
+```
+
+See Issue [#1938](https://github.com/strawberry-graphql/strawberry/issues/1938)
+for details.

--- a/strawberry/annotation.py
+++ b/strawberry/annotation.py
@@ -12,6 +12,8 @@ from typing import (  # type: ignore[attr-defined]
     _eval_type,
 )
 
+from strawberry.private import is_private
+
 
 try:
     from typing import ForwardRef
@@ -69,6 +71,8 @@ class StrawberryAnnotation:
             annotation = self.annotation
 
         evaled_type = _eval_type(annotation, self.namespace, None)
+        if is_private(evaled_type):
+            return evaled_type
         if self._is_async_type(evaled_type):
             evaled_type = self._strip_async_type(evaled_type)
         if self._is_lazy_type(evaled_type):


### PR DESCRIPTION
This PR prevents `StrawberryAnnotation.resolve` from attempting to convert a `strawberry.Private` annotated field into a `StrawberryType`. Doing so is uncessary, as private fields are not meant to be used in a GraphQL Schema anyway.

Summary of Changes:
- Modify `annotation.py` with an additional `is_private` check
- Add test to demonstrate resolution of `ValueError` when using an implicit `Any` Generic type

[#1654]: https://github.com/strawberry-graphql/strawberry/issues/1938

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #1938 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
