### PR TITLE
Modify LazyType to support using the local module implicitly

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: minor
+
+When using LazyType to create a forward declaration in the local module,
+it can now be used as LazyType["MyType"] instead of LazyType["MyType", "path.to.module"]

--- a/strawberry/lazy_type.py
+++ b/strawberry/lazy_type.py
@@ -15,7 +15,14 @@ class LazyType(Generic[TypeName, Module]):
     package: Optional[str]
 
     def __class_getitem__(cls, params):
-        type_name, module = params
+        if isinstance(params, str):
+            type_name = params
+            current_frame = inspect.currentframe()
+            assert current_frame is not None
+            assert current_frame.f_back is not None
+            module = current_frame.f_back.f_globals["__name__"]
+        else:
+            type_name, module = params
 
         package = None
 

--- a/tests/schema/test_lazy_types/test_forward_cyclic.py
+++ b/tests/schema/test_lazy_types/test_forward_cyclic.py
@@ -1,0 +1,69 @@
+import textwrap
+from typing import List, Optional
+
+import strawberry
+from strawberry.lazy_type import LazyType
+from strawberry.printer import print_schema
+
+
+TypeA = LazyType["TypeA"]
+TypeB = LazyType["TypeB"]
+
+
+@strawberry.type
+class TypeA:
+    list_of_a: Optional[List[TypeA]] = None
+    list_of_b: Optional[List[TypeB]] = None
+
+    @strawberry.field()
+    def type_a(self) -> TypeA:
+        return self
+
+    @strawberry.field()
+    def type_b(self) -> TypeB:
+        return TypeB()
+
+
+@strawberry.type
+class TypeB:
+    list_of_a: Optional[List[TypeA]] = None
+    list_of_b: Optional[List[TypeB]] = None
+
+    @strawberry.field()
+    def type_a(self) -> TypeA:
+        return TypeA
+
+    @strawberry.field()
+    def type_b(self) -> TypeB:
+        return self
+
+
+def test_cyclic_lazy():
+    @strawberry.type
+    class Query:
+        a: TypeA
+        b: TypeB
+
+    expected = """
+        type Query {
+          a: TypeA!
+          b: TypeB!
+        }
+
+        type TypeA {
+          listOfA: [TypeA!]
+          listOfB: [TypeB!]
+          typeA: TypeA!
+          typeB: TypeB!
+        }
+
+        type TypeB {
+          listOfA: [TypeA!]
+          listOfB: [TypeB!]
+          typeA: TypeA!
+          typeB: TypeB!
+        }
+    """
+    schema = strawberry.Schema(Query)
+
+    assert print_schema(schema) == textwrap.dedent(expected).strip()


### PR DESCRIPTION
## Description

When using LazyType to create a forward declaration in the local module, 
it can now be used as `LazyType["MyType"]` instead of `LazyType["MyType", "path.to.module"]`

This is just a minor comestic change

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
