### PR TITLE
graphql-transport-ws: Do not send "complete" after "error".

### DIFF
--- a/strawberry/channels/testing.py
+++ b/strawberry/channels/testing.py
@@ -131,5 +131,6 @@ class GraphQLWebsocketCommunicator(WebsocketCommunicator):
                         for message in error_payload
                     ],
                 )
+                return  # an error message is the last message for a subscription
             else:
                 return

--- a/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
@@ -205,6 +205,8 @@ class BaseGraphQLTransportWSHandler(ABC):
 
             result_source = get_result_source()
 
+        operation = Operation(self, message.id)
+
         # Handle initial validation errors
         if isinstance(result_source, GraphQLExecutionResult):
             assert result_source.errors
@@ -215,16 +217,19 @@ class BaseGraphQLTransportWSHandler(ABC):
 
         # Create task to handle this subscription, reserve the operation ID
         self.subscriptions[message.id] = result_source
-        operation = Operation(self, result_source, message.id)
-        self.tasks[message.id] = asyncio.create_task(self.operation_task(operation))
+        self.tasks[message.id] = asyncio.create_task(
+            self.operation_task(result_source, operation)
+        )
 
-    async def operation_task(self, operation: Operation) -> None:
+    async def operation_task(
+        self, result_source: AsyncGenerator, operation: Operation
+    ) -> None:
         """
         Operation task top level method.  Cleans up and de-registers the operation
         once it is done.
         """
         try:
-            await self.handle_async_results(operation)
+            await self.handle_async_results(result_source, operation)
         except BaseException:  # pragma: no cover
             # cleanup in case of something really unexpected
             # wait for generator to be closed to ensure that any existing
@@ -236,10 +241,6 @@ class BaseGraphQLTransportWSHandler(ABC):
             del self.tasks[operation.id]
             raise
         else:
-            # de-register the operation _before_ sending the `Complete` message
-            # to make the `operation_id` immediately available for re-use
-            del self.subscriptions[operation.id]
-            del self.tasks[operation.id]
             await operation.send_message(CompleteMessage(id=operation.id))
         finally:
             # add this task to a list to be reaped later
@@ -249,10 +250,11 @@ class BaseGraphQLTransportWSHandler(ABC):
 
     async def handle_async_results(
         self,
+        result_source: AsyncGenerator,
         operation: Operation,
     ) -> None:
         try:
-            async for result in operation.result_source:
+            async for result in result_source:
                 if result.errors:
                     error_payload = [format_graphql_error(err) for err in result.errors]
                     error_message = ErrorMessage(id=operation.id, payload=error_payload)
@@ -262,7 +264,7 @@ class BaseGraphQLTransportWSHandler(ABC):
                 else:
                     next_payload = {"data": result.data}
                     next_message = NextMessage(id=operation.id, payload=next_payload)
-                    await self.send_message(next_message)
+                    await operation.send_message(next_message)
         except asyncio.CancelledError:
             # CancelledErrors are expected during task cleanup.
             return
@@ -275,6 +277,12 @@ class BaseGraphQLTransportWSHandler(ABC):
             await operation.send_message(error_message)
             self.schema.process_errors([error])
             return
+
+    def forget_id(self, id: str) -> None:
+        # de-register the operation id making it immediately available
+        # for re-use
+        del self.subscriptions[id]
+        del self.tasks[id]
 
     async def handle_complete(self, message: CompleteMessage) -> None:
         await self.cleanup_operation(operation_id=message.id)
@@ -313,15 +321,17 @@ class Operation:
     A class encapsulating a single operation with its id.
     Helps enforce protocol state transition.
     """
-    def __init__(self, handler: BaseGraphQLTransportWSHandler, result_source: AsyncGenerator, id: str):
+
+    def __init__(self, handler: BaseGraphQLTransportWSHandler, id: str):
         self.handler = handler
-        self.result_source = result_source
         self.id = id
-        self.sent_error = False
+        self.completed = False
 
     async def send_message(self, message: GraphQLTransportMessage) -> None:
-        if self.sent_error:
+        if self.completed:
             return
+        if isinstance(message, (CompleteMessage, ErrorMessage)):
+            self.completed = True
+            # de-register the operation _before_ sending the final message
+            self.handler.forget_id(self.id)
         await self.handler.send_message(message)
-        if isinstance(message, ErrorMessage):
-            self.sent_error = True

--- a/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
@@ -215,35 +215,32 @@ class BaseGraphQLTransportWSHandler(ABC):
 
         # Create task to handle this subscription, reserve the operation ID
         self.subscriptions[message.id] = result_source
-        self.tasks[message.id] = asyncio.create_task(
-            self.operation_task(result_source, message.id)
-        )
+        operation = Operation(result_source, message.id)
+        self.tasks[message.id] = asyncio.create_task(self.operation_task(operation))
 
-    async def operation_task(
-        self, result_source: AsyncGenerator, operation_id: str
-    ) -> None:
+    async def operation_task(self, operation: Operation) -> None:
         """
         Operation task top level method.  Cleans up and de-registers the operation
         once it is done.
         """
         try:
-            await self.handle_async_results(result_source, operation_id)
+            await self.handle_async_results(operation)
         except BaseException:  # pragma: no cover
             # cleanup in case of something really unexpected
             # wait for generator to be closed to ensure that any existing
             # 'finally' statement is called
-            result_source = self.subscriptions[operation_id]
+            result_source = self.subscriptions[operation.id]
             with suppress(RuntimeError):
                 await result_source.aclose()
-            del self.subscriptions[operation_id]
-            del self.tasks[operation_id]
+            del self.subscriptions[operation.id]
+            del self.tasks[operation.id]
             raise
         else:
             # de-register the operation _before_ sending the `Complete` message
             # to make the `operation_id` immediately available for re-use
-            del self.subscriptions[operation_id]
-            del self.tasks[operation_id]
-            await self.send_message(CompleteMessage(id=operation_id))
+            del self.subscriptions[operation.id]
+            del self.tasks[operation.id]
+            await self.send_message(CompleteMessage(id=operation.id))
         finally:
             # add this task to a list to be reaped later
             task = asyncio.current_task()
@@ -252,20 +249,19 @@ class BaseGraphQLTransportWSHandler(ABC):
 
     async def handle_async_results(
         self,
-        result_source: AsyncGenerator,
-        operation_id: str,
+        operation: Operation,
     ) -> None:
         try:
-            async for result in result_source:
+            async for result in operation.result_source:
                 if result.errors:
                     error_payload = [format_graphql_error(err) for err in result.errors]
-                    error_message = ErrorMessage(id=operation_id, payload=error_payload)
+                    error_message = ErrorMessage(id=operation.id, payload=error_payload)
                     await self.send_message(error_message)
                     self.schema.process_errors(result.errors)
                     return
                 else:
                     next_payload = {"data": result.data}
-                    next_message = NextMessage(id=operation_id, payload=next_payload)
+                    next_message = NextMessage(id=operation.id, payload=next_payload)
                     await self.send_message(next_message)
         except asyncio.CancelledError:
             # CancelledErrors are expected during task cleanup.
@@ -275,7 +271,7 @@ class BaseGraphQLTransportWSHandler(ABC):
             # ExecutionResult
             error = GraphQLError(str(error), original_error=error)
             error_payload = [format_graphql_error(error)]
-            error_message = ErrorMessage(id=operation_id, payload=error_payload)
+            error_message = ErrorMessage(id=operation.id, payload=error_payload)
             await self.send_message(error_message)
             self.schema.process_errors([error])
             return
@@ -310,3 +306,13 @@ class BaseGraphQLTransportWSHandler(ABC):
         for task in tasks:
             with suppress(BaseException):
                 await task
+
+
+class Operation:
+    """
+    A class encapsulating a single operation with its id.
+    """
+
+    def __init__(self, result_source: AsyncGenerator, id: str):
+        self.result_source = result_source
+        self.id = id

--- a/tests/fastapi/test_graphql_transport_ws.py
+++ b/tests/fastapi/test_graphql_transport_ws.py
@@ -467,6 +467,46 @@ def test_subscription_errors(test_client):
         ws.close()
 
 
+def test_subscription_error_no_complete(test_client):
+    """
+    Test that an "error" message is not followed by "complete"
+    """
+    with test_client.websocket_connect(
+        "/graphql", [GRAPHQL_TRANSPORT_WS_PROTOCOL]
+    ) as ws:
+        ws.send_json(ConnectionInitMessage().as_dict())
+
+        response = ws.receive_json()
+        assert response == ConnectionAckMessage().as_dict()
+
+        ws.send_json(
+            SubscribeMessage(
+                id="sub1",
+                payload=SubscribeMessagePayload(
+                    query='subscription { error(message: "TEST ERR") }',
+                ),
+            ).as_dict()
+        )
+
+        response = ws.receive_json()
+        assert response["type"] == ErrorMessage.type
+        assert response["id"] == "sub1"
+
+        ws.send_json(
+            SubscribeMessage(
+                id="sub2",
+                payload=SubscribeMessagePayload(
+                    query='subscription { error(message: "TEST ERR") }',
+                ),
+            ).as_dict()
+        )
+
+        response = ws.receive_json()
+        assert response["type"] == ErrorMessage.type
+        assert response["id"] == "sub2"
+        ws.close()
+
+
 def test_subscription_exceptions(test_client):
     with test_client.websocket_connect(
         "/graphql", [GRAPHQL_TRANSPORT_WS_PROTOCOL]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The _graphql-transport-ws_ protocol specifies that an [error ](https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md#error )message should be the final
message for an _id_ coming from the server.  There were, however cases in strawberry where an
extra "complete" would be sent in violation of the protocol.

This PR cretates an Operation object which represents the state of an individual operation and ensures that
a "complete" or "error" message are the final messages for an active operation.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
