### PR TITLE
Fix compatibility with federation 1

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+Release type: patch
+
+This release hides `resolvable: True` in @keys directives
+when using Apollo Federation 1, to preserve compatibility
+with older Gateways.

--- a/tests/federation/printer/test_keys.py
+++ b/tests/federation/printer/test_keys.py
@@ -7,8 +7,69 @@ import strawberry
 from strawberry.federation.schema_directives import Key
 
 
-def test_multiple_keys():
-    # also confirm that the "resolvable: True" works
+def test_keys_federation_1():
+    global Review
+
+    @strawberry.federation.type
+    class User:
+        username: str
+
+    @strawberry.federation.type(keys=[Key("upc", True)], extend=True)
+    class Product:
+        upc: str = strawberry.federation.field(external=True)
+        reviews: List["Review"]
+
+    @strawberry.federation.type(keys=["body"])
+    class Review:
+        body: str
+        author: User
+        product: Product
+
+    @strawberry.federation.type
+    class Query:
+        @strawberry.field
+        def top_products(self, first: int) -> List[Product]:
+            return []
+
+    schema = strawberry.federation.Schema(query=Query, enable_federation_2=False)
+
+    expected = """
+        extend type Product @key(fields: "upc") {
+          upc: String! @external
+          reviews: [Review!]!
+        }
+
+        type Query {
+          _service: _Service!
+          _entities(representations: [_Any!]!): [_Entity]!
+          topProducts(first: Int!): [Product!]!
+        }
+
+        type Review @key(fields: "body") {
+          body: String!
+          author: User!
+          product: Product!
+        }
+
+        type User {
+          username: String!
+        }
+
+        scalar _Any
+
+        union _Entity = Product | Review
+
+        type _Service {
+          sdl: String!
+        }
+    """
+
+    assert schema.as_str() == textwrap.dedent(expected).strip()
+
+    del Review
+
+
+def test_keys_federation_2():
     global Review
 
     @strawberry.federation.type


### PR DESCRIPTION
This PR removes the `resolvable: True` from @keys directive when using Apollo Federation 1.
