### PR TITLE
fix: Prevent checks for auto from raising NameError when comparing a StrawberryType subclass to a string

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,5 @@
 Release type: patch
 
-This release fixes a regression introduced in version 0.118.2 which
-could make the check to see if a type is instance of auto raise
-`NameError` when that type is a subclass of `StrawberryType`.
+This release fixes a regression introduced in version 0.118.2 which was
+preventing using circular dependencies in Strawberry django and Strawberry
+django plus.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+Release type: patch
+
+This release fixes a regression introduced in version 0.118.2 which
+could make the check to see if a type is instance of auto raise
+`NameError` when that type is a subclass of `StrawberryType`.

--- a/strawberry/auto.py
+++ b/strawberry/auto.py
@@ -57,11 +57,12 @@ class StrawberryAutoMeta(type):
             if args[0] is Any:
                 return any(isinstance(arg, StrawberryAuto) for arg in args[1:])
 
-        # We can't compare StrawberryType subclasses to str because it will try to
-        # resolve the annotation in its __eq__ method and that might raise a
-        # NameError if "strawberry.auto" is not present in locals()/globals()
-        # It is not a problem though since StrawberryType subclasses for sure are
-        # not auto objects
+        # StrawberryType's `__eq__` tries to find the string passed in the global
+        # namespace, which will fail with a `NameError` if "strawberry.auto" hasn't
+        # been imported. So we can't use `instance == "strawberry.auto"` here.
+        # Instead, we'll use `isinstance(instance, str)` to check if the instance
+        # is a StrawberryType, in that case we can return False since we know it
+        # won't be a StrawberryAuto.
         if isinstance(instance, StrawberryType):
             return False
 

--- a/strawberry/auto.py
+++ b/strawberry/auto.py
@@ -57,6 +57,14 @@ class StrawberryAutoMeta(type):
             if args[0] is Any:
                 return any(isinstance(arg, StrawberryAuto) for arg in args[1:])
 
+        # We can't compare StrawberryType subclasses to str because it will try to
+        # resolve the annotation in its __eq__ method and that might raise a
+        # NameError if "strawberry.auto" is not present in locals()/globals()
+        # It is not a problem though since StrawberryType subclasses for sure are
+        # not auto objects
+        if isinstance(instance, StrawberryType):
+            return False
+
         return instance == "strawberry.auto"
 
 

--- a/tests/test_auto.py
+++ b/tests/test_auto.py
@@ -2,8 +2,15 @@ from typing import Any, cast
 
 from typing_extensions import Annotated, get_args
 
+import strawberry
 from strawberry.annotation import StrawberryAnnotation
 from strawberry.auto import StrawberryAuto, auto
+from strawberry.type import StrawberryList
+
+
+@strawberry.type
+class TestType:
+    some_var: str
 
 
 def test_singleton():
@@ -42,3 +49,8 @@ def test_isinstance_with_annotation():
 def test_isinstance_with_annotated():
     assert isinstance(Annotated[auto, object()], StrawberryAuto)
     assert not isinstance(Annotated[str, auto], StrawberryAuto)
+
+
+def test_isinstance_with_unresolvable_annotation():
+    type_ = StrawberryList(of_type=TestType)
+    assert not isinstance(type_, StrawberryAuto)


### PR DESCRIPTION
This issue was noted based on those reports in the `strawberry-django-plus` lib.

- https://github.com/blb-ventures/strawberry-django-plus/issues/89
- https://github.com/blb-ventures/strawberry-django-plus/issues/94

I also added a test that would fail if the change is reverted.


<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
