### PR TITLE
Generic scalars use the GraphQL scalar name instead of the Python class name.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,9 @@
+Release type: patch
+
+Generic scalars use the GraphQL scalar name instead of the Python class name.
+ ```python
+@strawberry.type
+class Output(Generic[T]):
+    data: T
+```
+`Output[str]` would be named `StringOutput` in the schema.

--- a/strawberry/schema/name_converter.py
+++ b/strawberry/schema/name_converter.py
@@ -29,6 +29,7 @@ class HasGraphQLName(Protocol):
 class NameConverter:
     def __init__(self, auto_camel_case: bool = True) -> None:
         self.auto_camel_case = auto_camel_case
+        self.scalar_registry: dict = {}
 
     def from_type(
         self,
@@ -147,6 +148,8 @@ class NameConverter:
                 name = self.from_generic(strawberry_type, types)
             else:
                 name = strawberry_type.name
+        elif type_ in self.scalar_registry:
+            name = self.scalar_registry[type_].name
         else:
             name = type_.__name__  # type: ignore
 

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -77,6 +77,7 @@ class Schema(BaseSchema):
             # TODO: check that the overrides are valid
             scalar_registry.update(cast(SCALAR_OVERRIDES_DICT_TYPE, scalar_overrides))
 
+        self.config.name_converter.scalar_registry.update(scalar_registry)
         self.schema_converter = GraphQLCoreConverter(self.config, scalar_registry)
         self.directives = directives
         self.schema_directives = schema_directives

--- a/tests/objects/generics/test_names.py
+++ b/tests/objects/generics/test_names.py
@@ -121,17 +121,17 @@ def test_nested_generics_aliases_with_schema():
 
     expected = textwrap.dedent(
         """
-        type IntStrDictItem {
+        type IntStringDictItem {
           key: Int!
           value: String!
         }
 
-        type IntStrDictItemListValue {
-          value: [IntStrDictItem!]!
+        type IntStringDictItemListValue {
+          value: [IntStringDictItem!]!
         }
 
         type Query {
-          d: IntStrDictItemListValue!
+          d: IntStringDictItemListValue!
         }
         """
     ).strip()

--- a/tests/schema/test_generics.py
+++ b/tests/schema/test_generics.py
@@ -110,7 +110,7 @@ def test_supports_multiple_generic():
 
     assert not result.errors
     assert result.data == {
-        "multiple": {"__typename": "IntStrMultiple", "a": 123, "b": "123"}
+        "multiple": {"__typename": "IntStringMultiple", "a": 123, "b": "123"}
     }
 
 
@@ -419,7 +419,7 @@ def test_supports_generic_in_unions_multiple_vars():
         example {
             __typename
 
-            ... on IntStrEdge {
+            ... on IntStringEdge {
                 node
                 info
             }
@@ -430,7 +430,7 @@ def test_supports_generic_in_unions_multiple_vars():
 
     assert not result.errors
     assert result.data == {
-        "example": {"__typename": "IntStrEdge", "node": "string", "info": 1}
+        "example": {"__typename": "IntStringEdge", "node": "string", "info": 1}
     }
 
 
@@ -511,13 +511,13 @@ def test_supports_multiple_generics_in_union():
         node: Int!
       }
 
-      union IntEdgeStrEdge = IntEdge | StrEdge
+      union IntEdgeStringEdge = IntEdge | StringEdge
 
       type Query {
-        example: [IntEdgeStrEdge!]!
+        example: [IntEdgeStringEdge!]!
       }
 
-      type StrEdge {
+      type StringEdge {
         cursor: ID!
         node: String!
       }
@@ -534,7 +534,7 @@ def test_supports_multiple_generics_in_union():
                 intNode: node
             }
 
-            ... on StrEdge {
+            ... on StringEdge {
                 cursor
                 strNode: node
             }
@@ -547,7 +547,7 @@ def test_supports_multiple_generics_in_union():
     assert result.data == {
         "example": [
             {"__typename": "IntEdge", "cursor": "1", "intNode": 1},
-            {"__typename": "StrEdge", "cursor": "2", "strNode": "string"},
+            {"__typename": "StringEdge", "cursor": "2", "strNode": "string"},
         ]
     }
 
@@ -852,7 +852,7 @@ def test_generic_interface():
     assert not query_result.errors
     assert query_result.data == {
         "foo": {
-            "__typename": "StrGenericObject",
+            "__typename": "StringGenericObject",
             "value": "foo",
             "repr": "foo",
         }


### PR DESCRIPTION
## Description
Generic scalars prepend the GraphQL scalar name, instead of the Python class name, to the base type name.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #1921 

## Checklist
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
- [X] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
