### PR TITLE
fix broken table in guide/file-upload

### DIFF
--- a/docs/guides/file-upload.md
+++ b/docs/guides/file-upload.md
@@ -11,8 +11,8 @@ This includes support for uploading single files as well as lists of files.
 Uploads can be used in mutations via the `Upload` scalar.
 The type passed at runtime depends on the integration:
 
-| Integration                               | Type                                                                                                                                                  |
-| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Integration                               | Type                                                                                                                                                |
+| ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [AIOHTTP](/docs/integrations/aiohttp)     | [io.BytesIO](https://docs.python.org/3/library/io.html#io.BytesIO)                                                                                  |
 | [ASGI](/docs/integrations/asgi)           | [starlette.datastructures.UploadFile](https://www.starlette.io/requests/#request-files)                                                             |
 | [Django](/docs/integrations/django)       | [django.core.files.uploadedfile.UploadedFile](https://docs.djangoproject.com/en/3.2/ref/files/uploads/#django.core.files.uploadedfile.UploadedFile) |

--- a/docs/guides/file-upload.md
+++ b/docs/guides/file-upload.md
@@ -13,13 +13,13 @@ The type passed at runtime depends on the integration:
 
 | Integration                               | Type                                                                                                                                                  |
 | ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [AIOHTTP](/docs/integrations/aiohttp)     | [`io.BytesIO`](https://docs.python.org/3/library/io.html#io.BytesIO)                                                                                  |
-| [ASGI](/docs/integrations/asgi)           | [`starlette.datastructures.UploadFile`](https://www.starlette.io/requests/#request-files)                                                             |
-| [Django](/docs/integrations/django)       | [`django.core.files.uploadedfile.UploadedFile`](https://docs.djangoproject.com/en/3.2/ref/files/uploads/#django.core.files.uploadedfile.UploadedFile) |
-| [FastAPI](/docs/integrations/fastapi)     | [`fastapi.UploadFile`](https://fastapi.tiangolo.com/tutorial/request-files/#file-parameters-with-uploadfile)                                          |
-| [Flask](/docs/integrations/flask)         | [`werkzeug.datastructures.FileStorage`](https://werkzeug.palletsprojects.com/en/2.0.x/datastructures/#werkzeug.datastructures.FileStorage)            |
-| [Sanic](/docs/integrations/sanic)         | [`sanic.request.File`](https://sanic.readthedocs.io/en/stable/sanic/api/core.html#sanic.request.File)                                                 |
-| [Starlette](/docs/integrations/starlette) | [`starlette.datastructures.UploadFile`](https://www.starlette.io/requests/#request-files)                                                             |
+| [AIOHTTP](/docs/integrations/aiohttp)     | [io.BytesIO](https://docs.python.org/3/library/io.html#io.BytesIO)                                                                                  |
+| [ASGI](/docs/integrations/asgi)           | [starlette.datastructures.UploadFile](https://www.starlette.io/requests/#request-files)                                                             |
+| [Django](/docs/integrations/django)       | [django.core.files.uploadedfile.UploadedFile](https://docs.djangoproject.com/en/3.2/ref/files/uploads/#django.core.files.uploadedfile.UploadedFile) |
+| [FastAPI](/docs/integrations/fastapi)     | [fastapi.UploadFile](https://fastapi.tiangolo.com/tutorial/request-files/#file-parameters-with-uploadfile)                                          |
+| [Flask](/docs/integrations/flask)         | [werkzeug.datastructures.FileStorage](https://werkzeug.palletsprojects.com/en/2.0.x/datastructures/#werkzeug.datastructures.FileStorage)            |
+| [Sanic](/docs/integrations/sanic)         | [sanic.request.File](https://sanic.readthedocs.io/en/stable/sanic/api/core.html#sanic.request.File)                                                 |
+| [Starlette](/docs/integrations/starlette) | [starlette.datastructures.UploadFile](https://www.starlette.io/requests/#request-files)                                                             |
 
 ## ASGI / FastAPI / Starlette
 


### PR DESCRIPTION
https://strawberry.rocks/docs/guides/file-upload

![image](https://user-images.githubusercontent.com/2917822/198836838-ded7198a-2725-4a78-8290-0163e76b8728.png)

origin table in official site is not correctly rendered

this may caused by either [`content`] or some strange table format definition.

I will need to view the dynamic env of pr to check it out.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
