### PR TITLE
feat: extension MaxAliasesLimiter

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,6 @@
 Release type: minor
 
-Extension MaxAliasesLimiter
-Add a validator to limit the maximum number of aliases in a GraphQL document.
+This PR adds a MaxAliasesLimiter extensions which limit the number of aliases in a GraphQL document.
 
 ## Usage example:
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
 Release type: minor
 
-This PR adds a MaxAliasesLimiter extensions which limit the number of aliases in a GraphQL document.
+This PR adds a MaxAliasesLimiter extensions which limits the number of aliases in a GraphQL document.
 
 ## Usage example:
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,18 @@
+Release type: minor
+
+Extension MaxAliasesLimiter
+Add a validator to limit the maximum number of aliases in a GraphQL document.
+
+## Usage example:
+
+```python
+import strawberry
+from strawberry.extensions import MaxAliasesLimiter
+
+schema = strawberry.Schema(
+    Query,
+    extensions=[
+        MaxAliasesLimiter(max_alias_count=15),
+    ],
+)
+```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
 Release type: minor
 
-This PR adds a MaxAliasesLimiter extensions which limits the number of aliases in a GraphQL document.
+This PR adds a MaxAliasesLimiter extension which limits the number of aliases in a GraphQL document.
 
 ## Usage example:
 

--- a/docs/extensions/max-aliases-limiter.md
+++ b/docs/extensions/max-aliases-limiter.md
@@ -1,0 +1,34 @@
+---
+title: MaxAliasesLimiter
+summary: Add a validator to limit the maximum number of aliases in a GraphQL document.
+tags: security
+---
+
+# `MaxAliasesLimiter`
+
+This extension adds a validator to limit the maximum number of aliases in a GraphQL document.
+
+## Usage example:
+
+```python
+import strawberry
+from strawberry.extensions import MaxAliasesLimiter
+
+schema = strawberry.Schema(
+    Query,
+    extensions=[
+        MaxAliasesLimiter(max_alias_count=15),
+    ],
+)
+```
+
+## API reference:
+
+```python
+class MaxAliasesLimiter(max_alias_count):
+    ...
+```
+
+#### `max_alias_count: int`
+
+The maximum allowed number of aliases in a GraphQL document.

--- a/strawberry/extensions/__init__.py
+++ b/strawberry/extensions/__init__.py
@@ -5,6 +5,7 @@ from .base_extension import SchemaExtension
 from .disable_validation import DisableValidation
 from .field_extension import FieldExtension
 from .mask_errors import MaskErrors
+from .max_aliases import MaxAliasesLimiter
 from .parser_cache import ParserCache
 from .query_depth_limiter import QueryDepthLimiter
 from .validation_cache import ValidationCache
@@ -34,4 +35,5 @@ __all__ = [
     "QueryDepthLimiter",
     "ValidationCache",
     "MaskErrors",
+    "MaxAliasesLimiter",
 ]

--- a/strawberry/extensions/max_aliases.py
+++ b/strawberry/extensions/max_aliases.py
@@ -1,0 +1,74 @@
+from typing import Type
+
+from graphql import (
+    ExecutableDefinitionNode,
+    FieldNode,
+    GraphQLError,
+    InlineFragmentNode,
+    ValidationContext,
+    ValidationRule,
+)
+
+from strawberry.extensions.add_validation_rules import AddValidationRules
+
+
+class MaxAliasesLimiter(AddValidationRules):
+    """
+    Add a validator to limit the number of aliases used.
+
+    Example:
+
+    >>> import strawberry
+    >>> from strawberry.extensions import QueryDepthLimiter
+    >>>
+    >>> schema = strawberry.Schema(
+    ...     Query,
+    ...     extensions=[
+    ...         MaxAliasesLimiter(max_alias_count=15)
+    ...     ]
+    ... )
+
+    Arguments:
+
+    `max_alias_count: int`
+        The maximum number of aliases allowed in a GraphQL document.
+    """
+
+    def __init__(
+        self,
+        max_alias_count: int,
+    ):
+        validator = create_validator(max_alias_count)
+        super().__init__([validator])
+
+
+def create_validator(max_alias_count: int) -> Type[ValidationRule]:
+    class MaxAliasesValidator(ValidationRule):
+        def __init__(self, validation_context: ValidationContext):
+            document = validation_context.document
+            def_that_can_contain_alias = [
+                def_
+                for def_ in document.definitions
+                if isinstance(def_, (ExecutableDefinitionNode))
+            ]
+            total_aliases = sum(
+                count_fields_with_alias(def_node)
+                for def_node in def_that_can_contain_alias
+            )
+            if total_aliases > max_alias_count:
+                msg = f"{total_aliases} aliases found. Allowed: {max_alias_count}"
+                validation_context.report_error(GraphQLError(msg))
+
+            super().__init__(validation_context)
+
+    return MaxAliasesValidator
+
+
+def count_fields_with_alias(selection_set_owner) -> int:
+    result = 0
+    for sel in selection_set_owner.selection_set.selections:
+        if isinstance(sel, FieldNode) and sel.alias:
+            result += 1
+        if isinstance(sel, (FieldNode, InlineFragmentNode)) and sel.selection_set:
+            result += count_fields_with_alias(sel)
+    return result

--- a/strawberry/extensions/max_aliases.py
+++ b/strawberry/extensions/max_aliases.py
@@ -46,11 +46,11 @@ def create_validator(max_alias_count: int) -> Type[ValidationRule]:
     class MaxAliasesValidator(ValidationRule):
         def __init__(self, validation_context: ValidationContext):
             document = validation_context.document
-            def_that_can_contain_alias = [
+            def_that_can_contain_alias = (
                 def_
                 for def_ in document.definitions
                 if isinstance(def_, (ExecutableDefinitionNode))
-            ]
+            )
             total_aliases = sum(
                 count_fields_with_alias(def_node)
                 for def_node in def_that_can_contain_alias

--- a/tests/schema/extensions/test_max_aliases.py
+++ b/tests/schema/extensions/test_max_aliases.py
@@ -131,7 +131,7 @@ def test_multiple_arguments():
     assert not result
 
 
-def test_aliased_argument():
+def test_aliased_in_nested_field():
     query = """
     query read {
       matt: user(name: "matt") {

--- a/tests/schema/extensions/test_max_aliases.py
+++ b/tests/schema/extensions/test_max_aliases.py
@@ -1,0 +1,200 @@
+from typing import Dict, List, Optional, Tuple, Union
+
+from graphql import (
+    GraphQLError,
+    parse,
+    specified_rules,
+    validate,
+)
+
+import strawberry
+from strawberry.extensions.max_aliases import create_validator
+
+
+@strawberry.type
+class Human:
+    name: str
+    email: str
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def user(self, name: Optional[str], email: Optional[str]) -> Human:
+        pass
+
+    version: str
+    user1: Human
+    user2: Human
+    user3: Human
+
+
+schema = strawberry.Schema(Query)
+
+
+def run_query(
+    query: str, max_aliases: int
+) -> Tuple[List[GraphQLError], Union[Dict[str, int], None]]:
+    document = parse(query)
+
+    result = None
+
+    validation_rule = create_validator(max_aliases)
+
+    errors = validate(
+        schema._schema,
+        document,
+        rules=(*specified_rules, validation_rule),
+    )
+
+    return errors, result
+
+
+def test_2_aliases_same_content():
+    query = """
+    query read {
+      matt: user(name: "matt") {
+        email
+      }
+      matt_alias: user(name: "matt") {
+        email
+      }
+    }
+    """
+
+    errors, result = run_query(query, 1)
+
+    assert len(errors) == 1
+    assert errors[0].message == "2 aliases found. Allowed: 1"
+    assert not result
+
+
+def test_2_aliases_different_content():
+    query = """
+    query read {
+      matt: user(name: "matt") {
+        email
+      }
+      matt_alias: user(name: "matt42") {
+        email
+      }
+    }
+    """
+
+    errors, result = run_query(query, 1)
+
+    assert len(errors) == 1
+    assert errors[0].message == "2 aliases found. Allowed: 1"
+
+
+def test_multiple_aliases_some_overlap_in_content():
+    query = """
+    query read {
+      matt: user(name: "matt") {
+        email
+      }
+      jane: user(name: "jane") {
+        email
+      }
+      matt_alias: user(name: "matt") {
+        email
+      }
+    }
+    """
+
+    errors, result = run_query(query, 1)
+
+    assert len(errors) == 1
+    assert errors[0].message == "3 aliases found. Allowed: 1"
+    assert not result
+
+
+def test_multiple_arguments():
+    query = """
+    query read {
+      matt: user(name: "matt", email: "matt@example.com") {
+        email
+      }
+      jane: user(name: "jane") {
+        email
+      }
+      matt_alias: user(name: "matt", email: "matt@example.com") {
+        email
+      }
+    }
+    """
+
+    errors, result = run_query(query, 1)
+
+    assert len(errors) == 1
+    assert errors[0].message == "3 aliases found. Allowed: 1"
+    assert not result
+
+
+def test_aliased_argument():
+    query = """
+    query read {
+      matt: user(name: "matt") {
+        email_address: email
+      }
+    }
+    """
+
+    errors, result = run_query(query, 1)
+
+    assert len(errors) == 1
+    assert errors[0].message == "2 aliases found. Allowed: 1"
+    assert not result
+
+
+def test_aliased_argument_in_fragment():
+    query = """
+    fragment humanInfo on Human {
+      email_address: email
+    }
+    query read {
+      matt: user(name: "matt") {
+        ...humanInfo
+      }
+    }
+    """
+
+    errors, result = run_query(query, 1)
+
+    assert len(errors) == 1
+    assert errors[0].message == "2 aliases found. Allowed: 1"
+    assert not result
+
+
+def test_no_error_one_aliased_one_without():
+    query = """
+    query read {
+      user(name: "matt") {
+        email
+      }
+      matt_alias: user(name: "matt") {
+        email
+      }
+    }
+    """
+
+    errors, result = run_query(query, 1)
+
+    assert len(errors) == 0
+
+
+def test_no_error_for_multiple_but_not_too_many_aliases():
+    query = """
+    query read {
+      matt: user(name: "matt") {
+        email
+      }
+      matt_alias: user(name: "matt") {
+        email
+      }
+    }
+    """
+
+    errors, result = run_query(query, 2)
+
+    assert len(errors) == 0


### PR DESCRIPTION
Limit the maximum number of aliases in a GraphQL document.

Implementation
---------------------

Recursively search for aliases in `FieldNode`, `InlineFragmentNode`

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
