### PR TITLE
fix: Prevent InvalidStateError when resolving canceled futures

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+Release type: patch
+
+This release changes the dataloader batch resolution to avoid resolving
+futures that were canceled, and also from reusing them from the cache.
+Trying to resolve a future that was canceled would raise `asyncio.InvalidStateError`


### PR DESCRIPTION
I see this error from time to time in my sentry installation: https://sentry.2u.app.br/share/issue/2c7efa8ad15145dd862cd2a95e455c98/