### PR TITLE
Fix duplication of generics with lazy types

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,15 @@
+Release type: patch
+
+This release fixes an issue with type duplication of generics.
+
+You can now use a lazy type with a generic even if
+the original type was already used with that generic in the schema.
+
+Example:
+
+```python3
+@strawberry.type
+class Query:
+    regular: Edge[User]
+    lazy: Edge[Annotated["User", strawberry.lazy(".user")]]
+```

--- a/tests/schema/test_lazy/test_lazy_generic.py
+++ b/tests/schema/test_lazy/test_lazy_generic.py
@@ -1,3 +1,4 @@
+import textwrap
 from typing import TYPE_CHECKING, Generic, TypeVar
 from typing_extensions import Annotated
 
@@ -23,3 +24,45 @@ def test_lazy_types_with_generic():
         users: Edge[TypeAType]
 
     strawberry.Schema(query=Query)
+
+
+def test_no_generic_type_duplication_with_lazy():
+    from tests.schema.test_lazy.type_a import TypeB_abs, TypeB_rel
+    from tests.schema.test_lazy.type_b import TypeB
+
+    @strawberry.type
+    class Edge(Generic[T]):
+        node: T
+
+    @strawberry.type
+    class Query:
+        users: Edge[TypeB]
+        relatively_lazy_users: Edge[TypeB_rel]
+        absolutely_lazy_users: Edge[TypeB_abs]
+
+    schema = strawberry.Schema(query=Query)
+
+    expected_schema = textwrap.dedent(
+        """
+        type Query {
+          users: TypeBEdge!
+          relativelyLazyUsers: TypeBEdge!
+          absolutelyLazyUsers: TypeBEdge!
+        }
+
+        type TypeA {
+          listOfB: [TypeB!]
+          typeB: TypeB!
+        }
+
+        type TypeB {
+          typeA: TypeA!
+        }
+
+        type TypeBEdge {
+          node: TypeB!
+        }
+        """
+    ).strip()
+
+    assert str(schema) == expected_schema


### PR DESCRIPTION
## Description

This PR makes lazy types treated as equal to their original types when comparing TypeVars inside generics.

Lazy types are resolved for the comparison.


## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #2379 

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
