### PR TITLE
Move fastapi handlers to instance methods.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Moves fastapi router's http hanlders to instance mthods, so that they can be extended.

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -246,7 +246,7 @@ class GraphQLRouter(APIRouter):
         request: Request,
         response: Response,
         context: Any = None,
-        root_value: Any = None
+        root_value: Any = None,
     ) -> Response:
         actual_response: Response
 


### PR DESCRIPTION
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This came up while I was trying to implement required persisted queries in my application, where I wanted to block regular queries in certain environments. But, because the handlers were closures, I had to do some janky stuff to overwrite them only in certain environments, which made testing a challenge. Moving them to instance methods should make it easy to subclass and override the handler.

NOTE: One downside to this change is that any changes to the handler function signatures (e.g. adding a new Fastapi.Depends) would not be backwards compatible.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ x ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

I'm a new contributor and am still working on getting the environment setup. Wanted to throw this by you preliminarily and if you're directionally aligned, I'll finish getting it setup and run the tests. I don't think we should need any new tests for this, unless you want to explicitly test subclassing the handlers.

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
