### PR TITLE
Use sys.__excepthook__ and threading.__excepthook__

### DIFF
--- a/strawberry/exceptions/handler.py
+++ b/strawberry/exceptions/handler.py
@@ -6,6 +6,12 @@ from typing import Any, Callable, Optional, Tuple, Type, cast
 
 from .exception import StrawberryException, UnableToFindExceptionSource
 
+if sys.version_info >= (3, 8):
+    original_threading_exception_hook = threading.excepthook
+else:
+    original_threading_exception_hook = None
+
+
 ExceptionHandler = Callable[
     [Type[BaseException], BaseException, Optional[TracebackType]], None
 ]
@@ -68,7 +74,7 @@ def strawberry_threading_exception_handler(
             # (we'd need to do type ignore for python 3.8 and above, but mypy
             # doesn't seem to be able to handle that and will complain in python 3.7)
 
-            cast(Any, threading.__excepthook__)(args)
+            cast(Any, original_threading_exception_hook)(args)
 
         return
 
@@ -79,7 +85,7 @@ def reset_exception_handler():
     sys.excepthook = sys.__excepthook__
 
     if sys.version_info >= (3, 8):
-        threading.excepthook = threading.__excepthook__
+        threading.excepthook = original_threading_exception_hook
 
 
 def setup_exception_handler():

--- a/strawberry/exceptions/handler.py
+++ b/strawberry/exceptions/handler.py
@@ -6,14 +6,6 @@ from typing import Any, Callable, Optional, Tuple, Type, cast
 
 from .exception import StrawberryException, UnableToFindExceptionSource
 
-original_exception_hook = sys.excepthook
-
-
-if sys.version_info >= (3, 8):
-    original_threading_exception_hook = threading.excepthook
-else:
-    original_threading_exception_hook = None
-
 ExceptionHandler = Callable[
     [Type[BaseException], BaseException, Optional[TracebackType]], None
 ]
@@ -44,11 +36,11 @@ def _get_handler(exception_type: Type[BaseException]) -> ExceptionHandler:
                 # we check if weren't able to find the exception source
                 # in that case we fallback to the original exception handler
                 except UnableToFindExceptionSource:
-                    original_exception_hook(exception_type, exception, traceback)
+                    sys.__excepthook__(exception_type, exception, traceback)
 
             return _handler
 
-    return original_exception_hook
+    return sys.__excepthook__
 
 
 def strawberry_exception_handler(
@@ -76,7 +68,7 @@ def strawberry_threading_exception_handler(
             # (we'd need to do type ignore for python 3.8 and above, but mypy
             # doesn't seem to be able to handle that and will complain in python 3.7)
 
-            cast(Any, original_threading_exception_hook)(args)
+            cast(Any, threading.__excepthook__)(args)
 
         return
 
@@ -84,10 +76,10 @@ def strawberry_threading_exception_handler(
 
 
 def reset_exception_handler():
-    sys.excepthook = original_exception_hook
+    sys.excepthook = sys.__excepthook__
 
     if sys.version_info >= (3, 8):
-        threading.excepthook = original_threading_exception_hook
+        threading.excepthook = threading.__excepthook__
 
 
 def setup_exception_handler():

--- a/tests/exceptions/test_exception_handler.py
+++ b/tests/exceptions/test_exception_handler.py
@@ -25,7 +25,7 @@ def test_exception_handler(mocker):
 def test_exception_handler_other_exceptions(mocker):
     print_mock = mocker.patch("rich.print", autospec=True)
     original_exception_mock = mocker.patch(
-        "strawberry.exceptions.handler.original_exception_hook", autospec=True
+        "strawberry.exceptions.handler.sys.__excepthook__", autospec=True
     )
 
     exception = ValueError("abc")
@@ -38,7 +38,7 @@ def test_exception_handler_other_exceptions(mocker):
 
 def test_exception_handler_uses_original_when_rich_is_not_installed(mocker):
     original_exception_mock = mocker.patch(
-        "strawberry.exceptions.handler.original_exception_hook", autospec=True
+        "strawberry.exceptions.handler.sys.__excepthook__", autospec=True
     )
 
     mocker.patch.dict("sys.modules", {"rich": None})
@@ -57,7 +57,7 @@ def test_exception_handler_uses_original_when_rich_is_not_installed(mocker):
 
 def test_exception_handler_uses_original_when_libcst_is_not_installed(mocker):
     original_exception_mock = mocker.patch(
-        "strawberry.exceptions.handler.original_exception_hook", autospec=True
+        "strawberry.exceptions.handler.sys.__excepthook__", autospec=True
     )
 
     mocker.patch.dict("sys.modules", {"libcst": None})

--- a/tests/exceptions/test_threading_exception_handler.py
+++ b/tests/exceptions/test_threading_exception_handler.py
@@ -30,7 +30,7 @@ def test_exception_handler(mocker):
 def test_exception_handler_other_exceptions(mocker):
     print_mock = mocker.patch("rich.print", autospec=True)
     original_exception_mock = mocker.patch(
-        "strawberry.exceptions.handler.original_exception_hook", autospec=True
+        "strawberry.exceptions.handler.sys.__excepthook__", autospec=True
     )
 
     exception = ValueError("abc")
@@ -43,7 +43,7 @@ def test_exception_handler_other_exceptions(mocker):
 
 def test_exception_handler_uses_original_when_rich_is_not_installed(mocker):
     original_exception_mock = mocker.patch(
-        "strawberry.exceptions.handler.original_exception_hook", autospec=True
+        "strawberry.exceptions.handler.sys.__excepthook__", autospec=True
     )
 
     mocker.patch.dict("sys.modules", {"rich": None})
@@ -64,7 +64,7 @@ def test_exception_handler_uses_original_when_rich_is_not_installed(mocker):
 
 def test_exception_handler_uses_original_when_libcst_is_not_installed(mocker):
     original_exception_mock = mocker.patch(
-        "strawberry.exceptions.handler.original_exception_hook", autospec=True
+        "strawberry.exceptions.handler.sys.__excepthook__", autospec=True
     )
 
     mocker.patch.dict("sys.modules", {"libcst": None})


### PR DESCRIPTION
As suggested by @BryceBeagle , python provides `sys.__excepthook__`
and ~`threading.__excepthook__`~ (this is only in python 3.10), so there's no need to store them 
in variables.

We can merge this without a release 😊