### PR TITLE
Fix error when trying to use a custom scalar in a union

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+Release type: patch
+
+This release fixes a bug where using a custom scalar in a union would result
+in an unclear exception. Instead, when using a custom scalar in a union,
+the `InvalidUnionType` exception is raised with a clear message that you
+cannot use that type in a union.

--- a/strawberry/union.py
+++ b/strawberry/union.py
@@ -26,6 +26,7 @@ from graphql import (
 )
 
 from strawberry.annotation import StrawberryAnnotation
+from strawberry.custom_scalar import ScalarWrapper
 from strawberry.exceptions import (
     InvalidUnionType,
     UnallowedReturnTypeForUnion,
@@ -233,8 +234,12 @@ def union(
 
     for _type in types:
         if not isinstance(_type, TypeVar) and not hasattr(_type, "_type_definition"):
+            if isinstance(_type, ScalarWrapper):
+                type_name = _type.wrap.__name__
+            else:
+                type_name = _type.__name__
             raise InvalidUnionType(
-                f"Type `{_type.__name__}` cannot be used in a GraphQL Union"
+                f"Type `{type_name}` cannot be used in a GraphQL Union"
             )
 
     union_definition = StrawberryUnion(

--- a/tests/types/resolving/test_unions.py
+++ b/tests/types/resolving/test_unions.py
@@ -1,6 +1,6 @@
 import sys
 from dataclasses import dataclass
-from typing import Generic, TypeVar, Union
+from typing import Generic, NewType, TypeVar, Union
 
 import pytest
 
@@ -144,6 +144,19 @@ def test_error_with_scalar_types():
         InvalidUnionType, match="Type `int` cannot be used in a GraphQL Union"
     ):
         strawberry.union("Result", (int,))
+
+
+def test_error_with_custom_scalar_types():
+    CustomScalar = strawberry.scalar(
+        NewType("CustomScalar", str),
+        serialize=lambda v: str(v),
+        parse_value=lambda v: str(v),
+    )
+
+    with pytest.raises(
+        InvalidUnionType, match="Type `CustomScalar` cannot be used in a GraphQL Union"
+    ):
+        strawberry.union("Result", (CustomScalar,))
 
 
 def test_error_with_non_strawberry_type():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This PR fixes a bug where using a custom scalar in a union would result
in an unclear exception. Instead, when using a custom scalar in a union,
the `InvalidUnionType` exception is raised with a clear message that you
cannot use that type in a union.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
