### PR TITLE
Auto generate a `resolve_reference` method for federation types

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,4 @@
-Release type: patch
+Release type: minor
 
 This release adds support for an implicit `resolve_reference` method
 on Federation type. This method will automatically create a Strawberry

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,25 @@
+Release type: patch
+
+This release adds support for an implicit `resolve_reference` method
+on Federation type. This method will automatically create a Strawberry
+instance for a federation type based on the input data received, for
+example, the following:
+
+```python
+@strawberry.federation.type(keys=["id"])
+class Something:
+    id: str
+
+@strawberry.federation.type(keys=["upc"])
+class Product:
+    upc: str
+    something: Something
+
+    @staticmethod
+    def resolve_reference(**data):
+        return Product(
+            upc=data["upc"], something=Something(id=data["something_id"])
+        )
+```
+
+doesn't need the resolve_reference method anymore.

--- a/docs/guides/federation.md
+++ b/docs/guides/federation.md
@@ -189,6 +189,22 @@ Finally we also need to let Strawberry know about our Book and Review types.
 Since they are not reachable from the `Query` field itself, Strawberry won't be
 able to find them.
 
+<Note>
+
+If you don't need any custom logic for your resolve_reference, you can omit it
+and Strawberry will automatically instanciate the type for you. For example,
+if we had a `Book` type with only an `id` field, Strawberry would be able to
+instanciate it for us based on the data returned by the gateway.
+
+```python
+@strawberry.federation.type(keys=["id"])
+class Book:
+    id: strawberry.ID
+    reviews: List[Review] = strawberry.field(resolver=get_reviews)
+```
+
+</Note>
+
 ## Let's run our services
 
 Before starting Apollo Router to compose our schemas we need to run the

--- a/strawberry/arguments.py
+++ b/strawberry/arguments.py
@@ -165,7 +165,7 @@ def convert_argument(
     if hasattr(type_, "_type_definition"):  # TODO: Replace with StrawberryInputObject
         type_definition: TypeDefinition = type_._type_definition
 
-        assert type_definition.is_input
+        # assert type_definition.is_input
 
         kwargs = {}
 

--- a/strawberry/arguments.py
+++ b/strawberry/arguments.py
@@ -133,6 +133,8 @@ def convert_argument(
     scalar_registry: Dict[object, Union[ScalarWrapper, ScalarDefinition]],
     config: StrawberryConfig,
 ) -> object:
+    # TODO: move this somewhere else and make it first class
+
     if value is None:
         return None
 
@@ -164,8 +166,6 @@ def convert_argument(
 
     if hasattr(type_, "_type_definition"):  # TODO: Replace with StrawberryInputObject
         type_definition: TypeDefinition = type_._type_definition
-
-        # assert type_definition.is_input
 
         kwargs = {}
 

--- a/tests/federation/test_entities.py
+++ b/tests/federation/test_entities.py
@@ -84,3 +84,85 @@ def test_info_param_in_resolve_reference():
         "GraphQLResolveInfo(field_name='_entities', field_nodes=[FieldNode"
         in result.data["_entities"][0]["info"]
     )
+
+
+def test_does_not_need_custom_resolve_reference_for_basic_things():
+    @strawberry.federation.type(keys=["upc"])
+    class Product:
+        upc: str
+
+    @strawberry.federation.type(extend=True)
+    class Query:
+        @strawberry.field
+        def top_products(self, first: int) -> typing.List[Product]:
+            return []
+
+    schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
+
+    query = """
+        query ($representations: [_Any!]!) {
+            _entities(representations: $representations) {
+                ... on Product {
+                    upc
+                }
+            }
+        }
+    """
+
+    result = schema.execute_sync(
+        query,
+        variable_values={
+            "representations": [{"__typename": "Product", "upc": "B00005N5PF"}]
+        },
+    )
+
+    assert not result.errors
+
+    assert result.data == {"_entities": [{"upc": "B00005N5PF"}]}
+
+
+def test_does_not_need_custom_resolve_reference_nested():
+    @strawberry.federation.type(keys=["id"])
+    class Something:
+        id: str
+
+    @strawberry.federation.type(keys=["upc"])
+    class Product:
+        upc: str
+        something: Something
+
+    @strawberry.federation.type(extend=True)
+    class Query:
+        @strawberry.field
+        def top_products(self, first: int) -> typing.List[Product]:
+            return []
+
+    schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
+
+    query = """
+        query ($representations: [_Any!]!) {
+            _entities(representations: $representations) {
+                ... on Product {
+                    upc
+                    something {
+                        id
+                    }
+                }
+            }
+        }
+    """
+
+    result = schema.execute_sync(
+        query,
+        variable_values={
+            "representations": [
+                {"__typename": "Product", "upc": "B00005N5PF", "something": {"id": "1"}}
+            ]
+        },
+    )
+
+    assert not result.errors
+
+    assert result.data == {
+        "_entities": [{"upc": "B00005N5PF", "something": {"id": "1"}}]
+    }


### PR DESCRIPTION
This PR introduces a new feature that should make it easier to use Apollo Federation with Strawberry.

I was writing an API and I found myself writing the reference resolver[1] manually all the time, Usually a reference resolver (in Strawberry) gets a dictionary and converts it to the Strawberry type, pretty much what we do for arguments. 

This PR adds automatic conversion when the reference resolver is not defined 😊

TODO:

- [x] Add a proper error message when the automatic conversion fail


I also think we can promote convert_arguments to a better place (and a better name, since it also supports this use case), but maybe we can do that in another PR :)


[1] https://www.apollographql.com/docs/federation/entities/#2-define-a-reference-resolver