### PR TITLE
Optimization: Improve performance of rich exceptions on custom scalar

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+Release type: patch
+
+This release improves the performance of rich exceptions on custom scalars
+by changing how frames are fetched from the call stack.
+Before the change, custom scalars were using a CPU intensive call to the
+`inspect` module to fetch frame info which could lead to serious CPU spikes.

--- a/strawberry/custom_scalar.py
+++ b/strawberry/custom_scalar.py
@@ -1,6 +1,5 @@
 import sys
 from dataclasses import dataclass
-from inspect import getframeinfo, stack
 from typing import (
     Any,
     Callable,
@@ -100,10 +99,10 @@ def _process_scalar(
     _source_line = None
 
     if should_use_rich_exceptions():
-        frame = getframeinfo(stack()[3][0])
+        frame = sys._getframe(3)
 
-        _source_file = frame.filename
-        _source_line = frame.lineno
+        _source_file = frame.f_code.co_filename
+        _source_line = frame.f_lineno
 
     wrapper = ScalarWrapper(cls)
     wrapper._scalar_definition = ScalarDefinition(


### PR DESCRIPTION
## Description

The release of [0.145.0](https://github.com/strawberry-graphql/strawberry/releases/tag/0.145.0) caused a production outage for us, with all of our Heroku dyno’s (machines) seeing high CPU usage and load figures immediately after our web server, gunicorn, was booted via Heroku’s Procfile.

After the initial rollback, we discovered that lowering the number of gunicorn workers we use concurrently (via **WEB_CONCURRENCY**) from 6 to 4 helped the gunicorn workers serve requests, but we still saw elongated startup times and a CPU spike on first boot. 

This led us to [this line](https://github.com/strawberry-graphql/strawberry/blob/main/strawberry/custom_scalar.py#L103) in the 0.145.0 release, which does an intensive call; we suspect that we’re doing this call about 11 times per worker on boot. So with 6 workers - we did an intensive call over 60 times, and that took so long that the parent gunicorn process considered the workers dead and started new ones…thus we never served any requests as they continually rebooted.

The whole issue is proven by the fact we can release with no CPU spike if we disable the new error checking with the included env var (i.e., if we set `STRAWBERRY_DISABLE_RICH_ERRORS` to `false`).

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
