### PR TITLE
Fix typing in experimental generation models from Pydantic models.

### DIFF
--- a/strawberry/experimental/pydantic/conversion_types.py
+++ b/strawberry/experimental/pydantic/conversion_types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, Optional, TypeVar
+from typing import TYPE_CHECKING, Any, Dict, Optional, TypeVar, Type
 from typing_extensions import Protocol
 
 from pydantic import BaseModel
@@ -33,5 +33,9 @@ class StrawberryTypeFromPydantic(Protocol[PydanticModel]):
         ...
 
     @property
-    def _pydantic_type(self) -> PydanticModel:
+    def _pydantic_type(self) -> Type[PydanticModel]:
+        ...
+
+    @property
+    def _original_model(self) -> PydanticModel:
         ...

--- a/strawberry/experimental/pydantic/conversion_types.py
+++ b/strawberry/experimental/pydantic/conversion_types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, Optional, TypeVar, Type
+from typing import TYPE_CHECKING, Any, Dict, Optional, Type, TypeVar
 from typing_extensions import Protocol
 
 from pydantic import BaseModel

--- a/strawberry/experimental/pydantic/object_type.py
+++ b/strawberry/experimental/pydantic/object_type.py
@@ -264,9 +264,11 @@ def type(
         def from_pydantic_default(
             instance: PydanticModel, extra: Optional[Dict[str, Any]] = None
         ) -> StrawberryTypeFromPydantic[PydanticModel]:
-            return convert_pydantic_model_to_strawberry_class(
+            ret = convert_pydantic_model_to_strawberry_class(
                 cls=cls, model_instance=instance, extra=extra
             )
+            ret._original_model = instance
+            return ret
 
         def to_pydantic_default(self, **kwargs) -> PydanticModel:
             instance_kwargs = {


### PR DESCRIPTION
## Description

Fix type hint for `StrawberryTypeFromPydantic._pydantic_type` to match real state and don't confuse type checkers.

Also add `StrawberryTypeFromPydantic._original_model` to make extending models easier.

MRE/Use case for `._original_model`:
```python
from pydantic import BaseModel

import strawberry
from strawberry.experimental.pydantic.conversion_types import StrawberryTypeFromPydantic

class User(BaseModel):
    name: str

@strawberry.experimental.pydantic.type(model=User, all_fields=True)
class UserType:
    @strawberry.field
    def upper_name(self: StrawberryTypeFromPydantic[User]) -> str:
        # we have to ignore E1101 error, bc pylint 2.17.1 don't agree with StrawberryTypeFromPydantic protocol
        self_model = self._original_model  # noqa: E1101
        return self_model.name.upper()

def get_users() -> UserType:
    return UserType.from_pydantic(User(name="test"))  # noqa: E1101

@strawberry.type
class Query:
    user: UserType = strawberry.field(resolver=get_users)

schema = strawberry.Schema(query=Query)
```

Anyway I personally don't like approach with Protocol with class decorator because it makes type checkers and linters go crazy.
So I think that this mechanism can be made more convenient.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

Didn't found right now.

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
