### PR TITLE
allowed 'CustomScalar | None' syntax for python >= 3.10

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Allowed `CustomScalar | None` syntax for python >= 3.10.

--- a/strawberry/custom_scalar.py
+++ b/strawberry/custom_scalar.py
@@ -15,7 +15,8 @@ from typing import (
 
 from graphql import GraphQLScalarType
 
-from strawberry.type import StrawberryType
+from strawberry.exceptions import InvalidUnionType
+from strawberry.type import StrawberryOptional, StrawberryType
 
 from .utils.str_converters import to_camel_case
 
@@ -63,6 +64,16 @@ class ScalarWrapper:
 
     def __call__(self, *args, **kwargs):
         return self.wrap(*args, **kwargs)
+
+    def __or__(self, other: Union[StrawberryType, type]) -> StrawberryType:
+        if other is None:
+            # Return the correct notation when using `StrawberryUnion | None`.
+            return StrawberryOptional(of_type=self)
+
+        # Raise an error in any other case.
+        # There is Work in progress to deal with more merging cases, see:
+        # https://github.com/strawberry-graphql/strawberry/pull/1455
+        raise InvalidUnionType(other)
 
 
 def _process_scalar(

--- a/tests/types/resolving/test_union_pipe.py
+++ b/tests/types/resolving/test_union_pipe.py
@@ -6,6 +6,7 @@ import pytest
 import strawberry
 from strawberry.annotation import StrawberryAnnotation
 from strawberry.exceptions import InvalidUnionType
+from strawberry.schema.types.base_scalars import Date, DateTime
 from strawberry.type import StrawberryOptional
 from strawberry.union import StrawberryUnion
 
@@ -91,3 +92,6 @@ def test_raises_error_when_piping_with_scalar():
 
     with pytest.raises(InvalidUnionType):
         StrawberryAnnotation(UserOrError | int)
+
+    with pytest.raises(InvalidUnionType):
+        StrawberryAnnotation(Date | DateTime)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

Since `ScalarWrapper` is kind of its own thing, I couldn't find another way than to define `__or__` directly on the class.
From what I've gather about pending refactors (i.e. `StrawberryScalar`), it shouldn't stay like that forever.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
