### PR TITLE
Fix aiohttp query operation selection

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+This release fixes that the AIOHTTP integration ignored the `operationName` of query
+operations. This behaviour is a regression introduced in version 0.107.0.

--- a/strawberry/aiohttp/handlers/http_handler.py
+++ b/strawberry/aiohttp/handlers/http_handler.py
@@ -87,6 +87,7 @@ class HTTPHandler:
                 root_value=root_value,
                 variable_values=request_data.variables,
                 context_value=context,
+                operation_name=request_data.operation_name,
                 allowed_operation_types=allowed_operation_types,
             )
         except InvalidOperationTypeError as e:

--- a/tests/aiohttp/test_http.py
+++ b/tests/aiohttp/test_http.py
@@ -120,3 +120,22 @@ async def test_not_allowed_methods(aiohttp_app_client):
     for method in not_allowed_methods:
         response = await aiohttp_app_client.request(method, "/graphql")
         assert response.status == 405, method
+
+
+async def test_operation_selection(aiohttp_app_client):
+    query = {
+        "query": """
+            query Operation1 {
+                hello(name: "Operation1")
+            }
+            query Operation2 {
+                hello(name: "Operation2")
+            }
+        """,
+        "operationName": "Operation2",
+    }
+
+    response = await aiohttp_app_client.post("/graphql", json=query)
+    data = await response.json()
+    assert response.status == 200
+    assert data["data"]["hello"] == "Hello Operation2"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
This PR fixed a regression introduced in #1686. Since said PR was released with version 0.107.0, the aiohttp integration ignored the `operationName` sent by clients. I fixed that and added a test for it :)

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* None

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
