### PR TITLE
Fix enums inside generics

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,24 @@
+Release type: patch
+
+This release fixes an issue that prevented using generic
+that had a field of type enum. The following works now:
+
+```python
+@strawberry.enum
+class EstimatedValueEnum(Enum):
+    test = "test"
+    testtest = "testtest"
+
+
+@strawberry.type
+class EstimatedValue(Generic[T]):
+    value: T
+    type: EstimatedValueEnum
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def estimated_value(self) -> Optional[EstimatedValue[int]]:
+        return EstimatedValue(value=1, type=EstimatedValueEnum.test)
+```

--- a/strawberry/enum.py
+++ b/strawberry/enum.py
@@ -41,7 +41,8 @@ class EnumDefinition(StrawberryType):
     def copy_with(
         self, type_var_map: Mapping[TypeVar, Union[StrawberryType, type]]
     ) -> Union[StrawberryType, type]:
-        return super().copy_with(type_var_map)  # type: ignore[safe-super]
+        # enum don't support type parameters, so we can safely return self
+        return self
 
     @property
     def is_generic(self) -> bool:

--- a/tests/schema/test_generics.py
+++ b/tests/schema/test_generics.py
@@ -395,6 +395,47 @@ def test_generic_with_enum_as_param_of_type_inside_unions():
     assert result.data == {"result": {"__typename": "CodesErrorNode", "code": "a"}}
 
 
+def test_generic_with_enum():
+    T = TypeVar("T")
+
+    @strawberry.enum
+    class EstimatedValueEnum(Enum):
+        test = "test"
+        testtest = "testtest"
+
+    @strawberry.type
+    class EstimatedValue(Generic[T]):
+        value: T
+        type: EstimatedValueEnum
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def estimated_value(self) -> Optional[EstimatedValue[int]]:
+            return EstimatedValue(value=1, type=EstimatedValueEnum.test)
+
+    schema = strawberry.Schema(query=Query)
+
+    query = """{
+        estimatedValue {
+            __typename
+            value
+            type
+        }
+    }"""
+
+    result = schema.execute_sync(query)
+
+    assert not result.errors
+    assert result.data == {
+        "estimatedValue": {
+            "__typename": "IntEstimatedValue",
+            "value": 1,
+            "type": "test",
+        }
+    }
+
+
 def test_supports_generic_in_unions_multiple_vars():
     A = TypeVar("A")
     B = TypeVar("B")


### PR DESCRIPTION
This PR implements `copy_with` inside `EnumDefinition`, previously it would just raise a `NotImplementedError` :)


Closes #2410