### PR TITLE
fix: edge case for nested generics in a union type

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,9 +1,8 @@
 Release type: patch
 
 Fixed edge case where `Union` types raised an `UnallowedReturnTypeForUnion` error when
-returning the correct type from the resolver due to only being able to partially match
-nested generic types. This is fixed by prioritising the types explicitly listed in the
-Union.
+returning the correct type from the resolver. This also improves performance of
+`StrawberryUnion.get_type_resolver()` from `O(n)` to `O(1)` in the majority of cases.
 
 For example the below ([link to playground](https://play.strawberry.rocks/?gist=f7d88898d127e65b12140fdd763f9ef2))
 would previously raise the error when querying `two` as `StrawberryUnion` would incorrectly

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,42 @@
+Release type: patch
+
+Fixed edge case where `Union` types raised an `UnallowedReturnTypeForUnion` error when
+returning the correct type from the resolver due to only being able to partially match
+nested generic types. This is fixed by prioritising the types explicitly listed in the
+Union.
+
+For example the below ([link to playground](https://play.strawberry.rocks/?gist=f7d88898d127e65b12140fdd763f9ef2))
+would previously raise the error when querying `two` as `StrawberryUnion` would incorrectly
+determine that the resolver returns `Container[TypeOne]`.
+
+```python
+import strawberry
+from typing import TypeVar, Generic, Union, List, Type
+
+T = TypeVar("T")
+
+@strawberry.type
+class Container(Generic[T]):
+    items: List[T]
+
+@strawberry.type
+class TypeOne:
+    attr: str
+
+@strawberry.type
+class TypeTwo:
+    attr: str
+
+def resolver_one():
+    return Container(items=[TypeOne("one")])
+    
+def resolver_two():
+    return Container(items=[TypeTwo("two")])
+
+@strawberry.type
+class Query:
+    one: Union[Container[TypeOne], TypeOne] = strawberry.field(resolver_one)
+    two: Union[Container[TypeTwo], TypeTwo] = strawberry.field(resolver_two)
+
+schema = strawberry.Schema(query=Query)
+```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,12 +1,14 @@
 Release type: patch
 
-Fixed edge case where `Union` types raised an `UnallowedReturnTypeForUnion` error when
-returning the correct type from the resolver. This also improves performance of
-StrawberryUnion's `_resolve_union_type` from `O(n)` to `O(1)` in the majority of cases.
+Fixed edge case where `Union` types raised an `UnallowedReturnTypeForUnion`
+error when returning the correct type from the resolver. This also improves
+performance of StrawberryUnion's `_resolve_union_type` from `O(n)` to `O(1)` in
+the majority of cases where `n` is the number of types in the schema.
 
-For example the below ([link to playground](https://play.strawberry.rocks/?gist=f7d88898d127e65b12140fdd763f9ef2))
-would previously raise the error when querying `two` as `StrawberryUnion` would incorrectly
-determine that the resolver returns `Container[TypeOne]`.
+For
+[example the below](https://play.strawberry.rocks/?gist=f7d88898d127e65b12140fdd763f9ef2))
+would previously raise the error when querying `two` as `StrawberryUnion` would
+incorrectly determine that the resolver returns `Container[TypeOne]`.
 
 ```python
 import strawberry

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,7 @@ Release type: patch
 
 Fixed edge case where `Union` types raised an `UnallowedReturnTypeForUnion` error when
 returning the correct type from the resolver. This also improves performance of
-`StrawberryUnion.get_type_resolver()` from `O(n)` to `O(1)` in the majority of cases.
+StrawberryUnion's `_resolve_union_type` from `O(n)` to `O(1)` in the majority of cases.
 
 For example the below ([link to playground](https://play.strawberry.rocks/?gist=f7d88898d127e65b12140fdd763f9ef2))
 would previously raise the error when querying `two` as `StrawberryUnion` would incorrectly

--- a/strawberry/union.py
+++ b/strawberry/union.py
@@ -153,7 +153,7 @@ class StrawberryUnion(StrawberryType):
                     ):
                         return inner_type.name
 
-                # Couldn't resolve using `is_type_of``
+                # Couldn't resolve using `is_type_of`
                 raise WrongReturnTypeForUnion(info.field_name, str(type(root)))
 
             return_type: Optional[GraphQLType]
@@ -161,8 +161,11 @@ class StrawberryUnion(StrawberryType):
             # Iterate over all of our known types and find the first concrete
             # type that implements the type. We prioritise checking types named in the
             # Union in case a nested generic object matches against more than one type.
+            concrete_types_for_union = (type_map[x.name] for x in type_.types)
+
+            # TODO: do we still need to iterate over all types in `type_map`?
             for possible_concrete_type in chain(
-                (type_map[x.name] for x in type_.types), type_map.values()
+                concrete_types_for_union, type_map.values()
             ):
                 possible_type = possible_concrete_type.definition
                 if not isinstance(possible_type, TypeDefinition):

--- a/strawberry/union.py
+++ b/strawberry/union.py
@@ -158,7 +158,8 @@ class StrawberryUnion(StrawberryType):
             return_type: Optional[GraphQLType]
 
             # Iterate over all of our known types and find the first concrete
-            # type that implements the type.
+            # type that implements the type. We prioritise checking types named in the
+            # Union in case a nested generic object matches against more than one type.
             union_type_names = tuple(x.name for x in type_.types)
             types_to_check = sorted(
                 type_map.keys(), key=lambda x: 1 - int(x in union_type_names)

--- a/strawberry/union.py
+++ b/strawberry/union.py
@@ -157,9 +157,14 @@ class StrawberryUnion(StrawberryType):
 
             return_type: Optional[GraphQLType]
 
-            # Iterate over all of our known types and find the first concrete type that
-            # implements the type
-            for possible_concrete_type in type_map.values():
+            # Iterate over all of our known types and find the first concrete
+            # type that implements the type.
+            union_type_names = tuple(x.name for x in type_.types)
+            types_to_check = sorted(
+                type_map.keys(), key=lambda x: 1 - int(x in union_type_names)
+            )
+            for possible_concrete_type_name in types_to_check:
+                possible_concrete_type = type_map[possible_concrete_type_name]
                 possible_type = possible_concrete_type.definition
                 if not isinstance(possible_type, TypeDefinition):
                     continue

--- a/strawberry/union.py
+++ b/strawberry/union.py
@@ -1,4 +1,5 @@
 import itertools
+from itertools import chain
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -160,12 +161,9 @@ class StrawberryUnion(StrawberryType):
             # Iterate over all of our known types and find the first concrete
             # type that implements the type. We prioritise checking types named in the
             # Union in case a nested generic object matches against more than one type.
-            union_type_names = tuple(x.name for x in type_.types)
-            types_to_check = sorted(
-                type_map.keys(), key=lambda x: 1 - int(x in union_type_names)
-            )
-            for possible_concrete_type_name in types_to_check:
-                possible_concrete_type = type_map[possible_concrete_type_name]
+            for possible_concrete_type in chain(
+                (type_map[x.name] for x in type_.types), type_map.values()
+            ):
                 possible_type = possible_concrete_type.definition
                 if not isinstance(possible_type, TypeDefinition):
                     continue

--- a/tests/schema/test_union.py
+++ b/tests/schema/test_union.py
@@ -1,7 +1,7 @@
 import sys
 from dataclasses import dataclass
 from textwrap import dedent
-from typing import Optional, Union
+from typing import Optional, Union, List, TypeVar, Generic
 
 import pytest
 
@@ -493,3 +493,76 @@ def test_union_with_input_types():
                 return User(name=data.name, age=100)
 
         strawberry.Schema(query=Query)
+
+
+def test_union_with_similar_nested_generic_types():
+    """
+    Previously this failed due to an edge case where Strawberry would choose AContainer
+    as the resolved type for container_b due to the inability to exactly match the
+    nested generic `Container.items`.
+    """
+    T = TypeVar("T")
+
+    @strawberry.type
+    class Container(Generic[T]):
+        items: List[T]
+
+    @strawberry.type
+    class A:
+        a: str
+
+    @strawberry.type
+    class B:
+        b: int
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def container_a(self) -> Union[Container[A], A]:
+            return Container(items=[A("hello")])
+
+        @strawberry.field
+        def container_b(self) -> Union[Container[B], B]:
+            return Container(items=[B(3)])
+
+    schema = strawberry.Schema(query=Query)
+
+    query = """
+     {
+        containerA {
+            __typename
+            ... on AContainer {
+                items {
+                    a
+                }
+            }
+            ... on A {
+                a
+            }
+        }
+    }
+    """
+
+    result = schema.execute_sync(query)
+
+    assert result.data["containerA"]["items"][0]["a"] == "hello"
+
+    query = """
+     {
+        containerB {
+            __typename
+            ... on BContainer {
+                items {
+                    b
+                }
+            }
+            ... on B {
+                b
+            }
+        }
+    }
+    """
+
+    result = schema.execute_sync(query)
+
+    assert result.data["containerB"]["items"][0]["b"] == 3


### PR DESCRIPTION
## Description

In `StrawberryUnion.get_type_resolver` prioritise testing against types that are explicitly in the Union type before checking all other known types. This fixes an edge case where StrawberryUnion would pick out an incorrect type that weakly matches (due to nested generics) the resolved object before testing the actual type in the union.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Resolves #2028.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
