### PR TITLE
fix: fixed room_id mismatch for send_chat_message mutation

### DIFF
--- a/docs/integrations/channels.md
+++ b/docs/integrations/channels.md
@@ -198,7 +198,7 @@ class Mutation:
             f"chat_{room.room_name}",
             {
                 "type": "chat.message",
-                "room_id": room.room_name,
+                "room_id": f"chat_{room.room_name}",
                 "message": message,
             },
         )


### PR DESCRIPTION
fix for room_id mismatch in send_chat_message mutation

## Description

During send_chat_message mutation, room.room_name was provided as room_id. 
In join_chat_rooms subscription, user subscribe to ws.channel_listen events with group of room_ids that is formatted as f"chat_{room.room_name}".

For this mismatch, no messages were passed to subscribed users as their room_id is different.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ x] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ x] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
