### PR TITLE
Fix default value

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+This release fixes a small issue that might happen when
+uploading files and not passing the operations object.

--- a/strawberry/asgi/handlers/http_handler.py
+++ b/strawberry/asgi/handlers/http_handler.py
@@ -92,8 +92,9 @@ class HTTPHandler:
                     )
             elif content_type.startswith("multipart/form-data"):
                 multipart_data = await request.form()
-                operations = json.loads(multipart_data.get("operations", "{}"))
-                files_map = json.loads(multipart_data.get("map", "{}"))
+                operations_text = multipart_data.get("operations", "{}")
+                operations = json.loads(operations_text)  # type: ignore
+                files_map = json.loads(multipart_data.get("map", "{}"))  # type: ignore
 
                 data = replace_placeholders_with_files(
                     operations, files_map, multipart_data

--- a/strawberry/asgi/handlers/http_handler.py
+++ b/strawberry/asgi/handlers/http_handler.py
@@ -93,8 +93,8 @@ class HTTPHandler:
             elif content_type.startswith("multipart/form-data"):
                 multipart_data = await request.form()
                 operations_text = multipart_data.get("operations", "{}")
-                operations = json.loads(operations_text)  # type: ignore
-                files_map = json.loads(multipart_data.get("map", "{}"))  # type: ignore
+                operations = json.loads(operations_text)
+                files_map = json.loads(multipart_data.get("map", "{}"))
 
                 data = replace_placeholders_with_files(
                     operations, files_map, multipart_data

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -189,8 +189,9 @@ class GraphQLRouter(APIRouter):
                     return self._merge_responses(response, actual_response)
             elif content_type.startswith("multipart/form-data"):
                 multipart_data = await request.form()
-                operations = json.loads(multipart_data.get("operations", {}))
-                files_map = json.loads(multipart_data.get("map", {}))
+                operations_text = multipart_data.get("operations", "{}")
+                operations = json.loads(operations_text)  # type: ignore
+                files_map = json.loads(multipart_data.get("map", "{}"))  # type: ignore
                 data = replace_placeholders_with_files(
                     operations, files_map, multipart_data
                 )

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -190,8 +190,8 @@ class GraphQLRouter(APIRouter):
             elif content_type.startswith("multipart/form-data"):
                 multipart_data = await request.form()
                 operations_text = multipart_data.get("operations", "{}")
-                operations = json.loads(operations_text)  # type: ignore
-                files_map = json.loads(multipart_data.get("map", "{}"))  # type: ignore
+                operations = json.loads(operations_text)
+                files_map = json.loads(multipart_data.get("map", "{}"))
                 data = replace_placeholders_with_files(
                     operations, files_map, multipart_data
                 )


### PR DESCRIPTION
This PR fixes a potential issue I found in our fastapi integration, where we were doing: 

```python
operations = json.loads(multipart_data.get("operations", {}))
```

Which will fail when the operation keys is not set, as we passing a dictionary and not a string to `json.loads`

```text
>>> multipart_data = {}
>>> operations = json.loads(multipart_data.get("operations", {}))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/patrick/.asdf/installs/python/3.11-dev/lib/python3.11/json/__init__.py", line 339, in loads
    raise TypeError(f'the JSON object must be str, bytes or bytearray, '
TypeError: the JSON object must be str, bytes or bytearray, not dict
```