### PR TITLE
Fix/field default

### DIFF
--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -319,8 +319,8 @@ def field(
     init: Literal[False] = False,
     permission_classes: Optional[List[Type[BasePermission]]] = None,
     deprecation_reason: Optional[str] = None,
-    default: Any = UNSET,
-    default_factory: Union[Callable, object] = UNSET,
+    default: Any = dataclasses.MISSING,
+    default_factory: Union[Callable, object] = dataclasses.MISSING,
     directives: Optional[Sequence[object]] = (),
 ) -> T:
     ...
@@ -335,8 +335,8 @@ def field(
     init: Literal[True] = True,
     permission_classes: Optional[List[Type[BasePermission]]] = None,
     deprecation_reason: Optional[str] = None,
-    default: Any = UNSET,
-    default_factory: Union[Callable, object] = UNSET,
+    default: Any = dataclasses.MISSING,
+    default_factory: Union[Callable, object] = dataclasses.MISSING,
     directives: Optional[Sequence[object]] = (),
 ) -> Any:
     ...
@@ -351,8 +351,8 @@ def field(
     description: Optional[str] = None,
     permission_classes: Optional[List[Type[BasePermission]]] = None,
     deprecation_reason: Optional[str] = None,
-    default: Any = UNSET,
-    default_factory: Union[Callable, object] = UNSET,
+    default: Any = dataclasses.MISSING,
+    default_factory: Union[Callable, object] = dataclasses.MISSING,
     directives: Optional[Sequence[object]] = (),
 ) -> StrawberryField:
     ...
@@ -366,8 +366,8 @@ def field(
     description=None,
     permission_classes=None,
     deprecation_reason=None,
-    default=UNSET,
-    default_factory=UNSET,
+    default=dataclasses.MISSING,
+    default_factory=dataclasses.MISSING,
     directives=(),
     # This init parameter is used by PyRight to determine whether this field
     # is added in the constructor or not. It is not used to change

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -73,7 +73,7 @@ class StrawberryField(dataclasses.Field):
 
         super().__init__(
             default=default,
-            default_factory=default_factory,
+            default_factory=default_factory,  # type: ignore
             init=is_basic_field,
             repr=is_basic_field,
             compare=is_basic_field,

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -57,8 +57,8 @@ class StrawberryField(dataclasses.Field):
         description: Optional[str] = None,
         base_resolver: Optional[StrawberryResolver] = None,
         permission_classes: List[Type[BasePermission]] = (),  # type: ignore
-        default: object = UNSET,
-        default_factory: Union[Callable[[], Any], object] = UNSET,
+        default: object = dataclasses.MISSING,
+        default_factory: Union[Callable[[], Any], object] = dataclasses.MISSING,
         deprecation_reason: Optional[str] = None,
         directives: Sequence[object] = (),
     ):
@@ -72,14 +72,8 @@ class StrawberryField(dataclasses.Field):
             kwargs["kw_only"] = False
 
         super().__init__(
-            default=(default if default is not UNSET else dataclasses.MISSING),
-            default_factory=(
-                # mypy is not able to understand that default factory
-                # is a callable so we do a type ignore
-                default_factory  # type: ignore
-                if default_factory is not UNSET
-                else dataclasses.MISSING
-            ),
+            default=default,
+            default_factory=default_factory,
             init=is_basic_field,
             repr=is_basic_field,
             compare=is_basic_field,


### PR DESCRIPTION
This PR changes value of `default` and `default_factory` to `dataclasses.MISSING` so `strawberry.UNSET` could be used to create optional fields in input types.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Checklsit

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
