### PR TITLE
Fix dataclass creation in Pydantic integration for Python 3.10.0

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+Fix Pydantic integration for Python 3.10.0 (which was missing the `kw_only`
+parameter for `dataclasses.make_dataclass()`).

--- a/strawberry/experimental/pydantic/object_type.py
+++ b/strawberry/experimental/pydantic/object_type.py
@@ -214,9 +214,11 @@ def type(
 
         kwargs: Dict[str, object] = {}
 
-        # Python 3.10 introduces the kw_only param. If we're on an older version
-        # then generate our own custom init function
-        if sys.version_info >= (3, 10):
+        # Python 3.10.1 introduces the kw_only param to `make_dataclass`.
+        # If we're on an older version then generate our own custom init function
+        # Note: Python 3.10.0 added the `kw_only` param to dataclasses, it was
+        # just missed from the `make_dataclass` function: https://github.com/python/cpython/issues/89961
+        if sys.version_info >= (3, 10, 1):
             kwargs["kw_only"] = dataclasses.MISSING
         else:
             kwargs["init"] = False
@@ -229,7 +231,7 @@ def type(
             **kwargs,  # type: ignore
         )
 
-        if sys.version_info < (3, 10):
+        if sys.version_info < (3, 10, 1):
             add_custom_init_fn(cls)
 
         _process_type(

--- a/strawberry/experimental/pydantic/object_type.py
+++ b/strawberry/experimental/pydantic/object_type.py
@@ -217,7 +217,8 @@ def type(
         # Python 3.10.1 introduces the kw_only param to `make_dataclass`.
         # If we're on an older version then generate our own custom init function
         # Note: Python 3.10.0 added the `kw_only` param to dataclasses, it was
-        # just missed from the `make_dataclass` function: https://github.com/python/cpython/issues/89961
+        # just missed from the `make_dataclass` function:
+        # https://github.com/python/cpython/issues/89961
         if sys.version_info >= (3, 10, 1):
             kwargs["kw_only"] = dataclasses.MISSING
         else:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Python 3.10.0 missed the `kw_only` parameter for
`dataclasses.make_dataclass()`: https://github.com/python/cpython/issues/89961 It was added in 3.10.1.

This change updates the version checking in the Pydantic integration to only use the `kw_only` parameter for 3.10.1 versions and above. Otherwise to falls back to our custom init function.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
