### PR TITLE
Allow passing schema directives to `strawberry.Schema`

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,44 @@
+Release type: patch
+
+This release adds support for passing schema directives to
+`Schema(..., types=[])`. This can be useful if using a built-inschema directive
+that's not supported by a gateway.
+
+For example the following:
+
+```python
+import strawberry
+from strawberry.scalars import JSON
+from strawberry.schema_directive import Location
+
+
+@strawberry.type
+class Query:
+    example: JSON
+
+
+@strawberry.schema_directive(locations=[Location.SCALAR], name="specifiedBy")
+class SpecifiedBy:
+    name: str
+
+
+schema = strawberry.Schema(query=Query, types=[SpecifiedBy])
+```
+
+will print the following SDL:
+
+```graphql
+directive @specifiedBy(name: String!) on SCALAR
+
+"""
+The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+"""
+scalar JSON
+  @specifiedBy(
+    url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf"
+  )
+
+type Query {
+  example: JSON!
+}
+```

--- a/strawberry/printer/printer.py
+++ b/strawberry/printer/printer.py
@@ -122,7 +122,7 @@ def print_schema_directive(
         StrawberrySchemaDirective, directive.__class__.__strawberry_directive__
     )
     schema_converter = schema.schema_converter
-    gql_directive = schema_converter.from_schema_directive(directive)
+    gql_directive = schema_converter.from_schema_directive(directive.__class__)
     params = print_schema_directive_params(
         gql_directive,
         {
@@ -533,12 +533,24 @@ def print_directive(
     )
 
 
+def is_builtin_directive(directive: GraphQLDirective) -> bool:
+    # this allows to force print the builtin directives if there's a
+    # directive that was implemented using the schema_directive
+
+    if is_specified_directive(directive):
+        strawberry_definition = directive.extensions.get("strawberry-definition")
+
+        return strawberry_definition is None
+
+    return False
+
+
 def print_schema(schema: BaseSchema) -> str:
     graphql_core_schema = schema._schema  # type: ignore
     extras = PrintExtras()
 
     directives = filter(
-        lambda n: not is_specified_directive(n), graphql_core_schema.directives
+        lambda n: not is_builtin_directive(n), graphql_core_schema.directives
     )
     type_map = graphql_core_schema.type_map
     types = filter(is_defined_type, map(type_map.get, sorted(type_map)))

--- a/strawberry/schema/compat.py
+++ b/strawberry/schema/compat.py
@@ -50,6 +50,10 @@ def is_enum(type_: Union[StrawberryType, type]) -> TypeGuard[type]:
     return hasattr(type_, "_enum_definition")
 
 
+def is_schema_directive(type_: Union[StrawberryType, type]) -> TypeGuard[type]:
+    return hasattr(type_, "__strawberry_directive__")
+
+
 def is_generic(type_: Union[StrawberryType, type]) -> bool:
     if hasattr(type_, "_type_definition"):
 

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -174,8 +174,7 @@ class GraphQLCoreConverter:
             },
         )
 
-    def from_schema_directive(self, directive: Any) -> GraphQLDirective:
-        cls = directive.__class__
+    def from_schema_directive(self, cls: Type) -> GraphQLDirective:
         strawberry_directive = cast(
             StrawberrySchemaDirective, cls.__strawberry_directive__
         )

--- a/tests/schema/test_basic.py
+++ b/tests/schema/test_basic.py
@@ -13,6 +13,7 @@ from strawberry.exceptions import (
     FieldWithResolverAndDefaultValueError,
 )
 from strawberry.scalars import Base64
+from strawberry.schema_directive import Location
 from strawberry.type import StrawberryList
 
 
@@ -548,10 +549,16 @@ def test_with_types():
     class Query:
         foo: int
 
+    @strawberry.schema_directive(locations=[Location.SCALAR], name="specifiedBy")
+    class SpecifiedBy:
+        name: str
+
     schema = strawberry.Schema(
-        query=Query, types=[Type, Interface, Input, Base64, ID, str, int]
+        query=Query, types=[Type, Interface, Input, Base64, ID, str, int, SpecifiedBy]
     )
     expected = '''
+        directive @specifiedBy(name: String!) on SCALAR
+
         """
         Represents binary data as Base64-encoded strings, using the standard alphabet.
         """


### PR DESCRIPTION
This PR allows to print any schema directive, even if they are not used. This can be useful if using a built-inschema directive
that's not supported by a gateway.

For example, the following:

```python
import strawberry
from strawberry.scalars import JSON
from strawberry.schema_directive import Location


@strawberry.type
class Query:
    example: JSON


@strawberry.schema_directive(locations=[Location.SCALAR], name="specifiedBy")
class SpecifiedBy:
    name: str


schema = strawberry.Schema(query=Query, types=[SpecifiedBy])
```

will print the following SDL:

```graphql
directive @specifiedBy(name: String!) on SCALAR

"""
The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
"""
scalar JSON
  @specifiedBy(
    url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf"
  )

type Query {
  example: JSON!
}
```
