### PR TITLE
Make tracing imports lazy

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: minor
+
+This release fixes an issue that required installing opentelemetry when
+trying to use the ApolloTracing extension

--- a/strawberry/extensions/tracing/__init__.py
+++ b/strawberry/extensions/tracing/__init__.py
@@ -25,9 +25,9 @@ def __getattr__(name):
         return importlib.import_module(f".{name}", __name__)
 
     if name in {"ApolloTracingExtension", "ApolloTracingExtensionSync"}:
-        return getattr(importlib.import_module("apollo", __name__), name)
+        return getattr(importlib.import_module(".apollo", __name__), name)
 
     if name in {"OpenTelemetryExtension", "OpenTelemetryExtensionSync"}:
-        return getattr(importlib.import_module("opentelemetry", __name__), name)
+        return getattr(importlib.import_module(".opentelemetry", __name__), name)
 
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/strawberry/extensions/tracing/__init__.py
+++ b/strawberry/extensions/tracing/__init__.py
@@ -1,2 +1,27 @@
-from .apollo import ApolloTracingExtension, ApolloTracingExtensionSync  # noqa
-from .opentelemetry import OpenTelemetryExtension, OpenTelemetryExtensionSync  # noqa
+import importlib
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from . import apollo, opentelemetry
+    from .apollo import ApolloTracingExtension, ApolloTracingExtensionSync  # noqa
+    from .opentelemetry import (  # noqa
+        OpenTelemetryExtension,
+        OpenTelemetryExtensionSync,
+    )
+
+__all__ = [
+    "opentelemetry",
+    "apollo",
+    "ApolloTracingExtension",
+    "ApolloTracingExtensionSync",
+    "OpenTelemetryExtension",
+    "OpenTelemetryExtensionSync",
+]
+
+
+def __getattr__(name):
+    if name in __all__:
+        return importlib.import_module(f".{name}", __name__)
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/strawberry/extensions/tracing/__init__.py
+++ b/strawberry/extensions/tracing/__init__.py
@@ -21,7 +21,13 @@ __all__ = [
 
 
 def __getattr__(name):
-    if name in __all__:
+    if name in {"apollo", "opentelemetry"}:
         return importlib.import_module(f".{name}", __name__)
+
+    if name in {"ApolloTracingExtension", "ApolloTracingExtensionSync"}:
+        return getattr(importlib.import_module("apollo", __name__), name)
+
+    if name in {"OpenTelemetryExtension", "OpenTelemetryExtensionSync"}:
+        return getattr(importlib.import_module("opentelemetry", __name__), name)
 
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/strawberry/extensions/tracing/__init__.py
+++ b/strawberry/extensions/tracing/__init__.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING
 
 
 if TYPE_CHECKING:
-    from . import apollo, opentelemetry
     from .apollo import ApolloTracingExtension, ApolloTracingExtensionSync  # noqa
     from .opentelemetry import (  # noqa
         OpenTelemetryExtension,
@@ -11,8 +10,6 @@ if TYPE_CHECKING:
     )
 
 __all__ = [
-    "opentelemetry",
-    "apollo",
     "ApolloTracingExtension",
     "ApolloTracingExtensionSync",
     "OpenTelemetryExtension",
@@ -20,10 +17,7 @@ __all__ = [
 ]
 
 
-def __getattr__(name):
-    if name in {"apollo", "opentelemetry"}:
-        return importlib.import_module(f".{name}", __name__)
-
+def __getattr__(name: str):
     if name in {"ApolloTracingExtension", "ApolloTracingExtensionSync"}:
         return getattr(importlib.import_module(".apollo", __name__), name)
 

--- a/tests/schema/extensions/test_imports.py
+++ b/tests/schema/extensions/test_imports.py
@@ -4,6 +4,8 @@ def test_can_import():
         ApolloTracingExtensionSync,
         OpenTelemetryExtension,
         OpenTelemetryExtensionSync,
+        apollo,
+        opentelemetry,
     )
     from strawberry.extensions.tracing.apollo import (  # noqa
         ApolloTracingExtension,

--- a/tests/schema/extensions/test_imports.py
+++ b/tests/schema/extensions/test_imports.py
@@ -1,0 +1,15 @@
+def test_can_import():
+    from strawberry.extensions.tracing import (  # noqa
+        ApolloTracingExtension,
+        ApolloTracingExtensionSync,
+        OpenTelemetryExtension,
+        OpenTelemetryExtensionSync,
+    )
+    from strawberry.extensions.tracing.apollo import (  # noqa
+        ApolloTracingExtension,
+        ApolloTracingExtensionSync,
+    )
+    from strawberry.extensions.tracing.opentelemetry import (  # noqa
+        OpenTelemetryExtension,
+        OpenTelemetryExtensionSync,
+    )

--- a/tests/schema/extensions/test_imports.py
+++ b/tests/schema/extensions/test_imports.py
@@ -1,3 +1,6 @@
+import pytest
+
+
 def test_can_import():
     from strawberry.extensions.tracing import (  # noqa
         ApolloTracingExtension,
@@ -15,3 +18,8 @@ def test_can_import():
         OpenTelemetryExtension,
         OpenTelemetryExtensionSync,
     )
+
+
+def test_fails_if_import_is_not_found():
+    with pytest.raises(ImportError):
+        from strawberry.extensions.tracing import Blueberry  # noqa


### PR DESCRIPTION
This PR changes the import the tracing extensions and makes them lazy. This prevents having to have opentelemetry installed when wanting to use ApolloTracing

Closes #565 
Closes #1753