### PR TITLE
Fix mypy false positives regarding to_pydantic

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,24 @@
+Release type: patch
+
+ Fixes issue where the mypy plugin would have a false positive error.
+ This happened to_pydantic was called on a type that was converted from
+ pydantic with all_fields=True
+
+```python
+from pydantic import BaseModel
+from typing import Optional
+import strawberry
+
+
+class MyModel(BaseModel):
+    email: str
+    password: Optional[str]
+
+
+@strawberry.experimental.pydantic.input(model=MyModel, all_fields=True)
+class MyModelStrawberry:
+    ...
+
+MyModelStrawberry(email="").to_pydantic()
+# previously would complain wrongly about missing email and password
+```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,8 +1,10 @@
 Release type: patch
 
- Fixes issue where the mypy plugin would have a false positive error.
- This happened to_pydantic was called on a type that was converted from
- pydantic with all_fields=True
+Fixes false positives with the mypy plugin.
+Happened when `to_pydantic` was called on a type that was converted
+pydantic with all_fields=True.
+
+Also fixes the type signature when `to_pydantic` is defined by the user.
 
 ```python
 from pydantic import BaseModel

--- a/strawberry/ext/mypy_plugin.py
+++ b/strawberry/ext/mypy_plugin.py
@@ -436,7 +436,7 @@ def strawberry_pydantic_class_callback(ctx: ClassDefContext) -> None:
         """
         is_all_fields: bool = len(potentially_missing_fields) == len(pydantic_fields)
         missing_pydantic_fields: Set["PydanticModelField"] = (
-            potentially_missing_fields if is_all_fields else set()
+            potentially_missing_fields if not is_all_fields else set()
         )
 
         # Add to_pydantic

--- a/strawberry/ext/mypy_plugin.py
+++ b/strawberry/ext/mypy_plugin.py
@@ -439,23 +439,23 @@ def strawberry_pydantic_class_callback(ctx: ClassDefContext) -> None:
             potentially_missing_fields if not is_all_fields else set()
         )
 
-        # Add to_pydantic
-        # TODO: Only add this if not manually defined
-        add_method(
-            ctx,
-            "to_pydantic",
-            args=[
-                f.to_argument(
-                    # TODO: use_alias should depend on config?
-                    info=model_type.type,
-                    typed=True,
-                    force_optional=False,
-                    use_alias=True,
-                )
-                for f in missing_pydantic_fields
-            ],
-            return_type=model_type,
-        )
+        # Add the default to_pydantic if undefined by the user
+        if "to_pydantic" not in ctx.cls.info.names:
+            add_method(
+                ctx,
+                "to_pydantic",
+                args=[
+                    f.to_argument(
+                        # TODO: use_alias should depend on config?
+                        info=model_type.type,
+                        typed=True,
+                        force_optional=False,
+                        use_alias=True,
+                    )
+                    for f in missing_pydantic_fields
+                ],
+                return_type=model_type,
+            )
 
         # Add from_pydantic
         model_argument = Argument(

--- a/strawberry/ext/mypy_plugin.py
+++ b/strawberry/ext/mypy_plugin.py
@@ -424,8 +424,19 @@ def strawberry_pydantic_class_callback(ctx: ClassDefContext) -> None:
                 ctx.reason,
             )
 
-        missing_pydantic_fields: Set["PydanticModelField"] = set(
+        potentially_missing_fields: Set["PydanticModelField"] = set(
             f for f in pydantic_fields if f.name not in new_strawberry_fields
+        )
+
+        """
+        Need to check if all_fields=True from the pydantic decorator
+        There is no way to real check that Literal[True] was used
+        We just check if the strawberry type is missing all the fields
+        This means that the user is using all_fields=True
+        """
+        is_all_fields: bool = len(potentially_missing_fields) == len(pydantic_fields)
+        missing_pydantic_fields: Set["PydanticModelField"] = (
+            potentially_missing_fields if is_all_fields else set()
         )
 
         # Add to_pydantic

--- a/tests/mypy/test_pydantic.decorators.yml
+++ b/tests/mypy/test_pydantic.decorators.yml
@@ -204,3 +204,22 @@
 
     MyModelStrawberry(email="").to_pydantic()
   out: |
+- case: test_to_pydantic_kwargs_with_all_fields
+  main: |
+    from pydantic import BaseModel
+    from typing import Optional
+    import strawberry
+
+
+    class MyModel(BaseModel):
+        email: str
+        password: Optional[str]
+
+
+    @strawberry.experimental.pydantic.input(model=MyModel, all_fields=True)
+    class MyModelStrawberry:
+        ...
+
+
+    MyModelStrawberry(email="").to_pydantic()
+  out: |

--- a/tests/mypy/test_pydantic.decorators.yml
+++ b/tests/mypy/test_pydantic.decorators.yml
@@ -246,3 +246,22 @@
 
     MyModelStrawberry(email="").to_pydantic()
   out: |
+- case: test_to_pydantic_kwargs_private_field
+  main: |
+    from pydantic import BaseModel
+    from typing import Optional
+    import strawberry
+
+
+    class MyModel(BaseModel):
+        email: str
+        _age: int # for pydantic, underscore means private field
+
+
+    @strawberry.experimental.pydantic.input(model=MyModel)
+    class MyModelStrawberry:
+        email: strawberry.auto
+
+
+    MyModelStrawberry(email="").to_pydantic()
+  out: |

--- a/tests/mypy/test_pydantic.decorators.yml
+++ b/tests/mypy/test_pydantic.decorators.yml
@@ -223,3 +223,26 @@
 
     MyModelStrawberry(email="").to_pydantic()
   out: |
+- case: test_to_pydantic_kwargs_with_all_fields_adding_field
+  main: |
+    from pydantic import BaseModel
+    from typing import Optional
+    import strawberry
+
+
+    class MyModel(BaseModel):
+        email: str
+        password: Optional[str]
+
+        @property
+        def age(self) -> int:
+            return 42
+
+
+    @strawberry.experimental.pydantic.input(model=MyModel, all_fields=True)
+    class MyModelStrawberry:
+        age: int # read from the property
+
+
+    MyModelStrawberry(email="").to_pydantic()
+  out: |

--- a/tests/mypy/test_pydantic.decorators.yml
+++ b/tests/mypy/test_pydantic.decorators.yml
@@ -265,3 +265,23 @@
 
     MyModelStrawberry(email="").to_pydantic()
   out: |
+- case: test_to_pydantic_custom
+  main: |
+    from pydantic import BaseModel
+    import strawberry
+
+    class MyModel(BaseModel):
+        email: str
+
+    @strawberry.experimental.pydantic.input(model=MyModel)
+    class MyModelStrawberry:
+        email: strawberry.auto
+
+        def to_pydantic(self, another_param: str):
+            # custom to_pydantic overwrites default params
+            ...
+
+    MyModelStrawberry(email="").to_pydantic()
+
+  out: |
+    main:15: error: Missing named argument "another_param" for "to_pydantic" of "MyModelStrawberry"  [call-arg]

--- a/tests/mypy/test_pydantic.decorators.yml
+++ b/tests/mypy/test_pydantic.decorators.yml
@@ -284,4 +284,4 @@
     MyModelStrawberry(email="").to_pydantic()
 
   out: |
-    main:15: error: Missing named argument "another_param" for "to_pydantic" of "MyModelStrawberry"  [call-arg]
+    main:15: error: Missing positional argument "another_param" in call to "to_pydantic" of "MyModelStrawberry"  [call-arg]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Closes #2015 

Fixes false positives with the mypy plugin.
Happened when `to_pydantic` was called on a type that was converted
pydantic with all_fields=True.

Also fixes the type signature when `to_pydantic` is defined by the user.

```python
from pydantic import BaseModel
from typing import Optional
import strawberry


class MyModel(BaseModel):
    email: str
    password: Optional[str]


@strawberry.experimental.pydantic.input(model=MyModel, all_fields=True)
class MyModelStrawberry:
    ...

MyModelStrawberry(email="").to_pydantic()
# previously would complain wrongly about missing email and password
```
## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
