### PR TITLE
Allow subclassing of reserved types in resolvers

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,20 @@
+Release type: patch
+
+Fix invalid deprecation warning issued on arguments annotated
+by a subclassed `strawberry.types.Info`.
+
+Thanks to @ThirVondukr for the bug report!
+
+Example:
+
+```python
+class MyInfo(Info)
+    pass
+
+@strawberry.type
+class Query:
+
+    @strawberry.field
+    def is_tasty(self, info: MyInfo) -> bool:
+        """Subclassed ``info`` argument no longer raises deprecation warning."""
+```

--- a/strawberry/types/fields/resolver.py
+++ b/strawberry/types/fields/resolver.py
@@ -20,6 +20,7 @@ from typing import (  # type: ignore[attr-defined]
     TypeVar,
     Union,
     _eval_type,
+    cast,
 )
 
 from typing_extensions import Annotated, Protocol, get_args, get_origin
@@ -129,12 +130,17 @@ class ReservedType(NamedTuple):
             return None
 
     def is_reserved_type(self, other: Type) -> bool:
-        if get_origin(other) is Annotated:
+        origin = cast(type, get_origin(other)) or other
+        if origin is Annotated:
             # Handle annotated arguments such as Private[str] and DirectiveValue[str]
             return any(isinstance(argument, self.type) for argument in get_args(other))
         else:
             # Handle both concrete and generic types (i.e Info, and Info[Any, Any])
-            return other is self.type or get_origin(other) is self.type
+            return (
+                issubclass(origin, self.type)
+                if isinstance(origin, type)
+                else origin is self.type
+            )
 
 
 SELF_PARAMSPEC = ReservedNameBoundParameter("self")

--- a/tests/types/test_argument_types.py
+++ b/tests/types/test_argument_types.py
@@ -129,8 +129,15 @@ def test_custom_info(annotation):
         assert info_parameter is not None
         assert info_parameter.name == "info"
 
+
+def test_custom_info_negative():
+    """Test to ensure deprecation warning is emitted."""
+    with pytest.warns(
+        DeprecationWarning, match=r"Argument name-based matching of 'info'"
+    ):
+
         @strawberry.field
-        def get_info(info: CustomInfo) -> bool:
+        def get_info(info) -> bool:
             _ = info
             return True
 

--- a/tests/types/test_argument_types.py
+++ b/tests/types/test_argument_types.py
@@ -1,7 +1,9 @@
+import warnings
 from enum import Enum
 from typing import List, Optional, TypeVar
 
 import strawberry
+from strawberry.types.info import Info
 
 
 def test_enum():
@@ -93,3 +95,23 @@ def test_type_var():
 
     argument = set_value.arguments[0]
     assert argument.type == T
+
+
+def test_custom_info():
+    class CustomInfo(Info):
+        pass
+
+    # Ensure no deprecation warning is thrown for info subclass
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+
+        @strawberry.field
+        def get_info(info: CustomInfo) -> bool:
+            _ = info
+            return True
+
+        assert not get_info.arguments  # Should have no arguments matched
+
+        info_parameter = get_info.base_resolver.info_parameter
+        assert info_parameter is not None
+        assert info_parameter.name == "info"


### PR DESCRIPTION
This commit Fixes #2134 by calling `issubclass` to check if a declared class is a subclass of a
reserved type.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Closes #2134 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
