### PR TITLE
Generic types allowed in schema's extra types.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,16 @@
+Release type: patch
+
+ Generic types allowed in schema's extra types.
+```python
+T = TypeVar('T')
+
+@strawberry.type
+class Node(Generic[T]):
+    field: T
+
+@strawberry.type
+class Query:
+    name: str
+
+schema = strawberry.Schema(Query, types=[Node[int]])
+```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
 Release type: patch
 
- Generic types allowed in schema's extra types.
+ Generic types are now allowed in the schema's extra types.
 ```python
 T = TypeVar('T')
 

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -13,6 +13,7 @@ from graphql import (
 from graphql.subscription import subscribe
 from graphql.type.directives import specified_directives
 
+from strawberry.annotation import StrawberryAnnotation
 from strawberry.custom_scalar import ScalarDefinition, ScalarWrapper
 from strawberry.directive import StrawberryDirective
 from strawberry.enum import EnumDefinition
@@ -104,6 +105,9 @@ class Schema(BaseSchema):
                     self.schema_converter.from_schema_directive(type_)
                 )
             else:
+                if hasattr(type_, "_type_definition"):
+                    if type_._type_definition.is_generic:
+                        type_ = StrawberryAnnotation(type_).resolve()
                 graphql_type = self.schema_converter.from_maybe_optional(type_)
                 if isinstance(graphql_type, GraphQLNonNull):
                     graphql_type = graphql_type.of_type

--- a/tests/schema/test_generics.py
+++ b/tests/schema/test_generics.py
@@ -775,6 +775,32 @@ def test_generic_argument():
     assert str(schema) == textwrap.dedent(expected_schema).strip()
 
 
+def test_generic_extra_type():
+    T = TypeVar("T")
+
+    @strawberry.type
+    class Node(Generic[T]):
+        field: T
+
+    @strawberry.type
+    class Query:
+        name: str
+
+    schema = strawberry.Schema(Query, types=[Node[int]])
+
+    expected_schema = """
+    type IntNode {
+      field: Int!
+    }
+
+    type Query {
+      name: String!
+    }
+    """
+
+    assert str(schema) == textwrap.dedent(expected_schema).strip()
+
+
 def test_generic_extending_with_type_var():
     T = TypeVar("T")
 


### PR DESCRIPTION
## Description
Generic types weren't resolving in the extra types of a schema.

## Types of Changes
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #2154 

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
