### PR TITLE
Allow custom url in GraphQLTestClient

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,16 @@
+Release type: minor
+
+These release allow you to define a different `url` in the `GraphQLTestClient`, the default is "/graphql/".
+
+Here's an example with Starlette client:
+```python
+import pytest
+
+from starlette.testclient import TestClient
+from strawberry.asgi.test import GraphQLTestClient
+
+
+@pytest.fixture
+def graphql_client() -> GraphQLTestClient:
+    return GraphQLTestClient(TestClient(app, base_url="http://localhost:8000"), url="/api/")
+```

--- a/strawberry/aiohttp/test/client.py
+++ b/strawberry/aiohttp/test/client.py
@@ -35,7 +35,7 @@ class GraphQLTestClient(BaseGraphQLTestClient):
         files: Optional[Dict[str, object]] = None,
     ):
         response = await self._client.post(
-            "/graphql",
+            self.url,
             json=body if not files else None,
             data=body if files else None,
         )

--- a/strawberry/asgi/test/client.py
+++ b/strawberry/asgi/test/client.py
@@ -37,7 +37,7 @@ class GraphQLTestClient(BaseGraphQLTestClient):
         files: Optional[Dict[str, object]] = None,
     ):
         return self._client.post(
-            "/graphql/",
+            self.url,
             json=body if not files else None,
             data=body if files else None,
             files=files,

--- a/strawberry/django/test/client.py
+++ b/strawberry/django/test/client.py
@@ -12,9 +12,9 @@ class GraphQLTestClient(BaseGraphQLTestClient):
     ):
         if files:
             return self._client.post(
-                "/graphql/", data=body, format="multipart", headers=headers
+                self.url, data=body, format="multipart", headers=headers
             )
 
         return self._client.post(
-            "/graphql/", data=body, content_type="application/json", headers=headers
+            self.url, data=body, content_type="application/json", headers=headers
         )

--- a/strawberry/test/client.py
+++ b/strawberry/test/client.py
@@ -21,8 +21,9 @@ class Body(TypedDict, total=False):
 
 
 class BaseGraphQLTestClient(ABC):
-    def __init__(self, client):
+    def __init__(self, client, url: str = "/graphql/"):
         self._client = client
+        self.url = url
 
     def query(
         self,

--- a/tests/aiohttp/conftest.py
+++ b/tests/aiohttp/conftest.py
@@ -22,4 +22,4 @@ async def aiohttp_app_client_no_get(event_loop, aiohttp_client):
 
 @pytest.fixture
 def graphql_client(aiohttp_app_client):
-    yield GraphQLTestClient(aiohttp_app_client)
+    yield GraphQLTestClient(aiohttp_app_client, url="/graphql")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->
This PR allows to configure the url in the `GraphQLTestClient`. Was fixed to `/graphql/` before. 
 
## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
