### PR TITLE
Added ability to dynamically update the Response `status_code` in the `MaskErrors` extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,3 +147,5 @@ pre-commit install
 
 The code in this project is licensed under MIT license. See [LICENSE](./LICENSE)
 for more information.
+
+![Recent Activity](https://images.repography.com/0/strawberry-graphql/strawberry/recent-activity/d751713988987e9331980363e24189ce.svg)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,11 +12,14 @@ class VisibleError(Exception):
     pass
 
 def status_code_hook(error: GraphQLError, execution_context: ExecutionContext) -> None:
+    response = execution_context.context['response']
+    existing_status_code = response.status_code
     if error.original_error and isinstance(error.orginal_error, VisibleError):
-        execution_context.context['response'].status_code = 400
+        new_status_code = 400
     else:
-        execution_context.context['response'].status_code = 500
-
+        new_status_code = 500
+    if new_status_code > existing_status_code:
+        response.status_code = new_status_code
 
 schema = strawberry.Schema(
     Query,

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,27 @@
+Release type: minor
+
+This release adds a new optional parameter `status_code_hook` to the `MaskErrors` extension that can be used to dynamically set the Response `status_code` based on the errors raised.
+
+```python
+import strawberry
+from strawberry.extensions import MaskErrors
+from graphql.error import GraphQLError
+from strawberry.types import ExecutionContext
+
+class VisibleError(Exception):
+    pass
+
+def status_code_hook(error: GraphQLError, execution_context: ExecutionContext) -> None:
+    if error.original_error and isinstance(error.orginal_error, VisibleError):
+        execution_context.context['response'].status_code = 400
+    else:
+        execution_context.context['response'].status_code = 500
+
+
+schema = strawberry.Schema(
+    Query,
+    extensions=[
+        MaskErrors(status_code_hook=status_code_hook),
+    ]
+)
+```

--- a/docs/extensions/mask-errors.md
+++ b/docs/extensions/mask-errors.md
@@ -111,9 +111,6 @@ from strawberry.extensions import MaskErrors
 from graphql.error import GraphQLError
 from strawberry.types import ExecutionContext
 
-VISIBLE_ERROR_STATUS_CODE = 400
-HIDDEN_ERROR_STATUS_CODE = 500
-
 class VisibleError(Exception):
     pass
 
@@ -130,11 +127,13 @@ def status_code_hook(error: GraphQLError, execution_context: ExecutionContext) -
     This example uses the default FastAPI config."""
     response = execution_context.context['response'] # change depending on your context config
     if response:
+        existing_status_code = response.status_code
         if should_mask_error(error):
-            response.status_code = HIDDEN_ERROR_STATUS_CODE
+            new_status_code = 400
         else:
-            response.status_code = VISIBLE_ERROR_STATUS_CODE
-
+            new_response.status_code = 500
+        if new_status_code > existing_status_code:
+            response.status_code = new_status_code
 
 schema = strawberry.Schema(
     Query,

--- a/docs/extensions/mask-errors.md
+++ b/docs/extensions/mask-errors.md
@@ -26,7 +26,7 @@ schema = strawberry.Schema(
 ## API reference:
 
 ```python
-class MaskErrors(should_mask_error=default_should_mask_error, error_message="Unexpected error.")`
+class MaskErrors(should_mask_error=default_should_mask_error, error_message="Unexpected error.", status_code_hook=None)
 ```
 
 #### `should_mask_error: Callable[[GraphQLError], bool] = default_should_mask_error`
@@ -44,6 +44,16 @@ The `default_should_mask_error` function always returns `True`.
 #### `error_message: str = "Unexpected error."`
 
 The error message to display to the client when there is an error.
+
+#### `status_code_hook: Callable[[GraphQLError, ExecutionContext], None] = None`
+
+Predicate function to update the `Response`, which can be accessed from the 
+`Execution Context` given. This allows you to dynamically set the `Response.status_code` 
+based on the `original_error` attribute from the `GraphQLError`.
+
+<Note>
+
+`status_code_hook` defaults to `None`.
 
 ## More examples:
 
@@ -86,6 +96,51 @@ schema = strawberry.Schema(
     Query,
     extensions=[
         MaskErrors(error_message="Oh no! An error occured. Very sorry about that."),
+    ]
+)
+```
+
+</details>
+
+
+<details>
+  <summary>Change response status code dynamically</summary>
+
+```python
+import strawberry
+from strawberry.extensions import MaskErrors
+from graphql.error import GraphQLError
+from strawberry.types import ExecutionContext
+
+VISIBLE_ERROR_STATUS_CODE = 400
+HIDDEN_ERROR_STATUS_CODE = 500
+
+class VisibleError(Exception):
+    pass
+
+def should_mask_error(error: GraphQLError) -> bool:
+    original_error = error.original_error
+    if original_error and isinstance(
+        original_error, (VisibleError, PermissionError)
+    ):
+        return False
+    return True
+
+def status_code_hook(error: GraphQLError, execution_context: ExecutionContext) -> None:
+    """Getting the response from the execution context depends on your context configuration.
+    This example uses the default FastAPI config."""
+    response = execution_context.context['response'] # change depending on your context config
+    if response:
+        if should_mask_error(error):
+            response.status_code = HIDDEN_ERROR_STATUS_CODE
+        else:
+            response.status_code = VISIBLE_ERROR_STATUS_CODE
+
+
+schema = strawberry.Schema(
+    Query,
+    extensions=[
+        MaskErrors(should_mask_error=should_mask_error, status_code_hook=status_code_hook),
     ]
 )
 ```

--- a/tests/schema/extensions/test_mask_errors.py
+++ b/tests/schema/extensions/test_mask_errors.py
@@ -140,7 +140,8 @@ def test_graphql_error_masking():
 
 
 def test_mask_some_errors_with_status_code_hook():
-    """This works when running the server. This test shows this does not break the extension."""
+    """This works when running the server.
+    This test shows this does not break the extension."""
     VISIBLE_ERROR_STATUS_CODE = 400
     HIDDEN_ERROR_STATUS_CODE = 500
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->


Add a new optional field `status_code_hook` to the `MaskErrors` extension to allow dynamically setting the Response `status_code`.

`status_code_hook` takes in an optional function of `Callable[[GraphQLError, ExecutionContext], None]` so you can update the Response, which you get from the `execution_context`, dynamically per error.

I'm using this in our app like so:

```

def should_mask_error(error: GraphQLError) -> bool:
    original_error = error.original_error
    if original_error and isinstance(
        original_error, (DisplayException, PermissionError)
    ):
        return False
    return True


def status_code_hook(error: GraphQLError, execution_context: ExecutionContext) -> None:
    if should_mask_error(error):
        execution_context.context.response.status_code = (
            settings.internal_server_error_status_code
        )
    else:
        status_code = settings.display_error_status_code
        original_error = error.original_error
        if original_error and isinstance(original_error, DisplayException):
            status_code = (
                original_error.status_code or settings.display_error_status_code
            )
        execution_context.context.response.status_code = status_code

MaskErrors(
        error_message="Internal Server Error",
        should_mask_error=should_mask_error,
        status_code_hook=status_code_hook,
)
```

I've also updated the docs to reflect this change.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes https://github.com/strawberry-graphql/strawberry/issues/2276

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
