### PR TITLE
Fix support for arguments where `arg.type=LazyType["EnumType"]`

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Fix support for arguments where `arg.type=LazyType["EnumType"]`

--- a/strawberry/arguments.py
+++ b/strawberry/arguments.py
@@ -158,6 +158,10 @@ def convert_argument(
     if isinstance(type_, LazyType):
         return convert_argument(value, type_.resolve_type(), scalar_registry, config)
 
+    if hasattr(type_, "_enum_definition"):
+        enum_definition: EnumDefinition = type_._enum_definition  # type: ignore
+        return convert_argument(value, enum_definition, scalar_registry, config)
+
     if hasattr(type_, "_type_definition"):  # TODO: Replace with StrawberryInputObject
         type_definition: TypeDefinition = type_._type_definition  # type: ignore
 

--- a/tests/schema/test_enum.py
+++ b/tests/schema/test_enum.py
@@ -5,7 +5,10 @@ from typing import List, Optional
 
 import pytest
 
+from typing_extensions import Annotated
+
 import strawberry
+from strawberry.lazy_type import lazy
 
 
 def test_enum_resolver():
@@ -98,6 +101,25 @@ def test_enum_arguments():
 
     assert not result.errors
     assert result.data["eatCone"] is True
+
+
+def test_lazy_enum_arguments():
+    LazyEnum = Annotated[
+        "LazyEnum", lazy("tests.schema.test_lazy_types.test_lazy_enums")
+    ]
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def something(self, enum: LazyEnum) -> LazyEnum:
+            return enum
+
+    schema = strawberry.Schema(query=Query)
+
+    query = "{ something(enum: BREAD) }"
+    result = schema.execute_sync(query)
+    assert not result.errors
+    assert result.data["something"] == "BREAD"
 
 
 def test_enum_falsy_values():


### PR DESCRIPTION
## Description

`convert_argument` is usually called with `type=EnumDefinition(...)`, which works fine.

However if the type is a lazy type, it is called initially with `type=LazyType["EnumType"]`, and then with `type=EnumType`.

Code was missing to convert the EnumType into an EnumDefinition

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
