### PR TITLE
Print schema directive on INPUT_FIELD_DEFINITION

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,26 @@
+Release type: patch
+
+This release add support for printing schema directives on an input type object, for example the following schema:
+
+```python
+@strawberry.schema_directive(locations=[Location.INPUT_FIELD_DEFINITION])
+class RangeInput:
+    min: int
+    max: int
+
+@strawberry.input
+class CreateUserInput:
+    name: str
+    age: int = strawberry.field(directives=[ValidRange(min=1, max=100)])
+```
+
+prints the following:
+
+```graphql
+directive @rangeInput(min: Int!, max: Int!) on INPUT_FIELD_DEFINITIO
+
+input Input @sensitiveInput(reason: "GDPR") {
+  firstName: String!
+  age: Int! @rangeInput(min: 1, max: 100)
+}
+```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
 Release type: patch
 
-This release add support for printing schema directives on an input type object, for example the following schema:
+This release adds support for printing schema directives on an input type object, for example the following schema:
 
 ```python
 @strawberry.schema_directive(locations=[Location.INPUT_FIELD_DEFINITION])

--- a/strawberry/printer/printer.py
+++ b/strawberry/printer/printer.py
@@ -400,10 +400,19 @@ def print_input_value(name: str, arg: GraphQLArgument) -> str:
 
 
 def _print_input_object(type_, schema: BaseSchema, *, extras: PrintExtras) -> str:
-    fields = [
-        print_description(field, "  ", not i) + "  " + print_input_value(name, field)
-        for i, (name, field) in enumerate(type_.fields.items())
-    ]
+    fields = []
+    for i, (name, field) in enumerate(type_.fields.items()):
+        strawberry_field = field.extensions and field.extensions.get(
+            GraphQLCoreConverter.DEFINITION_BACKREF
+        )
+
+        fields.append(
+            print_description(field, "  ", not i)
+            + "  "
+            + print_input_value(name, field)
+            + print_field_directives(strawberry_field, schema=schema, extras=extras)
+        )
+
     return (
         print_description(type_)
         + f"input {type_.name}"

--- a/tests/federation/printer/test_inaccessible.py
+++ b/tests/federation/printer/test_inaccessible.py
@@ -54,7 +54,7 @@ def test_field_inaccessible_printed_correctly():
         }
 
         input AnInput @inaccessible {
-          id: ID!
+          id: ID! @inaccessible
         }
 
         interface AnInterface @inaccessible {

--- a/tests/federation/printer/test_tag.py
+++ b/tests/federation/printer/test_tag.py
@@ -226,7 +226,7 @@ def test_tag_printed_correctly_on_inputs():
         }
 
         input Input @tag(name: "myTag") @tag(name: "anotherTag") {
-          a: String!
+          a: String! @tag(name: "myTag") @tag(name: "anotherTag")
         }
 
         type Query {


### PR DESCRIPTION
This PR adds support for printing schema directives on an input type object, for example the following schema:

```python
@strawberry.schema_directive(locations=[Location.INPUT_FIELD_DEFINITION])
class RangeInput:
    min: int
    max: int

@strawberry.input
class CreateUserInput:
    name: str
    age: int = strawberry.field(directives=[RangeInput(min=1, max=100)])
```

prints the following:

```graphql
directive @rangeInput(min: Int!, max: Int!) on INPUT_FIELD_DEFINITION

input Input @sensitiveInput(reason: "GDPR") {
  firstName: String!
  age: Int! @rangeInput(min: 1, max: 100)
}
```