### PR TITLE
Add support for printing custom scalars in schema directives

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,30 @@
+Relase type: patch
+
+This release adds support for priting custom scalar used only on
+schema directives, for example the following schema:
+
+```python
+SensitiveConfiguration = strawberry.scalar(str, name="SensitiveConfiguration")
+
+@strawberry.schema_directive(locations=[Location.FIELD_DEFINITION])
+class Sensitive:
+    config: SensitiveConfiguration
+
+@strawberry.type
+class Query:
+    first_name: str = strawberry.field(directives=[Sensitive(config="Some config")])
+```
+
+prints the following:
+
+```graphql
+directive @sensitive(config: SensitiveConfiguration!) on FIELD_DEFINITION
+
+type Query {
+    firstName: String! @sensitive(config: "Some config")
+}
+
+scalar SensitiveConfiguration
+```
+
+while previously it would omit the definition of the scalar.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,4 @@
-Relase type: patch
+Release type: patch
 
 This release adds support for priting custom scalar used only on
 schema directives, for example the following schema:

--- a/strawberry/federation/schema.py
+++ b/strawberry/federation/schema.py
@@ -21,13 +21,11 @@ from strawberry.utils.inspect import get_func_args
 
 from ..printer import print_schema
 from ..schema import Schema as BaseSchema
-from .types import FieldSet
 
 
 class Schema(BaseSchema):
     def __init__(self, *args, **kwargs):
         additional_types = list(kwargs.pop("types", []))
-        additional_types.extend([FieldSet])
 
         kwargs["types"] = additional_types
 

--- a/strawberry/printer/printer.py
+++ b/strawberry/printer/printer.py
@@ -127,12 +127,17 @@ def print_schema_directive(
     )
 
     extras.directives.add(print_directive(gql_directive))
+
     for field in strawberry_directive.fields:
         f_type = field.type
+
         while isinstance(f_type, StrawberryContainer):
             f_type = f_type.of_type
 
         if hasattr(f_type, "_type_definition"):
+            extras.types.add(cast(type, f_type))
+
+        if hasattr(f_type, "_scalar_definition"):
             extras.types.add(cast(type, f_type))
 
     return f" @{gql_directive.name}{params}"

--- a/tests/federation/test_printer.py
+++ b/tests/federation/test_printer.py
@@ -65,11 +65,11 @@ def test_entities_type_when_no_type_has_keys():
 
         union _Entity = Product
 
-        scalar _FieldSet
-
         type _Service {
           sdl: String!
         }
+
+        scalar _FieldSet
     """
 
     assert schema.as_str() == textwrap.dedent(expected).strip()
@@ -118,11 +118,11 @@ def test_entities_extending_interface():
 
         union _Entity = Product
 
-        scalar _FieldSet
-
         type _Service {
           sdl: String!
         }
+
+        scalar _FieldSet
     """
 
     assert schema.as_str() == textwrap.dedent(expected).strip()
@@ -195,11 +195,11 @@ def test_fields_requires_are_printed_correctly():
 
         union _Entity = Product
 
-        scalar _FieldSet
-
         type _Service {
           sdl: String!
         }
+
+        scalar _FieldSet
     """
 
     assert schema.as_str() == textwrap.dedent(expected).strip()
@@ -269,11 +269,11 @@ def test_field_provides_are_printed_correctly_camel_case_on():
 
         union _Entity = Product
 
-        scalar _FieldSet
-
         type _Service {
           sdl: String!
         }
+
+        scalar _FieldSet
     """
 
     assert schema.as_str() == textwrap.dedent(expected).strip()
@@ -343,11 +343,11 @@ def test_field_provides_are_printed_correctly_camel_case_off():
 
         union _Entity = Product
 
-        scalar _FieldSet
-
         type _Service {
           sdl: String!
         }
+
+        scalar _FieldSet
     """
 
     assert schema.as_str() == textwrap.dedent(expected).strip()
@@ -412,11 +412,11 @@ def test_multiple_keys():
 
         union _Entity = Product | Review
 
-        scalar _FieldSet
-
         type _Service {
           sdl: String!
         }
+
+        scalar _FieldSet
     """
 
     assert schema.as_str() == textwrap.dedent(expected).strip()
@@ -467,11 +467,11 @@ def test_field_shareable_printed_correctly():
 
         union _Entity = Product
 
-        scalar _FieldSet
-
         type _Service {
           sdl: String!
         }
+
+        scalar _FieldSet
     """
 
     assert schema.as_str() == textwrap.dedent(expected).strip()
@@ -520,11 +520,11 @@ def test_field_tag_printed_correctly():
 
         union _Entity = Product
 
-        scalar _FieldSet
-
         type _Service {
           sdl: String!
         }
+
+        scalar _FieldSet
     """
 
     assert schema.as_str() == textwrap.dedent(expected).strip()
@@ -573,11 +573,11 @@ def test_field_override_printed_correctly():
 
         union _Entity = Product
 
-        scalar _FieldSet
-
         type _Service {
           sdl: String!
         }
+
+        scalar _FieldSet
     """
 
     assert schema.as_str() == textwrap.dedent(expected).strip()
@@ -626,11 +626,11 @@ def test_field_inaccessible_printed_correctly():
 
         union _Entity = Product
 
-        scalar _FieldSet
-
         type _Service {
           sdl: String!
         }
+
+        scalar _FieldSet
     """
 
     assert schema.as_str() == textwrap.dedent(expected).strip()
@@ -665,6 +665,8 @@ def test_additional_schema_directives_printed_correctly_object():
     type Query {
       federatedType: FederatedType!
     }
+
+    scalar _FieldSet
     """
 
     schema = strawberry.Schema(
@@ -711,6 +713,8 @@ def test_additional_schema_directives_printed_in_order_object():
     type Query {
       federatedType: FederatedType!
     }
+
+    scalar _FieldSet
     """
 
     schema = strawberry.Schema(

--- a/tests/federation/test_schema.py
+++ b/tests/federation/test_schema.py
@@ -139,8 +139,6 @@ def test_service():
 
         scalar _Any
 
-        scalar _FieldSet
-
         type _Service {
           sdl: String!
         }
@@ -195,8 +193,6 @@ def test_using_generics():
         }
 
         scalar _Any
-
-        scalar _FieldSet
 
         type _Service {
           sdl: String!


### PR DESCRIPTION
This PRs add support for printing custom scalars in schema directive. Previously they wouldn't be printed if only the schema directive was using that scalar directive.