### PR TITLE
fix: Make sure print output doesn't change ordering for extra types

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+Keep extra discovered types sorted so that each schema printing is
+always the same.


### PR DESCRIPTION
I have a pre-commit rule in a project that when any python file gets changed, it prints a new schema to a `schema.gql` file. That rule has been failing randomly lately because the ordering of some extra types are random.

This ensures that those extra types are sorted as well to make sure 2 schema prints of the same schema are always the same.