### PR TITLE
Reimplement `annotations` property on `StrawberryResolver`

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+Release type: patch
+
+Reimplement `StrawberryResolver.annotations` property after removal in v0.115.
+
+Library authors who previously relied on the public `annotations` property
+can continue to do so after this fix.

--- a/strawberry/types/fields/resolver.py
+++ b/strawberry/types/fields/resolver.py
@@ -214,6 +214,25 @@ class StrawberryResolver(Generic[T]):
         return self._unbound_wrapped_func.__name__
 
     @cached_property
+    def annotations(self) -> Dict[str, object]:
+        """Annotations for the resolver.
+
+        Does not include special args defined in `RESERVED_PARAMSPEC` (e.g. self, root,
+        info)
+        """
+        reserved_parameters = self.reserved_parameters
+        reserved_names = {p.name for p in reserved_parameters.values() if p is not None}
+
+        annotations = self._unbound_wrapped_func.__annotations__
+        annotations = {
+            name: annotation
+            for name, annotation in annotations.items()
+            if name not in reserved_names
+        }
+
+        return annotations
+
+    @cached_property
     def type_annotation(self) -> Optional[StrawberryAnnotation]:
         return_annotation = self.signature.return_annotation
         if return_annotation is inspect.Signature.empty:

--- a/tests/fields/test_resolvers.py
+++ b/tests/fields/test_resolvers.py
@@ -11,6 +11,7 @@ from strawberry.exceptions import (
     MissingReturnAnnotationError,
 )
 from strawberry.types.fields.resolver import StrawberryResolver, UncallableResolverError
+from strawberry.types.info import Info
 
 
 def test_resolver_as_argument():
@@ -260,3 +261,26 @@ def test_with_resolver_fields():
 
     assert Query(1) == Query(1)
     assert Query(1) != Query(2)
+
+
+def test_resolver_annotations():
+    """Ensure only non-reserved annotations are returned."""
+
+    def resolver_annotated_info(
+        self, root, foo: str, bar: float, info: str, strawberry_info: Info
+    ) -> str:
+        return "Hello world"
+
+    resolver = StrawberryResolver(resolver_annotated_info)
+
+    expected_annotations = {"foo": str, "bar": float, "info": str, "return": str}
+    assert resolver.annotations == expected_annotations
+
+    # Sanity-check to ensure StrawberryArguments return the same annotations
+    assert {
+        **{
+            arg.python_name: arg.type_annotation.resolve()  # type: ignore
+            for arg in resolver.arguments
+        },
+        "return": str,
+    }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Library authors who previously relied on the `annotations` property were inconvenienced by its removal in Release v0.115. Therefore, this PR remedies this problem by re-implementing this public property.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #1989

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
