### PR TITLE
Fix for generic types to be used as argument annotations.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,13 @@
+Release type: patch
+
+ This release fixes support for generics in arguments, see the following example:
+
+ ```python
+ T = TypeVar('T')
+
+ @strawberry.type
+ class Node(Generic[T]):
+    @strawberry.field
+    def data(self, arg: T) -> T:  # `arg` is also generic
+        return arg
+ ```

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -282,7 +282,7 @@ class StrawberryField(dataclasses.Field):
     def copy_with(
         self, type_var_map: Mapping[TypeVar, Union[StrawberryType, builtins.type]]
     ) -> "StrawberryField":
-        new_type: Union[StrawberryType, type]
+        new_type: Union[StrawberryType, type] = self.type
 
         # TODO: Remove with creation of StrawberryObject. Will act same as other
         #       StrawberryTypes
@@ -292,9 +292,7 @@ class StrawberryField(dataclasses.Field):
             if type_definition.is_generic:
                 type_ = type_definition
                 new_type = type_.copy_with(type_var_map)
-        else:
-            assert isinstance(self.type, StrawberryType)
-
+        elif isinstance(self.type, StrawberryType):
             new_type = self.type.copy_with(type_var_map)
 
         new_resolver = (

--- a/strawberry/type.py
+++ b/strawberry/type.py
@@ -82,7 +82,7 @@ class StrawberryContainer(StrawberryType):
     def copy_with(
         self, type_var_map: Mapping[TypeVar, Union[StrawberryType, type]]
     ) -> StrawberryType:
-        of_type_copy: Union[StrawberryType, type]
+        of_type_copy: Union[StrawberryType, type] = self.of_type
 
         # TODO: Obsolete with StrawberryObject
         if hasattr(self.of_type, "_type_definition"):
@@ -93,8 +93,6 @@ class StrawberryContainer(StrawberryType):
 
         elif isinstance(self.of_type, StrawberryType) and self.of_type.is_generic:
             of_type_copy = self.of_type.copy_with(type_var_map)
-
-        assert of_type_copy
 
         return type(self)(of_type_copy)
 

--- a/strawberry/types/types.py
+++ b/strawberry/types/types.py
@@ -73,38 +73,8 @@ class TypeDefinition(StrawberryType):
     def copy_with(
         self, type_var_map: Mapping[TypeVar, Union[StrawberryType, type]]
     ) -> type:
-        from strawberry.annotation import StrawberryAnnotation
-
-        fields = []
-        for field in self.fields:
-            # TODO: Logic unnecessary with StrawberryObject
-            field_type = field.type
-            if hasattr(field_type, "_type_definition"):
-                field_type = field_type._type_definition
-
-            # TODO: All types should end up being StrawberryTypes
-            #       The first check is here as a symptom of strawberry.ID being a
-            #       Scalar, but not a StrawberryType
-            if isinstance(field_type, StrawberryType) and field_type.is_generic:
-                field = field.copy_with(type_var_map)
-
-            # Resolve generic arguments
-            generic_arguments = (
-                argument
-                for argument in field.arguments
-                if isinstance(argument.type, StrawberryType)
-                and argument.type.is_generic
-            )
-
-            for argument in generic_arguments:
-                assert isinstance(argument.type, StrawberryType)
-
-                argument.type_annotation = StrawberryAnnotation(
-                    annotation=argument.type.copy_with(type_var_map),
-                    namespace=argument.type_annotation.namespace,
-                )
-
-            fields.append(field)
+        # TODO: Logic unnecessary with StrawberryObject
+        fields = [field.copy_with(type_var_map) for field in self.fields]
 
         new_type_definition = TypeDefinition(
             name=self.name,

--- a/tests/schema/test_generics.py
+++ b/tests/schema/test_generics.py
@@ -753,24 +753,36 @@ def test_generic_argument():
     T = TypeVar("T")
 
     @strawberry.type
-    class Collection(Generic[T]):
+    class Node(Generic[T]):
         @strawberry.field
-        def by_id(self, ids: List[T]) -> List[T]:
-            return []
+        def edge(self, arg: T) -> bool:
+            return bool(arg)
+
+        @strawberry.field
+        def edges(self, args: List[T]) -> int:
+            return len(args)
 
     @strawberry.type
     class Query:
-        user: Collection[int]
+        i_node: Node[int]
+        b_node: Node[bool]
 
     schema = strawberry.Schema(Query)
 
     expected_schema = """
-    type IntCollection {
-      byId(ids: [Int!]!): [Int!]!
+    type BoolNode {
+      edge(arg: Boolean!): Boolean!
+      edges(args: [Boolean!]!): Int!
+    }
+
+    type IntNode {
+      edge(arg: Int!): Boolean!
+      edges(args: [Int!]!): Int!
     }
 
     type Query {
-      user: IntCollection!
+      iNode: IntNode!
+      bNode: BoolNode!
     }
     """
 


### PR DESCRIPTION
## Description
Field arguments are a property of resolver arguments, which are themselves a cached property. Moves the `copy_with` logic from the type definition to the resolver to avoid side-effects.

## Types of Changes
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #2285

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
