### PR TITLE
Add POC for fixing duplicated name with generics

### DIFF
--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -735,25 +735,31 @@ class GraphQLCoreConverter:
             # manually compare type_var_maps while resolving any lazy types
             # so that they're considered equal to the actual types they're referencing
             equal = True
+            lazy_types = False
+
             for type_var, type1 in cached_type.definition.type_var_map.items():
                 type2 = type_definition.type_var_map[type_var]
                 # both lazy types are always resolved because two different lazy types
                 # may be referencing the same actual type
                 if isinstance(type1, LazyType):
                     type1 = type1.resolve_type()
+                    lazy_types = True
                 elif isinstance(type1, StrawberryOptional) and isinstance(
                     type1.of_type, LazyType
                 ):
+                    lazy_types = True
                     type1.of_type = type1.of_type.resolve_type()
 
                 if isinstance(type2, LazyType):
                     type2 = type2.resolve_type()
+                    lazy_types = True
                 elif isinstance(type2, StrawberryOptional) and isinstance(
                     type2.of_type, LazyType
                 ):
                     type2.of_type = type2.of_type.resolve_type()
+                    lazy_types = True
 
-                if type1 != type2:
+                if lazy_types and type1 != type2:
                     equal = False
                     break
             if equal:

--- a/tests/schema/test_generics.py
+++ b/tests/schema/test_generics.py
@@ -1128,3 +1128,18 @@ def test_generic_interface():
             "repr": "foo",
         }
     }
+
+
+def test_nested_generics():
+    T = TypeVar("T")
+
+    @strawberry.type
+    class Wrapper(Generic[T]):
+        value: T
+
+    @strawberry.type
+    class Query:
+        a: Wrapper[Wrapper[int]]
+        b: Wrapper[Wrapper[int]]
+
+    schema = strawberry.Schema(query=Query)


### PR DESCRIPTION
Closes #2599

Not 100% sure why the check fails, for now my fix is a workaround. Just for reference this is what happens with the types inside `validate_same_type_definition`:

```
(Pdb++) type1 != type2
True
(Pdb++) type1
<class 'strawberry.types.types.Wrapper'>
(Pdb++) type2
<class 'strawberry.types.types.Wrapper'>
(Pdb++) type1._type_definition
TypeDefinition(name='Wrapper', is_input=False, is_interface=False, origin=<class 'strawberry.types.types.Wrapper'>, description=None, interfaces=[], extend=False, directives=(), is_type_of=None, _fields=[Field(name='value',type=<class 'int'>,default=<dataclasses._MISSING_TYPE object at 0x101527280>,default_factory=<dataclasses._MISSING_TYPE object at 0x101527280>,init=True,repr=True,hash=None,compare=True,metadata=mappingproxy({}),kw_only=<dataclasses._MISSING_TYPE object at 0x101527280>,_field_type=None)], concrete_of=TypeDefinition(name='Wrapper', is_input=False, is_interface=False, origin=<class 'tests.schema.test_generics.test_nested_generics.<locals>.Wrapper'>, description=None, interfaces=[], extend=False, directives=(), is_type_of=None, _fields=[Field(name='value',type=<strawberry.type.StrawberryTypeVar object at 0x10510b1f0>,default=<dataclasses._MISSING_TYPE object at 0x101527280>,default_factory=<dataclasses._MISSING_TYPE object at 0x101527280>,init=True,repr=True,hash=None,compare=True,metadata=mappingproxy({}),kw_only=<dataclasses._MISSING_TYPE object at 0x101527280>,_field_type=None)], concrete_of=None, type_var_map={}), type_var_map={~T: <class 'int'>})
(Pdb++) type2._type_definition
TypeDefinition(name='Wrapper', is_input=False, is_interface=False, origin=<class 'strawberry.types.types.Wrapper'>, description=None, interfaces=[], extend=False, directives=(), is_type_of=None, _fields=[Field(name='value',type=<class 'int'>,default=<dataclasses._MISSING_TYPE object at 0x101527280>,default_factory=<dataclasses._MISSING_TYPE object at 0x101527280>,init=True,repr=True,hash=None,compare=True,metadata=mappingproxy({}),kw_only=<dataclasses._MISSING_TYPE object at 0x101527280>,_field_type=None)], concrete_of=TypeDefinition(name='Wrapper', is_input=False, is_interface=False, origin=<class 'tests.schema.test_generics.test_nested_generics.<locals>.Wrapper'>, description=None, interfaces=[], extend=False, directives=(), is_type_of=None, _fields=[Field(name='value',type=<strawberry.type.StrawberryTypeVar object at 0x10510a650>,default=<dataclasses._MISSING_TYPE object at 0x101527280>,default_factory=<dataclasses._MISSING_TYPE object at 0x101527280>,init=True,repr=True,hash=None,compare=True,metadata=mappingproxy({}),kw_only=<dataclasses._MISSING_TYPE object at 0x101527280>,_field_type=None)], concrete_of=None, type_var_map={}), type_var_map={~T: <class 'int'>})
(Pdb++)
```

I didn't spend much time on this because I think we could refactor the whole logic.

@BryceBeagle @bellini666 what do you think?