### PR TITLE
graphql_transport_ws: Fix task shutdown/cancellation issues evident from testsuite warnings

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Minor adjustments for `graphql-transport-ws` and tests to reduce warnings when running unit tests.

--- a/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
@@ -304,7 +304,7 @@ class BaseGraphQLTransportWSHandler(ABC):
                     next_message = NextMessage(id=operation.id, payload=next_payload)
                     await operation.send_message(next_message)
         except asyncio.CancelledError:
-            # CancelledErrors are expected during task cleanup.
+            # Not a BaseException until 3.8.
             raise
         except Exception as error:
             # GraphQLErrors are handled by graphql-core and included in the

--- a/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
@@ -304,7 +304,9 @@ class BaseGraphQLTransportWSHandler(ABC):
                     next_message = NextMessage(id=operation.id, payload=next_payload)
                     await operation.send_message(next_message)
         except asyncio.CancelledError:
-            # Not a BaseException until 3.8.
+            # Need to catch and raise this separately because in versions <= 3.7
+            # asyncio.CancelledError is an Exception, not a direct subclass of
+            # BaseException
             raise
         except Exception as error:
             # GraphQLErrors are handled by graphql-core and included in the

--- a/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
@@ -269,6 +269,8 @@ class BaseGraphQLTransportWSHandler(ABC):
         Operation task top level method.  Cleans up and de-registers the operation
         once it is done.
         """
+        task = asyncio.current_task()
+        assert task is not None
         # TODO: Handle errors in this method using self.handle_task_exception()
         try:
             await self.handle_async_results(result_source, operation)
@@ -287,8 +289,6 @@ class BaseGraphQLTransportWSHandler(ABC):
             await operation.send_message(CompleteMessage(id=operation.id))
         finally:
             # add this task to a list to be reaped later
-            task = asyncio.current_task()
-            assert task is not None
             self.completed_tasks.append(task)
 
     async def handle_async_results(

--- a/tests/aiohttp/app.py
+++ b/tests/aiohttp/app.py
@@ -10,6 +10,7 @@ class DebuggableGraphQLTransportWSHandler(GraphQLTransportWSHandler):
         context["ws"] = self._ws
         context["tasks"] = self.tasks
         context["connectionInitTimeoutTask"] = self.connection_init_timeout_task
+        context["handler"] = self
         return context
 
 
@@ -19,6 +20,7 @@ class DebuggableGraphQLWSHandler(GraphQLWSHandler):
         context["ws"] = self._ws
         context["tasks"] = self.tasks
         context["connectionInitTimeoutTask"] = None
+        context["handler"] = self
         return context
 
 

--- a/tests/http/clients/base.py
+++ b/tests/http/clients/base.py
@@ -259,6 +259,7 @@ class DebuggableGraphQLTransportWSMixin:
         context["ws"] = self._ws
         context["tasks"] = self.tasks
         context["connectionInitTimeoutTask"] = self.connection_init_timeout_task
+        context["handler"] = self
         return context
 
 
@@ -268,4 +269,5 @@ class DebuggableGraphQLWSMixin:
         context["ws"] = self._ws
         context["tasks"] = self.tasks
         context["connectionInitTimeoutTask"] = None
+        context["handler"] = self
         return context

--- a/tests/http/clients/channels.py
+++ b/tests/http/clients/channels.py
@@ -25,6 +25,7 @@ class DebuggableGraphQLTransportWSConsumer(GraphQLWSConsumer):
     async def get_context(self, *args, **kwargs) -> object:
         context = await super().get_context(*args, **kwargs)
         context.tasks = self._handler.tasks
+        context.handler = self._handler
         context.connectionInitTimeoutTask = getattr(
             self._handler, "connection_init_timeout_task", None
         )

--- a/tests/views/schema.py
+++ b/tests/views/schema.py
@@ -115,6 +115,10 @@ class Query:
 
         return name
 
+    @strawberry.field
+    def finalizer_state(self, info: Info[Any, Any]) -> bool:
+        return getattr(info.context["handler"], "_debug_finalizer", False)
+
 
 @strawberry.type
 class Mutation:
@@ -228,12 +232,14 @@ class Subscription:
     async def long_finalizer(
         self, info: Info[Any, Any], delay: float = 0
     ) -> AsyncGenerator[str, None]:
+        info.context["handler"]._debug_finalizer = True
         try:
             for _i in range(100):
                 yield "hello"
                 await asyncio.sleep(0.01)
         finally:
             await asyncio.sleep(delay)
+            info.context["handler"]._debug_finalizer = False
 
 
 schema = strawberry.Schema(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

Examining the warnings after running the unittests for `test_graphql_transport_ws.py`
showed some problems in how we were handling task cleanup and cancellation.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

- AsyncGenerator doesn't need to be explicitly closed, but for expedient shutdown it should be done from witin
  within the task, using Finally semantics.
- The current `Task` instance should be retrieved at the start, not during shutdown when the event loop may be gone.
- CancelledError should raise out of the task.
- The cleanup of current operation id can race with an external `cleanup_operation` so must not fail if the id isn't on record.
- Added a unittest to verify that the subscription AsyncGenerators are properly finalized when an operation is cancelled.

As this is not a feature enhancement, a Release file is probably not warranted.  Also, this PR belongs in the group of
"subscription enhancements" that I am working on.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
