### PR TITLE
Fix problems with timeouts in graphql_transport_ws

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+`grapql-transport-ws`: Don't start the sub-protocol timeout until the `websockets` connection handshake is complete.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,3 @@
 Release type: patch
 
-`grapql-transport-ws`: Don't start the sub-protocol timeout until the `websockets` connection handshake is complete.
+This release improves the `graphql-transport-ws` implementation by starting the sub-protocol timeout only when the connection handshake is completed.

--- a/strawberry/aiohttp/handlers/graphql_transport_ws_handler.py
+++ b/strawberry/aiohttp/handlers/graphql_transport_ws_handler.py
@@ -44,6 +44,7 @@ class GraphQLTransportWSHandler(BaseGraphQLTransportWSHandler):
 
     async def handle_request(self) -> web.StreamResponse:
         await self._ws.prepare(self._request)
+        self.on_request_accepted()
 
         try:
             async for ws_message in self._ws:  # type: http.WSMessage

--- a/strawberry/aiohttp/handlers/graphql_transport_ws_handler.py
+++ b/strawberry/aiohttp/handlers/graphql_transport_ws_handler.py
@@ -54,8 +54,6 @@ class GraphQLTransportWSHandler(BaseGraphQLTransportWSHandler):
                     error_message = "WebSocket message type must be text"
                     await self.handle_invalid_message(error_message)
         finally:
-            for operation_id in list(self.subscriptions.keys()):
-                await self.cleanup_operation(operation_id)
-            await self.reap_completed_tasks()
+            await self.shutdown()
 
         return self._ws

--- a/strawberry/asgi/handlers/graphql_transport_ws_handler.py
+++ b/strawberry/asgi/handlers/graphql_transport_ws_handler.py
@@ -46,6 +46,7 @@ class GraphQLTransportWSHandler(BaseGraphQLTransportWSHandler):
 
     async def handle_request(self) -> None:
         await self._ws.accept(subprotocol=GRAPHQL_TRANSPORT_WS_PROTOCOL)
+        self.on_request_accepted()
 
         try:
             while self._ws.application_state != WebSocketState.DISCONNECTED:

--- a/strawberry/asgi/handlers/graphql_transport_ws_handler.py
+++ b/strawberry/asgi/handlers/graphql_transport_ws_handler.py
@@ -60,6 +60,4 @@ class GraphQLTransportWSHandler(BaseGraphQLTransportWSHandler):
         except WebSocketDisconnect:  # pragma: no cover
             pass
         finally:
-            for operation_id in list(self.subscriptions.keys()):
-                await self.cleanup_operation(operation_id)
-            await self.reap_completed_tasks()
+            await self.shutdown()

--- a/strawberry/channels/handlers/graphql_transport_ws_handler.py
+++ b/strawberry/channels/handlers/graphql_transport_ws_handler.py
@@ -53,6 +53,7 @@ class GraphQLTransportWSHandler(BaseGraphQLTransportWSHandler):
 
     async def handle_request(self) -> Any:
         await self._ws.accept(subprotocol=GRAPHQL_TRANSPORT_WS_PROTOCOL)
+        self.on_request_accepted()
 
     async def handle_disconnect(self, code) -> None:
         for operation_id in list(self.subscriptions.keys()):

--- a/strawberry/channels/handlers/graphql_transport_ws_handler.py
+++ b/strawberry/channels/handlers/graphql_transport_ws_handler.py
@@ -56,7 +56,4 @@ class GraphQLTransportWSHandler(BaseGraphQLTransportWSHandler):
         self.on_request_accepted()
 
     async def handle_disconnect(self, code) -> None:
-        for operation_id in list(self.subscriptions.keys()):
-            await self.cleanup_operation(operation_id)
-
-        await self.reap_completed_tasks()
+        await self.shutdown()

--- a/strawberry/starlite/handlers/graphql_transport_ws_handler.py
+++ b/strawberry/starlite/handlers/graphql_transport_ws_handler.py
@@ -39,6 +39,7 @@ class GraphQLTransportWSHandler(BaseGraphQLTransportWSHandler):
 
     async def handle_request(self) -> None:
         await self._ws.accept(subprotocols=GRAPHQL_TRANSPORT_WS_PROTOCOL)
+        self.on_request_accepted()
 
         try:
             while self._ws.connection_state != "disconnect":

--- a/strawberry/starlite/handlers/graphql_transport_ws_handler.py
+++ b/strawberry/starlite/handlers/graphql_transport_ws_handler.py
@@ -53,6 +53,4 @@ class GraphQLTransportWSHandler(BaseGraphQLTransportWSHandler):
         except WebSocketDisconnect:  # pragma: no cover
             pass
         finally:
-            for operation_id in list(self.subscriptions.keys()):
-                await self.cleanup_operation(operation_id)
-            await self.reap_completed_tasks()
+            await self.shutdown()

--- a/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
@@ -102,7 +102,7 @@ class BaseGraphQLTransportWSHandler(ABC):
             await asyncio.sleep(delay=delay)
 
             if self.connection_init_received:
-                return
+                return  # pragma: no cover
 
             self.connection_timed_out = True
             reason = "Connection initialisation timeout"
@@ -110,7 +110,7 @@ class BaseGraphQLTransportWSHandler(ABC):
         except asyncio.CancelledError:
             raise
         except Exception as error:
-            await self.handle_task_exception(error)
+            await self.handle_task_exception(error)  # pragma: no cover
         finally:
             # do not clear self.connection_init_timeout_task
             # so that unittests can inspect it.
@@ -118,7 +118,7 @@ class BaseGraphQLTransportWSHandler(ABC):
 
     async def handle_task_exception(self, _: Exception) -> None:
         # TODO: Log the error
-        pass
+        pass  # pragma: no cover
 
     async def handle_message(self, message: dict) -> None:
         handler: Callable
@@ -160,7 +160,8 @@ class BaseGraphQLTransportWSHandler(ABC):
 
     async def handle_connection_init(self, message: ConnectionInitMessage) -> None:
         if self.connection_timed_out:
-            return
+            # No way to reliably excercise this case during testing
+            return  # pragma: no cover
         if self.connection_init_timeout_task:
             self.connection_init_timeout_task.cancel()
 

--- a/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
@@ -74,9 +74,15 @@ class BaseGraphQLTransportWSHandler(ABC):
         """Handle the request this instance was created for"""
 
     async def handle(self) -> Any:
-        timeout_handler = self.handle_connection_init_timeout()
-        self.connection_init_timeout_task = asyncio.create_task(timeout_handler)
         return await self.handle_request()
+
+    def on_request_accepted(self) -> None:
+        #  handle_request should call this once it has sent the
+        # websocket.accept() response to start the timeout.
+        assert not self.connection_init_timeout_task
+        self.connection_init_timeout_task = asyncio.create_task(
+            self.handle_connection_init_timeout()
+        )
 
     async def handle_connection_init_timeout(self) -> None:
         task = asyncio.current_task()

--- a/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
@@ -87,7 +87,7 @@ class BaseGraphQLTransportWSHandler(ABC):
         await self.reap_completed_tasks()
 
     def on_request_accepted(self) -> None:
-        #  handle_request should call this once it has sent the
+        # handle_request should call this once it has sent the
         # websocket.accept() response to start the timeout.
         assert not self.connection_init_timeout_task
         self.connection_init_timeout_task = asyncio.create_task(

--- a/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from abc import ABC, abstractmethod
 from contextlib import suppress
 from typing import TYPE_CHECKING, Any, AsyncGenerator, Callable, Dict, List, Optional
@@ -35,6 +36,8 @@ if TYPE_CHECKING:
 
 
 class BaseGraphQLTransportWSHandler(ABC):
+    task_logger: logging.Logger = logging.getLogger("strawberry.ws.task")
+
     def __init__(
         self,
         schema: BaseSchema,
@@ -116,9 +119,8 @@ class BaseGraphQLTransportWSHandler(ABC):
             # so that unittests can inspect it.
             self.completed_tasks.append(task)
 
-    async def handle_task_exception(self, _: Exception) -> None:
-        # TODO: Log the error
-        pass  # pragma: no cover
+    async def handle_task_exception(self, error: Exception) -> None:
+        self.task_logger.exception("Exception in worker task", exc_info=error)
 
     async def handle_message(self, message: dict) -> None:
         handler: Callable

--- a/tests/http/clients/base.py
+++ b/tests/http/clients/base.py
@@ -243,6 +243,17 @@ class WebSocketClient(abc.ABC):
 
 
 class DebuggableGraphQLTransportWSMixin:
+    @staticmethod
+    def on_init(self):
+        """
+        This method can be patched by unittests to get the instance of the
+        transport handler when it is initialized
+        """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        DebuggableGraphQLTransportWSMixin.on_init(self)
+
     async def get_context(self) -> object:
         context = await super().get_context()
         context["ws"] = self._ws


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

This fixes an issue mentioned in #2702

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

After merging uniform websocket tests for Starlite extension, sporadic deadlocks were observed.
It turned out that  the timeout trigger, part of the `graphql_transport_ws` protocol, could trigger too early,
when the initial `websockets` handshake was still being done.  This caused the whole websocket connection
attempt to be rejected and this triggered a deadlock in Starlite, which still appears a bit un-robust.

This PR does a few things

1. provides an API to start the timeout, after the integration specific handler has completed the Websockets handshake.
2. Add initial synchronization (`connection_timed_out:bool`) to ensure that there is never a race between a timeout and accepting a connection.
3. Robustly terminate the timeout task when it is done, or no longer needed.
4. Add error handing around the timeout task.  
5. Add a Task error handling hook, to report unhandled errors in Tasks.  This is not yet in use, need to consult on which log handler to use, perhaps "strawberry.task"
6. Provide a shutdown() api to the integrations, rather than the former, rather unwieldly, boilerplate code.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR


* #2702 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
