### PR TITLE
Fix pydantic conversion of generic aliases

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+This release fixes the conversion of generic aliases when
+using pydantic.

--- a/strawberry/experimental/pydantic/error_type.py
+++ b/strawberry/experimental/pydantic/error_type.py
@@ -4,6 +4,7 @@ from typing import Any, List, Optional, Sequence, Tuple, Type, cast
 
 from pydantic import BaseModel
 from pydantic.fields import ModelField
+from pydantic.utils import lenient_issubclass
 
 from strawberry.auto import StrawberryAuto
 from strawberry.experimental.pydantic.utils import (
@@ -33,13 +34,13 @@ def field_type_to_type(type_):
 
         if is_list(child_type):
             strawberry_type = field_type_to_type(child_type)
-        elif issubclass(child_type, BaseModel):
+        elif lenient_issubclass(child_type, BaseModel):
             strawberry_type = get_strawberry_type_from_model(child_type)
         else:
             strawberry_type = List[error_class]
 
         strawberry_type = Optional[strawberry_type]
-    elif issubclass(type_, BaseModel):
+    elif lenient_issubclass(type_, BaseModel):
         strawberry_type = get_strawberry_type_from_model(type_)
         return Optional[strawberry_type]
 


### PR DESCRIPTION
This fixes the pydantic conversation handling of generic aliases (ex: `list[str]`).

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #2083

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
