### PR TITLE
Ensure that `StrawberryField.type_annotation` is always `StrawberryAnnotation`

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+[Internal] Update StrawberryField so that `type_annotation` is always an instance of StrawberryAnnotation.

--- a/strawberry/annotation.py
+++ b/strawberry/annotation.py
@@ -40,6 +40,7 @@ from strawberry.utils.typing import is_generic, is_list, is_type_var, is_union
 
 
 if TYPE_CHECKING:
+    from strawberry.field import StrawberryField
     from strawberry.union import StrawberryUnion
 
 
@@ -68,10 +69,20 @@ class StrawberryAnnotation:
         return self.resolve() == other.resolve()
 
     @staticmethod
+    def from_annotation(
+        annotation: object, namespace: Optional[Dict] = None
+    ) -> Optional["StrawberryAnnotation"]:
+        if annotation is None:
+            return None
+
+        if not isinstance(annotation, StrawberryAnnotation):
+            return StrawberryAnnotation(annotation, namespace=namespace)
+        return annotation
+
+    @staticmethod
     def parse_annotated(annotation: object) -> object:
         from strawberry.auto import StrawberryAuto
 
-        # If the annotation is a private field return it straight away
         if is_private(annotation):
             return annotation
 
@@ -152,6 +163,10 @@ class StrawberryAnnotation:
         # TODO: Raise exception now, or later?
         # ... raise NotImplementedError(f"Unknown type {evaled_type}")
         return evaled_type
+
+    def set_namespace_from_field(self, field: "StrawberryField"):
+        module = sys.modules[field.origin.__module__]
+        self.namespace = module.__dict__
 
     def create_concrete_type(self, evaled_type: type) -> type:
         if _is_object_type(evaled_type):

--- a/strawberry/annotation.py
+++ b/strawberry/annotation.py
@@ -71,6 +71,10 @@ class StrawberryAnnotation:
     def parse_annotated(annotation: object) -> object:
         from strawberry.auto import StrawberryAuto
 
+        # If the annotation is a private field return it straight away
+        if is_private(annotation):
+            return annotation
+
         annotation_origin = get_origin(annotation)
 
         if annotation_origin is Annotated:

--- a/strawberry/experimental/pydantic/object_type.py
+++ b/strawberry/experimental/pydantic/object_type.py
@@ -78,19 +78,13 @@ def _build_dataclass_creation_fields(
         elif field.has_alias and use_pydantic_alias:
             graphql_name = field.alias
 
-        type_annotation: Optional[StrawberryAnnotation] = None
-        if not isinstance(field_type, StrawberryAnnotation):
-            type_annotation = StrawberryAnnotation(field_type)
-        else:
-            type_annotation = field_type
-
         strawberry_field = StrawberryField(
             python_name=field.name,
             graphql_name=graphql_name,
             # always unset because we use default_factory instead
             default=dataclasses.MISSING,
             default_factory=get_default_factory_for_field(field),
-            type_annotation=type_annotation,
+            type_annotation=StrawberryAnnotation.from_annotation(field_type),
             description=field.field_info.description,
             deprecation_reason=(
                 existing_field.deprecation_reason if existing_field else None

--- a/strawberry/experimental/pydantic/utils.py
+++ b/strawberry/experimental/pydantic/utils.py
@@ -52,12 +52,12 @@ class DataclassCreationFields(NamedTuple):
     """Fields required for the fields parameter of make_dataclass"""
 
     name: str
-    type_annotation: Type
+    field_type: Type
     field: dataclasses.Field
 
     def to_tuple(self) -> Tuple[str, Type, dataclasses.Field]:
         # fields parameter wants (name, type, Field)
-        return self.name, self.type_annotation, self.field
+        return self.name, self.field_type, self.field
 
 
 def get_default_factory_for_field(

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -51,6 +51,7 @@ UNRESOLVED = object()
 
 class StrawberryField(dataclasses.Field):
     python_name: str
+    type_annotation: Optional[StrawberryAnnotation]
     default_resolver: Callable[[Any, str], object] = getattr
 
     def __init__(
@@ -231,10 +232,7 @@ class StrawberryField(dataclasses.Field):
         try:
             # Prioritise the field type over the resolver return type
             if self.type_annotation is not None:
-                if isinstance(self.type_annotation, StrawberryAnnotation):
-                    return self.type_annotation.resolve()
-
-                return self.type_annotation
+                return self.type_annotation.resolve()
 
             if self.base_resolver is not None:
                 # Handle unannotated functions (such as lambdas)
@@ -259,7 +257,17 @@ class StrawberryField(dataclasses.Field):
 
     @type.setter
     def type(self, type_: Any) -> None:
-        self.type_annotation = type_
+        if type_ is None:
+            return
+
+        if isinstance(type_, StrawberryAnnotation):
+            self.type_annotation = type_
+        else:
+            # Note: we aren't setting a namespace here for the annotation. That
+            # happens in the `_get_fields` function in `types/type_resolver` so
+            # that we have access to the correct namespace for the object type
+            # the field is attached to.
+            self.type_annotation = StrawberryAnnotation(type_)
 
     # TODO: add this to arguments (and/or move it to StrawberryType)
     @property

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -257,17 +257,13 @@ class StrawberryField(dataclasses.Field):
 
     @type.setter
     def type(self, type_: Any) -> None:
-        if type_ is None:
-            return
-
-        if isinstance(type_, StrawberryAnnotation):
-            self.type_annotation = type_
-        else:
-            # Note: we aren't setting a namespace here for the annotation. That
-            # happens in the `_get_fields` function in `types/type_resolver` so
-            # that we have access to the correct namespace for the object type
-            # the field is attached to.
-            self.type_annotation = StrawberryAnnotation(type_)
+        # Note: we aren't setting a namespace here for the annotation. That
+        # happens in the `_get_fields` function in `types/type_resolver` so
+        # that we have access to the correct namespace for the object type
+        # the field is attached to.
+        self.type_annotation = StrawberryAnnotation.from_annotation(
+            type_, namespace=None
+        )
 
     # TODO: add this to arguments (and/or move it to StrawberryType)
     @property

--- a/strawberry/types/type_resolver.py
+++ b/strawberry/types/type_resolver.py
@@ -125,8 +125,7 @@ def _get_fields(cls: Type) -> List[StrawberryField]:
             if isinstance(field.type_annotation, StrawberryAnnotation):
                 type_annotation = field.type_annotation
                 if type_annotation.namespace is None:
-                    module = sys.modules[field.origin.__module__]
-                    type_annotation.namespace = module.__dict__
+                    type_annotation.set_namespace_from_field(field)
 
         # Create a StrawberryField for fields that didn't use strawberry.field
         else:

--- a/strawberry/types/type_resolver.py
+++ b/strawberry/types/type_resolver.py
@@ -117,12 +117,16 @@ def _get_fields(cls: Type) -> List[StrawberryField]:
             # the types.
             field.origin = field.origin or cls
 
-            # Make sure types are StrawberryAnnotations
-            if not isinstance(field.type_annotation, StrawberryAnnotation):
-                module = sys.modules[field.origin.__module__]
-                field.type_annotation = StrawberryAnnotation(
-                    annotation=field.type_annotation, namespace=module.__dict__
-                )
+            # Set the correct namespace for annotations if a namespace isn't
+            # already set
+            # Note: We do this here rather in the `Strawberry.type` setter
+            # function because at that point we don't have a link to the object
+            # type that the field as attached to.
+            if isinstance(field.type_annotation, StrawberryAnnotation):
+                type_annotation = field.type_annotation
+                if type_annotation.namespace is None:
+                    module = sys.modules[field.origin.__module__]
+                    type_annotation.namespace = module.__dict__
 
         # Create a StrawberryField for fields that didn't use strawberry.field
         else:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Before this change `type_annotation` could be either an instance of `StrawberryAnnotation` or a raw field. This is confusing so this change always wraps the type in `StrawberryAnnotation`.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
