### PR TITLE
Update mypy.ini and pipeline

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -39,4 +39,4 @@ jobs:
         if: steps.cache-poetry-dependencies.outputs.cache-hit != 'true'
 
       - run: mkdir -p .mypy_cache
-      - run: poetry run mypy --ignore-missing-imports --config-file mypy.ini --install-types --non-interactive --show-traceback strawberry
+      - run: poetry run mypy --config-file mypy.ini

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,6 +119,7 @@ that the current tests are passing on your machine:
 ```bash
 $ poetry install
 $ poetry run pytest tests -n auto
+$ poetry run mypy
 ```
 
 Strawberry uses the [black](https://github.com/ambv/black) coding style and you

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,5 @@
 [mypy]
+files = strawberry
 plugins = pydantic.mypy, strawberry.ext.mypy_plugin
 implicit_reexport = False
 warn_unused_configs = True
@@ -8,6 +9,10 @@ ignore_errors = False
 strict_optional = True
 show_error_codes = True
 warn_redundant_casts = True
+ignore_missing_imports = True
+install_types = True
+non_interactive = True
+show_traceback = True
 # TODO: enable strict at some point
 ;strict = True
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Updates mypy.ini so that developers don't need to run the specific incantation of the pipeline commands to replicate the mypy pipeline.

All you'll need to do is
```
poetry run mypy
```