### PR TITLE
Add MaskErrors extension

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,8 @@
 Release type: minor
 
 This release adds a new `MaskErrors` extension that can be used to hide error
-messages from the client to prevent exposing sensitive details.
+messages from the client to prevent exposing sensitive details. By default it
+masks all errors raised in any field resolver.
 
 ```python
 import strawberry
@@ -10,7 +11,7 @@ from strawberry.extensions import MaskErrors
 schema = strawberry.Schema(
     Query,
     extensions=[
-        MaskErrors(visible_errors=[MyVisibleError]),
+        MaskErrors(),
     ]
 )
 ```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,16 @@
+Release type: minor
+
+This release adds a new `MaskErrors` extension that can be used to hide error
+messages from the client to prevent exposing sensitive details.
+
+```python
+import strawberry
+from strawberry.extensions import MaskErrors
+
+schema = strawberry.Schema(
+    Query,
+    extensions=[
+        MaskErrors(visible_errors=[MyVisibleError]),
+    ]
+)
+```

--- a/docs/extensions/mask-errors.md
+++ b/docs/extensions/mask-errors.md
@@ -1,0 +1,63 @@
+---
+title: MaskErrors
+summary: Hide error messages from the client.
+tags: security
+---
+
+# `MaskErrors`
+
+This extension hides error messages from the client to prevent exposing
+sensitive details.
+
+## Usage example:
+
+```python
+import strawberry
+from strawberry.extensions import MaskErrors
+
+schema = strawberry.Schema(
+    Query,
+    extensions=[
+        MaskErrors(visible_errors=[MyVisibleError]),
+    ]
+)
+```
+
+## API reference:
+
+```python
+class MaskErrors(visible_errors, error_message="Unexpected error.")`
+```
+
+#### `visible_errors: Sequence[Type[Exception]]`
+
+A sequence of exceptions that shouldn't be masked from the client.
+
+<Note>
+
+Passing an empty list will mask all errors.
+
+</Note>
+
+#### `error_message: str = "Unexpected error."`
+
+The error message to display to the client when there is an error.
+
+## More examples:
+
+<details>
+  <summary>Hide all exceptions</summary>
+
+```python
+import strawberry
+from strawberry.extensions import MaskErrors
+
+schema = strawberry.Schema(
+    Query,
+    extensions=[
+        MaskErrors(visible_errors=[]),
+    ]
+)
+```
+
+</details>

--- a/strawberry/extensions/__init__.py
+++ b/strawberry/extensions/__init__.py
@@ -1,6 +1,7 @@
 from .add_validation_rules import AddValidationRules
 from .base_extension import Extension
 from .disable_validation import DisableValidation
+from .mask_errors import MaskErrors
 from .parser_cache import ParserCache
 from .query_depth_limiter import QueryDepthLimiter
 from .validation_cache import ValidationCache
@@ -13,4 +14,5 @@ __all__ = [
     "ParserCache",
     "QueryDepthLimiter",
     "ValidationCache",
+    "MaskErrors",
 ]

--- a/strawberry/extensions/mask_errors.py
+++ b/strawberry/extensions/mask_errors.py
@@ -1,4 +1,4 @@
-from collections.abc import Callable
+from typing import Callable
 
 from graphql.error import GraphQLError
 

--- a/strawberry/extensions/mask_errors.py
+++ b/strawberry/extensions/mask_errors.py
@@ -1,0 +1,54 @@
+from typing import Sequence, Type
+
+from graphql.error import GraphQLError
+
+from strawberry.extensions import Extension
+
+
+class MaskErrors(Extension):
+    visible_errors: Sequence[Type[Exception]]
+    error_message: str
+
+    def __init__(
+        self,
+        visible_errors: Sequence[Type[Exception]],
+        error_message: str = "Unexpected error.",
+    ):
+        self.visible_errors = visible_errors
+        self.error_message = error_message
+
+    def __call__(self, execution_context):
+        self.execution_context = execution_context
+        return self
+
+    def anonymise_error(self, error: GraphQLError) -> GraphQLError:
+        return GraphQLError(
+            message=self.error_message,
+            nodes=error.nodes,
+            source=error.source,
+            positions=error.positions,
+            path=error.path,
+            original_error=None,
+        )
+
+    def on_request_end(self):
+        result = self.execution_context.result
+        if result and result.errors:
+            processed_errors = []
+            for error in result.errors:
+                if not error.original_error:
+                    processed_errors.append(error)
+                else:
+                    original_error = error.original_error
+
+                    if not self.visible_errors:
+                        # anonymise all errors
+                        processed_errors.append(self.anonymise_error(error))
+                    else:
+                        for visible_error_cls in self.visible_errors:
+                            if not isinstance(original_error, visible_error_cls):
+                                processed_errors.append(self.anonymise_error(error))
+                            else:
+                                processed_errors.append(error)
+
+            result.errors = processed_errors

--- a/strawberry/extensions/mask_errors.py
+++ b/strawberry/extensions/mask_errors.py
@@ -22,10 +22,6 @@ class MaskErrors(Extension):
         self.should_mask_error = should_mask_error
         self.error_message = error_message
 
-    def __call__(self, execution_context):
-        self.execution_context = execution_context
-        return self
-
     def anonymise_error(self, error: GraphQLError) -> GraphQLError:
         return GraphQLError(
             message=self.error_message,

--- a/strawberry/schema/execute.py
+++ b/strawberry/schema/execute.py
@@ -1,4 +1,5 @@
 from asyncio import ensure_future
+from collections.abc import Callable
 from inspect import isawaitable
 from typing import (
     Awaitable,
@@ -67,6 +68,7 @@ async def execute(
     extensions: Sequence[Union[Type[Extension], Extension]],
     execution_context: ExecutionContext,
     execution_context_class: Optional[Type[GraphQLExecutionContext]] = None,
+    process_errors: Callable[[List[GraphQLError], Optional[ExecutionContext]], None],
 ) -> ExecutionResult:
     extensions_runner = ExtensionsRunner(
         execution_context=execution_context,
@@ -131,6 +133,12 @@ async def execute(
                 if result.errors:
                     execution_context.errors = result.errors
 
+                    # Run the `Schema.process_errors` function here before
+                    # extensions have a chance to modify them (see the MaskErrors
+                    # extension). That way we can log the original errors but
+                    # only return a sanitised version to the client.
+                    process_errors(result.errors, execution_context)
+
     return ExecutionResult(
         data=execution_context.result.data,
         errors=execution_context.result.errors,
@@ -146,6 +154,7 @@ def execute_sync(
     extensions: Sequence[Union[Type[Extension], Extension]],
     execution_context: ExecutionContext,
     execution_context_class: Optional[Type[GraphQLExecutionContext]] = None,
+    process_errors: Callable[[List[GraphQLError], Optional[ExecutionContext]], None],
 ) -> ExecutionResult:
     extensions_runner = ExtensionsRunner(
         execution_context=execution_context,
@@ -213,6 +222,12 @@ def execute_sync(
                 # to access in extensions
                 if result.errors:
                     execution_context.errors = result.errors
+
+                    # Run the `Schema.process_errors` function here before
+                    # extensions have a chance to modify them (see the MaskErrors
+                    # extension). That way we can log the original errors but
+                    # only return a sanitised version to the client.
+                    process_errors(result.errors, execution_context)
 
     return ExecutionResult(
         data=execution_context.result.data,

--- a/strawberry/schema/execute.py
+++ b/strawberry/schema/execute.py
@@ -1,8 +1,8 @@
 from asyncio import ensure_future
-from collections.abc import Callable
 from inspect import isawaitable
 from typing import (
     Awaitable,
+    Callable,
     Iterable,
     List,
     Optional,

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -210,10 +210,8 @@ class Schema(BaseSchema):
             execution_context_class=self.execution_context_class,
             execution_context=execution_context,
             allowed_operation_types=allowed_operation_types,
+            process_errors=self.process_errors,
         )
-
-        if result.errors:
-            self.process_errors(result.errors, execution_context=execution_context)
 
         return result
 
@@ -245,10 +243,8 @@ class Schema(BaseSchema):
             execution_context_class=self.execution_context_class,
             execution_context=execution_context,
             allowed_operation_types=allowed_operation_types,
+            process_errors=self.process_errors,
         )
-
-        if result.errors:
-            self.process_errors(result.errors, execution_context=execution_context)
 
         return result
 

--- a/tests/schema/extensions/test_mask_errors.py
+++ b/tests/schema/extensions/test_mask_errors.py
@@ -1,12 +1,36 @@
 from unittest.mock import Mock
 
+from graphql.error import GraphQLError
 from graphql.error.graphql_error import format_error as format_graphql_error
 
 import strawberry
 from strawberry.extensions import MaskErrors
 
 
-def test_mask_errors():
+def test_mask_all_errors():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def hidden_error(self) -> str:
+            raise KeyError("This error is not visible")
+
+    schema = strawberry.Schema(query=Query, extensions=[MaskErrors()])
+
+    query = "query { hiddenError }"
+
+    result = schema.execute_sync(query)
+    assert result.errors is not None
+    formatted_errors = [format_graphql_error(err) for err in result.errors]
+    assert formatted_errors == [
+        {
+            "locations": [{"column": 9, "line": 1}],
+            "message": "Unexpected error.",
+            "path": ["hiddenError"],
+        }
+    ]
+
+
+def test_mask_some_errors():
     class VisibleError(Exception):
         pass
 
@@ -20,8 +44,14 @@ def test_mask_errors():
         def hidden_error(self) -> str:
             raise Exception("This error is not visible")
 
+    def should_mask_error(error: GraphQLError) -> bool:
+        original_error = error.original_error
+        if original_error and isinstance(original_error, VisibleError):
+            return False
+        return True
+
     schema = strawberry.Schema(
-        query=Query, extensions=[MaskErrors(visible_errors=[VisibleError])]
+        query=Query, extensions=[MaskErrors(should_mask_error=should_mask_error)]
     )
 
     query = "query { hiddenError }"
@@ -51,29 +81,6 @@ def test_mask_errors():
     ]
 
 
-def test_mask_all_errors():
-    @strawberry.type
-    class Query:
-        @strawberry.field
-        def hidden_error(self) -> str:
-            raise KeyError("This error is not visible")
-
-    schema = strawberry.Schema(query=Query, extensions=[MaskErrors(visible_errors=[])])
-
-    query = "query { hiddenError }"
-
-    result = schema.execute_sync(query)
-    assert result.errors is not None
-    formatted_errors = [format_graphql_error(err) for err in result.errors]
-    assert formatted_errors == [
-        {
-            "locations": [{"column": 9, "line": 1}],
-            "message": "Unexpected error.",
-            "path": ["hiddenError"],
-        }
-    ]
-
-
 def test_process_errors_original_error():
     @strawberry.type
     class Query:
@@ -88,7 +95,7 @@ def test_process_errors_original_error():
             for error in errors:
                 mock_process_error(error)
 
-    schema = CustomSchema(query=Query, extensions=[MaskErrors(visible_errors=[])])
+    schema = CustomSchema(query=Query, extensions=[MaskErrors()])
 
     query = "query { hiddenError }"
 
@@ -107,3 +114,26 @@ def test_process_errors_original_error():
     call = mock_process_error.call_args_list[0]
     assert call.args[0].message == "This error is not visible"
     assert isinstance(call.args[0].original_error, ValueError)
+
+
+def test_graphql_error_masking():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def graphql_error(self) -> str:
+            return None  # type: ignore
+
+    schema = strawberry.Schema(query=Query, extensions=[MaskErrors()])
+
+    query = "query { graphqlError }"
+
+    result = schema.execute_sync(query)
+    assert result.errors is not None
+    formatted_errors = [format_graphql_error(err) for err in result.errors]
+    assert formatted_errors == [
+        {
+            "locations": [{"column": 9, "line": 1}],
+            "message": "Unexpected error.",
+            "path": ["graphqlError"],
+        }
+    ]

--- a/tests/schema/extensions/test_mask_errors.py
+++ b/tests/schema/extensions/test_mask_errors.py
@@ -1,0 +1,109 @@
+from unittest.mock import Mock
+
+from graphql.error.graphql_error import format_error as format_graphql_error
+
+import strawberry
+from strawberry.extensions import MaskErrors
+
+
+def test_mask_errors():
+    class VisibleError(Exception):
+        pass
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def visible_error(self) -> str:
+            raise VisibleError("This error is visible")
+
+        @strawberry.field
+        def hidden_error(self) -> str:
+            raise Exception("This error is not visible")
+
+    schema = strawberry.Schema(
+        query=Query, extensions=[MaskErrors(visible_errors=[VisibleError])]
+    )
+
+    query = "query { hiddenError }"
+
+    result = schema.execute_sync(query)
+    assert result.errors is not None
+    formatted_errors = [format_graphql_error(err) for err in result.errors]
+    assert formatted_errors == [
+        {
+            "locations": [{"column": 9, "line": 1}],
+            "message": "Unexpected error.",
+            "path": ["hiddenError"],
+        }
+    ]
+
+    query = "query { visibleError }"
+
+    result = schema.execute_sync(query)
+    assert result.errors is not None
+    formatted_errors = [format_graphql_error(err) for err in result.errors]
+    assert formatted_errors == [
+        {
+            "locations": [{"column": 9, "line": 1}],
+            "message": "This error is visible",
+            "path": ["visibleError"],
+        }
+    ]
+
+
+def test_mask_all_errors():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def hidden_error(self) -> str:
+            raise KeyError("This error is not visible")
+
+    schema = strawberry.Schema(query=Query, extensions=[MaskErrors(visible_errors=[])])
+
+    query = "query { hiddenError }"
+
+    result = schema.execute_sync(query)
+    assert result.errors is not None
+    formatted_errors = [format_graphql_error(err) for err in result.errors]
+    assert formatted_errors == [
+        {
+            "locations": [{"column": 9, "line": 1}],
+            "message": "Unexpected error.",
+            "path": ["hiddenError"],
+        }
+    ]
+
+
+def test_process_errors_original_error():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def hidden_error(self) -> str:
+            raise ValueError("This error is not visible")
+
+    mock_process_error = Mock()
+
+    class CustomSchema(strawberry.Schema):
+        def process_errors(self, errors, execution_context):
+            for error in errors:
+                mock_process_error(error)
+
+    schema = CustomSchema(query=Query, extensions=[MaskErrors(visible_errors=[])])
+
+    query = "query { hiddenError }"
+
+    result = schema.execute_sync(query)
+    assert result.errors is not None
+    formatted_errors = [format_graphql_error(err) for err in result.errors]
+    assert formatted_errors == [
+        {
+            "locations": [{"column": 9, "line": 1}],
+            "message": "Unexpected error.",
+            "path": ["hiddenError"],
+        }
+    ]
+
+    assert mock_process_error.call_count == 1
+    call = mock_process_error.call_args_list[0]
+    assert call.args[0].message == "This error is not visible"
+    assert isinstance(call.args[0].original_error, ValueError)

--- a/tests/schema/extensions/test_mask_errors.py
+++ b/tests/schema/extensions/test_mask_errors.py
@@ -112,8 +112,8 @@ def test_process_errors_original_error():
 
     assert mock_process_error.call_count == 1
     call = mock_process_error.call_args_list[0]
-    assert call.args[0].message == "This error is not visible"
-    assert isinstance(call.args[0].original_error, ValueError)
+    assert call[0][0].message == "This error is not visible"
+    assert isinstance(call[0][0].original_error, ValueError)
 
 
 def test_graphql_error_masking():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Add a new `MaskErrors` extension that can be used to hide error messages from the client to prevent exposing sensitive details.

It also moves the `Schema.process_errors` call to happen before the `on_request_end` extension hook so that the unmasked errors are logged.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #1221 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
