### PR TITLE
Make pygments and python-multipart optional dependencies, expand extras

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,8 @@
+Release type: minor
+
+Reduce the number of required dependencies, by marking Pygments and python-multipart as optional. These dependencies are still necessary for some functionality, and so users of that functionality need to ensure they're installed, either explicitly or via an extra:
+
+- Pygments is still necessary when using Strawberry in debug mode, and is included in the `strawberry[debug-server]` extra.
+- python-multipart is still necessary when using `strawberry.file_uploads.Upload` with FastAPI or Starlette, and is included in the `strawberry[fastapi]` and `strawberry[asgi]` extras, respectively.
+
+There is now also the `strawberry[cli]` extra to support commands like `strawberry codegen` and `strawberry export-schema`.

--- a/docs/guides/file-upload.md
+++ b/docs/guides/file-upload.md
@@ -27,7 +27,7 @@ Since these integrations use asyncio for communication, the resolver _must_ be a
 
 Additionally, these servers rely on the `python-multipart` package, which is not included by Strawberry by default. It can be installed directly, or, for convenience, it is included in extras: `strawberry[asgi]` (for ASGI/Starlette) or `strawberry[fastapi]` (for FastAPI). For example:
 
-- if using Pip, `pip install 'strawbrry[fastapi]'`
+- if using Pip, `pip install 'strawberry[fastapi]'`
 - if using Poetry, `strawberry = { version = "...", extras = ["fastapi"] }` in `pyproject.toml`.
 
 Example:

--- a/docs/guides/file-upload.md
+++ b/docs/guides/file-upload.md
@@ -25,6 +25,11 @@ The type passed at runtime depends on the integration:
 
 Since these integrations use asyncio for communication, the resolver _must_ be async.
 
+Additionally, these servers rely on the `python-multipart` package, which is not included by Strawberry by default. It can be installed directly, or, for convenience, it is included in extras: `strawberry[asgi]` (for ASGI/Starlette) or `strawberry[fastapi]` (for FastAPI). For example:
+
+- if using Pip, `pip install 'strawbrry[fastapi]'`
+- if using Poetry, `strawberry = { version = "...", extras = ["fastapi"] }` in `pyproject.toml`.
+
 Example:
 
 ```python

--- a/poetry.lock
+++ b/poetry.lock
@@ -1730,12 +1730,12 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 
 [extras]
 aiohttp = ["aiohttp"]
-asgi = ["starlette"]
+asgi = ["starlette", "python-multipart"]
 chalice = ["chalice"]
 channels = ["channels", "asgiref"]
-debug-server = ["starlette", "uvicorn"]
+debug-server = ["starlette", "uvicorn", "python-multipart"]
 django = ["Django", "asgiref"]
-fastapi = ["fastapi"]
+fastapi = ["fastapi", "python-multipart"]
 flask = ["flask"]
 opentelemetry = ["opentelemetry-api", "opentelemetry-sdk"]
 pydantic = ["pydantic"]
@@ -1744,7 +1744,7 @@ sanic = ["sanic"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "ae22545c6b08c8983df81d5fbf70cbf21768e731e742fc069a3886afde42f103"
+content-hash = "e48a5aed0649f9dc9e4f2ef7f3786e83a236412011347af81c4c00b306e37096"
 
 [metadata.files]
 aiofiles = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -1733,7 +1733,8 @@ aiohttp = ["aiohttp"]
 asgi = ["starlette", "python-multipart"]
 chalice = ["chalice"]
 channels = ["channels", "asgiref"]
-debug-server = ["starlette", "uvicorn", "python-multipart"]
+cli = ["click", "pygments"]
+debug-server = ["starlette", "uvicorn", "python-multipart", "click", "pygments"]
 django = ["Django", "asgiref"]
 fastapi = ["fastapi", "python-multipart"]
 flask = ["flask"]
@@ -1744,7 +1745,7 @@ sanic = ["sanic"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "e48a5aed0649f9dc9e4f2ef7f3786e83a236412011347af81c4c00b306e37096"
+content-hash = "5b131a9e6ef8b877f8100d3f7b827f73e59cd63b4df12060741e184fa019da70"
 
 [metadata.files]
 aiofiles = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ build-backend = "poetry.masonry.api"
 python = "^3.7"
 starlette = {version = ">=0.13.6", optional = true}
 click = {version = ">=7.0,<9.0", optional = true}
-pygments = "^2.3"
+pygments = {version = "^2.3", optional = true}
 uvicorn = {version = ">=0.11.6,<0.19.0", optional = true}
 Django = {version = ">=3.2", optional = true}
 graphql-core = "~3.2.0"
@@ -104,11 +104,12 @@ MarkupSafe = "2.1.1"
 pytest-snapshot = "^0.9.0"
 channels = "^3.0.5"
 python-multipart = "^0.0.5"
+pygments = "^2.3"
 
 [tool.poetry.extras]
 aiohttp = ["aiohttp", "pytest-aiohttp"]
 asgi = ["starlette", "python-multipart"]
-debug-server = ["starlette", "uvicorn", "python-multipart"]
+debug-server = ["starlette", "uvicorn", "python-multipart", "click", "pygments"]
 django = ["Django", "pytest-django", "asgiref"]
 channels = ["channels", "asgiref"]
 flask = ["flask", "pytest-flask"]
@@ -117,6 +118,7 @@ pydantic = ["pydantic"]
 sanic = ["sanic"]
 fastapi = ["fastapi", "python-multipart"]
 chalice = ["chalice"]
+cli = ["click", "pygments"]
 
 [tool.poetry.scripts]
 strawberry = "strawberry.cli:run"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,26 +33,28 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry.dependencies]
 python = "^3.7"
+
+graphql-core = "~3.2.0"
+typing_extensions = ">=3.7.4,<5.0.0"
+python-dateutil = "^2.7.0"
+"backports.cached-property" = {version = "^1.0.2", python = "<3.8"}
+
 starlette = {version = ">=0.13.6", optional = true}
 click = {version = ">=7.0,<9.0", optional = true}
 pygments = {version = "^2.3", optional = true}
 uvicorn = {version = ">=0.11.6,<0.19.0", optional = true}
 Django = {version = ">=3.2", optional = true}
-graphql-core = "~3.2.0"
 asgiref = {version = "^3.2", optional = true}
 flask = {version = ">=1.1", optional = true}
-typing_extensions = ">=3.7.4,<5.0.0"
 opentelemetry-api = {version = "<2", optional = true}
 opentelemetry-sdk = {version = "<2", optional = true}
 chalice = {version = "^1.22", optional = true}
-python-dateutil = "^2.7.0"
 pydantic = {version = "<2", optional = true}
 python-multipart = {version = "^0.0.5", optional = true}
 sanic = {version = ">=20.12.2,<22.0.0", optional = true}
 aiohttp = {version = "^3.7.4.post0", optional = true}
 fastapi = {version = ">=0.65.2", optional = true}
 channels = {version = ">=3.0.5", optional = true}
-"backports.cached-property" = {version = "^1.0.2", python = "<3.8"}
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ opentelemetry-sdk = {version = "<2", optional = true}
 chalice = {version = "^1.22", optional = true}
 python-dateutil = "^2.7.0"
 pydantic = {version = "<2", optional = true}
-python-multipart = "^0.0.5"
+python-multipart = {version = "^0.0.5", optional = true}
 sanic = {version = ">=20.12.2,<22.0.0", optional = true}
 aiohttp = {version = "^3.7.4.post0", optional = true}
 fastapi = {version = ">=0.65.2", optional = true}
@@ -103,18 +103,19 @@ pytest-xprocess = "^0.20.0"
 MarkupSafe = "2.1.1"
 pytest-snapshot = "^0.9.0"
 channels = "^3.0.5"
+python-multipart = "^0.0.5"
 
 [tool.poetry.extras]
 aiohttp = ["aiohttp", "pytest-aiohttp"]
-asgi = ["starlette"]
-debug-server = ["starlette", "uvicorn"]
+asgi = ["starlette", "python-multipart"]
+debug-server = ["starlette", "uvicorn", "python-multipart"]
 django = ["Django", "pytest-django", "asgiref"]
 channels = ["channels", "asgiref"]
 flask = ["flask", "pytest-flask"]
 opentelemetry = ["opentelemetry-api", "opentelemetry-sdk"]
 pydantic = ["pydantic"]
 sanic = ["sanic"]
-fastapi = ["fastapi"]
+fastapi = ["fastapi", "python-multipart"]
 chalice = ["chalice"]
 
 [tool.poetry.scripts]

--- a/strawberry/utils/debug.py
+++ b/strawberry/utils/debug.py
@@ -3,11 +3,6 @@ import json
 from json import JSONEncoder
 from typing import Any, Dict, Optional
 
-from pygments import highlight, lexers
-from pygments.formatters import Terminal256Formatter
-
-from .graphql_lexer import GraphQLLexer
-
 
 class StrawberryJSONEncoder(JSONEncoder):
     def default(self, o: Any) -> Any:
@@ -20,6 +15,17 @@ def pretty_print_graphql_operation(
     """Pretty print a GraphQL operation using pygments.
 
     Won't print introspection operation to prevent noise in the output."""
+
+    try:
+        from pygments import highlight, lexers
+        from pygments.formatters import Terminal256Formatter
+    except ImportError as e:
+        raise ImportError(
+            "pygments is not installed but is required for debug output, install it "
+            "directly or run `pip install strawberry-graphql[debug-server]`"
+        ) from e
+
+    from .graphql_lexer import GraphQLLexer
 
     if operation_name == "IntrospectionQuery":
         return


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This PR reduces the number of required dependencies, by marking Pygments and python-multipart as optional. These dependencies are still necessary for some functionality, and so the extras have been expanded:

- Pygments is still necessary when using Strawberry in debug mode, and is included in the `strawberry[debug-server]` extra.
- python-multipart is still necessary when using `strawberry.file_uploads.Upload` with FastAPI or Starlette, and is included in the `strawberry[fastapi]` and `strawberry[asgi]` extras, respectively.
- Following the suggestion on #1460, I also added the `strawberry[cli]` extra including `click` and `pygments`. This is presumably to support commands like `strawberry codegen` and `strawberry export-schema`, so I'm not entirely sure that `pygments` is necessary here?

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Closes #1460 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
