### PR TITLE
Experiment with using libgraphqlparser for query validation

### DIFF
--- a/strawberry/schema/execute.py
+++ b/strawberry/schema/execute.py
@@ -103,8 +103,14 @@ async def execute(
         if execution_context.operation_type not in allowed_operation_types:
             raise InvalidOperationTypeError(execution_context.operation_type)
 
-        async with extensions_runner.validation():
-            _run_validation(execution_context)
+        with extensions_runner.validation():
+            if hasattr(schema, "cpp_schema"):
+                from tartiflette.execution.collect import parse_and_validate_query
+
+                _, errors = parse_and_validate_query(query, schema.cpp_schema)
+                execution_context.errors = errors or []
+            else:
+                _run_validation(execution_context)
             if execution_context.errors:
                 return ExecutionResult(data=None, errors=execution_context.errors)
 
@@ -183,7 +189,13 @@ def execute_sync(
             raise InvalidOperationTypeError(execution_context.operation_type)
 
         with extensions_runner.validation():
-            _run_validation(execution_context)
+            if hasattr(schema, "cpp_schema"):
+                from tartiflette.execution.collect import parse_and_validate_query
+
+                _, errors = parse_and_validate_query(query, schema.cpp_schema)
+                execution_context.errors = errors or []
+            else:
+                _run_validation(execution_context)
             if execution_context.errors:
                 return ExecutionResult(data=None, errors=execution_context.errors)
 

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -131,8 +131,9 @@ class Schema(BaseSchema):
             raise ValueError(f"Invalid Schema. Errors:\n\n{formatted_errors}")
 
         if use_libgraphqlparser:
-            from tartiflette.schema.transformer import schema_from_sdl
             import json
+
+            from tartiflette.schema.transformer import schema_from_sdl
 
             self._schema.cpp_schema = schema_from_sdl(str(self), "CPPSchema")
             self._schema.cpp_schema.json_loader = json.loads

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -59,6 +59,7 @@ class Schema(BaseSchema):
             Dict[object, Union[ScalarWrapper, ScalarDefinition]]
         ] = None,
         schema_directives: Iterable[object] = (),
+        use_libgraphqlparser: bool = False,
     ):
         self.query = query
         self.mutation = mutation
@@ -128,6 +129,13 @@ class Schema(BaseSchema):
         if errors:
             formatted_errors = "\n\n".join(f"❌ {error.message}" for error in errors)
             raise ValueError(f"Invalid Schema. Errors:\n\n{formatted_errors}")
+
+        if use_libgraphqlparser:
+            from tartiflette.schema.transformer import schema_from_sdl
+            import json
+
+            self._schema.cpp_schema = schema_from_sdl(str(self), "CPPSchema")
+            self._schema.cpp_schema.json_loader = json.loads
 
     def get_extensions(
         self, sync: bool = False


### PR DESCRIPTION
Currently a bottleneck in performance is query validation using `graphql-core`, which can consume up to 75% of execution time for the synthetic query given below. Without requiring a larger internal refactor, a potential exists to increase runtime performance by using another library to perform *only* the validation step of the query, and still rely on `graphql-core` for performing document parsing / response creation. Preliminary benchmarks reveal that anywhere between a ~2-5x speed-up in validation performance can be achieved using this approach. Using different bindings this performance is expected to be even higher, see disclaimer below.

### Validation with `graphql-core`
![image](https://user-images.githubusercontent.com/29230371/192141156-07b64cc7-3795-4a15-b3f5-fcaed5584e27.png)

### Validation with `libgraphqlparser`
![image](https://user-images.githubusercontent.com/29230371/192141171-dc6f04da-358b-46da-9b70-2663de7c8bce.png)


<details>
  <summary>Benchmark Code</summary>

  ```python
from __future__ import annotations

from timeit import timeit

from pyinstrument import Profiler

import strawberry
from strawberry.types.info import Info


@strawberry.type
class Query:
    @strawberry.field
    def foo(self, info: Info) -> None:
        return None


for label, use_libgraphqlparser in {
    "libgraphqlparser": True,
    "graphql-core": False,
}.items():
    schema = strawberry.Schema(Query, use_libgraphqlparser=use_libgraphqlparser)
    profiler = Profiler(interval=0.0001)
    profiler.start()
    N = 10000
    duration = timeit(
        lambda: schema.execute_sync("query { foo }", root_value=Query()),
        number=N,
    )
    profiler.stop()
    with open(f"{label}.html", "w") as f:
        f.write(profiler.output_html())

  ```
</details>

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This commit adds a new `use_libgraphqlparser` argument to `strawberry.Schema` that parses queries using the CFFI bindings to [libgraphqlparser](https://github.com/graphql/libgraphqlparser) created by the developers of [tartiflette](https://github.com/tartiflette/tartiflette)

**Disclaimer**: This is a quick and dirty proof of concept and not intended to be representative of the desired implementation which would not dynamically link to `libgraphqlparser` using CFFI. Further experimentation is required into generating bindings to relevant portions of `libgraphqlparser` using `pybind11`, and compare that to using `pyo3` with [`apollo-rs`](https://github.com/apollographql/apollo-rs). As pointed out by @patrick91 during the discussion on Discord, `apollo-rs` would probably recieve quicker updates to new GraphQL specifications than `libgraphqlparser`.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
