### PR TITLE
Fix duplicated type name on generics

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,33 @@
+Release type: patch
+
+Fix `DuplicatedTypeName` exception being raised on generics declared using
+`strawberry.lazy`. Previously the following would raise:
+
+```python
+# issue_2397.py
+from typing import Annotated, Generic, TypeVar
+
+import strawberry
+
+T = TypeVar("T")
+
+
+@strawberry.type
+class Item:
+    name: str
+
+
+@strawberry.type
+class Edge(Generic[T]):
+    node: T
+
+
+@strawberry.type
+class Query:
+    edges_normal: Edge[Item]
+    edges_lazy: Edge[Annotated["Item", strawberry.lazy("issue_2397")]]
+
+
+if __name__ == "__main__":
+    schema = strawberry.Schema(query=Query)
+```

--- a/strawberry/lazy_type.py
+++ b/strawberry/lazy_type.py
@@ -47,12 +47,13 @@ class LazyType(Generic[TypeName, Module]):
             # Refer to: https://github.com/strawberry-graphql/strawberry/issues/2397
             if main_module.__spec__ and main_module.__spec__.name == self.module:
                 module = main_module
-            elif (
-                main_module.__file__
-                and module.__file__
-                and Path(main_module.__file__).samefile(module.__file__)
-            ):
-                module = main_module
+            elif hasattr(main_module, "__file__") and hasattr(module, "__file__"):
+                if (
+                    main_module.__file__
+                    and module.__file__
+                    and Path(main_module.__file__).samefile(module.__file__)
+                ):
+                    module = main_module
         return module.__dict__[self.type_name]
 
     # this empty call method allows LazyTypes to be used in generic types

--- a/strawberry/lazy_type.py
+++ b/strawberry/lazy_type.py
@@ -1,7 +1,9 @@
 import importlib
 import inspect
+import sys
 import warnings
 from dataclasses import dataclass
+from pathlib import Path
 from typing import ForwardRef, Generic, Optional, Type, TypeVar, cast
 
 TypeName = TypeVar("TypeName")
@@ -38,7 +40,19 @@ class LazyType(Generic[TypeName, Module]):
 
     def resolve_type(self) -> Type:
         module = importlib.import_module(self.module, self.package)
-
+        main_module = sys.modules.get("__main__", None)
+        if main_module:
+            # If lazy type points to the main module, use it instead of the imported
+            # module. Otherwise duplication checks during schema-conversion might fail.
+            # Refer to: https://github.com/strawberry-graphql/strawberry/issues/2397
+            if main_module.__spec__ and main_module.__spec__.name == self.module:
+                module = main_module
+            elif (
+                main_module.__file__
+                and module.__file__
+                and Path(main_module.__file__).samefile(module.__file__)
+            ):
+                module = main_module
         return module.__dict__[self.type_name]
 
     # this empty call method allows LazyTypes to be used in generic types

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -721,8 +721,18 @@ class GraphQLCoreConverter:
                 # may be referencing the same actual type
                 if isinstance(type1, LazyType):
                     type1 = type1.resolve_type()
+                elif isinstance(type1, StrawberryOptional) and isinstance(
+                    type1.of_type, LazyType
+                ):
+                    type1.of_type = type1.of_type.resolve_type()
+
                 if isinstance(type2, LazyType):
                     type2 = type2.resolve_type()
+                elif isinstance(type2, StrawberryOptional) and isinstance(
+                    type2.of_type, LazyType
+                ):
+                    type2.of_type = type2.of_type.resolve_type()
+
                 if type1 != type2:
                     equal = False
                     break

--- a/tests/schema/test_lazy/test_lazy_generic.py
+++ b/tests/schema/test_lazy/test_lazy_generic.py
@@ -1,6 +1,11 @@
+import os
+import subprocess
+import sys
 import textwrap
-from typing import TYPE_CHECKING, Generic, TypeVar
+from typing import TYPE_CHECKING, Generic, List, Optional, Sequence, TypeVar
 from typing_extensions import Annotated
+
+import pytest
 
 import strawberry
 
@@ -60,6 +65,63 @@ def test_no_generic_type_duplication_with_lazy():
 
         type TypeBEdge {
           node: TypeB!
+        }
+        """
+    ).strip()
+
+    assert str(schema) == expected_schema
+
+
+@pytest.mark.parametrize(
+    "commands",
+    [
+        pytest.param(["tests/schema/test_lazy/type_c.py"], id="script"),
+        pytest.param(["-m", "tests.schema.test_lazy.type_c"], id="module"),
+    ],
+)
+def test_lazy_types_loaded_from_same_module(commands: Sequence[str]):
+    """Test if lazy types resolved from the same module produce duplication error.
+
+    Note:
+      `subprocess` is used since the test must be run as the main module / script.
+    """
+    result = subprocess.run(
+        args=[sys.executable, *commands],
+        env=os.environ,
+        capture_output=True,
+    )
+    result.check_returncode()
+
+
+def test_lazy_types_declared_within_optional():
+    from tests.schema.test_lazy.type_c import Edge, TypeC
+
+    @strawberry.type
+    class Query:
+
+        normal_edges: List[Edge[Optional[TypeC]]]
+        lazy_edges: List[
+            Edge[
+                Optional[
+                    Annotated["TypeC", strawberry.lazy("tests.schema.test_lazy.type_c")]
+                ]
+            ]
+        ]
+
+    schema = strawberry.Schema(query=Query)
+    expected_schema = textwrap.dedent(
+        """
+        type Query {
+          normalEdges: [TypeCOptionalEdge!]!
+          lazyEdges: [TypeCOptionalEdge!]!
+        }
+
+        type TypeC {
+          name: String!
+        }
+
+        type TypeCOptionalEdge {
+          node: TypeC
         }
         """
     ).strip()

--- a/tests/schema/test_lazy/type_c.py
+++ b/tests/schema/test_lazy/type_c.py
@@ -1,0 +1,28 @@
+from typing import Annotated, Generic, TypeVar
+
+import strawberry
+
+T = TypeVar("T")
+
+
+@strawberry.type
+class TypeC:
+    name: str
+
+
+@strawberry.type
+class Edge(Generic[T]):
+    @strawberry.field
+    def node(self) -> T:  # type: ignore
+        ...
+
+
+@strawberry.type
+class Query:
+
+    type_a: Edge[TypeC]
+    type_b: Edge[Annotated["TypeC", strawberry.lazy("tests.schema.test_lazy.type_c")]]
+
+
+if __name__ == "__main__":
+    schema = strawberry.Schema(query=Query)

--- a/tests/schema/test_lazy/type_c.py
+++ b/tests/schema/test_lazy/type_c.py
@@ -1,4 +1,5 @@
-from typing import Annotated, Generic, TypeVar
+from typing import Generic, TypeVar
+from typing_extensions import Annotated
 
 import strawberry
 


### PR DESCRIPTION
This commit addresses #2379 by implementing additional logic to resolve
`strawberry.lazy` annotated types. Previously, if the same return type
was declared in one location using `strawberry.lazy` and in another
location without, then a `DuplicatedTypeName` exception would be raised.

Summary of Changes:
- Added logic to handle `StrawberryOptional` in `schema_converter.py`
- Added check to determine if `strawberry.lazy` refers to the
    `__main__` module to prevent an import leading to instantiation
    of new module members.
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #2397 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
