### PR TITLE
Fix strawberry.lazy() when using relative modules

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,11 @@
 Release type: patch
 
-Fix wrong stack frame being used in strawberry.lazy()
+This release fixes an issue that prevented using strawberry.lazy with relative paths.
+
+The following should work now:
+
+```python
+@strawberry.type
+class TypeA:
+    b: Annotated["TypeB", strawberry.lazy(".type_b")]
+```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Fix wrong stack frame being used in strawberry.lazy()

--- a/strawberry/lazy_type.py
+++ b/strawberry/lazy_type.py
@@ -58,8 +58,7 @@ class StrawberryLazyReference:
             frame = inspect.stack()[2][0]
             # TODO: raise a nice error if frame is None
             assert frame is not None
-            assert frame.f_back is not None
-            self.package = cast(str, frame.f_back.f_globals["__package__"])
+            self.package = cast(str, frame.f_globals["__package__"])
 
     def resolve_forward_ref(self, forward_ref: ForwardRef) -> LazyType:
         return LazyType(forward_ref.__forward_arg__, self.module, self.package)

--- a/tests/schema/test_lazy/type_a.py
+++ b/tests/schema/test_lazy/type_a.py
@@ -8,15 +8,19 @@ import strawberry
 if TYPE_CHECKING:
     from .type_b import TypeB
 
+    TypeB_rel = TypeB
+    TypeB_abs = TypeB
+else:
+    TypeB_rel = Annotated["TypeB", strawberry.lazy(".type_b")]
+    TypeB_abs = Annotated["TypeB", strawberry.lazy("tests.schema.test_lazy.type_b")]
+
 
 @strawberry.type
 class TypeA:
-    list_of_b: Optional[
-        List[Annotated["TypeB", strawberry.lazy("tests.schema.test_lazy.type_b")]]
-    ] = None
+    list_of_b: Optional[List[TypeB_abs]] = None
 
     @strawberry.field
-    def type_b(self) -> Annotated["TypeB", strawberry.lazy(".type_b")]:
+    def type_b(self) -> TypeB_rel:
         from .type_b import TypeB
 
         return TypeB()

--- a/tests/schema/test_lazy/type_b.py
+++ b/tests/schema/test_lazy/type_b.py
@@ -7,6 +7,8 @@ import strawberry
 
 if TYPE_CHECKING:
     from .type_a import TypeA
+else:
+    TypeA = Annotated["TypeA", strawberry.lazy("tests.schema.test_lazy_types.type_a")]
 
 
 @strawberry.type
@@ -14,7 +16,7 @@ class TypeB:
     @strawberry.field()
     def type_a(
         self,
-    ) -> Annotated["TypeA", strawberry.lazy("tests.schema.test_lazy_types.type_a")]:
+    ) -> TypeA:
         from .type_a import TypeA
 
         return TypeA()


### PR DESCRIPTION
When using `Annotated["SomeType", lazy(".some_module")]`, the call stack is inspected to fetch the proper __package__ necessary to resolve `.some_module`.

There was a mistake where the wrong frame was being inspected (4rd frame instead of 3rd).

This wasn't caught in the tests previously because there were 2 frames for `type_a.py` when calling `lazy()` inside a class definition:

```
  File "/media/Paulo/Workspace/pass2go/strawberry/tests/schema/test_lazy/type_a.py", line 13, in <module>
    class TypeA:
  File "/media/Paulo/Workspace/pass2go/strawberry/tests/schema/test_lazy/type_a.py", line 19, in TypeA
    def type_b(self) -> Annotated["TypeB", strawberry.lazy(".type_b")]:
  File "/media/Paulo/Workspace/pass2go/strawberry/strawberry/lazy_type.py", line 70, in lazy
    return StrawberryLazyReference(module_path)
  File "/media/Paulo/Workspace/pass2go/strawberry/strawberry/lazy_type.py", line 61, in __init__
    frame = inspect.stack()[2][0]
```

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
