### PR TITLE
fix enum handling of non-unique values or strawberry.enum_value

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,2 @@
+Release type: patch
+Fix enum issues with strawberry.enum_value or non-unique values

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -16,6 +16,7 @@ from typing import (
 )
 
 from graphql import (
+    EnumValueNode,
     GraphQLArgument,
     GraphQLDirective,
     GraphQLEnumType,
@@ -81,12 +82,20 @@ class CustomGraphQLEnumType(GraphQLEnumType):
         return super().serialize(output_value)
 
     def parse_value(self, input_value: str) -> Any:
-        return self.wrapped_cls(super().parse_value(input_value))
+        # execute checks
+        super().parse_value(input_value)
+        # return enum value
+        return self.wrapped_cls[input_value]
 
     def parse_literal(
         self, value_node: ValueNode, _variables: Optional[Dict[str, Any]] = None
     ) -> Any:
-        return self.wrapped_cls(super().parse_literal(value_node, _variables))
+        # execute checks
+        super().parse_literal(value_node, _variables)
+        # for mypy, also handy for checking the check
+        assert isinstance(value_node, EnumValueNode), "must be a EnumValueNode"
+        # return enum value
+        return self.wrapped_cls[value_node.value]
 
 
 class GraphQLCoreConverter:

--- a/tests/schema/test_enum.py
+++ b/tests/schema/test_enum.py
@@ -56,12 +56,19 @@ def test_enum_arguments():
         VANILLA = "vanilla"
         STRAWBERRY = "strawberry"
         CHOCOLATE = "chocolate"
+        DARK_CHOCOLATE = strawberry.enum_value(
+            "chocolate", description="chocolate but bitter"
+        )
 
     @strawberry.type
     class Query:
         @strawberry.field
         def flavour_available(self, flavour: IceCreamFlavour) -> bool:
             return flavour == IceCreamFlavour.STRAWBERRY
+
+        @strawberry.field
+        def bitter(self, flavour: IceCreamFlavour) -> bool:
+            return flavour is IceCreamFlavour.DARK_CHOCOLATE
 
     @strawberry.input
     class ConeInput:
@@ -80,6 +87,18 @@ def test_enum_arguments():
 
     assert not result.errors
     assert result.data["flavourAvailable"] is False
+
+    query = "{ bitter(flavour: CHOCOLATE) }"
+    result = schema.execute_sync(query)
+
+    assert not result.errors
+    assert result.data["bitter"] is False
+
+    query = "{ bitter(flavour: DARK_CHOCOLATE) }"
+    result = schema.execute_sync(query)
+
+    assert not result.errors
+    assert result.data["bitter"] is True
 
     query = "{ flavourAvailable(flavour: STRAWBERRY) }"
     result = schema.execute_sync(query)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
We try to initialize an enum with the value of a value. This doesn't work (why it worked some time ago, I don't know).
This PR fixes the logic:
- first execute the checks of the underlying graphql enum
- if no error happened then return the value by using the proper enum access


<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR
Strange: no issue was opened? The code must have been broken for some time.
It fails for me for some versions.

Edit: see comments or heading.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
