### PR TITLE
Fix typing for `strawberry.federation.field`

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,15 @@
+Release type: patch
+
+This release fixes the type of strawberry.federation.field,
+this will prevent errors from mypy and pyright when doing the following:
+
+```python
+@strawberry.federation.type(keys=["id"])
+class Location:
+    id: strawberry.ID
+
+    # the following field was reporting an error in mypy and pylance
+    celestial_body: CelestialBody = strawberry.federation.field(
+        resolver=resolve_celestial_body
+    )
+```

--- a/strawberry/federation/field.py
+++ b/strawberry/federation/field.py
@@ -25,7 +25,7 @@ T = TypeVar("T")
 @overload
 def field(
     *,
-    resolver: Callable[[], T],
+    resolver: _RESOLVER_TYPE[T],
     name: Optional[str] = None,
     is_subscription: bool = False,
     description: Optional[str] = None,

--- a/tests/mypy/federation/test_fields.yml
+++ b/tests/mypy/federation/test_fields.yml
@@ -19,12 +19,15 @@
     def some_resolver() -> str:
         return ""
 
+    def some_resolver_2(root: "Example") -> str:
+        return ""
+
     @strawberry.type
     class Example:
         a: str
         b: str = strawberry.federation.field(name="b")
         c: str = strawberry.federation.field(name="c", resolver=some_resolver)
-        d: str = strawberry.federation.field(resolver=some_resolver)
+        d: str = strawberry.federation.field(resolver=some_resolver_2)
 
         @strawberry.federation.field(description="ABC")
         def e(self, info: Info) -> str:
@@ -41,12 +44,12 @@
     reveal_type(Example.e)
     reveal_type(Example.f_resolver)
   out: |
-    main:22: note: Revealed type is "builtins.str"
-    main:23: note: Revealed type is "builtins.str"
-    main:24: note: Revealed type is "builtins.str"
     main:25: note: Revealed type is "builtins.str"
-    main:26: note: Revealed type is "Any"
-    main:27: note: Revealed type is "Any"
+    main:26: note: Revealed type is "builtins.str"
+    main:27: note: Revealed type is "builtins.str"
+    main:28: note: Revealed type is "builtins.str"
+    main:29: note: Revealed type is "Any"
+    main:30: note: Revealed type is "Any"
 
 - case: test_private_field
   main: |

--- a/tests/pyright/test_federation_fields.py
+++ b/tests/pyright/test_federation_fields.py
@@ -6,11 +6,18 @@ pytestmark = [skip_on_windows, requires_pyright]
 CODE = """
 import strawberry
 
+def some_resolver(root: "User") -> str:
+    return "An address"
+
+def some_resolver_2() -> str:
+    return "Another address"
 
 @strawberry.federation.type
 class User:
     age: int = strawberry.federation.field(description="Age")
     name: str
+    address: str = strawberry.federation.field(resolver=some_resolver)
+    another_address: str = strawberry.federation.field(resolver=some_resolver_2)
 
 @strawberry.federation.input
 class UserInput:
@@ -39,45 +46,45 @@ def test_pyright():
         Result(
             type="error",
             message='No parameter named "n" (reportGeneralTypeIssues)',
-            line=17,
+            line=24,
             column=6,
         ),
         Result(
             type="error",
             message='Argument missing for parameter "name" (reportGeneralTypeIssues)',
-            line=17,
+            line=24,
             column=1,
         ),
         Result(
             type="error",
             message='No parameter named "n" (reportGeneralTypeIssues)',
-            line=20,
+            line=27,
             column=11,
         ),
         Result(
             type="error",
             message='Argument missing for parameter "name" '
             "(reportGeneralTypeIssues)",
-            line=20,
+            line=27,
             column=1,
         ),
         Result(
             type="information",
             message='Type of "User" is "Type[User]"',
-            line=22,
+            line=29,
             column=13,
         ),
         Result(
             type="information",
             message='Type of "User.__init__" is "(self: User, *, age: int, name: str) '
             '-> None"',
-            line=23,
+            line=30,
             column=13,
         ),
         Result(
             type="information",
             message='Type of "UserInput" is "Type[UserInput]"',
-            line=25,
+            line=32,
             column=13,
         ),
         Result(
@@ -86,7 +93,7 @@ def test_pyright():
                 'Type of "UserInput.__init__" is "(self: UserInput, *, age: int, '
                 'name: str) -> None"'
             ),
-            line=26,
+            line=33,
             column=13,
         ),
     ]


### PR DESCRIPTION
The following was throwing an error in mypy and pyright:

```python
@strawberry.federation.type(keys=["id"])
class Location:
    id: strawberry.ID
    celestial_body: CelestialBody = strawberry.federation.field(
        resolver=resolve_celestial_body
    )
```

This PR fixes it :)

This wasn't happening when passing a resolver that didn't accept any argument