### PR TITLE
Support storing metadata in strawberry fields.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: minor
+
+Support storing metadata in strawberry fields.

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -66,6 +66,7 @@ class StrawberryField(dataclasses.Field):
         permission_classes: List[Type[BasePermission]] = (),  # type: ignore
         default: object = UNSET,
         default_factory: Union[Callable[[], Any], object] = UNSET,
+        metadata: Optional[Mapping[Any, Any]] = None,
         deprecation_reason: Optional[str] = None,
         directives: Sequence[object] = (),
     ):
@@ -91,7 +92,7 @@ class StrawberryField(dataclasses.Field):
             repr=is_basic_field,
             compare=is_basic_field,
             hash=None,
-            metadata={},
+            metadata=metadata or {},
             **kwargs,
         )
 
@@ -331,6 +332,7 @@ def field(
     deprecation_reason: Optional[str] = None,
     default: Any = UNSET,
     default_factory: Union[Callable[..., object], object] = UNSET,
+    metadata: Optional[Mapping[Any, Any]] = None,
     directives: Optional[Sequence[object]] = (),
 ) -> T:
     ...
@@ -347,6 +349,7 @@ def field(
     deprecation_reason: Optional[str] = None,
     default: Any = UNSET,
     default_factory: Union[Callable[..., object], object] = UNSET,
+    metadata: Optional[Mapping[Any, Any]] = None,
     directives: Optional[Sequence[object]] = (),
 ) -> Any:
     ...
@@ -363,6 +366,7 @@ def field(
     deprecation_reason: Optional[str] = None,
     default: Any = UNSET,
     default_factory: Union[Callable[..., object], object] = UNSET,
+    metadata: Optional[Mapping[Any, Any]] = None,
     directives: Optional[Sequence[object]] = (),
 ) -> StrawberryField:
     ...
@@ -378,6 +382,7 @@ def field(
     deprecation_reason: Optional[str] = None,
     default: Any = UNSET,
     default_factory: Union[Callable[..., object], object] = UNSET,
+    metadata: Optional[Mapping[Any, Any]] = None,
     directives: Optional[Sequence[object]] = (),
     # This init parameter is used by PyRight to determine whether this field
     # is added in the constructor or not. It is not used to change
@@ -409,6 +414,7 @@ def field(
         deprecation_reason=deprecation_reason,
         default=default,
         default_factory=default_factory,
+        metadata=metadata,
         directives=directives or (),
     )
 

--- a/tests/schema/test_fields.py
+++ b/tests/schema/test_fields.py
@@ -1,3 +1,4 @@
+import dataclasses
 from operator import getitem
 
 import strawberry
@@ -69,3 +70,12 @@ def test_can_change_default_resolver():
     assert not result.errors
     assert result.data
     assert result.data["user"]["name"] == "Patrick"
+
+
+def test_field_metadata():
+    @strawberry.type
+    class Query:
+        a: str = strawberry.field(default="Example", metadata={"Foo": "Bar"})
+
+    (a,) = dataclasses.fields(Query)
+    assert a.metadata == {"Foo": "Bar"}


### PR DESCRIPTION
I'm trying to add SQLAlchemy annotations in my strawberry type (using [declarative mapping](https://docs.sqlalchemy.org/en/14/orm/dataclasses.html#mapping-dataclasses-using-declarative-mapping)), which looks like this:

```
@registry.mapped
@strawberry.type
class MyEntity:
    __tablename__ = "MyEntity"
    __sa_dataclass_metadata_key__ = "sa"

    id: int = strawberry.field(metadata={"sa": Column(Integer, primary_key=True)})
```

however strawberry.field() currently doesn't support specifying field metadata.

This PR adds a simple passthrough for it in strawberry

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
