### PR TITLE
Define PartialType metaclass

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,17 @@
+Release type: minor
+
+Add `PartialType` metaclass to make fields optional dynamically.
+
+```py
+from strawberry.tools import PartialType
+
+@strawberry.type
+class UserCreate:
+    firstname: str
+    lastname: str
+
+@strawberry.type
+class UserUpdate(UserCreate, metaclass=PartialType):
+    pass
+
+```

--- a/docs/guides/tools.md
+++ b/docs/guides/tools.md
@@ -76,3 +76,29 @@ type ComboQuery {
   performA: String!
 }
 ```
+
+### `PartialType`
+
+`PartialType` metaclass is used to extend your type but makes its all field optional. Consider
+you have different types for each operation on the same model such as `UserCreate`, `UserUpdate`
+and `UserQuery`. `UserQuery` should have id field but the other does not. All fields of
+`UserQuery` and `UserUpdate` might be optional. In this case instead of defining the same field for
+each type one can define in a single type and extend it.
+
+```py
+from strawberry.tools import PartialType
+
+@strawberry.type
+class UserCreate:
+    firstname: str
+    lastname: str
+
+@strawberry.type
+class UserUpdate(UserCreate, metaclass=PartialType):
+    pass
+
+@strawberry.type
+class UserQuery(UserCreate, metaclass=PartialType):
+    id: Optional[strawberry.ID]
+
+```

--- a/strawberry/tools/__init__.py
+++ b/strawberry/tools/__init__.py
@@ -1,8 +1,10 @@
 from .create_type import create_type
 from .merge_types import merge_types
+from .partialtype import PartialType
 
 
 __all__ = [
     "create_type",
     "merge_types",
+    "PartialType",
 ]

--- a/strawberry/tools/partialtype.py
+++ b/strawberry/tools/partialtype.py
@@ -1,0 +1,30 @@
+from abc import ABCMeta
+from typing import Optional
+
+import strawberry
+
+
+class PartialType(ABCMeta):
+    def __new__(cls, name: str, bases: tuple, namespaces: dict, **kwargs):
+        mro = super().__new__(cls, name, bases, namespaces, **kwargs).mro()
+        annotations = namespaces.get("__annotations__", {})
+        fields: list[str] = []
+        for base in mro[:-1]:  # the object class has no __annotations__ attr
+            for k, v in base.__annotations__.items():
+                # To prevent overriding the higher attr annotation
+                if k not in annotations:
+                    annotations[k] = v
+
+            fields.extend(field.name for field in base._type_definition.fields)
+
+        for field in annotations:
+            if not field.startswith("_"):
+                annotations[field] = Optional[annotations[field]]
+
+        namespaces["__annotations__"] = annotations
+        klass = super().__new__(cls, name, bases, namespaces, **kwargs)
+        for field in fields:
+            if not hasattr(klass, field):
+                setattr(klass, field, strawberry.UNSET)
+
+        return klass

--- a/tests/tools/test_partialtype.py
+++ b/tests/tools/test_partialtype.py
@@ -1,0 +1,68 @@
+import dataclasses
+
+import strawberry
+from strawberry.tools import PartialType
+from strawberry.type import StrawberryOptional
+
+
+def test_partialtype():
+    @strawberry.type
+    class RoleRead:
+        name: str
+        description: str
+
+    @strawberry.type
+    class UserRead:
+        firstname: str
+        lastname: str
+        role: RoleRead
+
+    @strawberry.input
+    class RoleInput(RoleRead):
+        pass
+
+    @strawberry.input
+    class UserQuery(UserRead, metaclass=PartialType):
+        role: RoleInput
+
+    read_firstname, read_lastname, read_role = UserRead._type_definition.fields
+
+    # user read type firstname field tests
+    assert read_firstname.python_name == "firstname"
+    assert read_firstname.graphql_name is None
+    assert read_firstname.default is dataclasses.MISSING
+    assert read_firstname.type is str
+
+    # user read type lastname field tests
+    assert read_lastname.python_name == "lastname"
+    assert read_lastname.graphql_name is None
+    assert read_lastname.default is dataclasses.MISSING
+    assert read_lastname.type is str
+
+    assert read_role.python_name == "role"
+    assert read_role.graphql_name is None
+    assert read_role.default is dataclasses.MISSING
+    assert read_role.type is RoleRead
+
+    query_firstname, query_lastname, query_role = UserQuery._type_definition.fields
+
+    # user query type firstname field tests
+    assert query_firstname.python_name == "firstname"
+    assert query_firstname.graphql_name is None
+    assert query_firstname.default is strawberry.UNSET
+    assert isinstance(query_firstname.type, StrawberryOptional)
+    assert query_firstname.type.of_type is str
+
+    # user query type lastname field tests
+    assert query_lastname.python_name == "lastname"
+    assert query_lastname.graphql_name is None
+    assert query_lastname.default is strawberry.UNSET
+    assert isinstance(query_lastname.type, StrawberryOptional)
+    assert query_lastname.type.of_type is str
+
+    # user query type role field tests
+    assert query_role.python_name == "role"
+    assert query_role.graphql_name is None
+    assert query_role.default is strawberry.UNSET
+    assert isinstance(query_role.type, StrawberryOptional)
+    assert query_role.type.of_type is RoleInput


### PR DESCRIPTION
To prevent defining the same field for different types on the same model I defined a metaclass called PartialType that makes fields optional. 

Currently, we define the same fields in multiple types for the same model since the field might be optional for one type but not for the other.

```py
from typing import Optional


@strawberry.type
class UserCreate:
    firstname: str
    lastname: str

@strawberry.type
class UserUpdate:
    firstname: Optional[str] = strawberry.UNSET
    lastname: Optional[str] = strawberry.UNSET

@strawberry.type
class UserQuery(UserUpdate):
    id: Optional[strawberry.ID] = strawberry.UNSET

```
Imagine that `UserCreate`  has a bunch of fields. One has to define all of them in the `UserUpdate` type. With `PartialType` metaclass reusing is possible. 

```py
from strawberry.tools import PartialType


@strawberry.type
class UserCreate:
    firstname: str
    lastname: str

@strawberry.type
class UserUpdate(UserCreate, metaclass=PartialType):
    pass

@strawberry.type
class UserQuery(UserCreate, metaclass=PartialType):
     id: Optional[strawberry.ID] = strawberry.UNSET

```

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
