### PR TITLE
pydantic: use strawberry alias if any

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,12 @@
+Release type: patch
+
+Allow to add alias to fields generated from pydantic with `strawberry.field(name="ageAlias")`.
+
+```
+class User(pydantic.BaseModel):
+    age: int
+
+@strawberry.experimental.pydantic.type(User)
+class UserType:
+    age: strawberry.auto = strawberry.field(name="ageAlias")
+```

--- a/strawberry/experimental/pydantic/object_type.py
+++ b/strawberry/experimental/pydantic/object_type.py
@@ -71,11 +71,14 @@ def _build_dataclass_creation_fields(
     else:
         # otherwise we build an appropriate strawberry field that resolves it
         existing_field = existing_fields.get(field.name)
+        graphql_name = None
+        if existing_field and existing_field.graphql_name:
+            graphql_name = existing_field.graphql_name
+        elif field.has_alias:
+            graphql_name = field.alias
         strawberry_field = StrawberryField(
             python_name=field.name,
-            graphql_name=field.alias
-            if field.has_alias and use_pydantic_alias
-            else None,
+            graphql_name=graphql_name,
             # always unset because we use default_factory instead
             default=UNSET,
             default_factory=get_default_factory_for_field(field),

--- a/strawberry/experimental/pydantic/object_type.py
+++ b/strawberry/experimental/pydantic/object_type.py
@@ -74,7 +74,7 @@ def _build_dataclass_creation_fields(
         graphql_name = None
         if existing_field and existing_field.graphql_name:
             graphql_name = existing_field.graphql_name
-        elif field.has_alias:
+        elif field.has_alias and use_pydantic_alias:
             graphql_name = field.alias
         strawberry_field = StrawberryField(
             python_name=field.name,

--- a/tests/experimental/pydantic/test_basic.py
+++ b/tests/experimental/pydantic/test_basic.py
@@ -795,3 +795,21 @@ def test_field_directives():
     assert field2.graphql_name is None
     assert isinstance(field2.type, StrawberryOptional)
     assert field2.type.of_type is str
+
+
+def test_alias_fields():
+    class User(pydantic.BaseModel):
+        age: int
+
+    @strawberry.experimental.pydantic.type(User)
+    class UserType:
+        age: strawberry.auto = strawberry.field(name="ageAlias")
+
+    definition: TypeDefinition = UserType._type_definition
+    assert definition.name == "UserType"
+
+    field1 = definition.fields[0]
+
+    assert field1.python_name == "age"
+    assert field1.graphql_name == "ageAlias"
+    assert field1.type is int

--- a/tests/experimental/pydantic/test_basic.py
+++ b/tests/experimental/pydantic/test_basic.py
@@ -813,3 +813,30 @@ def test_alias_fields():
     assert field1.python_name == "age"
     assert field1.graphql_name == "ageAlias"
     assert field1.type is int
+
+
+def test_alias_fields_with_use_pydantic_alias():
+    class User(pydantic.BaseModel):
+        age: int
+        state: str = pydantic.Field(alias="statePydantic")
+        country: str = pydantic.Field(alias="countryPydantic")
+
+    @strawberry.experimental.pydantic.type(User, use_pydantic_alias=True)
+    class UserType:
+        age: strawberry.auto = strawberry.field(name="ageAlias")
+        state: strawberry.auto = strawberry.field(name="state")
+        country: strawberry.auto
+
+    definition: TypeDefinition = UserType._type_definition
+    assert definition.name == "UserType"
+
+    [field1, field2, field3] = definition.fields
+
+    assert field1.python_name == "age"
+    assert field1.graphql_name == "ageAlias"
+
+    assert field2.python_name == "state"
+    assert field2.graphql_name == "state"
+
+    assert field3.python_name == "country"
+    assert field3.graphql_name == "countryPydantic"


### PR DESCRIPTION
Closes https://github.com/strawberry-graphql/strawberry/issues/1964:

> cannot set `graphql_name` with `strawberry.field(name='someName')` on `pydantic.type`

Feel free to edit my PR if such behaviour was not intended. 🙂 