### PR TITLE
Fix types on latest pyright

### DIFF
--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -47,8 +47,8 @@ _RESOLVER_TYPE = Union[
     # we initially used Awaitable, but that was triggering the following mypy bug:
     # https://github.com/python/mypy/issues/14669
     Callable[..., Coroutine[T, Any, Any]],
-    "staticmethod[T]",
-    "classmethod[T]",
+    "staticmethod[Any, T]",
+    "classmethod[Any, Any, T]",
 ]
 
 UNRESOLVED = object()


### PR DESCRIPTION
This PR adds a couple of missing type params to prevent errors from pyright
