### PR TITLE
Fix deprecation warnings in Sanic's upload test

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,9 @@
+Release type: patch
+
+Fix warnings during unit tests for Sanic's upload.
+
+Otherwise running unit tests results in a bunch of warning like this:
+
+```
+DeprecationWarning: Use 'content=<...>' to upload raw bytes/text content.
+```

--- a/tests/sanic/test_upload.py
+++ b/tests/sanic/test_upload.py
@@ -77,12 +77,12 @@ END = "------sanic--"
 
 
 def test_single_file_upload(sanic_client):
-    data = OPERATIONS_FIELD + MAP_FIELD + TEXT_FILE_FIELD + END
+    content = OPERATIONS_FIELD + MAP_FIELD + TEXT_FILE_FIELD + END
     headers = {"content-type": "multipart/form-data; boundary=----sanic"}
 
     request, response = sanic_client.test_client.post(
         "/graphql",
-        data=data,
+        content=content,
         headers=headers,
     )
 
@@ -92,7 +92,7 @@ def test_single_file_upload(sanic_client):
 
 
 def test_file_list_upload(sanic_client):
-    data = (
+    content = (
         MULTI_UPLOAD_OPERATIONS_FIELD
         + MULTI_UPLOAD_MAP_FIELD
         + MULTI_UPLOAD_TEXT_FILE1_FIELD
@@ -103,7 +103,7 @@ def test_file_list_upload(sanic_client):
 
     request, response = sanic_client.test_client.post(
         "/graphql",
-        data=data,
+        content=content,
         headers=headers,
     )
 
@@ -116,7 +116,7 @@ def test_file_list_upload(sanic_client):
 
 
 def test_nested_file_list(sanic_client):
-    data = (
+    content = (
         COMPLEX_UPLOAD_OPERATIONS_FIELD
         + COMPLEX_UPLOAD_MAP_FIELD
         + MULTI_UPLOAD_TEXT_FILE1_FIELD
@@ -127,7 +127,7 @@ def test_nested_file_list(sanic_client):
 
     request, response = sanic_client.test_client.post(
         "/graphql",
-        data=data,
+        content=content,
         headers=headers,
     )
 
@@ -147,12 +147,12 @@ def test_extra_form_data_fields_are_ignored(sanic_client):
         "{}\r\n"
     )
 
-    data = OPERATIONS_FIELD + MAP_FIELD + TEXT_FILE_FIELD + extra_field + END
+    content = OPERATIONS_FIELD + MAP_FIELD + TEXT_FILE_FIELD + extra_field + END
     headers = {"content-type": "multipart/form-data; boundary=----sanic"}
 
     request, response = sanic_client.test_client.post(
         "/graphql",
-        data=data,
+        content=content,
         headers=headers,
     )
 
@@ -182,12 +182,12 @@ def test_malformed_query(sanic_client):
         "}\r\n"
     )
 
-    data = operations_field + MAP_FIELD + TEXT_FILE_FIELD + END
+    content = operations_field + MAP_FIELD + TEXT_FILE_FIELD + END
     headers = {"content-type": "multipart/form-data; boundary=----sanic"}
 
     request, response = sanic_client.test_client.post(
         "/graphql",
-        data=data,
+        content=content,
         headers=headers,
     )
 
@@ -203,12 +203,12 @@ def test_sending_invalid_json_body(sanic_client):
         "}\r\n"
     )
 
-    data = operations_field + MAP_FIELD + TEXT_FILE_FIELD + END
+    content = operations_field + MAP_FIELD + TEXT_FILE_FIELD + END
     headers = {"content-type": "multipart/form-data; boundary=----sanic"}
 
     request, response = sanic_client.test_client.post(
         "/graphql",
-        data=data,
+        content=content,
         headers=headers,
     )
 
@@ -217,12 +217,12 @@ def test_sending_invalid_json_body(sanic_client):
 
 
 def test_upload_with_missing_file(sanic_client):
-    data = OPERATIONS_FIELD + MAP_FIELD + END
+    content = OPERATIONS_FIELD + MAP_FIELD + END
     headers = {"content-type": "multipart/form-data; boundary=----sanic"}
 
     request, response = sanic_client.test_client.post(
         "/graphql",
-        data=data,
+        data=content,
         headers=headers,
     )
 


### PR DESCRIPTION
Otherwise running unit tests results in a bunch of warning like this:

```
DeprecationWarning: Use 'content=<...>' to upload raw bytes/text content.
```
## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* None

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
