### PR TITLE
Mutable default values are frozen to support lists and objects.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,8 @@
+Release type: patch
+
+Mutable default values are frozen to support lists and objects.
+```python
+@strawberry.field
+def search(self, arg: List[int] = [], input: MyInput = {}) -> int:
+    ...
+```

--- a/tests/test_printer/test_basic.py
+++ b/tests/test_printer/test_basic.py
@@ -137,7 +137,7 @@ def test_input_defaults():
     @strawberry.type
     class Query:
         @strawberry.field
-        def search(self, input: MyInput) -> int:
+        def search(self, arg: List[int] = [0], input: MyInput = {"l": []}) -> int:
             return input.i
 
     expected_type = """
@@ -149,7 +149,7 @@ def test_input_defaults():
     }
 
     type Query {
-      search(input: MyInput!): Int!
+      search(arg: [Int!]! = [0], input: MyInput! = {l: []}): Int!
     }
     """
 


### PR DESCRIPTION
## Description
Restores the ability to use mutable default values, freezing them to support lists and objects.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #1983 

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
