### PR TITLE
Let type checkers know that fields are kwonly

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Update mypy plugin to treat all strawberry fields as kw_only

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,5 @@
 Release type: patch
 
-Update mypy plugin to treat all strawberry fields as kw_only
+This release updates the mypy plugin and the typing for Pyright to treat all
+strawberry fields as keyword-only arguments. This reflects a previous change to
+the Strawberry API.

--- a/strawberry/ext/mypy_plugin.py
+++ b/strawberry/ext/mypy_plugin.py
@@ -18,7 +18,6 @@ from mypy.nodes import (
     CallExpr,
     CastExpr,
     ClassDef,
-    Context,
     Expression,
     FuncDef,
     IndexExpr,
@@ -756,7 +755,7 @@ class CustomDataclassTransformer:
             if MypyVersion.VERSION >= Decimal("0.800"):
                 params["info"] = cls.info
             if MypyVersion.VERSION >= Decimal("0.920"):
-                params["kw_only"] = False
+                params["kw_only"] = True
 
             attribute = DataclassAttribute(**params)  # type: ignore
             attrs.append(attribute)
@@ -793,28 +792,6 @@ class CustomDataclassTransformer:
                             super_attrs.append(attr)
                             break
             all_attrs = super_attrs + all_attrs
-
-        # Ensure that arguments without a default don't follow
-        # arguments that have a default.
-        found_default = False
-        for attr in all_attrs:
-            # If we find any attribute that is_in_init but that
-            # doesn't have a default after one that does have one,
-            # then that's an error.
-            if found_default and attr.is_in_init and not attr.has_default:
-                # If the issue comes from merging different classes, report it
-                # at the class definition point.
-                context = (
-                    Context(line=attr.line, column=attr.column)
-                    if attr in attrs
-                    else ctx.cls
-                )
-                ctx.api.fail(
-                    "Attributes without a default cannot follow attributes with one",
-                    context,
-                )
-
-            found_default = found_default or (attr.has_default and attr.is_in_init)
 
         return all_attrs
 

--- a/strawberry/federation/object_type.py
+++ b/strawberry/federation/object_type.py
@@ -75,7 +75,9 @@ def _impl_type(
 
 @overload
 @__dataclass_transform__(
-    order_default=True, field_descriptors=(base_field, field, StrawberryField)
+    order_default=True,
+    kw_only_default=True,
+    field_descriptors=(base_field, field, StrawberryField),
 )
 def type(
     cls: T,
@@ -92,7 +94,9 @@ def type(
 
 @overload
 @__dataclass_transform__(
-    order_default=True, field_descriptors=(base_field, field, StrawberryField)
+    order_default=True,
+    kw_only_default=True,
+    field_descriptors=(base_field, field, StrawberryField),
 )
 def type(
     *,
@@ -135,7 +139,9 @@ def type(
 
 @overload
 @__dataclass_transform__(
-    order_default=True, field_descriptors=(base_field, field, StrawberryField)
+    order_default=True,
+    kw_only_default=True,
+    field_descriptors=(base_field, field, StrawberryField),
 )
 def input(
     cls: T,
@@ -151,7 +157,9 @@ def input(
 
 @overload
 @__dataclass_transform__(
-    order_default=True, field_descriptors=(base_field, field, StrawberryField)
+    order_default=True,
+    kw_only_default=True,
+    field_descriptors=(base_field, field, StrawberryField),
 )
 def input(
     *,
@@ -186,7 +194,9 @@ def input(
 
 @overload
 @__dataclass_transform__(
-    order_default=True, field_descriptors=(base_field, field, StrawberryField)
+    order_default=True,
+    kw_only_default=True,
+    field_descriptors=(base_field, field, StrawberryField),
 )
 def interface(
     cls: T,
@@ -203,7 +213,9 @@ def interface(
 
 @overload
 @__dataclass_transform__(
-    order_default=True, field_descriptors=(base_field, field, StrawberryField)
+    order_default=True,
+    kw_only_default=True,
+    field_descriptors=(base_field, field, StrawberryField),
 )
 def interface(
     *,

--- a/strawberry/federation/union.py
+++ b/strawberry/federation/union.py
@@ -1,17 +1,20 @@
-from typing import Iterable, Optional, Sequence, Type, Union
+from typing import Iterable, Optional, Tuple, Type, TypeVar, Union
 
 from strawberry.union import union as base_union
 
 
+Types = TypeVar("Types", bound=Type)
+
+
 def union(
     name: str,
-    types: Sequence[Type],
+    types: Tuple[Types, ...],
     *,
     description: str = None,
     directives: Iterable[object] = (),
     inaccessible: bool = False,
     tags: Optional[Iterable[str]] = (),
-) -> Union[Type]:
+) -> Union[Types]:
     """Creates a new named Union type.
 
     Example usages:

--- a/strawberry/federation/union.py
+++ b/strawberry/federation/union.py
@@ -1,20 +1,17 @@
-from typing import Iterable, Optional, Tuple, Type, TypeVar, Union
+from typing import Iterable, Optional, Sequence, Type, Union
 
 from strawberry.union import union as base_union
 
 
-Types = TypeVar("Types", bound=Type)
-
-
 def union(
     name: str,
-    types: Tuple[Types, ...],
+    types: Sequence[Type],
     *,
     description: str = None,
     directives: Iterable[object] = (),
     inaccessible: bool = False,
     tags: Optional[Iterable[str]] = (),
-) -> Union[Types]:
+) -> Union[Type]:
     """Creates a new named Union type.
 
     Example usages:

--- a/strawberry/object_type.py
+++ b/strawberry/object_type.py
@@ -175,7 +175,9 @@ T = TypeVar("T", bound=Type)
 
 
 @overload
-@__dataclass_transform__(order_default=True, field_descriptors=(field, StrawberryField))
+@__dataclass_transform__(
+    order_default=True, kw_only_default=True, field_descriptors=(field, StrawberryField)
+)
 def type(
     cls: T,
     *,
@@ -190,7 +192,9 @@ def type(
 
 
 @overload
-@__dataclass_transform__(order_default=True, field_descriptors=(field, StrawberryField))
+@__dataclass_transform__(
+    order_default=True, kw_only_default=True, field_descriptors=(field, StrawberryField)
+)
 def type(
     *,
     name: Optional[str] = None,
@@ -250,7 +254,9 @@ def type(
 
 
 @overload
-@__dataclass_transform__(order_default=True, field_descriptors=(field, StrawberryField))
+@__dataclass_transform__(
+    order_default=True, kw_only_default=True, field_descriptors=(field, StrawberryField)
+)
 def input(
     cls: T,
     *,
@@ -262,7 +268,9 @@ def input(
 
 
 @overload
-@__dataclass_transform__(order_default=True, field_descriptors=(field, StrawberryField))
+@__dataclass_transform__(
+    order_default=True, kw_only_default=True, field_descriptors=(field, StrawberryField)
+)
 def input(
     *,
     name: Optional[str] = None,
@@ -296,7 +304,9 @@ def input(
 
 
 @overload
-@__dataclass_transform__(order_default=True, field_descriptors=(field, StrawberryField))
+@__dataclass_transform__(
+    order_default=True, kw_only_default=True, field_descriptors=(field, StrawberryField)
+)
 def interface(
     cls: T,
     *,
@@ -308,7 +318,9 @@ def interface(
 
 
 @overload
-@__dataclass_transform__(order_default=True, field_descriptors=(field, StrawberryField))
+@__dataclass_transform__(
+    order_default=True, kw_only_default=True, field_descriptors=(field, StrawberryField)
+)
 def interface(
     *,
     name: Optional[str] = None,
@@ -318,7 +330,9 @@ def interface(
     ...
 
 
-@__dataclass_transform__(order_default=True, field_descriptors=(field, StrawberryField))
+@__dataclass_transform__(
+    order_default=True, kw_only_default=True, field_descriptors=(field, StrawberryField)
+)
 def interface(
     cls: Optional[T] = None,
     *,

--- a/strawberry/schema_directive.py
+++ b/strawberry/schema_directive.py
@@ -40,7 +40,9 @@ T = TypeVar("T", bound=Type)
 
 
 @__dataclass_transform__(
-    order_default=True, field_descriptors=(directive_field, field, StrawberryField)
+    order_default=True,
+    kw_only_default=True,
+    field_descriptors=(directive_field, field, StrawberryField),
 )
 def schema_directive(
     *,

--- a/strawberry/union.py
+++ b/strawberry/union.py
@@ -3,12 +3,12 @@ from itertools import chain
 from typing import (
     TYPE_CHECKING,
     Any,
+    Collection,
     Iterable,
     List,
     Mapping,
     NoReturn,
     Optional,
-    Sequence,
     Tuple,
     Type,
     TypeVar,
@@ -197,6 +197,9 @@ class StrawberryUnion(StrawberryType):
         return _resolve_union_type
 
 
+Types = TypeVar("Types", bound=Type)
+
+
 # We return a Union type here in order to allow to use the union type as type
 # annotation.
 # For the `types` argument we'd ideally use a TypeVarTuple, but that's not
@@ -204,11 +207,11 @@ class StrawberryUnion(StrawberryType):
 # See https://www.python.org/dev/peps/pep-0646/ for more information
 def union(
     name: str,
-    types: Sequence[Type],
+    types: Collection[Types],
     *,
     description: str = None,
     directives: Iterable[object] = (),
-) -> Union[Type]:
+) -> Union[Types]:
     """Creates a new named Union type.
 
     Example usages:

--- a/strawberry/union.py
+++ b/strawberry/union.py
@@ -8,6 +8,7 @@ from typing import (
     Mapping,
     NoReturn,
     Optional,
+    Sequence,
     Tuple,
     Type,
     TypeVar,
@@ -196,9 +197,6 @@ class StrawberryUnion(StrawberryType):
         return _resolve_union_type
 
 
-Types = TypeVar("Types", bound=Type)
-
-
 # We return a Union type here in order to allow to use the union type as type
 # annotation.
 # For the `types` argument we'd ideally use a TypeVarTuple, but that's not
@@ -206,11 +204,11 @@ Types = TypeVar("Types", bound=Type)
 # See https://www.python.org/dev/peps/pep-0646/ for more information
 def union(
     name: str,
-    types: Tuple[Types, ...],
+    types: Sequence[Type],
     *,
     description: str = None,
     directives: Iterable[object] = (),
-) -> Union[Types]:
+) -> Union[Type]:
     """Creates a new named Union type.
 
     Example usages:

--- a/tests/mypy/federation/test_fields.yml
+++ b/tests/mypy/federation/test_fields.yml
@@ -68,7 +68,7 @@
     main:13: note: Revealed type is "builtins.int"
     main:14: error: "int" has no attribute "trim"  [attr-defined]
 
-- case: test_field_with_default_cannot_be_before_non_default
+- case: test_field_with_default_before_non_default
   main: |
     import strawberry
 
@@ -78,7 +78,6 @@
         b: str
 
   out: |
-    main:6: error: Attributes without a default cannot follow attributes with one  [misc]
 
 - case: test_using_strawberry_field_does_not_break
   main: |

--- a/tests/mypy/test_fields.yml
+++ b/tests/mypy/test_fields.yml
@@ -68,7 +68,7 @@
     main:13: note: Revealed type is "builtins.int"
     main:14: error: "int" has no attribute "trim"  [attr-defined]
 
-- case: test_field_with_default_cannot_be_before_non_default
+- case: test_field_with_default_before_non_default
   main: |
     import strawberry
 
@@ -78,7 +78,6 @@
         b: str
 
   out: |
-    main:6: error: Attributes without a default cannot follow attributes with one  [misc]
 
 - case: test_using_strawberry_field_does_not_break
   main: |

--- a/tests/mypy/test_scalar.yml
+++ b/tests/mypy/test_scalar.yml
@@ -24,7 +24,7 @@
     reveal_type(X())
     reveal_type(Y())
     reveal_type(Z())
-    reveal_type(Me(Z()).z)
+    reveal_type(Me(z=Z()).z)
   out: |
     main:19: note: Revealed type is "def () -> main.X"
     main:20: note: Revealed type is "def () -> main.Y"
@@ -47,7 +47,7 @@
 
     reveal_type(X())
     reveal_type(Y())
-    reveal_type(Me(X("1")).x)
+    reveal_type(Me(x=X("1")).x)
   out: |
     main:10: note: Revealed type is "builtins.int"
     main:11: note: Revealed type is "builtins.str"
@@ -66,7 +66,7 @@
         x: Z
 
     reveal_type(Z())
-    reveal_type(Me(Z("1")).x)
+    reveal_type(Me(x=Z("1")).x)
   out: |
     main:10: note: Revealed type is "Any"
     main:11: note: Revealed type is "Any"

--- a/tests/mypy/test_union.yml
+++ b/tests/mypy/test_union.yml
@@ -18,7 +18,7 @@
     reveal_type(Response)
     reveal_type(a)
 
-    a = User("abc")
+    a = User(name="abc")
     reveal_type(a)
   out: |
     main:16: note: Revealed type is "builtins.object"
@@ -70,7 +70,7 @@
     reveal_type(Response)
     reveal_type(a)
 
-    a = User("abc")
+    a = User(name="abc")
     reveal_type(a)
   out: |
     main:16: note: Revealed type is "builtins.object"

--- a/tests/pyright/test_federation.py
+++ b/tests/pyright/test_federation.py
@@ -50,7 +50,7 @@ def test_federation_type():
         ),
         Result(
             type="information",
-            message='Type of "User.__init__" is "(self: User, name: str) -> None"',
+            message='Type of "User.__init__" is "(self: User, *, name: str) -> None"',
             line=19,
             column=13,
         ),
@@ -99,7 +99,7 @@ def test_federation_interface():
         ),
         Result(
             type="information",
-            message='Type of "User.__init__" is "(self: User, name: str, age: int) -> None"',
+            message='Type of "User.__init__" is "(self: User, *, name: str, age: int) -> None"',
             line=15,
             column=13,
         ),
@@ -146,7 +146,7 @@ def test_federation_input():
         ),
         Result(
             type="information",
-            message='Type of "User.__init__" is "(self: User, name: str) -> None"',
+            message='Type of "User.__init__" is "(self: User, *, name: str) -> None"',
             line=13,
             column=13,
         ),

--- a/tests/pyright/test_federation_fields.py
+++ b/tests/pyright/test_federation_fields.py
@@ -69,7 +69,7 @@ def test_pyright():
         ),
         Result(
             type="information",
-            message='Type of "User.__init__" is "(self: User, age: int, name: str) '
+            message='Type of "User.__init__" is "(self: User, *, age: int, name: str) '
             '-> None"',
             line=23,
             column=13,
@@ -82,8 +82,10 @@ def test_pyright():
         ),
         Result(
             type="information",
-            message='Type of "UserInput.__init__" is "(self: UserInput, age: int, '
-            'name: str) -> None"',
+            message=(
+                'Type of "UserInput.__init__" is "(self: UserInput, *, age: int, '
+                'name: str) -> None"'
+            ),
             line=26,
             column=13,
         ),

--- a/tests/pyright/test_fields_input.py
+++ b/tests/pyright/test_fields_input.py
@@ -44,7 +44,7 @@ def test_pyright():
         ),
         Result(
             type="information",
-            message='Type of "User.__init__" is "(self: User, name: str) -> None"',
+            message='Type of "User.__init__" is "(self: User, *, name: str) -> None"',
             line=14,
             column=13,
         ),

--- a/tests/pyright/test_fields_keyword.py
+++ b/tests/pyright/test_fields_keyword.py
@@ -13,10 +13,8 @@ class User:
     name: str
 
 
-User(name="Patrick")
-User(n="Patrick")
+User("Patrick")
 
-reveal_type(User)
 reveal_type(User.__init__)
 """
 
@@ -27,26 +25,14 @@ def test_pyright():
     assert results == [
         Result(
             type="error",
-            message='No parameter named "n" (reportGeneralTypeIssues)',
-            line=11,
+            message="Expected 0 positional arguments (reportGeneralTypeIssues)",
+            line=10,
             column=6,
-        ),
-        Result(
-            type="error",
-            message='Argument missing for parameter "name" (reportGeneralTypeIssues)',
-            line=11,
-            column=1,
-        ),
-        Result(
-            type="information",
-            message='Type of "User" is "Type[User]"',
-            line=13,
-            column=13,
         ),
         Result(
             type="information",
             message='Type of "User.__init__" is "(self: User, *, name: str) -> None"',
-            line=14,
+            line=12,
             column=13,
         ),
     ]

--- a/tests/pyright/test_fields_resolver.py
+++ b/tests/pyright/test_fields_resolver.py
@@ -48,7 +48,7 @@ def test_pyright():
         ),
         Result(
             type="information",
-            message='Type of "User.__init__" is "(self: User, name: str) -> None"',
+            message='Type of "User.__init__" is "(self: User, *, name: str) -> None"',
             line=18,
             column=13,
         ),


### PR DESCRIPTION
This should bring mypy plugin in sync with #1187

- Set `kw_only=True` in DataclassAttribute object
- Remove code to check that `Attributes without a default cannot follow attributes with one`

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
