### PR TITLE
Fix support for Union-of-LazyType

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: minor
+
+This release fixes errors when using Union-of-lazy-types

--- a/strawberry/schema/name_converter.py
+++ b/strawberry/schema/name_converter.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List, Optional, Union
+from typing import TYPE_CHECKING, List, Optional, Union, cast
 
 from typing_extensions import Protocol
 
@@ -95,6 +95,9 @@ class NameConverter:
         name = ""
 
         for type_ in union.types:
+            if isinstance(type_, LazyType):
+                type_ = cast(StrawberryType, type_.resolve_type())
+
             assert hasattr(type_, "_type_definition")
             name += self.from_type(type_._type_definition)  # type: ignore
 

--- a/strawberry/union.py
+++ b/strawberry/union.py
@@ -31,6 +31,7 @@ from strawberry.exceptions import (
     UnallowedReturnTypeForUnion,
     WrongReturnTypeForUnion,
 )
+from strawberry.lazy_type import LazyType
 from strawberry.type import StrawberryOptional, StrawberryType
 
 
@@ -88,6 +89,9 @@ class StrawberryUnion(StrawberryType):
     @property
     def type_params(self) -> List[TypeVar]:
         def _get_type_params(type_: StrawberryType):
+            if isinstance(type_, LazyType):
+                type_ = cast(StrawberryType, type_.resolve_type())
+
             if hasattr(type_, "_type_definition"):
                 parameters = getattr(type_, "__parameters__", None)
 

--- a/tests/schema/test_union.py
+++ b/tests/schema/test_union.py
@@ -5,7 +5,10 @@ from typing import Generic, List, Optional, TypeVar, Union
 
 import pytest
 
+from typing_extensions import Annotated
+
 import strawberry
+from strawberry.lazy_type import lazy
 
 
 def test_union_as_field():
@@ -602,3 +605,43 @@ def test_union_with_similar_nested_generic_types():
     result = schema.execute_sync(query)
 
     assert result.data["containerB"]["items"][0]["b"] == 3
+
+
+def test_lazy_union():
+    """
+    Previously this failed to evaluate generic parameters on lazy types
+    """
+    TypeA = Annotated["TypeA", lazy("tests.schema.test_lazy_types.type_a")]
+    TypeB = Annotated["TypeB", lazy("tests.schema.test_lazy_types.type_b")]
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def a(self) -> Union[TypeA, TypeB]:
+            from tests.schema.test_lazy_types.type_a import TypeA
+
+            return TypeA(list_of_b=[])
+
+        @strawberry.field
+        def b(self) -> Union[TypeA, TypeB]:
+            from tests.schema.test_lazy_types.type_b import TypeB
+
+            return TypeB()
+
+    schema = strawberry.Schema(query=Query)
+
+    query = """
+     {
+        a {
+            __typename
+        }
+        b {
+            __typename
+        }
+    }
+    """
+
+    result = schema.execute_sync(query)
+
+    assert result.data["a"]["__typename"] == "TypeA"
+    assert result.data["b"]["__typename"] == "TypeB"


### PR DESCRIPTION
I found strawberry failed when trying to use LazyTypes in an union:

```
Success = Annotated["Result", lazy(".success")]
Error = Annotated["Error", lazy(".error")]

@strawberry.type
class Query:
    @strawberry.type
    def doSomething() -> Success | Error:
        ...
```

This PR adds handling for LazyType where necessary and adds a test case

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
