### PR TITLE
Fix lazy types inside generics

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,20 @@
+Release type: patch
+
+This release fixes an issue that prevented using lazy types inside
+generic types.
+
+The following is now allowed:
+
+```python
+T = TypeVar("T")
+
+TypeAType = Annotated["TypeA", strawberry.lazy("tests.schema.test_lazy.type_a")]
+
+@strawberry.type
+class Edge(Generic[T]):
+    node: T
+
+@strawberry.type
+class Query:
+    users: Edge[TypeAType]
+```

--- a/strawberry/annotation.py
+++ b/strawberry/annotation.py
@@ -85,7 +85,7 @@ class StrawberryAnnotation:
 
             return StrawberryAnnotation.parse_annotated(annotation_type)
 
-        if is_union(annotation):
+        elif is_union(annotation):
             return Union[
                 tuple(
                     StrawberryAnnotation.parse_annotated(arg)
@@ -93,8 +93,16 @@ class StrawberryAnnotation:
                 )  # pyright: ignore
             ]  # pyright: ignore
 
-        if is_list(annotation):
+        elif is_list(annotation):
             return List[StrawberryAnnotation.parse_annotated(get_args(annotation)[0])]  # type: ignore  # noqa: E501
+
+        else:
+            args = get_args(annotation)
+
+            if args:
+                return annotation.__origin__[
+                    tuple(StrawberryAnnotation.parse_annotated(arg) for arg in args)
+                ]
 
         return annotation
 

--- a/strawberry/annotation.py
+++ b/strawberry/annotation.py
@@ -100,7 +100,7 @@ class StrawberryAnnotation:
             args = get_args(annotation)
 
             if args:
-                return annotation.__origin__[
+                return annotation.__origin__[  # type: ignore
                     tuple(StrawberryAnnotation.parse_annotated(arg) for arg in args)
                 ]
 

--- a/strawberry/annotation.py
+++ b/strawberry/annotation.py
@@ -70,7 +70,9 @@ class StrawberryAnnotation:
     def parse_annotated(annotation: object) -> object:
         from strawberry.auto import StrawberryAuto
 
-        if get_origin(annotation) is Annotated:
+        annotation_origin = get_origin(annotation)
+
+        if annotation_origin is Annotated:
             annotated_args = get_args(annotation)
             annotation_type = annotated_args[0]
 
@@ -96,13 +98,12 @@ class StrawberryAnnotation:
         elif is_list(annotation):
             return List[StrawberryAnnotation.parse_annotated(get_args(annotation)[0])]  # type: ignore  # noqa: E501
 
-        else:
+        elif annotation_origin and is_generic(annotation_origin):
             args = get_args(annotation)
 
-            if args:
-                return annotation.__origin__[  # type: ignore
-                    tuple(StrawberryAnnotation.parse_annotated(arg) for arg in args)
-                ]
+            return annotation_origin[
+                tuple(StrawberryAnnotation.parse_annotated(arg) for arg in args)
+            ]
 
         return annotation
 

--- a/tests/schema/test_lazy/test_lazy_generic.py
+++ b/tests/schema/test_lazy/test_lazy_generic.py
@@ -1,0 +1,26 @@
+from typing import TYPE_CHECKING, Generic, TypeVar
+
+from typing_extensions import Annotated
+
+import strawberry
+
+
+if TYPE_CHECKING:
+    from tests.schema.test_lazy.type_a import TypeA  # noqa
+
+
+T = TypeVar("T")
+
+TypeAType = Annotated["TypeA", strawberry.lazy("tests.schema.test_lazy.type_a")]
+
+
+def test_lazy_types_with_generic():
+    @strawberry.type
+    class Edge(Generic[T]):
+        node: T
+
+    @strawberry.type
+    class Query:
+        users: Edge[TypeAType]
+
+    strawberry.Schema(query=Query)


### PR DESCRIPTION
This issue was reported on discord. The fix allows to use lazy types inside generics:

```python
T = TypeVar("T")

TypeAType = Annotated["TypeA", strawberry.lazy("tests.schema.test_lazy.type_a")]


def test_lazy_types_with_generic():
    @strawberry.type
    class Edge(Generic[T]):
        node: T

    @strawberry.type
    class Query:
        users: Edge[TypeAType]

    strawberry.Schema(query=Query)
```

~The implementation is not the best, I'll see if I can make it better 😊~