### PR TITLE
update MaskErrors extension to use new extension api

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Updates the `MaskErrors` extension to the new extension API, which was missed previously.

--- a/strawberry/extensions/mask_errors.py
+++ b/strawberry/extensions/mask_errors.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from typing import Callable, Iterator
 
 from graphql.error import GraphQLError
 
@@ -32,7 +32,8 @@ class MaskErrors(SchemaExtension):
             original_error=None,
         )
 
-    def on_request_end(self):
+    def on_operation(self) -> Iterator[None]:
+        yield
         result = self.execution_context.result
         if result and result.errors:
             processed_errors = []


### PR DESCRIPTION
Seems this extension was missed when the new extension api was introduced.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation
