### PR TITLE
Include deprecated arguments in GraphiQL

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+Release type: patch
+
+Version 1.5.10 of GraphiQL disabled introspection for deprecated
+arguments because it wasn't supported by all GraphQL server versions.
+This PR enables it so that deprecated arguments show up again in
+GraphiQL.

--- a/strawberry/static/graphiql.html
+++ b/strawberry/static/graphiql.html
@@ -147,6 +147,7 @@
           plugins: [explorerPlugin],
           query: query,
           onEditQuery: setQuery,
+          inputValueDeprecation: true,
         });
       }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Version 1.5.10 of GraphiQL ([ref](https://github.com/graphql/graphiql/pull/2087)) disabled introspection for deprecated arguments because it wasn't supported by all GraphQL server versions. This PR enables it so that deprecated arguments show up again in GraphiQL.

Fixes: https://github.com/strawberry-graphql/strawberry/issues/2532

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #2532

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
