### PR TITLE
Add support for printing enums only used in schema directives

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,36 @@
+Release type: patch
+
+This release adds support for priting custom enums used only on
+schema directives, for example the following schema:
+
+```python
+@strawberry.enum
+class Reason(str, Enum):
+    EXAMPLE = "example"
+
+@strawberry.schema_directive(locations=[Location.FIELD_DEFINITION])
+class Sensitive:
+    reason: Reason
+
+@strawberry.type
+class Query:
+    first_name: str = strawberry.field(
+        directives=[Sensitive(reason=Reason.EXAMPLE)]
+    )
+```
+
+prints the following:
+
+```graphql
+directive @sensitive(reason: Reason!) on FIELD_DEFINITION
+
+type Query {
+    firstName: String! @sensitive(reason: EXAMPLE)
+}
+
+enum Reason {
+    EXAMPLE
+}
+```
+
+while previously it would omit the definition of the enum.

--- a/strawberry/printer/printer.py
+++ b/strawberry/printer/printer.py
@@ -39,6 +39,7 @@ from graphql.utilities.print_schema import (
     print_type as original_print_type,
 )
 
+from strawberry.enum import EnumDefinition
 from strawberry.field import StrawberryField
 from strawberry.schema.schema_converter import GraphQLCoreConverter
 from strawberry.schema_directive import Location, StrawberrySchemaDirective
@@ -138,6 +139,9 @@ def print_schema_directive(
             extras.types.add(cast(type, f_type))
 
         if hasattr(f_type, "_scalar_definition"):
+            extras.types.add(cast(type, f_type))
+
+        if isinstance(f_type, EnumDefinition):
             extras.types.add(cast(type, f_type))
 
     return f" @{gql_directive.name}{params}"

--- a/tests/test_printer/test_schema_directives.py
+++ b/tests/test_printer/test_schema_directives.py
@@ -1,4 +1,5 @@
 import textwrap
+from enum import Enum
 from typing import List, Optional
 
 import strawberry
@@ -360,6 +361,38 @@ def test_prints_with_scalar():
     }
 
     scalar SensitiveConfiguration
+    """
+
+    schema = strawberry.Schema(query=Query)
+
+    assert print_schema(schema) == textwrap.dedent(expected_output).strip()
+
+
+def test_prints_with_enum():
+    @strawberry.enum
+    class Reason(str, Enum):
+        EXAMPLE = "example"
+
+    @strawberry.schema_directive(locations=[Location.FIELD_DEFINITION])
+    class Sensitive:
+        reason: Reason
+
+    @strawberry.type
+    class Query:
+        first_name: str = strawberry.field(
+            directives=[Sensitive(reason=Reason.EXAMPLE)]
+        )
+
+    expected_output = """
+    directive @sensitive(reason: Reason!) on FIELD_DEFINITION
+
+    type Query {
+      firstName: String! @sensitive(reason: EXAMPLE)
+    }
+
+    enum Reason {
+      EXAMPLE
+    }
     """
 
     schema = strawberry.Schema(query=Query)


### PR DESCRIPTION
Exactly the same as https://github.com/strawberry-graphql/strawberry/pull/2058 but for enums 😊