### PR TITLE
Add support for custom default resolvers

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,28 @@
+Release type: minor
+
+This release adds support for overriding the default resolver for fields.
+
+Currentily the default resolver is `getattr`, but now you can change it to any
+function you like, for example you can allow returning dictionaries:
+
+
+```python
+@strawberry.type
+class User:
+    name: str
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def user(self) -> User:
+        return {"name": "Patrick"}  # type: ignore
+
+schema = strawberry.Schema(
+    query=Query,
+    config=StrawberryConfig(default_resolver=getitem),
+)
+
+query = "{ user { name } }"
+
+result = schema.execute_sync(query)
+```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,9 +2,8 @@ Release type: minor
 
 This release adds support for overriding the default resolver for fields.
 
-Currentily the default resolver is `getattr`, but now you can change it to any
+Currently the default resolver is `getattr`, but now you can change it to any
 function you like, for example you can allow returning dictionaries:
-
 
 ```python
 @strawberry.type

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -5,7 +5,6 @@ import sys
 from typing import (
     TYPE_CHECKING,
     Any,
-    Awaitable,
     Callable,
     Dict,
     List,
@@ -25,7 +24,6 @@ from strawberry.annotation import StrawberryAnnotation
 from strawberry.arguments import StrawberryArgument
 from strawberry.exceptions import InvalidDefaultFactoryError, InvalidFieldArgument
 from strawberry.type import StrawberryType, StrawberryTypeVar
-from strawberry.types.info import Info
 from strawberry.union import StrawberryUnion
 from strawberry.unset import UNSET
 
@@ -280,19 +278,6 @@ class StrawberryField(dataclasses.Field):
             default_factory=self.default_factory,
             deprecation_reason=self.deprecation_reason,
         )
-
-    def get_result(
-        self, source: Any, info: Info, args: List[Any], kwargs: Dict[str, Any]
-    ) -> Union[Awaitable[Any], Any]:
-        """
-        Calls the resolver defined for the StrawberryField. If the field doesn't have a
-        resolver defined we default to using getattr on `source`.
-        """
-
-        if self.base_resolver:
-            return self.base_resolver(*args, **kwargs)
-
-        return getattr(source, self.python_name)
 
     @property
     def _has_async_permission_classes(self) -> bool:

--- a/strawberry/schema/config.py
+++ b/strawberry/schema/config.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
 from dataclasses import InitVar, dataclass, field
+from typing import Any, Callable
 
 from .name_converter import NameConverter
 
 
 @dataclass
 class StrawberryConfig:
-    auto_camel_case: InitVar[bool] = None
+    auto_camel_case: InitVar[bool] = None  # pyright: reportGeneralTypeIssues=false
     name_converter: NameConverter = field(default_factory=NameConverter)
+    default_resolver: Callable[[Any, str], object] = getattr
 
     def __post_init__(
         self,

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -483,9 +483,10 @@ class GraphQLCoreConverter:
                 source=_source, info=info, kwargs=kwargs
             )
 
-            return field.get_result(
-                _source, info=info, args=field_args, kwargs=field_kwargs
-            )
+            if field.base_resolver:
+                return field.base_resolver(*field_args, **field_kwargs)
+
+            return self.config.default_resolver(_source, field.python_name)
 
         def _resolver(_source: Any, info: GraphQLResolveInfo, **kwargs):
             strawberry_info = _strawberry_info_from_graphql(info)

--- a/tests/schema/test_default_resolver.py
+++ b/tests/schema/test_default_resolver.py
@@ -1,0 +1,51 @@
+from operator import getitem
+
+import strawberry
+from strawberry.schema.config import StrawberryConfig
+
+
+def test_default_resolver_gets_attribute():
+    @strawberry.type
+    class User:
+        name: str
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def user(self) -> User:
+            return User(name="Patrick")
+
+    schema = strawberry.Schema(query=Query)
+
+    query = "{ user { name } }"
+
+    result = schema.execute_sync(query)
+
+    assert not result.errors
+    assert result.data
+    assert result.data["user"]["name"] == "Patrick"
+
+
+def test_can_change_default_resolver():
+    @strawberry.type
+    class User:
+        name: str
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def user(self) -> User:
+            return {"name": "Patrick"}  # type: ignore
+
+    schema = strawberry.Schema(
+        query=Query,
+        config=StrawberryConfig(default_resolver=getitem),
+    )
+
+    query = "{ user { name } }"
+
+    result = schema.execute_sync(query)
+
+    assert not result.errors
+    assert result.data
+    assert result.data["user"]["name"] == "Patrick"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
This PR adds a new configuration option that allows to change the default resolver:

```python
@strawberry.type
class User:
    name: str

@strawberry.type
class Query:
    @strawberry.field
    def user(self) -> User:
        return {"name": "Patrick"}  # type: ignore

schema = strawberry.Schema(
    query=Query,
    config=StrawberryConfig(default_resolver=getitem),
)

query = "{ user { name } }"

result = schema.execute_sync(query)
```

This is useful for when people want to allow returning dictionaries and not just objects (the example above only allows dictionaries, but it can be easily changed to allow dict and objects)


## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 


