### PR TITLE
resolve_references for federation schema

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,11 @@
+Release type: patch
+
+For federation schema types has been added a posibility to implement `resolve_references` method.
+Such implementation can have `info` parameter and also a parameter which hols a list of unique identificators.
+Usually those identificators are ids primary keys. This parameter must have same name as it has in
+implementation of method `resolve_reference`.
+
+Such possibility allows to query for entities in database with one query. This can speed up response
+for large federation queries.
+
+`resolve_references` method is not mandatory, if it is not implemented, `resolve_reference` method is used.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,8 +1,8 @@
 Release type: patch
 
 For federation schema types has been added a posibility to implement `resolve_references` method.
-Such implementation can have `info` parameter and also a parameter which hols a list of unique identificators.
-Usually those identificators are ids primary keys. This parameter must have same name as it has in
+Such implementation can have `info` parameter and also a parameter which holds a list of unique identificators.
+Usually those identificators are ids (primary keys). This parameter must have same name as it has in
 implementation of method `resolve_reference`.
 
 Such possibility allows to query for entities in database with one query. This can speed up response

--- a/docs/guides/federation-v1.md
+++ b/docs/guides/federation-v1.md
@@ -154,13 +154,12 @@ the requested `id` and a fixed number of reviews.
 <Note>
 
 If the class implements `resolve_references` (focus on plural form), this can be used.
-The parameter ideeentifing entities is considered as a list of identificators. Such 
-implementation allows resolve multiple entities in a single call. This speeds up 
-resolving, especially if communication with a database server is needed as this can 
+The parameter ideeentifing entities is considered as a list of identificators. Such
+implementation allows resolve multiple entities in a single call. This speeds up
+resolving, especially if communication with a database server is needed as this can
 be done with single database query.
 
 </Note>
-
 
 If we were to add more fields to `Book` that were stored in a database, this
 would be where we could perform queries for these fields' values.

--- a/docs/guides/federation-v1.md
+++ b/docs/guides/federation-v1.md
@@ -151,6 +151,17 @@ by the books service. Recall that above we defined the `id` field as the `key`
 for the `Book` type. In this example we are creating an instance of `Book` with
 the requested `id` and a fixed number of reviews.
 
+<Note>
+
+If the class implements `resolve_references` (focus on plural form), this can be used.
+The parameter ideeentifing entities is considered as a list of identificators. Such 
+implementation allows resolve multiple entities in a single call. This speeds up 
+resolving, especially if communication with a database server is needed as this can 
+be done with single database query.
+
+</Note>
+
+
 If we were to add more fields to `Book` that were stored in a database, this
 would be where we could perform queries for these fields' values.
 

--- a/docs/guides/federation-v1.md
+++ b/docs/guides/federation-v1.md
@@ -153,8 +153,8 @@ the requested `id` and a fixed number of reviews.
 
 <Note>
 
-If the class implements `resolve_references` (focus on plural form), this can be used.
-The parameter ideeentifing entities is considered as a list of identificators. Such
+If the class implements `resolve_references` (focus on plural form), it can be used.
+The parameter identifying entities is considered as a list of identificators. Such
 implementation allows resolve multiple entities in a single call. This speeds up
 resolving, especially if communication with a database server is needed as this can
 be done with single database query.

--- a/strawberry/federation/schema.py
+++ b/strawberry/federation/schema.py
@@ -199,7 +199,6 @@ class Schema(BaseSchema):
                     func_args = get_func_args(resolve_references)
 
                     if key_name not in func_args:
-
                         def get_result(
                             representation,
                             type_row=type_row,
@@ -209,20 +208,13 @@ class Schema(BaseSchema):
                             info=info,
                             func_args=func_args,
                         ):
-                            result = (
+                            raise Exception(
                                 "Got confused while trying use resolve_references for"
                                 f" {definition.origin}. "
                                 "Resolver resolve_references has not a prameter"
                                 f" {key_names[0]}"
-                            )
-
-                            if result.startswith("G"):
-                                raise Exception(result)
-                            else:
-                                return result
-
+                            )                           
                     else:
-
                         def get_result_func(
                             representation,
                             type_row=type_row,

--- a/strawberry/federation/schema.py
+++ b/strawberry/federation/schema.py
@@ -1,10 +1,10 @@
+import asyncio
+import inspect
 from collections import defaultdict
 from copy import copy
 from functools import partial
 from itertools import chain
 from typing import Any, Dict, Iterable, List, Optional, Type, Union, cast
-import inspect
-import asyncio
 
 from graphql import ExecutionContext as GraphQLExecutionContext
 from graphql import (
@@ -43,6 +43,7 @@ def create_catch_GraphQLError(get_result, definition):
                 original_error=e,
             )
         return result
+
     return catch_GraphQLError
 
 
@@ -222,47 +223,63 @@ class Schema(BaseSchema):
             type_row = type_dict.get(type_name, None)
             if type_row is None:
                 type_row = {
-                    'type': type_, 
-                    'questions': [],
-                    'indexes': [],
-                    'results': [],
-                    'lazy': False,
-                    'get_result': lambda item: None
+                    "type": type_,
+                    "questions": [],
+                    "indexes": [],
+                    "results": [],
+                    "lazy": False,
+                    "get_result": lambda item: None,
                 }
                 type_dict[type_name] = type_row
                 definition = cast(TypeDefinition, type_.definition)
                 key_names = list(representation.keys())
-                #key_values = list(representation.values())
-                if hasattr(definition.origin, "resolve_references") and (len(key_names) == 1):
+                if hasattr(definition.origin, "resolve_references") and (
+                    len(key_names) == 1
+                ):
                     key_name = key_names[0]
-                    type_row['lazy'] = True
-                    #type_row['solved'] = False
+                    type_row["lazy"] = True
 
                     resolve_references = definition.origin.resolve_references
 
                     func_args = get_func_args(resolve_references)
 
-                    def get_result_func(_, type_row=type_row, key_name=key_name, resolve_references=resolve_references, func_args=func_args):
-                        key_values = type_row['questions']
+                    def get_result_func(
+                        _,
+                        type_row=type_row,
+                        key_name=key_name,
+                        resolve_references=resolve_references,
+                        func_args=func_args,
+                    ):
+                        key_values = type_row["questions"]
                         kwargs = {}
-                        kwargs[key_name] = list(map(lambda item: item[key_name], key_values))
+                        kwargs[key_name] = list(
+                            map(lambda item: item[key_name], key_values)
+                        )
                         # TODO: use the same logic we use for other resolvers
                         if "info" in func_args:
                             kwargs["info"] = info
                         return resolve_references(**kwargs)
 
                     if key_name not in func_args:
-                        def get_result(_, type_row=type_row, definition=definition, key_names=key_names):
+
+                        def get_result(
+                            _,
+                            type_row=type_row,
+                            definition=definition,
+                            key_names=key_names,
+                        ):
                             result = GraphQLError(
                                 f"Got confused while trying use resolve_references for {definition.origin}. Resolver resolve_references has not a prameter {key_names[0]}"
-                                )
-                            return [result] * len(type_row['questions'])
-                    #get_result = partial(resolve_references, **kwargs)
+                            )
+                            return [result] * len(type_row["questions"])
+
                     else:
-                        get_result = create_catch_GraphQLError(get_result_func, definition)
-                    type_row['get_result'] = get_result
+                        get_result = create_catch_GraphQLError(
+                            get_result_func, definition
+                        )
+                    type_row["get_result"] = get_result
                 elif hasattr(definition.origin, "resolve_reference"):
-                    type_row['lazy'] = False
+                    type_row["lazy"] = False
 
                     resolve_reference = definition.origin.resolve_reference
 
@@ -270,79 +287,98 @@ class Schema(BaseSchema):
 
                     # TODO: use the same logic we use for other resolvers
                     if "info" in func_args:
-                        def get_result_func(representation, resolve_reference=resolve_reference, info=info):
+
+                        def get_result_func(
+                            representation,
+                            resolve_reference=resolve_reference,
+                            info=info,
+                        ):
                             return resolve_reference(info=info, **representation)
+
                     else:
-                        def get_result_func(representation, resolve_reference=resolve_reference):
+
+                        def get_result_func(
+                            representation, resolve_reference=resolve_reference
+                        ):
                             return resolve_reference(**representation)
 
-                    type_row['get_result'] = create_catch_GraphQLError(get_result_func, definition)
+                    type_row["get_result"] = create_catch_GraphQLError(
+                        get_result_func, definition
+                    )
                 else:
                     from strawberry.arguments import convert_argument
 
-                    type_row['lazy'] = False
+                    type_row["lazy"] = False
                     strawberry_schema = info.schema.extensions["strawberry-definition"]
                     config = strawberry_schema.config
                     scalar_registry = strawberry_schema.schema_converter.scalar_registry
 
-                    def create_get_result(convert_argument,
-                        type_,
-                        scalar_registry,
-                        config):
+                    def create_get_result(
+                        convert_argument, type_, scalar_registry, config
+                    ):
                         def get_result(representation):
-                            result = convert_argument(representation, 
+                            result = convert_argument(
+                                representation,
                                 type_=type_,
                                 scalar_registry=scalar_registry,
-                                config=config)
+                                config=config,
+                            )
                             return result
+
                         return get_result
 
                         # return partial(
                         #     convert_argument,
                         #     representation,
-                        #     type_=definition.origin,
-                        #     scalar_registry=scalar_registry,
-                        #     config=config,
-                        # )
-                    get_result = create_get_result(convert_argument, type_=definition.origin, scalar_registry=scalar_registry,
-                        config=config)
-                    type_row['get_result'] = create_catch_GraphQLError(get_result, definition)
-            type_row['indexes'].append(index)
-            type_row['questions'].append(representation)
 
+                    get_result = create_get_result(
+                        convert_argument,
+                        type_=definition.origin,
+                        scalar_registry=scalar_registry,
+                        config=config,
+                    )
+                    type_row["get_result"] = create_catch_GraphQLError(
+                        get_result, definition
+                    )
+            type_row["indexes"].append(index)
+            type_row["questions"].append(representation)
 
         async def awaitable_wrapper(index, row):
-            semaphore = row['semaphore']
-            list_of_indexes = row['indexes']
+            semaphore = row["semaphore"]
+            list_of_indexes = row["indexes"]
             index_of = list_of_indexes.index(index)
             async with semaphore:
-                list_of_results = row['results']
+                list_of_results = row["results"]
                 if inspect.isawaitable(list_of_results):
                     list_of_results = await list_of_results
-                    row['results'] = list_of_results
+                    row["results"] = list_of_results
                 single_result = list_of_results[index_of]
             return single_result
 
         indexed_results = []
-        for entity_name, row in type_dict.items():
-            if row['lazy']:
-                row['semaphore'] = asyncio.BoundedSemaphore(1)
+        for _entity_name, row in type_dict.items():
+            if row["lazy"]:
+                row["semaphore"] = asyncio.BoundedSemaphore(1)
 
-                get_result = row['get_result']
+                get_result = row["get_result"]
                 result = get_result(None)
-                row['results'] = result
-                current_indexed_results = [(index, awaitable_wrapper(index, row)) for index in row['indexes']]
+                row["results"] = result
+                current_indexed_results = [
+                    (index, awaitable_wrapper(index, row)) for index in row["indexes"]
+                ]
                 indexed_results.extend(current_indexed_results)
             else:
-                get_result = row['get_result']
-                row['results'] = [get_result(item) for item in row['questions']]
-                current_indexed_results = [(index, result) for index, result in zip(row['indexes'], row['results'])]
+                get_result = row["get_result"]
+                row["results"] = [get_result(item) for item in row["questions"]]
+                current_indexed_results = [
+                    (index, result)
+                    for index, result in zip(row["indexes"], row["results"])
+                ]
                 indexed_results.extend(current_indexed_results)
 
         indexed_results.sort(key=lambda a: a[0])
         results = list(map(lambda item: item[1], indexed_results))
         return results
-
 
     def _add_scalars(self):
         self.Any = GraphQLScalarType("_Any")

--- a/strawberry/federation/schema.py
+++ b/strawberry/federation/schema.py
@@ -198,6 +198,7 @@ class Schema(BaseSchema):
                     func_args = get_func_args(resolve_references)
 
                     if key_name not in func_args:
+
                         def get_result(
                             representation,
                             type_row=type_row,
@@ -212,8 +213,10 @@ class Schema(BaseSchema):
                                 f" {definition.origin}. "
                                 "Resolver resolve_references has not a prameter"
                                 f" {key_names[0]}"
-                            )                           
+                            )
+
                     else:
+
                         def get_result_func(
                             representation,
                             type_row=type_row,

--- a/tests/federation/test_entities.py
+++ b/tests/federation/test_entities.py
@@ -448,6 +448,7 @@ async def test_got_confused_resolve_references():
         "Got confused while trying use resolve_references for"
     )
 
+
 async def test_info_param_in_resolve_references():
     used_resolve_references = False
 


### PR DESCRIPTION
This patch proposal allows to speed up resolving of multiple entities (same type) for queries on federation member.

## Description

In federation schema is method `entities_resolver` which calls appropriate `resolve_reference` on federation types one by one.
Proposed code allows to extend federation type by method `resolve_references` (notice "s" - plural form),
which can serve as multiple ids resolver. In case when a database query is needed, this could speed up 
the resolving significantly, especially when large query goes thorough multiple federation members.

Implementation of  `resolve_references` is optionally, when it is missing, `resolve_reference` is used.
`resolve_reference` remains mandatory if it needs more attributes than `info` and `id` (or other unique identificator).

`resolve_references` must use the singular form of parameter (aka `id` not ~~`ids`~~) passing unique identificators.

Only the method `entities_resolver` in /strawberry/federation/schema.py has been changed. This implementation
take into account both sync and async possible definitions of `resolve_reference` and `resolve_references`.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
