### PR TITLE
Fix exclude_unset issue when converting strawberry type to pydantic type

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,2 @@
+Release type: patch
+Fix exclude_unset issue when converting strawberry type to pydantic type

--- a/strawberry/experimental/pydantic/object_type.py
+++ b/strawberry/experimental/pydantic/object_type.py
@@ -251,6 +251,7 @@ def type(
                     getattr(self, f.name)
                 )
                 for f in dataclasses.fields(self)
+                if getattr(self, f.name) is not None
             }
             instance_kwargs.update(kwargs)
             return model(**instance_kwargs)

--- a/tests/experimental/pydantic/test_conversion.py
+++ b/tests/experimental/pydantic/test_conversion.py
@@ -1247,3 +1247,31 @@ def test_can_convert_optional_union_type_expression_fields_to_strawberry():
 
     assert test.optional_list == [1, 2, 3]
     assert test.optional_str is None
+
+
+def test_exclude_unset_parameter_when_convert_strawberry_type_to_pydantic_type():
+    class User(BaseModel):
+        id: int
+        name: str
+        surname: Optional[str]
+
+    @strawberry.experimental.pydantic.type(model=User, all_fields=True)
+    class UserType:
+        pass
+
+    user = User(id=1, name="leffe")
+    user_type = UserType(id=1, name="leffe")
+    user_type_pydantic = user_type.to_pydantic()
+
+    assert user.dict(exclude_unset=True) == user_type_pydantic.dict(exclude_unset=True)
+    assert user.json(exclude_unset=True) == user_type_pydantic.json(exclude_unset=True)
+
+    user_type_has_surname = UserType(id=1, name="leffe", surname="yoon")
+    user_type_has_surname_pydantic = user_type_has_surname.to_pydantic()
+
+    assert user.dict(exclude_unset=True) != user_type_has_surname_pydantic.dict(
+        exclude_unset=True
+    )
+    assert user.json(exclude_unset=True) != user_type_has_surname_pydantic.json(
+        exclude_unset=True
+    )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Fix exclude_unset issue when converting strawberry type to pydantic type


<!--- Describe your changes in detail here. -->
In the process of converting to pydantic type through `to_pydantic_default`, if Value is unset(== None) it is not put in `instance_kwargs`. 
So, make sure have the `__fields_set__` value properly.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fix #2163 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
