### PR TITLE
Make Websocket context_getter dependency async

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+Release type: patch
+
+This release changes an internal implementation for FastAPI's
+GraphQL router. This should reduce overhead when using the context,
+and it shouldn't affect your code.

--- a/release.md
+++ b/release.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Internal GrapQLRouter FastAPI dependency is now async

--- a/release.md
+++ b/release.md
@@ -1,3 +1,0 @@
-Release type: patch
-
-Internal GrapQLRouter FastAPI dependency is now async

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -54,7 +54,7 @@ class GraphQLRouter(APIRouter):
     def __get_context_getter(
         custom_getter: Callable[..., Optional[CustomContext]]
     ) -> Callable[..., CustomContext]:
-        def dependency(
+        async def dependency(
             custom_context: Optional[CustomContext],
             background_tasks: BackgroundTasks,
             request: Request = None,

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -1,11 +1,21 @@
 import json
 from datetime import timedelta
 from inspect import signature
-from typing import Any, Awaitable, Callable, Dict, Iterable, Optional, Sequence, Union
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    Iterable,
+    Optional,
+    Sequence,
+    Union,
+    cast,
+)
 
 from starlette import status
 from starlette.background import BackgroundTasks
-from starlette.requests import Request
+from starlette.requests import HTTPConnection, Request
 from starlette.responses import HTMLResponse, JSONResponse, PlainTextResponse, Response
 from starlette.types import ASGIApp
 from starlette.websockets import WebSocket
@@ -59,21 +69,21 @@ class GraphQLRouter(APIRouter):
         async def dependency(
             custom_context: Optional[CustomContext],
             background_tasks: BackgroundTasks,
-            request: Request = None,
+            connection: HTTPConnection,
             response: Response = None,
-            ws: WebSocket = None,
         ) -> MergedContext:
-            default_context = {
-                "request": request or ws,
-                "background_tasks": background_tasks,
-                "response": response,
-            }
+            request = cast(Union[Request, WebSocket], connection)
             if isinstance(custom_context, BaseContext):
-                custom_context.request = request or ws
+                custom_context.request = request
                 custom_context.background_tasks = background_tasks
                 custom_context.response = response
                 return custom_context
-            elif isinstance(custom_context, dict):
+            default_context = {
+                "request": request,
+                "background_tasks": background_tasks,
+                "response": response,
+            }
+            if isinstance(custom_context, dict):
                 return {
                     **default_context,
                     **custom_context,

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -1,7 +1,7 @@
 import json
 from datetime import timedelta
 from inspect import signature
-from typing import Any, Callable, Dict, Iterable, Optional, Sequence, Union
+from typing import Any, Awaitable, Callable, Dict, Iterable, Optional, Sequence, Union
 
 from starlette import status
 from starlette.background import BackgroundTasks
@@ -52,8 +52,10 @@ class GraphQLRouter(APIRouter):
 
     @staticmethod
     def __get_context_getter(
-        custom_getter: Callable[..., Optional[CustomContext]]
-    ) -> Callable[..., CustomContext]:
+        custom_getter: Callable[
+            ..., Union[Optional[CustomContext], Awaitable[Optional[CustomContext]]]
+        ]
+    ) -> Callable[..., Awaitable[CustomContext]]:
         async def dependency(
             custom_context: Optional[CustomContext],
             background_tasks: BackgroundTasks,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
A `GrapQLRouter` has a `context_getter` dependency.  This is evaluated internally by another hidden dependency
to add default values onto the context object (or dict).  However, this internal depdenency wasn't defined as `async`
causing FastAPI to unnecessarily evaluate it on a worker thread, increasing overhead.  This change makes it async, causing it to be evaluated normally.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
