### PR TITLE
Support new Self type as an annotation.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,13 @@
+Release type: minor
+
+This release adds support for `typing.Self` and `typing_extensions.Self` for types and interfaces.
+
+```python
+from typing_extensions import Self
+
+@strawberry.type
+class Node:
+    @strawberry.field
+    def field(self) -> Self:
+        return self
+```

--- a/strawberry/annotation.py
+++ b/strawberry/annotation.py
@@ -13,7 +13,7 @@ from typing import (  # type: ignore[attr-defined]
     _eval_type,
 )
 
-from typing_extensions import Annotated, get_args, get_origin
+from typing_extensions import Annotated, Self, get_args, get_origin
 
 from strawberry.exceptions import StrawberryException
 from strawberry.private import is_private
@@ -157,7 +157,7 @@ class StrawberryAnnotation:
             return self.create_optional(evaled_type)
         elif self._is_union(evaled_type):
             return self.create_union(evaled_type)
-        elif is_type_var(evaled_type):
+        elif is_type_var(evaled_type) or evaled_type is Self:
             return self.create_type_var(evaled_type)
 
         # TODO: Raise exception now, or later?

--- a/strawberry/type.py
+++ b/strawberry/type.py
@@ -24,6 +24,9 @@ class StrawberryType(ABC):
     def is_generic(self) -> bool:
         raise NotImplementedError()
 
+    def has_generic(self, type_var) -> bool:
+        return False
+
     def __eq__(self, other: object) -> bool:
         from strawberry.annotation import StrawberryAnnotation
 
@@ -107,6 +110,11 @@ class StrawberryContainer(StrawberryType):
 
         return False
 
+    def has_generic(self, type_var) -> bool:
+        if isinstance(self.of_type, StrawberryType):
+            return self.of_type.has_generic(type_var)
+        return False
+
 
 class StrawberryList(StrawberryContainer):
     ...
@@ -128,6 +136,9 @@ class StrawberryTypeVar(StrawberryType):
     @property
     def is_generic(self) -> bool:
         return True
+
+    def has_generic(self, type_var) -> bool:
+        return self.type_var == type_var
 
     @property
     def type_params(self) -> List[TypeVar]:

--- a/strawberry/types/types.py
+++ b/strawberry/types/types.py
@@ -14,6 +14,8 @@ from typing import (
     Union,
 )
 
+from typing_extensions import Self
+
 from strawberry.type import StrawberryType, StrawberryTypeVar
 from strawberry.utils.typing import is_generic as is_type_generic
 
@@ -43,6 +45,12 @@ class TypeDefinition(StrawberryType):
     type_var_map: Mapping[TypeVar, Union[StrawberryType, type]] = dataclasses.field(
         default_factory=dict
     )
+
+    def __post_init__(self):
+        # resolve `Self` annotation with the origin type
+        for index, field in enumerate(self.fields):
+            if isinstance(field.type, StrawberryType) and field.type.has_generic(Self):
+                self.fields[index] = field.copy_with({Self: self.origin})  # type: ignore
 
     # TODO: remove wrapped cls when we "merge" this with `StrawberryObject`
     def resolve_generic(self, wrapped_cls: type) -> type:


### PR DESCRIPTION
## Description
`typing.Self` is a supported annotation, for types and interfaces.

```python
from strawberry.types import Self

@strawberry.type
class Node:
    @strawberry.field
    def field(self) -> Self:
        return self
```

## Types of Changes
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #2292

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
