### PR TITLE
Update tests for latest version of pyright

### DIFF
--- a/tests/pyright/test_union.py
+++ b/tests/pyright/test_union.py
@@ -26,15 +26,28 @@ reveal_type(x)
 """
 
 
+# Pyright removed support for being able to return a type from a function
+# in future we'll probably implement union using Annotated so we can
+# get a more type friendly API :)
+
+
 def test_pyright():
     results = run_pyright(CODE)
 
     assert results == [
         Result(
             type="information",
-            message='Type of "UserOrError" is "Type[User] | Type[Error]"',
+            message='Type of "UserOrError" is "Unknown"',
             line=16,
             column=13,
         ),
-        Result(type="information", message='Type of "x" is "User"', line=20, column=13),
+        Result(
+            type="error",
+            message='Type of "x" is unknown (reportUnknownVariableType)',
+            line=18,
+            column=1,
+        ),
+        Result(
+            type="information", message='Type of "x" is "Unknown"', line=20, column=13
+        ),
     ]


### PR DESCRIPTION
Looks like one of the latest version of pyright removed support
for returning a type from a function. I did ask about this a while
ago and [looks like](https://mail.python.org/archives/list/typing-sig@python.org/thread/OJZGI5XH5LR24ZPK3CPKXE45JW2EI7QM/#L2W44M5FOJU62S4PJV65F2SPYJ24LP3P)
this won't be supported in Python, so I've updated the tests to
not fail.

We'll implement a version of union that uses `Annotated` in future :)
