### PR TITLE
Fix: copy field metadata for pydantic

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,13 @@
+Release type: patch
+
+The recent addition of support for the metadata attribute for fields isn't handled for Pydantic support.
+This ensures that the metadata attribute on fields isn't lost when a @strawberry.experimental.pydantic.type
+is created.
+
+Example:
+```python
+@strawberry.experimental.pydantic.type(model=User)
+class UserType:
+    private: strawberry.auto = strawberry.field(metadata={"admin_only": True})
+    public: strawberry.auto
+```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,8 +1,6 @@
 Release type: patch
 
-The recent addition of support for the metadata attribute for fields isn't handled for Pydantic support.
-This ensures that the metadata attribute on fields isn't lost when a @strawberry.experimental.pydantic.type
-is created.
+This release fixes `@strawberry.experimental.pydantic.type` and adds support for the metadata attribute on fields.
 
 Example:
 ```python

--- a/strawberry/experimental/pydantic/object_type.py
+++ b/strawberry/experimental/pydantic/object_type.py
@@ -92,6 +92,7 @@ def _build_dataclass_creation_fields(
                 existing_field.permission_classes if existing_field else []
             ),
             directives=existing_field.directives if existing_field else (),
+            metadata=existing_field.metadata if existing_field else {},
         )
 
     return DataclassCreationFields(

--- a/tests/experimental/pydantic/test_basic.py
+++ b/tests/experimental/pydantic/test_basic.py
@@ -841,6 +841,7 @@ def test_alias_fields_with_use_pydantic_alias():
     assert field3.python_name == "country"
     assert field3.graphql_name == "countryPydantic"
 
+
 def test_field_metadata():
     class User(pydantic.BaseModel):
         private: bool
@@ -861,5 +862,3 @@ def test_field_metadata():
 
     assert field2.python_name == "public"
     assert not field2.metadata
-
-

--- a/tests/experimental/pydantic/test_basic.py
+++ b/tests/experimental/pydantic/test_basic.py
@@ -840,3 +840,26 @@ def test_alias_fields_with_use_pydantic_alias():
 
     assert field3.python_name == "country"
     assert field3.graphql_name == "countryPydantic"
+
+def test_field_metadata():
+    class User(pydantic.BaseModel):
+        private: bool
+        public: bool
+
+    @strawberry.experimental.pydantic.type(User)
+    class UserType:
+        private: strawberry.auto = strawberry.field(metadata={"admin_only": True})
+        public: strawberry.auto
+
+    definition: TypeDefinition = UserType._type_definition
+    assert definition.name == "UserType"
+
+    [field1, field2] = definition.fields
+
+    assert field1.python_name == "private"
+    assert field1.metadata["admin_only"]
+
+    assert field2.python_name == "public"
+    assert not field2.metadata
+
+


### PR DESCRIPTION
Adds to PR strawberry-graphql/strawberry#2190

See https://github.com/strawberry-graphql/strawberry/pull/2190#issuecomment-1358333300

<!--- Provide a general summary of your changes in the title above. -->

The addition of the `metadata` attribute for fields isn't handled for Pydantic support. This ensures that the `metadata` attribute on fields isn't lost when a `@strawberry.experimental.pydantic.type` is created.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
In the module `strawberry/experimental/pydantic/object_type.py`, function `_build_dataclass_creation_fields`, a `StrawberryField` is constructed.  This code change just makes sure that the `metadata` attribute isn't forgotten.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* None

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
