### PR TITLE
Change json_encoder to be a function, add it to all integrations

### DIFF
--- a/strawberry/http/json_encoder.py
+++ b/strawberry/http/json_encoder.py
@@ -1,0 +1,11 @@
+import json
+from typing import Callable
+
+from . import GraphQLHTTPResponse
+
+
+JsonEncoder = Callable[[GraphQLHTTPResponse], str]
+
+
+def default_json_encoder(data: GraphQLHTTPResponse) -> str:
+    return json.dumps(data)


### PR DESCRIPTION
This PR supersedes #2213 by adding a json_encoder param to the HTTP views. I've implemented yet for the other integrations, because I want to get feedback on the Django integration first.

Currently due to how django class views work, we need to mark the default encoder function as a static method. Not sure if this is nice, but it allows to make this function a classmethod too.

@jkimbo, @marcoacierno, @BryceBeagle what do you think?


Closes #2213