### PR TITLE
Bugfix: fix strawberry.enum_value handling

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: minor
+Fix enum issues with strawberry.enum_value.
+BREAKING: When strawberry.enum_value is used the wrapped Enum is re-created.

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -81,11 +81,15 @@ class CustomGraphQLEnumType(GraphQLEnumType):
         return super().serialize(output_value)
 
     def parse_value(self, input_value: str) -> Any:
+        # return singleton enum value
+        # an enum value has only a reference to the first key with the value
         return self.wrapped_cls(super().parse_value(input_value))
 
     def parse_literal(
         self, value_node: ValueNode, _variables: Optional[Dict[str, Any]] = None
     ) -> Any:
+        # return singleton enum value
+        # an enum value has only a reference to the first key with the value
         return self.wrapped_cls(super().parse_literal(value_node, _variables))
 
 

--- a/tests/schema/test_enum.py
+++ b/tests/schema/test_enum.py
@@ -56,12 +56,19 @@ def test_enum_arguments():
         VANILLA = "vanilla"
         STRAWBERRY = "strawberry"
         CHOCOLATE = "chocolate"
+        DARK_CHOCOLATE = strawberry.enum_value(
+            "dark chocolate", description="chocolate but bitter"
+        )
 
     @strawberry.type
     class Query:
         @strawberry.field
         def flavour_available(self, flavour: IceCreamFlavour) -> bool:
             return flavour == IceCreamFlavour.STRAWBERRY
+
+        @strawberry.field
+        def bitter(self, flavour: IceCreamFlavour) -> bool:
+            return flavour is IceCreamFlavour.DARK_CHOCOLATE
 
     @strawberry.input
     class ConeInput:
@@ -80,6 +87,18 @@ def test_enum_arguments():
 
     assert not result.errors
     assert result.data["flavourAvailable"] is False
+
+    query = "{ bitter(flavour: CHOCOLATE) }"
+    result = schema.execute_sync(query)
+
+    assert not result.errors
+    assert result.data["bitter"] is False
+
+    query = "{ bitter(flavour: DARK_CHOCOLATE) }"
+    result = schema.execute_sync(query)
+
+    assert not result.errors
+    assert result.data["bitter"] is True
 
     query = "{ flavourAvailable(flavour: STRAWBERRY) }"
     result = schema.execute_sync(query)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Currently strawberry.enum_value causes errors. Here I add a test for the issue, a bugfix and some documentation about the way it works.

note: you cannot differ keys with the same value in a resolver.
This is a limitation by python enum itself (uses singletons for values).

note: I recreate the Enum if an EnumValueDefinition instance is detected, otherwise it breaks the logic

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
