### PR TITLE
WIP - Fix `enum_value`

### DIFF
--- a/tests/enums/test_enum.py
+++ b/tests/enums/test_enum.py
@@ -92,6 +92,10 @@ def test_can_deprecate_enum_values():
     assert definition.values[2].value == "chocolate"
     assert definition.values[2].deprecation_reason is None
 
+    assert IceCreamFlavour("strawberry") == IceCreamFlavour.STRAWBERRY
+    assert IceCreamFlavour("vanilla") == IceCreamFlavour.VANILLA
+    assert IceCreamFlavour("chocolate") == IceCreamFlavour.CHOCOLATE
+
 
 def test_can_describe_enum_values():
     @strawberry.enum


### PR DESCRIPTION
This PR will fix an issue that doesn't allow you from using Enums that use `enum_value` for defining their value. The issue comes from `Enum(...)` trying to find the enum value using it's value, but when using `strawberry.enum_value` the value is the enum value definition.

We can fix this by changing the value or by adding an `__eq__` method, not sure which one is better. 

The PR has only the tests :)