### PR TITLE
Prefer class annotation over resolver annotation when determining field type

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,28 @@
+Release type: minor
+
+This release changes the type resolution priority to prefer the field annotation over the resolver return type.
+
+```python
+def my_resolver() -> str:
+    return "1.33"
+
+@strawberry.type
+class Query:
+    a: float = strawberry.field(resolver=my_resolver)
+
+schema = strawberry.Schema(Query)
+
+# Before:
+str(schema) == """
+type Query {
+  a: String!
+}
+"""
+
+# After:
+str(schema) == """
+type Query {
+  a: Float!
+}
+"""
+```

--- a/tests/schema/test_fields.py
+++ b/tests/schema/test_fields.py
@@ -1,8 +1,10 @@
 import dataclasses
+import textwrap
 from operator import getitem
 
 import strawberry
 from strawberry.field import StrawberryField
+from strawberry.printer import print_schema
 from strawberry.schema.config import StrawberryConfig
 
 
@@ -79,3 +81,35 @@ def test_field_metadata():
 
     (a,) = dataclasses.fields(Query)
     assert a.metadata == {"Foo": "Bar"}
+
+
+def test_field_type_priority():
+    """
+    Prioritise the field annotation on the class over the resolver annotation.
+    """
+
+    def my_resolver() -> str:
+        return "1.33"
+
+    @strawberry.type
+    class Query:
+        a: float = strawberry.field(resolver=my_resolver)
+
+    schema = strawberry.Schema(Query)
+
+    expected = """
+    type Query {
+      a: Float!
+    }
+    """
+
+    assert print_schema(schema) == textwrap.dedent(expected).strip()
+
+    query = "{ a }"
+
+    result = schema.execute_sync(query, root_value=Query())
+
+    assert not result.errors
+    assert result.data == {
+        "a": 1.33,
+    }

--- a/tests/types/cross_module_resolvers/test_cross_module_resolvers.py
+++ b/tests/types/cross_module_resolvers/test_cross_module_resolvers.py
@@ -113,7 +113,9 @@ def test_c_inheritance_resolver_only():
 def test_c_composition_resolver():
     @strawberry.type
     class Query:
-        c: c_mod.CComposition = strawberry.field(resolver=c_mod.c_composition_resolver)
+        c: List[c_mod.CComposition] = strawberry.field(
+            resolver=c_mod.c_composition_resolver
+        )
 
     [field] = Query._type_definition.fields
     assert field.type == List[c_mod.CComposition]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This PR changes the type resolution priority to prefer the field annotation over the resolver return type.

```python
def my_resolver() -> str:
    return "1.33"

@strawberry.type
class Query:
    a: float = strawberry.field(resolver=my_resolver)

schema = strawberry.Schema(Query)

# Before:
str(schema) == """
type Query {
  a: String!
}
"""

# After:
str(schema) == """
type Query {
  a: Float!
}
"""
```

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
