### PR TITLE
Updated documentation for types/Union

### DIFF
--- a/docs/types/union.md
+++ b/docs/types/union.md
@@ -100,7 +100,7 @@ class Query:
 union MediaItem = Audio | Video | Image
 
 type Query {
-  latest_media: AudioVideoImage!
+  latest_media: MediaItem!
 }
 
 type Audio {


### PR DESCRIPTION
## Description

It looks like a copy / paste error, but I _think_ the type of `latest_media` should be `MediaItem`, not `AudioVideoImage` from the previous example.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

No issue opened

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
