### PR TITLE
Cancelling subscriptions with finalizers does not block websocket

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+`graphql_transport_ws`: Cancelling a subscription no longer blocks the connection
+while any subscription finalizers run.

--- a/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
@@ -300,11 +300,8 @@ class BaseGraphQLTransportWSHandler(ABC):
         result_source = self.subscriptions.pop(operation_id)
         task = self.tasks.pop(operation_id)
         task.cancel()
-        with suppress(BaseException):
-            await task
-        # since python 3.8, generators cannot be reliably closed
-        with suppress(RuntimeError):
-            await result_source.aclose()
+        # do not await the task here, lest we block the main
+        # websocket handler Task.
 
     async def reap_completed_tasks(self) -> None:
         """

--- a/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
@@ -237,8 +237,9 @@ class BaseGraphQLTransportWSHandler(ABC):
             result_source = self.subscriptions[operation.id]
             with suppress(RuntimeError):
                 await result_source.aclose()
-            del self.subscriptions[operation.id]
-            del self.tasks[operation.id]
+            if operation.id in self.subscriptions:
+                del self.subscriptions[operation.id]
+                del self.tasks[operation.id]
             raise
         else:
             await operation.send_message(CompleteMessage(id=operation.id))
@@ -267,7 +268,7 @@ class BaseGraphQLTransportWSHandler(ABC):
                     await operation.send_message(next_message)
         except asyncio.CancelledError:
             # CancelledErrors are expected during task cleanup.
-            return
+            raise
         except Exception as error:
             # GraphQLErrors are handled by graphql-core and included in the
             # ExecutionResult

--- a/tests/views/schema.py
+++ b/tests/views/schema.py
@@ -224,6 +224,17 @@ class Subscription:
     ) -> AsyncGenerator[str, None]:
         yield info.context["connection_params"]["strawberry"]
 
+    @strawberry.subscription
+    async def long_finalizer(
+        self, info: Info[Any, Any], delay: float = 0
+    ) -> AsyncGenerator[str, None]:
+        try:
+            for _i in range(100):
+                yield "hello"
+                await asyncio.sleep(0.01)
+        finally:
+            await asyncio.sleep(delay)
+
 
 schema = strawberry.Schema(
     query=Query,

--- a/tests/websockets/test_graphql_transport_ws.py
+++ b/tests/websockets/test_graphql_transport_ws.py
@@ -749,7 +749,6 @@ async def test_rejects_connection_params_not_unset(ws_raw: WebSocketClient):
     ws.assert_reason("Invalid connection init payload")
 
 
-@pytest.mark.xfail
 async def test_subsciption_cancel_finalization_delay(ws: WebSocketClient):
     # Test that when we cancel a subscription, the websocket isn't blocked
     # while some complex finalization takes place.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

Make sure the websocket connection remains responsive even when cancelling subscriptions.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Previously a `Complete` message would both `cancel()` a subscription and `await` for the worker thread to finish.
As this was done on the task handling the websocket messages, a _finalizer_ which might take time to complete would
cause the main Task to block.

There is no need to await this task at this point, neither is there any need to explicitly close the AsyncGenerator, so simply
avoiding the await frees up the handling Task.

- Added unittest demonstrating the problem
- Resolved the problem

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
