### PR TITLE
Add temporary fix for strawberry.auto and future annotations

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+This release adds an initial fix to make `strawberry.auto` work when using
+`from __future__ import annotations`.

--- a/strawberry/auto.py
+++ b/strawberry/auto.py
@@ -57,7 +57,7 @@ class StrawberryAutoMeta(type):
             if args[0] is Any:
                 return any(isinstance(arg, StrawberryAuto) for arg in args[1:])
 
-        return False
+        return instance == "strawberry.auto"
 
 
 class StrawberryAuto(metaclass=StrawberryAutoMeta):

--- a/tests/experimental/pydantic/schema/test_forward_reference.py
+++ b/tests/experimental/pydantic/schema/test_forward_reference.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import textwrap
+from typing import Optional
+
+import pydantic
+
+import strawberry
+
+
+def test_auto_fields():
+    global User
+
+    class UserModel(pydantic.BaseModel):
+        age: int
+        password: Optional[str]
+        other: float
+
+    @strawberry.experimental.pydantic.type(UserModel)
+    class User:
+        age: strawberry.auto
+        password: strawberry.auto
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def user(self) -> User:
+            return User(age=1, password="ABC")
+
+    schema = strawberry.Schema(query=Query)
+
+    expected_schema = """
+    type Query {
+      user: User!
+    }
+
+    type User {
+      age: Int!
+      password: String
+    }
+    """
+
+    assert str(schema) == textwrap.dedent(expected_schema).strip()
+
+    query = "{ user { age } }"
+
+    result = schema.execute_sync(query)
+
+    assert not result.errors
+    assert result.data["user"]["age"] == 1


### PR DESCRIPTION
This PR is a temporary fix for auto not working when using `from __future__ import annotations`.

We should find a better way to fix this, but it will take a bit of time to refactor some of the code. /cc @thejaminator maybe we can discuss how to best make this work :)

It might fix #1819, @eddysen I'll make a pre-release, could you check if that works for you? :)