### PR TITLE
Add support for schema directives on schema

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,31 @@
+Release type: minor
+
+This PR adds support for adding schema directives to the schema of
+your GraphQL API. For printing the following schema:
+
+```python
+@strawberry.schema_directive(locations=[Location.SCHEMA])
+class Tag:
+    name: str
+
+@strawberry.type
+class Query:
+    first_name: str = strawberry.field(directives=[Tag(name="team-1")])
+
+schema = strawberry.Schema(query=Query, schema_directives=[Tag(name="team-1")])
+```
+
+will print the following:
+
+```graphql
+directive @tag(name: String!) on SCHEMA
+
+schema @tag(name: "team-1") {
+    query: Query
+}
+
+type Query {
+    firstName: String!
+}
+"""
+```

--- a/strawberry/directive.py
+++ b/strawberry/directive.py
@@ -16,12 +16,14 @@ from strawberry.types.fields.resolver import (
     ReservedType,
     StrawberryResolver,
 )
+from strawberry.unset import UNSET
 
 
-def directive_field(name: str) -> Any:
+def directive_field(name: str, default: object = UNSET) -> Any:
     return StrawberryField(
         python_name=None,
         graphql_name=name,
+        default=default,
     )
 
 

--- a/strawberry/schema/base.py
+++ b/strawberry/schema/base.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 from functools import lru_cache
-from typing import Any, Dict, Iterable, List, Optional, Union
+from typing import Any, Dict, Iterable, List, Optional, Type, Union
 
 from typing_extensions import Protocol
 
@@ -22,6 +22,10 @@ from .config import StrawberryConfig
 class BaseSchema(Protocol):
     config: StrawberryConfig
     schema_converter: GraphQLCoreConverter
+    query: Type
+    mutation: Optional[Type]
+    subscription: Optional[Type]
+    schema_directives: Iterable[object]
 
     @abstractmethod
     async def execute(

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -57,7 +57,12 @@ class Schema(BaseSchema):
         scalar_overrides: Optional[
             Dict[object, Union[ScalarWrapper, ScalarDefinition]]
         ] = None,
+        schema_directives: Iterable[object] = (),
     ):
+        self.query = query
+        self.mutation = mutation
+        self.subscription = subscription
+
         self.extensions = extensions
         self.execution_context_class = execution_context_class
         self.config = config or StrawberryConfig()
@@ -70,6 +75,7 @@ class Schema(BaseSchema):
 
         self.schema_converter = GraphQLCoreConverter(self.config, scalar_registry)
         self.directives = directives
+        self.schema_directives = schema_directives
 
         query_type = self.schema_converter.from_object(query._type_definition)
         mutation_type = (

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -204,8 +204,8 @@ class GraphQLCoreConverter:
             locations=[
                 DirectiveLocation(loc.value) for loc in strawberry_directive.locations
             ],
-            is_repeatable=False,
             args=args,
+            is_repeatable=strawberry_directive.repeatable,
             description=strawberry_directive.description,
             extensions={
                 GraphQLCoreConverter.DEFINITION_BACKREF: strawberry_directive,

--- a/strawberry/schema_directive.py
+++ b/strawberry/schema_directive.py
@@ -31,6 +31,7 @@ class StrawberrySchemaDirective:
     locations: List[Location]
     fields: List["StrawberryField"]
     description: Optional[str] = None
+    repeatable: bool = False
 
 
 T = TypeVar("T", bound=Type)
@@ -43,7 +44,8 @@ def schema_directive(
     *,
     locations: List[Location],
     description: Optional[str] = None,
-    name: Optional[str] = None
+    name: Optional[str] = None,
+    repeatable: bool = False,
 ):
     def _wrap(cls: T) -> T:
         cls = _wrap_dataclass(cls)
@@ -54,6 +56,7 @@ def schema_directive(
             graphql_name=name,
             locations=locations,
             description=description,
+            repeatable=repeatable,
             fields=fields,
         )
 

--- a/tests/test_printer/test_basic.py
+++ b/tests/test_printer/test_basic.py
@@ -332,3 +332,43 @@ def test_interface():
     schema = strawberry.Schema(query=Query)
 
     assert print_schema(schema) == textwrap.dedent(expected_type).strip()
+
+
+def test_root_objects_with_different_names():
+    @strawberry.type
+    class Domanda:
+        name: str
+
+    @strawberry.type
+    class Mutazione:
+        name: str
+
+    @strawberry.type
+    class Abbonamento:
+        name: str
+
+    expected_type = """
+    schema {
+      query: Domanda
+      mutation: Mutazione
+      subscription: Abbonamento
+    }
+
+    type Abbonamento {
+      name: String!
+    }
+
+    type Domanda {
+      name: String!
+    }
+
+    type Mutazione {
+      name: String!
+    }
+    """
+
+    schema = strawberry.Schema(
+        query=Domanda, mutation=Mutazione, subscription=Abbonamento
+    )
+
+    assert print_schema(schema) == textwrap.dedent(expected_type).strip()


### PR DESCRIPTION
This PR adds support for printing schema directives on the schema itself. There's not a lot of use cases for this, but Apollo Federation (https://github.com/strawberry-graphql/strawberry/pull/2047) uses them.

I'm a bit annoyed at the fact we now have 2 parameters, `directives` and `schema_directives` and specifically the fact that `directives` is actually used for schema directives when used on the fields:

```
strawberry.Schema(
    Query, 
    directives=[...], # directives that can be used in GraphQL operations
    schema_directives=[...], # directives that are printed on the schema
)
```

We **could** rename things, but it is annoying, and needs to be done in multiple steps, for example:

1. rename `directives` to `client_directives` and deprecate passing `directives` to the Schema
2. remove `directives` after some time
3. rename `schema_directives` to `directives` and deprecate passing `schema_directives` to the Schema
4. remove `schema_directives`