### PR TITLE
Fix interface duplication for multiple inheritance

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+Release type: patch
+
+Fix interface duplication leading to schema compilation error in multiple
+inheritance scenarios (i.e. "Diamond Problem" inheritance)
+
+Thank you @mzhu22 for the thorough bug report!

--- a/strawberry/object_type.py
+++ b/strawberry/object_type.py
@@ -3,6 +3,7 @@ import inspect
 import sys
 import types
 from typing import (
+    Any,
     Callable,
     Dict,
     List,
@@ -30,24 +31,19 @@ from .utils.typing import __dataclass_transform__
 T = TypeVar("T", bound=Type)
 
 
-def _get_interfaces(cls: Type) -> List[TypeDefinition]:
-    interfaces = []
-
-    for base in cls.__bases__:
+def _get_interfaces(cls: Type[Any]) -> List[TypeDefinition]:
+    interfaces: List[TypeDefinition] = []
+    for base in cls.__mro__[1:]:  # Exclude current class
         type_definition = cast(
             Optional[TypeDefinition], getattr(base, "_type_definition", None)
         )
-
         if type_definition and type_definition.is_interface:
             interfaces.append(type_definition)
-
-        for inherited_interface in _get_interfaces(base):
-            interfaces.append(inherited_interface)
 
     return interfaces
 
 
-def _check_field_annotations(cls: Type):
+def _check_field_annotations(cls: Type[Any]):
     """Are any of the dataclass Fields missing type annotations?
 
     This is similar to the check that dataclasses do during creation, but allows us to
@@ -103,7 +99,7 @@ def _check_field_annotations(cls: Type):
             raise MissingFieldAnnotationError(field_name, cls)
 
 
-def _wrap_dataclass(cls: Type):
+def _wrap_dataclass(cls: Type[Any]):
     """Wrap a strawberry.type class with a dataclass and check for any issues
     before doing so"""
 

--- a/strawberry/types/types.py
+++ b/strawberry/types/types.py
@@ -30,7 +30,7 @@ class TypeDefinition(StrawberryType):
     name: str
     is_input: bool
     is_interface: bool
-    origin: Type
+    origin: Type[Any]
     description: Optional[str]
     interfaces: List[TypeDefinition]
     extend: bool


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Previously interfaces were duplicated within a "Diamond Problem" inheritance
scenario which is tested here. Using the MRO instead of the `__bases__` attribute of
a class in :py:func:`strawberry.object_type._get_interfaces` allows Python's C3
linearization algorithm to create a consistent precedents graph without duplicates.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #2646

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
