### PR TITLE
Link to the changelog from PyPI

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+A link to the changelog has been added to the package metadata, so it shows up on PyPI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
 include = ["strawberry/py.typed"]
 
 [tool.poetry.urls]
+"Changelog" = "https://github.com/strawberry-graphql/strawberry/blob/main/CHANGELOG.md"
 "Discord" = "https://discord.com/invite/3uQ2PaY"
 "Twitter" = "https://twitter.com/strawberry_gql"
 "Mastodon" = "https://farbun.social/@strawberry"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 include = ["strawberry/py.typed"]
 
 [tool.poetry.urls]
-"Changelog" = "https://github.com/strawberry-graphql/strawberry/blob/main/CHANGELOG.md"
+"Changelog" = "https://strawberry.rocks/changelog"
 "Discord" = "https://discord.com/invite/3uQ2PaY"
 "Twitter" = "https://twitter.com/strawberry_gql"
 "Mastodon" = "https://farbun.social/@strawberry"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This adds a link to the changelog to the sidebar of the [PyPI project page](https://pypi.org/project/strawberry-graphql/). It'll look a bit like this:

![image](https://user-images.githubusercontent.com/43662/214193346-bbf48e74-163a-4702-ab3e-afd75361c66f.png)


I find myself having to search for the changelog each time I upgrade Strawberry; this is the first place I look.

It would also be nice to include a prominent link in the docs — I'm happy to help, just let me know where.


## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

* N/A

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).  (I checked the generated metadata in the sdist.)
