### PR TITLE
Fix custom scalar base64 example in Type docs

### DIFF
--- a/docs/types/scalars.md
+++ b/docs/types/scalars.md
@@ -105,7 +105,7 @@ import strawberry
 Base64 = strawberry.scalar(
     NewType("Base64", bytes),
     serialize=lambda v: base64.b64encode(v).decode("utf-8"),
-    parse_value=lambda v: base64.b64decode(v).encode("utf-8")),
+    parse_value=lambda v: base64.b64decode(v).encode("utf-8"),
 )
 
 @strawberry.type


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This PR fixes the documentation of the custom scalar example in the docs. It had an extra `)`.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
