### PR TITLE
Move tasks into Operation object for GraphqlTransportWS handler

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+`graphql-transport-ws` handler now uses a single dict to manage active operations.

--- a/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
@@ -51,8 +51,7 @@ class BaseGraphQLTransportWSHandler(ABC):
         self.connection_init_received = False
         self.connection_acknowledged = False
         self.connection_timed_out = False
-        self.subscriptions: Dict[str, AsyncGenerator] = {}
-        self.tasks: Dict[str, asyncio.Task] = {}
+        self.operations: Dict[str, Operation] = {}
         self.completed_tasks: List[asyncio.Task] = []
         self.connection_params: Optional[Dict[str, Any]] = None
 
@@ -85,7 +84,7 @@ class BaseGraphQLTransportWSHandler(ABC):
             with suppress(asyncio.CancelledError):
                 await self.connection_init_timeout_task
 
-        for operation_id in list(self.subscriptions.keys()):
+        for operation_id in list(self.operations.keys()):
             await self.cleanup_operation(operation_id)
         await self.reap_completed_tasks()
 
@@ -207,7 +206,7 @@ class BaseGraphQLTransportWSHandler(ABC):
             await self.close(code=4400, reason="Can't get GraphQL operation type")
             return
 
-        if message.id in self.subscriptions:
+        if message.id in self.operations:
             reason = f"Subscriber for {message.id} already exists"
             await self.close(code=4409, reason=reason)
             return
@@ -257,10 +256,10 @@ class BaseGraphQLTransportWSHandler(ABC):
             return
 
         # Create task to handle this subscription, reserve the operation ID
-        self.subscriptions[message.id] = result_source
-        self.tasks[message.id] = asyncio.create_task(
+        operation.task = asyncio.create_task(
             self.operation_task(result_source, operation)
         )
+        self.operations[message.id] = operation
 
     async def operation_task(
         self, result_source: AsyncGenerator, operation: Operation
@@ -276,12 +275,10 @@ class BaseGraphQLTransportWSHandler(ABC):
             # cleanup in case of something really unexpected
             # wait for generator to be closed to ensure that any existing
             # 'finally' statement is called
-            if operation.id in self.subscriptions:
-                result_source = self.subscriptions[operation.id]
-                with suppress(RuntimeError):
-                    await result_source.aclose()
-                del self.subscriptions[operation.id]
-                del self.tasks[operation.id]
+            with suppress(RuntimeError):
+                await result_source.aclose()
+            if operation.id in self.operations:
+                del self.operations[operation.id]
             raise
         else:
             await operation.send_message(CompleteMessage(id=operation.id))
@@ -324,8 +321,7 @@ class BaseGraphQLTransportWSHandler(ABC):
     def forget_id(self, id: str) -> None:
         # de-register the operation id making it immediately available
         # for re-use
-        del self.subscriptions[id]
-        del self.tasks[id]
+        del self.operations[id]
 
     async def handle_complete(self, message: CompleteMessage) -> None:
         await self.cleanup_operation(operation_id=message.id)
@@ -338,11 +334,11 @@ class BaseGraphQLTransportWSHandler(ABC):
         await self.send_json(data)
 
     async def cleanup_operation(self, operation_id: str) -> None:
-        if operation_id not in self.subscriptions:
+        if operation_id not in self.operations:
             return
-        result_source = self.subscriptions.pop(operation_id)
-        task = self.tasks.pop(operation_id)
-        task.cancel()
+        operation = self.operations.pop(operation_id)
+        assert operation.task
+        operation.task.cancel()
         # do not await the task here, lest we block the main
         # websocket handler Task.
 
@@ -362,12 +358,13 @@ class Operation:
     Helps enforce protocol state transition.
     """
 
-    __slots__ = ["handler", "id", "completed"]
+    __slots__ = ["handler", "id", "completed", "task"]
 
     def __init__(self, handler: BaseGraphQLTransportWSHandler, id: str):
         self.handler = handler
         self.id = id
         self.completed = False
+        self.task: Optional[asyncio.Task] = None
 
     async def send_message(self, message: GraphQLTransportMessage) -> None:
         if self.completed:

--- a/tests/aiohttp/app.py
+++ b/tests/aiohttp/app.py
@@ -7,19 +7,25 @@ from tests.views.schema import Query, schema
 
 
 class DebuggableGraphQLTransportWSHandler(GraphQLTransportWSHandler):
+    def get_tasks(self) -> list:
+        return [op.task for op in self.operations.values()]
+
     async def get_context(self) -> object:
         context = await super().get_context()
         context["ws"] = self._ws
-        context["tasks"] = self.tasks
+        context["get_tasks"] = self.get_tasks
         context["connectionInitTimeoutTask"] = self.connection_init_timeout_task
         return context
 
 
 class DebuggableGraphQLWSHandler(GraphQLWSHandler):
+    def get_tasks(self) -> list:
+        return list(self.tasks.values())
+
     async def get_context(self) -> object:
         context = await super().get_context()
         context["ws"] = self._ws
-        context["tasks"] = self.tasks
+        context["get_tasks"] = self.get_tasks
         context["connectionInitTimeoutTask"] = None
         return context
 

--- a/tests/http/clients/base.py
+++ b/tests/http/clients/base.py
@@ -254,18 +254,24 @@ class DebuggableGraphQLTransportWSMixin:
         super().__init__(*args, **kwargs)
         DebuggableGraphQLTransportWSMixin.on_init(self)
 
+    def get_tasks(self) -> List:
+        return [op.task for op in self.operations.values()]
+
     async def get_context(self) -> object:
         context = await super().get_context()
         context["ws"] = self._ws
-        context["tasks"] = self.tasks
+        context["get_tasks"] = self.get_tasks
         context["connectionInitTimeoutTask"] = self.connection_init_timeout_task
         return context
 
 
 class DebuggableGraphQLWSMixin:
+    def get_tasks(self) -> List:
+        return list(self.tasks.values())
+
     async def get_context(self) -> object:
         context = await super().get_context()
         context["ws"] = self._ws
-        context["tasks"] = self.tasks
+        context["get_tasks"] = self.get_tasks
         context["connectionInitTimeoutTask"] = None
         return context

--- a/tests/http/clients/channels.py
+++ b/tests/http/clients/channels.py
@@ -63,10 +63,16 @@ def create_multipart_request_body(
 
 
 class DebuggableGraphQLTransportWSConsumer(GraphQLWSConsumer):
+    def get_tasks(self) -> List[Any]:
+        if hasattr(self._handler, "operations"):
+            return [op.task for op in self._handler.operations.values()]
+        else:
+            return list(self._handler.tasks.values())
+
     async def get_context(self, *args: str, **kwargs: Any) -> object:
         context = await super().get_context(*args, **kwargs)
         context["ws"] = self._handler._ws
-        context["tasks"] = self._handler.tasks
+        context["get_tasks"] = self.get_tasks
         context["connectionInitTimeoutTask"] = getattr(
             self._handler, "connection_init_timeout_task", None
         )

--- a/tests/starlite/schema.py
+++ b/tests/starlite/schema.py
@@ -134,7 +134,7 @@ class Subscription:
     @strawberry.subscription
     async def debug(self, info) -> typing.AsyncGenerator[DebugInfo, None]:
         active_result_handlers = [
-            task for task in info.context["tasks"].values() if not task.done()
+            task for task in info.context["get_tasks"]() if not task.done()
         ]
 
         connection_init_timeout_task = info.context["connectionInitTimeoutTask"]

--- a/tests/views/schema.py
+++ b/tests/views/schema.py
@@ -186,7 +186,7 @@ class Subscription:
     @strawberry.subscription
     async def debug(self, info: Info[Any, Any]) -> AsyncGenerator[DebugInfo, None]:
         active_result_handlers = [
-            task for task in info.context["tasks"].values() if not task.done()
+            task for task in info.context["get_tasks"]() if not task.done()
         ]
 
         connection_init_timeout_task = info.context["connectionInitTimeoutTask"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

Simplify the handling of tasks/generators for the GraphQLTransportWS handler.  This helps as a preparation for some restructuring I have planned to fix some actual problems soon.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

- The handler now contains a single `operations` member which holds `Operation` instances.
  The `task` is an attribute of the object
- We no longer keep track of the `AsyncGenerator` objects especially.  They are closed inside the task when handling base exceptions and do not require special guard constructs.  The operation tasks themselves only need to be cancelled.
- We make necessary changes to test harnesses.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
