### PR TITLE
Fix defaults for strawberry.federation.field

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+This release fixes an issue with `strawberry.federation.field` that
+prevented instantiating field when passing a resolver function.

--- a/strawberry/federation/field.py
+++ b/strawberry/federation/field.py
@@ -1,3 +1,4 @@
+import dataclasses
 from typing import (
     Any,
     Callable,
@@ -106,8 +107,8 @@ def field(
     inaccessible: bool = False,
     permission_classes: Optional[List[Type[BasePermission]]] = None,
     deprecation_reason: Optional[str] = None,
-    default: Any = UNSET,
-    default_factory: Union[Callable[..., object], object] = UNSET,
+    default: Any = dataclasses.MISSING,
+    default_factory: Union[Callable[..., object], object] = dataclasses.MISSING,
     directives: Sequence[object] = (),
     # This init parameter is used by PyRight to determine whether this field
     # is added in the constructor or not. It is not used to change

--- a/tests/federation/test_schema.py
+++ b/tests/federation/test_schema.py
@@ -162,7 +162,7 @@ def test_using_generics():
     class Query:
         @strawberry.field
         def top_products(self, first: int) -> ListOfProducts[Product]:
-            return ListOfProducts([])
+            return ListOfProducts(products=[])
 
     schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
 

--- a/tests/federation/test_types.py
+++ b/tests/federation/test_types.py
@@ -1,0 +1,34 @@
+import strawberry
+
+
+def test_type():
+    @strawberry.federation.type(keys=["id"])
+    class Location:
+        id: strawberry.ID
+
+    assert Location(id=strawberry.ID("1")).id == "1"
+
+
+def test_type_and_override():
+    @strawberry.federation.type(keys=["id"])
+    class Location:
+        id: strawberry.ID
+        address: str = strawberry.federation.field(override="start")
+
+    location = Location(id=strawberry.ID("1"), address="ABC")
+
+    assert location.id == "1"
+    assert location.address == "ABC"
+
+
+def test_type_and_override_with_resolver():
+    @strawberry.federation.type(keys=["id"])
+    class Location:
+        id: strawberry.ID
+        address: str = strawberry.federation.field(
+            override="start", resolver=lambda: "ABC"
+        )
+
+    location = Location(id=strawberry.ID("1"))
+
+    assert location.id == "1"


### PR DESCRIPTION
This PR fixes the defaults of strawberry.federation.field.

This issue prevented the following from working:

```python
@strawberry.federation.type(keys=["id"])
class Location:
    id: strawberry.ID
    address: str = strawberry.federation.field(
        override="start", resolver=lambda: "ABC"
    )

location = Location(id=strawberry.ID("1"))
```
