### PR TITLE
Improve interface performance using resolve_type

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,32 @@
+Release type: minor
+
+Improve the time complexity of `strawberry.interface` using `resolve_type`.
+Achieved time complexity is now O(1) with respect to the number of
+implementations of an interface. Previously, the use of `is_type_of` resulted
+in a worst-case performance of O(n).
+
+**Before**:
+
+```shell
+---------------------------------------------------------------------------
+Name (time in ms)                         Min                 Max
+---------------------------------------------------------------------------
+test_interface_performance[1]         18.0224 (1.0)       50.3003 (1.77)
+test_interface_performance[16]        22.0060 (1.22)      28.4240 (1.0)
+test_interface_performance[256]       69.1364 (3.84)      76.1349 (2.68)
+test_interface_performance[4096]     219.6461 (12.19)    231.3732 (8.14)
+---------------------------------------------------------------------------
+```
+
+**After**:
+
+```shell
+---------------------------------------------------------------------------
+Name (time in ms)                        Min                Max
+---------------------------------------------------------------------------
+test_interface_performance[1]        14.3921 (1.0)      46.2064 (2.79)
+test_interface_performance[16]       14.8669 (1.03)     16.5732 (1.0)
+test_interface_performance[256]      15.8977 (1.10)     24.4618 (1.48)
+test_interface_performance[4096]     18.7340 (1.30)     21.2899 (1.28)
+---------------------------------------------------------------------------
+```

--- a/strawberry/object_type.py
+++ b/strawberry/object_type.py
@@ -139,6 +139,7 @@ def _process_type(
     interfaces = _get_interfaces(cls)
     fields = _get_fields(cls)
     is_type_of = getattr(cls, "is_type_of", None)
+    resolve_type = getattr(cls, "resolve_type", None)
 
     cls.__strawberry_definition__ = StrawberryObjectDefinition(
         name=name,
@@ -151,6 +152,7 @@ def _process_type(
         extend=extend,
         _fields=fields,
         is_type_of=is_type_of,
+        resolve_type=resolve_type,
     )
     # TODO: remove when deprecating _type_definition
     DeprecatedDescriptor(

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -80,7 +80,6 @@ if TYPE_CHECKING:
         GraphQLOutputType,
         GraphQLResolveInfo,
         GraphQLScalarType,
-        ValueNode,
     )
 
     from strawberry.custom_scalar import ScalarDefinition
@@ -439,6 +438,8 @@ class GraphQLCoreConverter:
                 if isinstance(obj, interface.origin):
                     return obj._type_definition.name
                 else:
+                    # Revert to calling is_type_of for cases where a direct subclass
+                    # of the interface is not returned (i.e. an ORM object)
                     return default_type_resolver(obj, info, abstract_type)
 
             return resolve_type

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -6,6 +6,7 @@ from functools import partial, reduce
 from typing import (
     TYPE_CHECKING,
     Any,
+    Awaitable,
     Callable,
     Dict,
     Generic,
@@ -33,6 +34,8 @@ from graphql import (
     GraphQLObjectType,
     GraphQLUnionType,
     Undefined,
+    ValueNode,
+    default_type_resolver,
 )
 from graphql.language.directive_locations import DirectiveLocation
 
@@ -426,6 +429,20 @@ class GraphQLCoreConverter:
             assert isinstance(graphql_interface, GraphQLInterfaceType)  # For mypy
             return graphql_interface
 
+        def _get_resolve_type():
+            if interface.resolve_type:
+                return interface.resolve_type
+
+            def resolve_type(
+                obj: Any, info: GraphQLResolveInfo, abstract_type: GraphQLInterfaceType
+            ) -> Union[Awaitable[Optional[str]], str, None]:
+                if isinstance(obj, interface.origin):
+                    return obj._type_definition.name
+                else:
+                    return default_type_resolver(obj, info, abstract_type)
+
+            return resolve_type
+
         graphql_interface = GraphQLInterfaceType(
             name=interface_name,
             fields=lambda: self.get_graphql_fields(interface),
@@ -434,6 +451,7 @@ class GraphQLCoreConverter:
             extensions={
                 GraphQLCoreConverter.DEFINITION_BACKREF: interface,
             },
+            resolve_type=_get_resolve_type(),
         )
 
         self.type_map[interface_name] = ConcreteType(

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -21,6 +21,7 @@ from typing import (
 from typing_extensions import Protocol
 
 from graphql import (
+    GraphQLAbstractType,
     GraphQLArgument,
     GraphQLDirective,
     GraphQLEnumType,
@@ -67,9 +68,7 @@ from strawberry.union import StrawberryUnion
 from strawberry.unset import UNSET
 from strawberry.utils.await_maybe import await_maybe
 
-from ..extensions.field_extension import (
-    build_field_extension_resolvers,
-)
+from ..extensions.field_extension import build_field_extension_resolvers
 from . import compat
 from .types.concrete_type import ConcreteType
 
@@ -433,7 +432,7 @@ class GraphQLCoreConverter:
                 return interface.resolve_type
 
             def resolve_type(
-                obj: Any, info: GraphQLResolveInfo, abstract_type: GraphQLInterfaceType
+                obj: Any, info: GraphQLResolveInfo, abstract_type: GraphQLAbstractType
             ) -> Union[Awaitable[Optional[str]], str, None]:
                 if isinstance(obj, interface.origin):
                     return obj._type_definition.name

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -435,7 +435,7 @@ class GraphQLCoreConverter:
                 obj: Any, info: GraphQLResolveInfo, abstract_type: GraphQLAbstractType
             ) -> Union[Awaitable[Optional[str]], str, None]:
                 if isinstance(obj, interface.origin):
-                    return obj._type_definition.name
+                    return obj.__strawberry_definition__.name
                 else:
                     # Revert to calling is_type_of for cases where a direct subclass
                     # of the interface is not returned (i.e. an ORM object)

--- a/strawberry/types/types.py
+++ b/strawberry/types/types.py
@@ -51,6 +51,9 @@ class StrawberryObjectDefinition(StrawberryType):
     extend: bool
     directives: Optional[Sequence[object]]
     is_type_of: Optional[Callable[[Any, GraphQLResolveInfo], bool]]
+    resolve_type: Optional[
+        Callable[[Any, GraphQLResolveInfo, GraphQLAbstractType], str]
+    ]
 
     _fields: List[StrawberryField]
 
@@ -97,6 +100,7 @@ class StrawberryObjectDefinition(StrawberryType):
             description=self.description,
             extend=self.extend,
             is_type_of=self.is_type_of,
+            resolve_type=self.resolve_type,
             _fields=fields,
             concrete_of=self,
             type_var_map=type_var_map,

--- a/strawberry/types/types.py
+++ b/strawberry/types/types.py
@@ -28,7 +28,7 @@ from strawberry.utils.typing import (
 )
 
 if TYPE_CHECKING:
-    from graphql import GraphQLResolveInfo
+    from graphql import GraphQLAbstractType, GraphQLResolveInfo
 
     from strawberry.field import StrawberryField
 

--- a/tests/benchmarks/test_execute.py
+++ b/tests/benchmarks/test_execute.py
@@ -1,13 +1,14 @@
 import datetime
 import random
 from datetime import date
-from typing import List
+from typing import List, Type, cast
 
 import pytest
 from asgiref.sync import async_to_sync
 from pytest_codspeed.plugin import BenchmarkFixture
 
 import strawberry
+from strawberry.scalars import ID
 
 
 @pytest.mark.benchmark
@@ -72,3 +73,29 @@ def test_execute(benchmark: BenchmarkFixture):
     """
 
     benchmark(async_to_sync(schema.execute), query)
+
+
+@pytest.mark.parametrize("ntypes", [2**k for k in range(0, 13, 4)])
+def test_interface_performance(benchmark: BenchmarkFixture, ntypes: int):
+    @strawberry.interface
+    class Item:
+        id: ID
+
+    CONCRETE_TYPES: List[Type[Item]] = []
+    for i in range(ntypes):
+        CONCRETE_TYPES.append(strawberry.type(type(f"Item{i}", (Item,), {})))
+
+    @strawberry.type
+    class Query:
+        items: List[Item]
+
+    schema = strawberry.Schema(query=Query, types=CONCRETE_TYPES)
+    query = "query { items { id } }"
+
+    benchmark(
+        async_to_sync(schema.execute),
+        query,
+        root_value=Query(
+            items=[CONCRETE_TYPES[i % ntypes](id=cast(ID, i)) for i in range(1000)]
+        ),
+    )

--- a/tests/schema/test_interface.py
+++ b/tests/schema/test_interface.py
@@ -279,7 +279,8 @@ def test_interface_resolve_type(mocker: MockerFixture):
         title: str
 
         @classmethod
-        def is_type_of(cls, *_) -> bool:
+        def is_type_of(cls, *args: Any, **kwargs: Any) -> bool:
+            del args, kwargs
             raise RuntimeError("Movie.is_type_of shouldn't have been called")
 
     @strawberry.type
@@ -303,7 +304,8 @@ def test_interface_specialized_resolve_type(mocker: MockerFixture):
 
     class InterfaceTester:
         @classmethod
-        def resolve_type(cls, obj: Any, *_) -> str:
+        def resolve_type(cls, obj: Any, *args: Any, **kwargs: Any) -> str:
+            del args, kwargs
             return obj._type_definition.name
 
     spy_resolve_type = mocker.spy(InterfaceTester, "resolve_type")
@@ -336,12 +338,14 @@ async def test_derived_interface(mocker: MockerFixture):
 
     class NodeInterfaceTester:
         @classmethod
-        def resolve_type(cls, obj: Any, *_) -> str:
+        def resolve_type(cls, obj: Any, *args: Any, **kwargs: Any) -> str:
+            del args, kwargs
             return obj._type_definition.name
 
     class NamedNodeInterfaceTester:
         @classmethod
-        def resolve_type(cls, obj: Any, *_) -> str:
+        def resolve_type(cls, obj: Any, *args: Any, **kwargs: Any) -> str:
+            del args, kwargs
             return obj._type_definition.name
 
     spy_node_resolve_type = mocker.spy(NodeInterfaceTester, "resolve_type")


### PR DESCRIPTION
This commit improves the performance of type resolution when returning interface types from a resolver by defining [`resolve_type`](https://github.com/strawberry-graphql/strawberry/pull/1949) that is called once per item. Without the existence of `resolve_type` the `is_type_of` method on each interface implementation is called until a `True` value is returned. See performance improvements below:

![resolve_performance_dracula](https://user-images.githubusercontent.com/29230371/172447974-612a371d-882c-4257-b6fe-cf9d873af46f.svg#gh-dark-mode-only)
![resolve_performance_dufte](https://user-images.githubusercontent.com/29230371/172447993-0ff1ee76-6a81-4860-a5a2-cd9bfcc3e551.svg#gh-light-mode-only)

<details>
  <summary>Benchmark Code</summary>

  ```python

  from collections import defaultdict
  from functools import partial
  from timeit import timeit
  from typing import DefaultDict, List, Sequence, Type, TypeVar
  
  import matplotx
  import numpy as np
  from matplotlib import pyplot as plt
  from perfplot._main import PerfplotData
  
  import strawberry
  from strawberry.scalars import ID
  
  
  T = TypeVar("T")
  
  
  @strawberry.interface
  class Item:
  
      id: ID
  
  
  @strawberry.interface
  class ResolvedItem:
  
      id: ID
  
      def resolve_type(self, *args):
          type_definition = self._type_definition  # type: ignore
          if isinstance(self, type_definition.origin):
              return type_definition.name
  
  
  def create_schema(n_items: int, n_types: int, item_type: Type) -> strawberry.Schema:
      CONCRETE_TYPES = []
      for i in range(n_types):
          CONCRETE_TYPES.append(strawberry.type(type(f"Item{i}", (item_type,), {})))
  
      items_list = [CONCRETE_TYPES[i % n_types](id=i) for i in range(n_items)]
  
      @strawberry.type
      class Query:
  
          items: List[item_type]  # type: ignore
  
      class Schema(strawberry.Schema):
          def execute_sync(self, *args, **kwargs):
              kwargs.update(root_value=Query(items=items_list))
              return super().execute_sync(*args, **kwargs)
  
      return Schema(query=Query, types=CONCRETE_TYPES)
  
  
  get_resolve_type_schema = partial(create_schema, item_type=ResolvedItem)
  get_is_type_of_schema = partial(create_schema, item_type=Item)
  
  query = "query { items { id } }"
  
  
  def benchmark(n_range: Sequence[int], n_repeats: int = 3):
      kernels = {
          "is_type_of (n_types = 2)": partial(get_is_type_of_schema, n_types=2),
          "is_type_of (n_types = 16)": partial(get_is_type_of_schema, n_types=16),
          "is_type_of (n_types = 32)": partial(get_is_type_of_schema, n_types=32),
          "resolve_type (n_types = 2)": partial(get_resolve_type_schema, n_types=2),
          "resolve_type (n_types = 16)": partial(get_resolve_type_schema, n_types=16),
          "resolve_type (n_types = 32)": partial(get_resolve_type_schema, n_types=32),
      }
      results: DefaultDict[str, List[float]] = defaultdict(list)
      for label, schema_fn in kernels.items():
          timings = results[label]
          for n_items in n_range:
              schema = schema_fn(n_items=n_items)
              repeats = []
              for _ in range(n_repeats):
                  repeats.append(timeit(lambda: schema.execute_sync(query), number=1))
              timings.append(min(repeats))
      timings = np.vstack([np.array(r) for r in results.values()])
      return PerfplotData(
          n_range=n_range,
          labels=tuple(kernels.keys()),
          xlabel="$n_{items}$",
          timings_s=timings,
          flop=None,
          title=None,
      )
  
  
  results = benchmark(n_range=[2 ** k for k in range(0, 13, 4)], n_repeats=10)
  
  for style in ("dufte", "dracula"):
      plt.style.use(getattr(matplotx.styles, style))
      results.save(
          f"resolve_performance_{style}.svg",
          transparent=False,
          bbox_inches="tight",
          relative_to=0,
      )
  
  ```
</details>

## Issues Fixed or Closed by This PR

- Closes #2320

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Documentation

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
