### PR TITLE
Add support for passing through custom dataclasses

### DIFF
--- a/strawberry/experimental/pydantic/object_type.py
+++ b/strawberry/experimental/pydantic/object_type.py
@@ -223,7 +223,11 @@ def type(
         if hasattr(cls, "resolve_reference"):
             namespace["resolve_reference"] = cls.resolve_reference
 
-        kwargs: Dict[str, object] = {}
+        # Copy the dataclass params from the underlying pydantic dataclass
+        dclass_params = wrapped.__dataclass_params__  # type: ignore
+        dclass_kwargs: Dict[str, object] = {
+            slot: getattr(dclass_params, slot) for slot in dclass_params.__slots__
+        }
 
         # Python 3.10.1 introduces the kw_only param to `make_dataclass`.
         # If we're on an older version then generate our own custom init function
@@ -231,16 +235,16 @@ def type(
         # just missed from the `make_dataclass` function:
         # https://github.com/python/cpython/issues/89961
         if sys.version_info >= (3, 10, 1):
-            kwargs["kw_only"] = dataclasses.MISSING
+            dclass_kwargs["kw_only"] = True
         else:
-            kwargs["init"] = False
+            dclass_kwargs["init"] = False
 
         cls = dataclasses.make_dataclass(
             cls.__name__,
             [field.to_tuple() for field in all_model_fields],
             bases=cls.__bases__,
             namespace=namespace,
-            **kwargs,  # type: ignore
+            **dclass_kwargs,  # type: ignore
         )
 
         if sys.version_info < (3, 10, 1):

--- a/strawberry/object_type.py
+++ b/strawberry/object_type.py
@@ -108,6 +108,34 @@ def _wrap_dataclass(cls: Type[Any]):
 
     dclass_kwargs: Dict[str, bool] = {}
 
+    if dataclasses.is_dataclass(cls):
+        # TODO: it would be nice if we had an easy way to check if a class is a
+        # Strawberry type
+        if not hasattr(cls, "_type_definition"):
+            # If the class is already a dataclass and not a strawberry type then just
+            # return it directly
+            return cls
+
+        # Because the class is a Strawberry type we need to copy it's dataclass params
+        # so that we can inherit them correctly.
+        # This allows us to support things like this:
+        #
+        # >> import strawberry
+        # >>
+        # >> @strawberry.type
+        # >> class A:
+        # >>     number: int
+        # >>
+        # >> @strawberry.type
+        # >> @dataclass(repr=False)
+        # >> class B(A):
+        # >>     string: str
+        #
+        dclass_params = cls.__dataclass_params__  # type: ignore
+        dclass_kwargs = {
+            slot: getattr(dclass_params, slot) for slot in dclass_params.__slots__
+        }
+
     # Python 3.10 introduces the kw_only param. If we're on an older version
     # then generate our own custom init function
     if sys.version_info >= (3, 10):

--- a/tests/experimental/pydantic/test_basic.py
+++ b/tests/experimental/pydantic/test_basic.py
@@ -862,3 +862,16 @@ def test_field_metadata():
 
     assert field2.python_name == "public"
     assert not field2.metadata
+
+
+def test_type_with_kwargs():
+    class User(pydantic.BaseModel):
+        number: int
+
+    @strawberry.experimental.pydantic.type(User)
+    @dataclasses.dataclass(repr=False)
+    class UserTypeWithNoRepr:
+        number: strawberry.auto
+
+    instance = UserTypeWithNoRepr(number=5)
+    assert "UserTypeWithNoRepr object at" in repr(instance)

--- a/tests/experimental/pydantic/test_error_type.py
+++ b/tests/experimental/pydantic/test_error_type.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import List, Optional
 
 import pydantic
@@ -349,3 +350,16 @@ def test_error_type_with_matrix_list_of_scalar():
     )
 
     assert field.type.of_type.of_type.of_type.of_type.of_type.of_type is str
+
+
+def test_error_type_with_kwargs():
+    class UserModel(pydantic.BaseModel):
+        number: int
+
+    @strawberry.experimental.pydantic.type(UserModel)
+    @dataclass(repr=False)
+    class UserErrorWithNoRepr:
+        number: strawberry.auto
+
+    instance = UserErrorWithNoRepr(number=5)
+    assert "UserErrorWithNoRepr object at" in repr(instance)

--- a/tests/objects/generics/test_generic_objects.py
+++ b/tests/objects/generics/test_generic_objects.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 import datetime
 from typing import Generic, List, Optional, TypeVar, Union
 
@@ -614,3 +615,29 @@ def test_federation():
 
     assert field2_copy.python_name == "node_field"
     assert field2_copy.type is str
+
+
+def test_custom_dataclasses():
+    T = TypeVar("T")
+
+    @dataclass
+    class MyGeneric(Generic[T]):
+        attr: T
+
+    _T = TypeVar("T")
+
+    @strawberry.type
+    class MyGenericChild(MyGeneric[_T], Generic[_T]):
+        attr: _T
+
+    def resolve() -> MyGenericChild[int]:
+        return MyGenericChild(attr=1)
+
+    @strawberry.type
+    class Query:
+        concrete_resolver: MyGenericChild[int] = strawberry.field(resolver=resolve)
+
+    schema = strawberry.Schema(Query)
+    res = schema.execute_sync("query { concreteResolver { attr } }")
+    assert not res.errors
+    assert res.data == {"concreteResolver": {"attr": 1}}

--- a/tests/objects/generics/test_generic_objects.py
+++ b/tests/objects/generics/test_generic_objects.py
@@ -1,5 +1,5 @@
-from dataclasses import dataclass
 import datetime
+from dataclasses import dataclass
 from typing import Generic, List, Optional, TypeVar, Union
 
 import pytest

--- a/tests/objects/test_types.py
+++ b/tests/objects/test_types.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass
+
 import pytest
 
 import strawberry
@@ -41,3 +43,34 @@ def test_raises_error_when_using_interface_with_a_not_class_object():
     @strawberry.interface
     def not_a_class():
         pass
+
+
+def test_type_with_dataclass():
+    @strawberry.type
+    @dataclass(repr=False)
+    class ClassWithNoRepr:
+        number: int
+
+    instance = ClassWithNoRepr(number=5)
+    assert "ClassWithNoRepr object at" in repr(instance)
+
+
+def test_type_with_dataclass_inheritance():
+    @strawberry.type
+    class A:
+        number: int
+
+    @strawberry.type
+    @dataclass(repr=False)
+    class B(A):
+        string: str
+
+    instance = B(number=5, string="foo")
+    # note: `number` is included in the repr of B because `number` is part of
+    # `A` which was created with `repr=True`.
+    # `string` is correctly missing from the repr of `B` because `B` has been
+    # created with `repr=False`.
+    assert "B(number=5)" in repr(instance)
+
+    instance2 = A(number=3)
+    assert "A(number=3)" in repr(instance2)

--- a/tests/test_printer/test_schema_directives.py
+++ b/tests/test_printer/test_schema_directives.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 import textwrap
 from enum import Enum
 from typing import List, Optional
@@ -636,3 +637,13 @@ def test_print_directive_on_argument_with_description():
     schema = strawberry.Schema(query=Query)
 
     assert print_schema(schema) == textwrap.dedent(expected_output).strip()
+
+
+def test_schema_directive_with_kwargs():
+    @strawberry.schema_directive(locations=[Location.OBJECT])
+    @dataclass(repr=False)
+    class CacheControlWithNoRepr:
+        max_age: int
+
+    instance = CacheControlWithNoRepr(max_age=50)
+    assert "CacheControlWithNoRepr object at" in repr(instance)

--- a/tests/test_printer/test_schema_directives.py
+++ b/tests/test_printer/test_schema_directives.py
@@ -1,5 +1,5 @@
-from dataclasses import dataclass
 import textwrap
+from dataclasses import dataclass
 from enum import Enum
 from typing import List, Optional
 from typing_extensions import Annotated


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This PR adds support for `strawberry.type` to handle dataclasses that have custom parameters (e.g. `repr=False`) rather than recreating the dataclass from scratch.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #2688

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
