### PR TITLE
Update _RESOLVER_TYPE to prevent error in mypy

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,20 @@
+Release type: patch
+
+This release fixes a regression introduce in version 0.156.2 that
+would make Mypy throw an error in the following code:
+
+```python
+import strawberry
+
+
+@strawberry.type
+class Author:
+    name: str
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    async def get_authors(self) -> list[Author]:
+        return [Author(name="Michael Crichton")]
+```

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -7,6 +7,7 @@ from typing import (
     Any,
     Awaitable,
     Callable,
+    Coroutine,
     Dict,
     List,
     Mapping,
@@ -39,7 +40,9 @@ T = TypeVar("T")
 _RESOLVER_TYPE = Union[
     StrawberryResolver[T],
     Callable[..., T],
-    Callable[..., Awaitable[T]],
+    # we initially used Awaitable, but that was triggering the following mypy bug:
+    # https://github.com/python/mypy/issues/14669
+    Callable[..., Coroutine[T, Any, Any]],
     "staticmethod[T]",
     "classmethod[T]",
 ]

--- a/tests/mypy/test_fields.yml
+++ b/tests/mypy/test_fields.yml
@@ -110,3 +110,22 @@
     reveal_type(i.a)
   out: |
     main:14: note: Revealed type is "builtins.str"
+
+- case: test_does_not_put_fields_with_async_resolver_in_init
+  main: |
+    import strawberry
+
+    async def resolver() -> str:
+        return "hi"
+
+    @strawberry.type
+    class Example:
+        a: str = strawberry.field(description="Example")
+        b: str = strawberry.field(resolver=resolver)
+        c: str
+
+    i = Example(a="a", c="c")
+
+    reveal_type(i.a)
+  out: |
+    main:14: note: Revealed type is "builtins.str"


### PR DESCRIPTION
Closes #2534

This PR updates the type for _RESOLVER_TYPE to prevent this issue in Mypy: 
https://github.com/python/mypy/issues/14669

The types should be equivalent 😊
