### PR TITLE
Update matrix for starlette tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,7 +125,7 @@ jobs:
   starlette-unit-tests:
     strategy:
       matrix:
-        starlette: ["0.17.1", "0.18.0", "0.19.1", "0.20.4"]
+        starlette: ["0.19.1", "0.20.4", "0.21.0", "0.22.0"]
 
     name: Starlette ${{ matrix.starlette }}
     runs-on: ubuntu-latest
@@ -146,10 +146,13 @@ jobs:
       - name: Install starlette ${{ matrix.starlette }}
         run: poetry run pip install starlette==${{ matrix.starlette }}
 
-      # install fastapi < 0.85.0 if we are testing starlette before 0.20.4
       - name: Install fastapi 0.85.0
         run: poetry run pip install "fastapi<0.85.0"
-        if: matrix.starlette != '0.20.4'
+        if: matrix.starlette == '0.19.1'
+
+      - name: Install fastapi 0.88.0
+        run: poetry run pip install "fastapi<0.88.0"
+        if: matrix.starlette == '0.20.4'
 
       - name: pytest
         run:


### PR DESCRIPTION
Tests here are failing due to an update to Fastapi

https://github.com/strawberry-graphql/strawberry/pull/2374

I've removed older version of Starlette and added 0.21 and 0.22
