### PR TITLE
Add FieldSet to federated schema types

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,9 @@
+Release type: patch
+
+This release fixes the following error when trying to use Strawberry
+with Apollo Federation:
+
+```
+Error: A valid schema couldn't be composed. The following composition errors were found:
+	[burro-api] Unknown type _FieldSet
+```

--- a/strawberry/federation/object_type.py
+++ b/strawberry/federation/object_type.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Callable, List, Sequence, TypeVar, Union, over
 
 from strawberry.field import StrawberryField, field as base_field
 from strawberry.object_type import type as base_type
+from strawberry.unset import UNSET
 from strawberry.utils.typing import __dataclass_transform__
 
 from .field import field
@@ -56,7 +57,9 @@ def type(
 ):
     from strawberry.federation.schema_directives import Key, Shareable
 
-    all_directives = [Key(key) if isinstance(key, str) else key for key in keys or []]
+    all_directives = [
+        Key(key, UNSET) if isinstance(key, str) else key for key in keys or []
+    ]
     if shareable:
         all_directives.append(Shareable())  # type: ignore
     all_directives.extend(directives)  # type: ignore

--- a/strawberry/federation/schema.py
+++ b/strawberry/federation/schema.py
@@ -21,10 +21,16 @@ from strawberry.utils.inspect import get_func_args
 
 from ..printer import print_schema
 from ..schema import Schema as BaseSchema
+from .types import FieldSet
 
 
 class Schema(BaseSchema):
     def __init__(self, *args, **kwargs):
+        additional_types = list(kwargs.pop("types", []))
+        additional_types.extend([FieldSet])
+
+        kwargs["types"] = additional_types
+
         super().__init__(*args, **kwargs)
 
         self._add_scalars()

--- a/strawberry/federation/schema_directives.py
+++ b/strawberry/federation/schema_directives.py
@@ -4,7 +4,6 @@ from typing_extensions import Literal
 
 from strawberry import directive_field
 from strawberry.schema_directive import Location, schema_directive
-from strawberry.unset import UNSET
 
 from .types import FieldSet
 
@@ -30,7 +29,7 @@ class Provides:
 @schema_directive(locations=[Location.OBJECT, Location.INTERFACE], name="key")
 class Key:
     fields: FieldSet
-    resolvable: Optional[bool] = UNSET
+    resolvable: Optional[bool] = True
 
 
 @schema_directive(

--- a/strawberry/federation/schema_directives.py
+++ b/strawberry/federation/schema_directives.py
@@ -3,14 +3,13 @@ from typing import Optional
 from typing_extensions import Literal
 
 from strawberry import directive_field
-from strawberry.custom_scalar import scalar
 from strawberry.schema_directive import Location, schema_directive
 from strawberry.unset import UNSET
 
+from .types import FieldSet
 
-FieldSet = scalar(str, name="_FieldSet")
+
 LinkPurpose = Literal["SECURITY", "EXECUTION"]
-LinkImport = scalar(list, name="link__Import")
 
 
 @schema_directive(locations=[Location.FIELD_DEFINITION], name="external")

--- a/strawberry/federation/types.py
+++ b/strawberry/federation/types.py
@@ -1,0 +1,7 @@
+from strawberry.custom_scalar import scalar
+
+
+FieldSet = scalar(str, name="_FieldSet")
+
+# TODO: this is not used yet
+LinkImport = scalar(list, name="link__Import")

--- a/tests/federation/test_printer.py
+++ b/tests/federation/test_printer.py
@@ -65,6 +65,8 @@ def test_entities_type_when_no_type_has_keys():
 
         union _Entity = Product
 
+        scalar _FieldSet
+
         type _Service {
           sdl: String!
         }
@@ -115,6 +117,8 @@ def test_entities_extending_interface():
         scalar _Any
 
         union _Entity = Product
+
+        scalar _FieldSet
 
         type _Service {
           sdl: String!
@@ -191,6 +195,8 @@ def test_fields_requires_are_printed_correctly():
 
         union _Entity = Product
 
+        scalar _FieldSet
+
         type _Service {
           sdl: String!
         }
@@ -262,6 +268,8 @@ def test_field_provides_are_printed_correctly_camel_case_on():
         scalar _Any
 
         union _Entity = Product
+
+        scalar _FieldSet
 
         type _Service {
           sdl: String!
@@ -335,6 +343,8 @@ def test_field_provides_are_printed_correctly_camel_case_off():
 
         union _Entity = Product
 
+        scalar _FieldSet
+
         type _Service {
           sdl: String!
         }
@@ -402,6 +412,8 @@ def test_multiple_keys():
 
         union _Entity = Product | Review
 
+        scalar _FieldSet
+
         type _Service {
           sdl: String!
         }
@@ -455,6 +467,8 @@ def test_field_shareable_printed_correctly():
 
         union _Entity = Product
 
+        scalar _FieldSet
+
         type _Service {
           sdl: String!
         }
@@ -505,6 +519,8 @@ def test_field_tag_printed_correctly():
         scalar _Any
 
         union _Entity = Product
+
+        scalar _FieldSet
 
         type _Service {
           sdl: String!
@@ -557,6 +573,8 @@ def test_field_override_printed_correctly():
 
         union _Entity = Product
 
+        scalar _FieldSet
+
         type _Service {
           sdl: String!
         }
@@ -607,6 +625,8 @@ def test_field_inaccessible_printed_correctly():
         scalar _Any
 
         union _Entity = Product
+
+        scalar _FieldSet
 
         type _Service {
           sdl: String!

--- a/tests/federation/test_printer.py
+++ b/tests/federation/test_printer.py
@@ -38,7 +38,7 @@ def test_entities_type_when_no_type_has_keys():
     expected = """
         directive @external on FIELD_DEFINITION
 
-        directive @key(fields: _FieldSet!, resolvable: Boolean) on OBJECT | INTERFACE
+        directive @key(fields: _FieldSet!, resolvable: Boolean = true) on OBJECT | INTERFACE
 
         extend type Product @key(fields: "upc") {
           upc: String! @external
@@ -97,7 +97,7 @@ def test_entities_extending_interface():
     expected = """
         directive @external on FIELD_DEFINITION
 
-        directive @key(fields: _FieldSet!, resolvable: Boolean) on OBJECT | INTERFACE
+        directive @key(fields: _FieldSet!, resolvable: Boolean = true) on OBJECT | INTERFACE
 
         extend type Product implements SomeInterface @key(fields: "upc") {
           id: ID!
@@ -163,7 +163,7 @@ def test_fields_requires_are_printed_correctly():
     expected = """
         directive @external on FIELD_DEFINITION
 
-        directive @key(fields: _FieldSet!, resolvable: Boolean) on OBJECT | INTERFACE
+        directive @key(fields: _FieldSet!, resolvable: Boolean = true) on OBJECT | INTERFACE
 
         directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
 
@@ -239,7 +239,7 @@ def test_field_provides_are_printed_correctly_camel_case_on():
     expected = """
         directive @external on FIELD_DEFINITION
 
-        directive @key(fields: _FieldSet!, resolvable: Boolean) on OBJECT | INTERFACE
+        directive @key(fields: _FieldSet!, resolvable: Boolean = true) on OBJECT | INTERFACE
 
         directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
 
@@ -313,7 +313,7 @@ def test_field_provides_are_printed_correctly_camel_case_off():
     expected = """
         directive @external on FIELD_DEFINITION
 
-        directive @key(fields: _FieldSet!, resolvable: Boolean) on OBJECT | INTERFACE
+        directive @key(fields: _FieldSet!, resolvable: Boolean = true) on OBJECT | INTERFACE
 
         directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
 
@@ -385,7 +385,7 @@ def test_multiple_keys():
     expected = """
         directive @external on FIELD_DEFINITION
 
-        directive @key(fields: _FieldSet!, resolvable: Boolean) on OBJECT | INTERFACE
+        directive @key(fields: _FieldSet!, resolvable: Boolean = true) on OBJECT | INTERFACE
 
         extend type Product @key(fields: "upc", resolvable: true) {
           upc: String! @external
@@ -444,7 +444,7 @@ def test_field_shareable_printed_correctly():
     expected = """
         directive @external on FIELD_DEFINITION
 
-        directive @key(fields: _FieldSet!, resolvable: Boolean) on OBJECT | INTERFACE
+        directive @key(fields: _FieldSet!, resolvable: Boolean = true) on OBJECT | INTERFACE
 
         directive @shareable on FIELD_DEFINITION | OBJECT
 
@@ -497,7 +497,7 @@ def test_field_tag_printed_correctly():
     expected = """
         directive @external on FIELD_DEFINITION
 
-        directive @key(fields: _FieldSet!, resolvable: Boolean) on OBJECT | INTERFACE
+        directive @key(fields: _FieldSet!, resolvable: Boolean = true) on OBJECT | INTERFACE
 
         directive @tag(name: String!) on FIELD_DEFINITION | INTERFACE | OBJECT | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
@@ -550,7 +550,7 @@ def test_field_override_printed_correctly():
     expected = """
         directive @external on FIELD_DEFINITION
 
-        directive @key(fields: _FieldSet!, resolvable: Boolean) on OBJECT | INTERFACE
+        directive @key(fields: _FieldSet!, resolvable: Boolean = true) on OBJECT | INTERFACE
 
         directive @override(from: String!) on FIELD_DEFINITION
 
@@ -605,7 +605,7 @@ def test_field_inaccessible_printed_correctly():
 
         directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION
 
-        directive @key(fields: _FieldSet!, resolvable: Boolean) on OBJECT | INTERFACE
+        directive @key(fields: _FieldSet!, resolvable: Boolean = true) on OBJECT | INTERFACE
 
         extend type Product implements SomeInterface @key(fields: "upc") {
           id: ID!
@@ -654,7 +654,7 @@ def test_additional_schema_directives_printed_correctly_object():
     expected_type = """
     directive @CacheControl(max_age: Int!) on OBJECT
 
-    directive @key(fields: _FieldSet!, resolvable: Boolean) on OBJECT | INTERFACE
+    directive @key(fields: _FieldSet!, resolvable: Boolean = true) on OBJECT | INTERFACE
 
     directive @shareable on FIELD_DEFINITION | OBJECT
 
@@ -700,7 +700,7 @@ def test_additional_schema_directives_printed_in_order_object():
 
     directive @CacheControl1(min_age: Int!) on OBJECT
 
-    directive @key(fields: _FieldSet!, resolvable: Boolean) on OBJECT | INTERFACE
+    directive @key(fields: _FieldSet!, resolvable: Boolean = true) on OBJECT | INTERFACE
 
     directive @shareable on FIELD_DEFINITION | OBJECT
 

--- a/tests/federation/test_schema.py
+++ b/tests/federation/test_schema.py
@@ -139,6 +139,8 @@ def test_service():
 
         scalar _Any
 
+        scalar _FieldSet
+
         type _Service {
           sdl: String!
         }
@@ -193,6 +195,8 @@ def test_using_generics():
         }
 
         scalar _Any
+
+        scalar _FieldSet
 
         type _Service {
           sdl: String!


### PR DESCRIPTION
## Description

This PR fixes the following error when using apollo federation:

```
Error: A valid schema couldn't be composed. The following composition errors were found:
	[burro-api] Unknown type _FieldSet
```

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Closes #1943

