### PR TITLE
fix a breaking internal error in mypy if using field() with positional arguments

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,12 @@
+Release type: patch
+
+This release fixes a breaking internal error in mypy plugin for the following case.
+- using positional arguments to pass a resolver for `strawberry.field()` or `strawberry.mutation()`
+
+```python
+failed: str = strawberry.field(resolver)
+successed: str = strawberry.field(resolver=resolver)
+```
+
+now mypy returns an error with `"field()" or "mutation()" only takes keyword arguments` message
+rather than an internal error.

--- a/tests/mypy/test_fields.yml
+++ b/tests/mypy/test_fields.yml
@@ -124,3 +124,17 @@
     reveal_type(Example.a)
   out: |
     main:8: note: Revealed type is "builtins.str"
+
+- case: test_positional_arguments_in_field
+  main: |
+    import strawberry
+
+    def resolver() -> str:
+      return 'Hello, World!'
+
+    @strawberry.type
+    class Example:
+      passed: str = strawberry.field(resolver=resolver)
+      failed: str = strawberry.field(resolver)
+  out: |
+    main:9: error: "field()" or "mutation()" only takes keyword arguments  [misc]

--- a/tests/mypy/test_mutation.yml
+++ b/tests/mypy/test_mutation.yml
@@ -29,3 +29,18 @@
     Mutation(n="Patrick")
   out: |
     main:11: error: Unexpected keyword argument "n" for "Mutation"  [call-arg]
+
+
+- case: test_positional_arguments_in_mutation
+  main: |
+    import strawberry
+
+    def set_name(self, name: str) -> None:
+      self.name = name
+
+    @strawberry.type
+    class Example:
+      passed: None = strawberry.mutation(resolver=set_name)
+      failed: None = strawberry.mutation(set_name)
+  out: |
+    main:9: error: "field()" or "mutation()" only takes keyword arguments  [misc]


### PR DESCRIPTION
fix a breaking internal error in mypy if using field() with positional arguments

## Description

- add handling logic for positional arguments in mypy plugin

more concretely, mypy raises a breaking error for the following code:

```python
import strawberry

def resolver() -> str:
    return 'Hello, World!'

@strawberry.type
class Example:
    successed: str = strawberry.field(resolver=resolver)
    failed: str = strawberry.field(resolver)  # makes mypy break
```

```python
../t.py:7: error: INTERNAL ERROR -- Please try using mypy master on Github:
https://mypy.readthedocs.io/en/stable/common_issues.html#using-a-development-mypy-build
Please report a bug at https://github.com/python/mypy/issues
version: 0.950
Traceback (most recent call last):
  File "mypy/semanal.py", line 5301, in accept
  File "mypy/nodes.py", line 1021, in accept
  File "mypy/semanal.py", line 1121, in visit_class_def
  File "mypy/semanal.py", line 1201, in analyze_class
  File "mypy/semanal.py", line 1210, in analyze_class_body_common
  File "mypy/semanal.py", line 1256, in apply_class_plugin_hooks
  File "/home/msc-elice/git-cloned/strawberry/strawberry/ext/mypy_plugin.py", line 809, in custom_dataclass_class_maker_callback
    transformer.transform()
  File "/home/msc-elice/git-cloned/strawberry/strawberry/ext/mypy_plugin.py", line 487, in transform
    attributes = self.collect_attributes()
  File "/home/msc-elice/git-cloned/strawberry/strawberry/ext/mypy_plugin.py", line 664, in collect_attributes
    has_field_call, field_args = _collect_field_args(stmt.rvalue)
  File "/home/msc-elice/git-cloned/strawberry/strawberry/ext/mypy_plugin.py", line 454, in _collect_field_args
    assert name is not None
AssertionError: 
../t.py:7: : note: use --pdb to drop into pd
```

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
