### PR TITLE
Add support for printing dictionaries when using custom scalars

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -13,3 +13,4 @@ per-file-ignores =
     tests/types/test_string_annotations.py:E800
     tests/federation/test_printer.py:E800
     tests/federation/test_printer.py:E501
+    tests/test_printer/test_basic.py:E501

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,25 @@
+Release type: minor
+
+This release adds support for printing default values for scalars like JSON.
+
+For example the following:
+
+```python
+import strawberry
+from strawberry.scalars import JSON
+
+
+@strawberry.input
+class MyInput:
+    j: JSON = strawberry.field(default_factory=dict)
+    j2: JSON = strawberry.field(default_factory=lambda: {"hello": "world"})
+```
+
+will print the following schema:
+
+```graphql
+input MyInput {
+    j: JSON! = {}
+    j2: JSON! = {hello: "world"}
+}
+```

--- a/strawberry/printer/__init__.py
+++ b/strawberry/printer/__init__.py
@@ -1,0 +1,4 @@
+from .printer import print_schema
+
+
+__all__ = ["print_schema"]

--- a/strawberry/printer/ast_from_value.py
+++ b/strawberry/printer/ast_from_value.py
@@ -73,7 +73,7 @@ def ast_from_leaf_type(
             ]
         )
 
-    raise TypeError(f"Cannot convert value to AST: {inspect(serialized)}.")
+    raise TypeError(f"Cannot convert value to AST: {inspect(serialized)}.")   # pragma: no cover
 
 
 def ast_from_value(value: Any, type_: GraphQLInputType) -> Optional[ValueNode]:

--- a/strawberry/printer/ast_from_value.py
+++ b/strawberry/printer/ast_from_value.py
@@ -73,7 +73,9 @@ def ast_from_leaf_type(
             ]
         )
 
-    raise TypeError(f"Cannot convert value to AST: {inspect(serialized)}.")   # pragma: no cover
+    raise TypeError(
+        f"Cannot convert value to AST: {inspect(serialized)}."
+    )  # pragma: no cover
 
 
 def ast_from_value(value: Any, type_: GraphQLInputType) -> Optional[ValueNode]:

--- a/strawberry/printer/ast_from_value.py
+++ b/strawberry/printer/ast_from_value.py
@@ -118,6 +118,7 @@ def ast_from_value(value: Any, type_: GraphQLInputType) -> Optional[ValueNode]:
 
         if value is None or not isinstance(value, Mapping):
             return None
+
         type_ = cast(GraphQLInputObjectType, type_)
         field_items = (
             (field_name, ast_from_value(value[field_name], field.type))

--- a/strawberry/printer/ast_from_value.py
+++ b/strawberry/printer/ast_from_value.py
@@ -1,0 +1,133 @@
+import re
+from math import isfinite
+from typing import Any, Mapping, Optional, cast
+
+from graphql.language import (
+    BooleanValueNode,
+    EnumValueNode,
+    FloatValueNode,
+    IntValueNode,
+    ListValueNode,
+    NameNode,
+    NullValueNode,
+    ObjectFieldNode,
+    ObjectValueNode,
+    StringValueNode,
+    ValueNode,
+)
+from graphql.pyutils import Undefined, inspect, is_iterable
+from graphql.type import (
+    GraphQLID,
+    GraphQLInputObjectType,
+    GraphQLInputType,
+    GraphQLList,
+    GraphQLNonNull,
+    is_enum_type,
+    is_input_object_type,
+    is_leaf_type,
+    is_list_type,
+    is_non_null_type,
+)
+
+
+__all__ = ["ast_from_value"]
+
+_re_integer_string = re.compile("^-?(?:0|[1-9][0-9]*)$")
+
+
+def ast_from_value(value: Any, type_: GraphQLInputType) -> Optional[ValueNode]:
+    # custom ast_from_value that allows to also serialize custom scalar that aren't
+    # basic types, namely JSON scalar types
+
+    if is_non_null_type(type_):
+        type_ = cast(GraphQLNonNull, type_)
+        ast_value = ast_from_value(value, type_.of_type)
+        if isinstance(ast_value, NullValueNode):
+            return None
+        return ast_value
+
+    # only explicit None, not Undefined or NaN
+    if value is None:
+        return NullValueNode()
+
+    # undefined
+    if value is Undefined:
+        return None
+
+    # Convert Python list to GraphQL list. If the GraphQLType is a list, but the value
+    # is not a list, convert the value using the list's item type.
+    if is_list_type(type_):
+        type_ = cast(GraphQLList, type_)
+        item_type = type_.of_type
+        if is_iterable(value):
+            maybe_value_nodes = (ast_from_value(item, item_type) for item in value)
+            value_nodes = tuple(node for node in maybe_value_nodes if node)
+            return ListValueNode(values=value_nodes)
+        return ast_from_value(value, item_type)
+
+    # Populate the fields of the input object by creating ASTs from each value in the
+    # Python dict according to the fields in the input type.
+    if is_input_object_type(type_):
+        if value is None or not isinstance(value, Mapping):
+            return None
+        type_ = cast(GraphQLInputObjectType, type_)
+        field_items = (
+            (field_name, ast_from_value(value[field_name], field.type))
+            for field_name, field in type_.fields.items()
+            if field_name in value
+        )
+        field_nodes = tuple(
+            ObjectFieldNode(name=NameNode(value=field_name), value=field_value)
+            for field_name, field_value in field_items
+            if field_value
+        )
+        return ObjectValueNode(fields=field_nodes)
+
+    if is_leaf_type(type_):
+        # Since value is an internally represented value, it must be serialized to an
+        # externally represented value before converting into an AST.
+        serialized = type_.serialize(value)  # type: ignore
+        if serialized is None or serialized is Undefined:
+            return None
+
+        # Others serialize based on their corresponding Python scalar types.
+        if isinstance(serialized, bool):
+            return BooleanValueNode(value=serialized)
+
+        # Python ints and floats correspond nicely to Int and Float values.
+        if isinstance(serialized, int):
+            return IntValueNode(value=str(serialized))
+        if isinstance(serialized, float) and isfinite(serialized):
+            value = str(serialized)
+            if value.endswith(".0"):
+                value = value[:-2]
+            return FloatValueNode(value=value)
+
+        if isinstance(serialized, str):
+            # Enum types use Enum literals.
+            if is_enum_type(type_):
+                return EnumValueNode(value=serialized)
+
+            # ID types can use Int literals.
+            if type_ is GraphQLID and _re_integer_string.match(serialized):
+                return IntValueNode(value=serialized)
+
+            return StringValueNode(value=serialized)
+
+        if isinstance(serialized, dict):
+            return ObjectValueNode(
+                fields=[
+                    ObjectFieldNode(
+                        name=NameNode(value=key),
+                        value=StringValueNode(value=value),
+                    )
+                    for key, value in serialized.items()
+                ]
+            )
+
+        breakpoint()
+
+        raise TypeError(f"Cannot convert value to AST: {inspect(serialized)}.")
+
+    # Not reachable. All possible input types have been considered.
+    raise TypeError(f"Unexpected input type: {inspect(type_)}.")

--- a/strawberry/printer/ast_from_value.py
+++ b/strawberry/printer/ast_from_value.py
@@ -137,9 +137,9 @@ def ast_from_value(value: Any, type_: GraphQLInputType) -> Optional[ValueNode]:
         # externally represented value before converting into an AST.
         serialized = type_.serialize(value)  # type: ignore
         if serialized is None or serialized is Undefined:
-            return None
+            return None  # pragma: no cover
 
         return ast_from_leaf_type(serialized, type_)
 
     # Not reachable. All possible input types have been considered.
-    raise TypeError(f"Unexpected input type: {inspect(type_)}.")
+    raise TypeError(f"Unexpected input type: {inspect(type_)}.")  # pragma: no cover

--- a/strawberry/printer/ast_from_value.py
+++ b/strawberry/printer/ast_from_value.py
@@ -128,11 +128,10 @@ def ast_from_value(value: Any, type_: GraphQLInputType) -> Optional[ValueNode]:
         # Since value is an internally represented value, it must be serialized to an
         # externally represented value before converting into an AST.
         serialized = type_.serialize(value)  # type: ignore
-
         if serialized is None or serialized is Undefined:
             return None
 
-        return ast_from_leaf_type(value, type_)
+        return ast_from_leaf_type(serialized, type_)
 
     # Not reachable. All possible input types have been considered.
     raise TypeError(f"Unexpected input type: {inspect(type_)}.")

--- a/strawberry/printer/ast_from_value.py
+++ b/strawberry/printer/ast_from_value.py
@@ -1,3 +1,4 @@
+import dataclasses
 import re
 from math import isfinite
 from typing import Any, Mapping, Optional, cast
@@ -111,6 +112,10 @@ def ast_from_value(value: Any, type_: GraphQLInputType) -> Optional[ValueNode]:
     # Populate the fields of the input object by creating ASTs from each value in the
     # Python dict according to the fields in the input type.
     if is_input_object_type(type_):
+        # TODO: is this the right place?
+        if hasattr(value, "_type_definition"):
+            value = dataclasses.asdict(value)
+
         if value is None or not isinstance(value, Mapping):
             return None
         type_ = cast(GraphQLInputObjectType, type_)

--- a/strawberry/printer/ast_from_value.py
+++ b/strawberry/printer/ast_from_value.py
@@ -125,6 +125,8 @@ def ast_from_value(value: Any, type_: GraphQLInputType) -> Optional[ValueNode]:
         return ObjectValueNode(fields=field_nodes)
 
     if is_leaf_type(type_):
+        # Since value is an internally represented value, it must be serialized to an
+        # externally represented value before converting into an AST.
         serialized = type_.serialize(value)  # type: ignore
 
         if serialized is None or serialized is Undefined:

--- a/strawberry/printer/printer.py
+++ b/strawberry/printer/printer.py
@@ -29,7 +29,6 @@ from graphql.type import (
 from graphql.type.directives import GraphQLDirective
 from graphql.utilities.print_schema import (
     is_defined_type,
-    print_args,
     print_block,
     print_deprecated,
     print_description,
@@ -160,6 +159,30 @@ def print_field_directives(
             print_schema_directive(directive, schema=schema, extras=extras)
             for directive in directives
         )
+    )
+
+
+def print_args(args: Dict[str, GraphQLArgument], indentation: str = "") -> str:
+    if not args:
+        return ""
+
+    # If every arg does not have a description, print them on one line.
+    if not any(arg.description for arg in args.values()):
+        return (
+            "("
+            + ", ".join(print_input_value(name, arg) for name, arg in args.items())
+            + ")"
+        )
+
+    return (
+        "(\n"
+        + "\n".join(
+            print_description(arg, f"  {indentation}", not i)
+            + f"  {indentation}"
+            + print_input_value(name, arg)
+            for i, (name, arg) in enumerate(args.items())
+        )
+        + f"\n{indentation})"
     )
 
 

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -1,5 +1,5 @@
 from functools import lru_cache
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Type, Union
+from typing import Any, Dict, Iterable, List, Optional, Type, Union
 
 from graphql import (
     ExecutionContext as GraphQLExecutionContext,
@@ -49,9 +49,9 @@ class Schema(BaseSchema):
         query: Type,
         mutation: Optional[Type] = None,
         subscription: Optional[Type] = None,
-        directives: Sequence[StrawberryDirective] = (),
+        directives: Iterable[StrawberryDirective] = (),
         types=(),
-        extensions: Sequence[Union[Type[Extension], Extension]] = (),
+        extensions: Iterable[Union[Type[Extension], Extension]] = (),
         execution_context_class: Optional[Type[GraphQLExecutionContext]] = None,
         config: Optional[StrawberryConfig] = None,
         scalar_overrides: Optional[
@@ -116,8 +116,6 @@ class Schema(BaseSchema):
         if errors:
             formatted_errors = "\n\n".join(f"❌ {error.message}" for error in errors)
             raise ValueError(f"Invalid Schema. Errors:\n\n{formatted_errors}")
-
-        self.query = self.schema_converter.type_map[query_type.name]
 
     def get_extensions(
         self, sync: bool = False

--- a/tests/test_printer/test_basic.py
+++ b/tests/test_printer/test_basic.py
@@ -181,6 +181,44 @@ def test_input_defaults():
     assert print_schema(schema) == textwrap.dedent(expected_type).strip()
 
 
+def test_input_other_inputs():
+    @strawberry.input
+    class Nested:
+        s: str
+
+    @strawberry.input
+    class MyInput:
+        nested: Nested
+        nested2: Nested = Nested("a")
+        nested3: Nested = strawberry.field(default_factory=lambda: {"s": "a"})
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def search(self, input: MyInput) -> str:
+            return input.nested.s
+
+    expected_type = """
+    input MyInput {
+      nested: Nested!
+      nested2: Nested! = {s: "a"}
+      nested3: Nested! = {s: "a"}
+    }
+
+    input Nested {
+      s: String!
+    }
+
+    type Query {
+      search(input: MyInput!): String!
+    }
+    """
+
+    schema = strawberry.Schema(query=Query)
+
+    assert print_schema(schema) == textwrap.dedent(expected_type).strip()
+
+
 def test_input_defaults_scalars():
     @strawberry.input
     class MyInput:

--- a/tests/test_printer/test_basic.py
+++ b/tests/test_printer/test_basic.py
@@ -164,6 +164,9 @@ def test_input_defaults_scalars():
     class MyInput:
         j: JSON = strawberry.field(default_factory=dict)
         j2: JSON = strawberry.field(default_factory=lambda: {"hello": "world"})
+        j3: JSON = strawberry.field(
+            default_factory=lambda: {"hello": {"nice": "world"}}
+        )
 
     @strawberry.type
     class Query:
@@ -180,6 +183,7 @@ def test_input_defaults_scalars():
     input MyInput {
       j: JSON! = {}
       j2: JSON! = {hello: "world"}
+      j3: JSON! = {hello: {nice: "world"}}
     }
 
     type Query {

--- a/tests/test_printer/test_basic.py
+++ b/tests/test_printer/test_basic.py
@@ -98,6 +98,7 @@ def test_input_simple_required_types():
         f: float
         id: strawberry.ID
         uid: UUID
+        s2: str = None  # type: ignore - we do this for testing purposes
 
     @strawberry.type
     class Query:
@@ -113,6 +114,7 @@ def test_input_simple_required_types():
       f: Float!
       id: ID!
       uid: UUID!
+      s2: String!
     }
 
     type Query {

--- a/tests/test_printer/test_basic.py
+++ b/tests/test_printer/test_basic.py
@@ -144,6 +144,10 @@ def test_input_defaults():
         list_with_values: List[str] = strawberry.field(
             default_factory=lambda: ["a", "b"]
         )
+        list_from_generator: List[str] = strawberry.field(
+            default_factory=lambda: (x for x in ["a", "b"])
+        )
+        list_from_string: List[str] = "ab" # type: ignore - we do this for testing purposes
 
     @strawberry.type
     class Query:
@@ -163,6 +167,8 @@ def test_input_defaults():
       x: Int
       l: [String!]! = []
       listWithValues: [String!]! = ["a", "b"]
+      listFromGenerator: [String!]! = ["a", "b"]
+      listFromString: [String!]! = "ab"
     }
 
     type Query {

--- a/tests/test_printer/test_basic.py
+++ b/tests/test_printer/test_basic.py
@@ -139,6 +139,9 @@ def test_input_defaults():
         id_number_string: strawberry.ID = strawberry.ID("123")
         x: Optional[int] = UNSET
         l: List[str] = strawberry.field(default_factory=list)
+        list_with_values: List[str] = strawberry.field(
+            default_factory=lambda: ["a", "b"]
+        )
 
     @strawberry.type
     class Query:
@@ -157,6 +160,7 @@ def test_input_defaults():
       idNumberString: ID! = 123
       x: Int
       l: [String!]! = []
+      listWithValues: [String!]! = ["a", "b"]
     }
 
     type Query {

--- a/tests/test_printer/test_basic.py
+++ b/tests/test_printer/test_basic.py
@@ -147,7 +147,7 @@ def test_input_defaults():
         list_from_generator: List[str] = strawberry.field(
             default_factory=lambda: (x for x in ["a", "b"])
         )
-        list_from_string: List[str] = "ab" # type: ignore - we do this for testing purposes
+        list_from_string: List[str] = "ab"  # type: ignore - we do this for testing purposes
 
     @strawberry.type
     class Query:

--- a/tests/test_printer/test_basic.py
+++ b/tests/test_printer/test_basic.py
@@ -196,6 +196,47 @@ def test_input_defaults_scalars():
     assert print_schema(schema) == textwrap.dedent(expected_type).strip()
 
 
+def test_arguments_scalar():
+    @strawberry.input
+    class MyInput:
+        j: JSON = strawberry.field(default_factory=dict)
+        j2: JSON = strawberry.field(default_factory=lambda: {"hello": "world"})
+        j3: JSON = strawberry.field(
+            default_factory=lambda: {"hello": {"nice": "world"}}
+        )
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def search(self, j: JSON = {}) -> JSON:
+            return j
+
+        @strawberry.field
+        def search2(self, j: JSON = {"hello": "world"}) -> JSON:
+            return j
+
+        @strawberry.field
+        def search3(self, j: JSON = {"hello": {"nice": "world"}}) -> JSON:
+            return j
+
+    expected_type = """
+    \"\"\"
+    The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+    \"\"\"
+    scalar JSON @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
+
+    type Query {
+      search(j: JSON! = {}): JSON!
+      search2(j: JSON! = {hello: "world"}): JSON!
+      search3(j: JSON! = {hello: {nice: "world"}}): JSON!
+    }
+    """
+
+    schema = strawberry.Schema(query=Query)
+
+    assert print_schema(schema) == textwrap.dedent(expected_type).strip()
+
+
 def test_interface():
     @strawberry.interface
     class Node:

--- a/tests/test_printer/test_basic.py
+++ b/tests/test_printer/test_basic.py
@@ -136,6 +136,7 @@ def test_input_defaults():
         i: int = 0
         b: bool = False
         f: float = 0.0
+        f2: float = 0.1
         id: strawberry.ID = strawberry.ID("some_id")
         id_number: strawberry.ID = strawberry.ID(123)  # type: ignore
         id_number_string: strawberry.ID = strawberry.ID("123")
@@ -161,6 +162,7 @@ def test_input_defaults():
       i: Int! = 0
       b: Boolean! = false
       f: Float! = 0
+      f2: Float! = 0.1
       id: ID! = "some_id"
       idNumber: ID! = 123
       idNumberString: ID! = 123

--- a/tests/test_printer/test_basic.py
+++ b/tests/test_printer/test_basic.py
@@ -132,6 +132,8 @@ def test_input_defaults():
     class MyInput:
         s: Optional[str] = None
         i: int = 0
+        b: bool = False
+        f: float = 0.0
         x: Optional[int] = UNSET
         l: List[str] = strawberry.field(default_factory=list)
 
@@ -145,6 +147,8 @@ def test_input_defaults():
     input MyInput {
       s: String = null
       i: Int! = 0
+      b: Boolean! = false
+      f: Float! = 0
       x: Int
       l: [String!]! = []
     }

--- a/tests/test_printer/test_basic.py
+++ b/tests/test_printer/test_basic.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 import strawberry
 from strawberry.printer import print_schema
+from strawberry.scalars import JSON
 from strawberry.schema.config import StrawberryConfig
 from strawberry.unset import UNSET
 
@@ -150,6 +151,39 @@ def test_input_defaults():
 
     type Query {
       search(input: MyInput!): Int!
+    }
+    """
+
+    schema = strawberry.Schema(query=Query)
+
+    assert print_schema(schema) == textwrap.dedent(expected_type).strip()
+
+
+def test_input_defaults_scalars():
+    @strawberry.input
+    class MyInput:
+        j: JSON = strawberry.field(default_factory=dict)
+        j2: JSON = strawberry.field(default_factory=lambda: {"hello": "world"})
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def search(self, input: MyInput) -> JSON:
+            return input.j
+
+    expected_type = """
+    \"\"\"
+    The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+    \"\"\"
+    scalar JSON @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
+
+    input MyInput {
+      j: JSON! = {}
+      j2: JSON! = {hello: "world"}
+    }
+
+    type Query {
+      search(input: MyInput!): JSON!
     }
     """
 

--- a/tests/test_printer/test_basic.py
+++ b/tests/test_printer/test_basic.py
@@ -191,6 +191,7 @@ def test_input_other_inputs():
         nested: Nested
         nested2: Nested = Nested("a")
         nested3: Nested = strawberry.field(default_factory=lambda: {"s": "a"})
+        nested4: Nested = "abc"  # type: ignore - we do this for testing purposes
 
     @strawberry.type
     class Query:
@@ -203,6 +204,7 @@ def test_input_other_inputs():
       nested: Nested!
       nested2: Nested! = {s: "a"}
       nested3: Nested! = {s: "a"}
+      nested4: Nested!
     }
 
     input Nested {

--- a/tests/test_printer/test_basic.py
+++ b/tests/test_printer/test_basic.py
@@ -134,6 +134,9 @@ def test_input_defaults():
         i: int = 0
         b: bool = False
         f: float = 0.0
+        id: strawberry.ID = strawberry.ID("some_id")
+        id_number: strawberry.ID = strawberry.ID(123)  # type: ignore
+        id_number_string: strawberry.ID = strawberry.ID("123")
         x: Optional[int] = UNSET
         l: List[str] = strawberry.field(default_factory=list)
 
@@ -149,6 +152,9 @@ def test_input_defaults():
       i: Int! = 0
       b: Boolean! = false
       f: Float! = 0
+      id: ID! = "some_id"
+      idNumber: ID! = 123
+      idNumberString: ID! = 123
       x: Int
       l: [String!]! = []
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

This PR add support for printing dictionaries as default values, for example:

```python
@strawberry.input
class MyInput:
    j: JSON = strawberry.field(default_factory=dict)
    j2: JSON = strawberry.field(default_factory=lambda: {"hello": "world"})

@strawberry.type
class Query:
    @strawberry.field
    def search(self, input: MyInput) -> JSON:
        return input.j
```

will print the following

```graphql
input MyInput {
    j: JSON! = {}
    j2: JSON! = {hello: "world"}
}

type Query {
    search(input: MyInput!): JSON!
}
```

Here's an example of this working in another server: https://codesandbox.io/s/apollo-json-default-value-4mkreh?file=/index.js:0-899

## TODO:

- [x] allow nested dictionaries
- [x] this, but also for arguments

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation


