### PR TITLE
docs: Fix typing in resolver examples

### DIFF
--- a/docs/types/resolvers.md
+++ b/docs/types/resolvers.md
@@ -211,7 +211,7 @@ the value of the parent:
 import strawberry
 
 
-def full_name(root: User) -> str:
+def full_name(root: "User") -> str:
     return f"{root.first_name} {root.last_name}"
 
 
@@ -234,7 +234,7 @@ import strawberry
 from strawberry.types import Info
 
 
-def full_name(root: User, info: Info) -> str:
+def full_name(root: "User", info: Info) -> str:
     return f"{root.first_name} {root.last_name} {info.field_name}"
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Two of the code examples in the "Resolvers" page have an issue where the `User` class is referenced in a type annotation before it is defined. The resolver is referenced by the `User` class so the order can't be changed. I changed the code to use [forward reference](https://peps.python.org/pep-0484/#forward-references) to mitigate this.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
