### PR TITLE
remove strawberry.enum class decorator in object-is-not-an-enum.md

### DIFF
--- a/docs/errors/object-is-not-an-enum.md
+++ b/docs/errors/object-is-not-an-enum.md
@@ -13,7 +13,7 @@ example the following code will throw this error:
 import strawberry
 
 
-@strawberry.enum
+# note the lack of @strawberry.enum here:
 class NotAnEnum:
     A = "A"
 


### PR DESCRIPTION
Remove @strawberry.enum class decorator in object-is-not-an-enum.md

## Fix typo in negative example for object-is-not-an-enum.md

Our error example doesn't show an error :) the class NotAnEnum is really still an enum as we decorated it in the negative example. This PR removes that and leaves a comment that it is missing that enum decorator.