### PR TITLE
feat: MaxTokensLimiter extension

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,6 +122,8 @@ $ poetry run pytest tests -n auto
 $ poetry run mypy
 ```
 
+Some tests are known to be inconsistent. (The fix is in progress.) These tests are marked with the `pytest.mark.flaky` marker.
+
 Strawberry uses the [black](https://github.com/ambv/black) coding style and you
 must ensure that your code follows it. If not, the CI will fail and your Pull Request will not be merged.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,17 @@
+Release type: minor
+
+This PR adds a MaxTokensLimiter extension which limits the number of tokens in a GraphQL document.
+
+## Usage example:
+
+```python
+import strawberry
+from strawberry.extensions import MaxTokensLimiter
+
+schema = strawberry.Schema(
+    Query,
+    extensions=[
+        MaxTokensLimiter(max_token_count=1000),
+    ],
+)
+```

--- a/docs/_test.md
+++ b/docs/_test.md
@@ -38,6 +38,7 @@ This is probably not implemented in the best way, but for now it works:
 ```python
 import strawberry
 
+
 #      ^^^^^^^^^^
 #      This is a note about this line
 @strawberry.type

--- a/docs/extensions/max-tokens-limiter.md
+++ b/docs/extensions/max-tokens-limiter.md
@@ -1,0 +1,44 @@
+---
+title: MaxTokensLimiter
+summary: Add a validator to limit the maximum number of tokens in a GraphQL document.
+tags: security
+---
+
+# `MaxTokensLimiter`
+
+This extension adds a validator to limit the maximum number of tokens in a GraphQL document.
+
+## Usage example:
+
+```python
+import strawberry
+from strawberry.extensions import MaxTokensLimiter
+
+schema = strawberry.Schema(
+    Query,
+    extensions=[
+        MaxTokensLimiter(max_token_count=1000),
+    ],
+)
+```
+
+## API reference:
+
+```python
+class MaxTokensLimiter(max_token_count):
+    ...
+```
+
+#### `max_token_count: int`
+
+The maximum allowed number of tokens in a GraphQL document.
+
+The following things are counted as tokens:
+
+- various brackets: "{", "}", "(", ")"
+- colon :
+- words
+
+Not counted:
+
+- quotes

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -39,11 +39,13 @@ Introspection should primarily be used as a discovery and diagnostic tool for te
 
 You can disable introspection by [adding a validation rule extension](../extensions/add-validation-rules.md#more-examples).
 
-## Other considerations
+## Security extensions
 
-### Query depth
+Strawberry provides some security extensions to limit various aspects of the GraphQL document. These are recommended in production.
 
-You may also want to limit the query depth of GraphQL operations, which can be done via an [extension](../extensions/query-depth-limiter.md)
+- [query depth](../extensions/query-depth-limiter.md)
+- [max number of aliases](../extensions/max-aliases-limiter.md)
+- [max number of tokens](../extensions/max-tokens-limiter.md)
 
 # More resources
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -13,6 +13,7 @@ ignore_missing_imports = True
 install_types = True
 non_interactive = True
 show_traceback = True
+enable_incomplete_feature = Unpack
 # TODO: enable strict at some point
 ;strict = True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,7 +151,8 @@ markers = [
     "fastapi",
     "chalice",
     "flask",
-    "starlite"
+    "starlite",
+    "flaky"
 ]
 asyncio_mode = "auto"
 filterwarnings = [

--- a/strawberry/extensions/__init__.py
+++ b/strawberry/extensions/__init__.py
@@ -6,6 +6,7 @@ from .disable_validation import DisableValidation
 from .field_extension import FieldExtension
 from .mask_errors import MaskErrors
 from .max_aliases import MaxAliasesLimiter
+from .max_tokens import MaxTokensLimiter
 from .parser_cache import ParserCache
 from .query_depth_limiter import QueryDepthLimiter
 from .validation_cache import ValidationCache
@@ -36,4 +37,5 @@ __all__ = [
     "ValidationCache",
     "MaskErrors",
     "MaxAliasesLimiter",
+    "MaxTokensLimiter",
 ]

--- a/strawberry/extensions/max_aliases.py
+++ b/strawberry/extensions/max_aliases.py
@@ -19,7 +19,7 @@ class MaxAliasesLimiter(AddValidationRules):
     Example:
 
     >>> import strawberry
-    >>> from strawberry.extensions import QueryDepthLimiter
+    >>> from strawberry.extensions import MaxAliasesLimiter
     >>>
     >>> schema = strawberry.Schema(
     ...     Query,

--- a/strawberry/extensions/max_tokens.py
+++ b/strawberry/extensions/max_tokens.py
@@ -1,0 +1,44 @@
+from typing import Iterator
+
+from strawberry.extensions.base_extension import SchemaExtension
+
+
+class MaxTokensLimiter(SchemaExtension):
+    """
+    Add a validator to limit the number of tokens in a GraphQL document.
+
+    Example:
+
+    >>> import strawberry
+    >>> from strawberry.extensions import MaxTokensLimiter
+    >>>
+    >>> schema = strawberry.Schema(
+    ...     Query,
+    ...     extensions=[
+    ...         MaxTokensLimiter(max_token_count=1000)
+    ...     ]
+    ... )
+
+    Arguments:
+
+    `max_token_count: int`
+        The maximum number of tokens allowed in a GraphQL document.
+
+    The following things are counted as tokens:
+    * various brackets: "{", "}", "(", ")"
+    * colon :
+    * words
+
+    Not counted:
+    * quotes
+    """
+
+    def __init__(
+        self,
+        max_token_count: int,
+    ):
+        self.max_token_count = max_token_count
+
+    def on_operation(self) -> Iterator[None]:
+        self.execution_context.parse_options["max_tokens"] = self.max_token_count
+        yield

--- a/strawberry/schema/execute.py
+++ b/strawberry/schema/execute.py
@@ -27,6 +27,8 @@ from strawberry.types import ExecutionResult
 from .exceptions import InvalidOperationTypeError
 
 if TYPE_CHECKING:
+    from typing_extensions import Unpack
+
     from graphql import ExecutionContext as GraphQLExecutionContext
     from graphql import ExecutionResult as GraphQLExecutionResult
     from graphql import GraphQLSchema
@@ -35,10 +37,11 @@ if TYPE_CHECKING:
 
     from strawberry.extensions import SchemaExtension
     from strawberry.types import ExecutionContext
+    from strawberry.types.execution import ParseOptions
     from strawberry.types.graphql import OperationType
 
 
-def parse_document(query: str, **kwargs) -> DocumentNode:
+def parse_document(query: str, **kwargs: Unpack[ParseOptions]) -> DocumentNode:
     return parse(query, **kwargs)
 
 

--- a/strawberry/schema/execute.py
+++ b/strawberry/schema/execute.py
@@ -38,8 +38,8 @@ if TYPE_CHECKING:
     from strawberry.types.graphql import OperationType
 
 
-def parse_document(query: str) -> DocumentNode:
-    return parse(query)
+def parse_document(query: str, **kwargs) -> DocumentNode:
+    return parse(query, **kwargs)
 
 
 def validate_document(
@@ -90,7 +90,7 @@ async def execute(
             try:
                 if not execution_context.graphql_document:
                     execution_context.graphql_document = parse_document(
-                        execution_context.query
+                        execution_context.query, **execution_context.parse_options
                     )
 
             except GraphQLError as error:
@@ -183,7 +183,7 @@ def execute_sync(
             try:
                 if not execution_context.graphql_document:
                     execution_context.graphql_document = parse_document(
-                        execution_context.query
+                        execution_context.query, **execution_context.parse_options
                     )
 
             except GraphQLError as error:

--- a/strawberry/types/execution.py
+++ b/strawberry/types/execution.py
@@ -1,7 +1,17 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    NotRequired,
+    Optional,
+    Tuple,
+    Type,
+    TypedDict,
+)
 
 from graphql import specified_rules
 
@@ -24,7 +34,9 @@ class ExecutionContext:
     schema: Schema
     context: Any = None
     variables: Optional[Dict[str, Any]] = None
-    parse_options: Dict[str, Any] = dataclasses.field(default_factory=lambda: {})
+    parse_options: ParseOptions = dataclasses.field(
+        default_factory=lambda: ParseOptions()
+    )
     root_value: Optional[Any] = None
     validation_rules: Tuple[Type[ASTValidationRule], ...] = dataclasses.field(
         default_factory=lambda: tuple(specified_rules)
@@ -77,3 +89,7 @@ class ExecutionResult:
     data: Optional[Dict[str, Any]]
     errors: Optional[List[GraphQLError]]
     extensions: Optional[Dict[str, Any]] = None
+
+
+class ParseOptions(TypedDict):
+    max_tokens: NotRequired[int]

--- a/strawberry/types/execution.py
+++ b/strawberry/types/execution.py
@@ -24,6 +24,9 @@ class ExecutionContext:
     schema: Schema
     context: Any = None
     variables: Optional[Dict[str, Any]] = None
+    parse_options: Optional[Dict[str, Any]] = dataclasses.field(
+        default_factory=lambda: {}
+    )
     root_value: Optional[Any] = None
     validation_rules: Tuple[Type[ASTValidationRule], ...] = dataclasses.field(
         default_factory=lambda: tuple(specified_rules)

--- a/strawberry/types/execution.py
+++ b/strawberry/types/execution.py
@@ -9,14 +9,16 @@ from typing import (
     Optional,
     Tuple,
     Type,
-    TypedDict,
 )
+from typing_extensions import TypedDict
 
 from graphql import specified_rules
 
 from strawberry.utils.operation import get_first_operation, get_operation_type
 
 if TYPE_CHECKING:
+    from typing_extensions import NotRequired
+
     from graphql import ASTValidationRule
     from graphql import ExecutionResult as GraphQLExecutionResult
     from graphql.error.graphql_error import GraphQLError
@@ -90,7 +92,5 @@ class ExecutionResult:
     extensions: Optional[Dict[str, Any]] = None
 
 
-class ParseOptions(TypedDict, total=False):
-    # Change this to typing.NotRequired
-    # when we don't support versions older than 3.11
-    max_tokens: Optional[int]
+class ParseOptions(TypedDict):
+    max_tokens: NotRequired[int]

--- a/strawberry/types/execution.py
+++ b/strawberry/types/execution.py
@@ -6,7 +6,6 @@ from typing import (
     Any,
     Dict,
     List,
-    NotRequired,
     Optional,
     Tuple,
     Type,
@@ -91,5 +90,7 @@ class ExecutionResult:
     extensions: Optional[Dict[str, Any]] = None
 
 
-class ParseOptions(TypedDict):
-    max_tokens: NotRequired[int]
+class ParseOptions(TypedDict, total=False):
+    # Change this to typing.NotRequired
+    # when we don't support versions older than 3.11
+    max_tokens: Optional[int]

--- a/strawberry/types/execution.py
+++ b/strawberry/types/execution.py
@@ -24,9 +24,7 @@ class ExecutionContext:
     schema: Schema
     context: Any = None
     variables: Optional[Dict[str, Any]] = None
-    parse_options: Optional[Dict[str, Any]] = dataclasses.field(
-        default_factory=lambda: {}
-    )
+    parse_options: Dict[str, Any] = dataclasses.field(default_factory=lambda: {})
     root_value: Optional[Any] = None
     validation_rules: Tuple[Type[ASTValidationRule], ...] = dataclasses.field(
         default_factory=lambda: tuple(specified_rules)

--- a/tests/schema/extensions/test_max_tokens.py
+++ b/tests/schema/extensions/test_max_tokens.py
@@ -1,0 +1,64 @@
+from typing import Optional
+
+import strawberry
+from strawberry.extensions.max_tokens import MaxTokensLimiter
+
+
+@strawberry.type
+class Human:
+    name: str
+    email: str
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def user(self, name: Optional[str] = None, email: Optional[str] = None) -> Human:
+        return Human(name="Jane Doe", email="jane@example.com")
+
+    version: str
+    user1: Human
+    user2: Human
+    user3: Human
+
+
+def test_1_more_token_than_allowed():
+    query = """
+    {
+      matt: user(name: "matt") {
+        name
+        email
+      }
+    }
+    """
+
+    result = _execute_with_max_tokens(query, 13)
+
+    assert len(result.errors) == 1
+    assert (
+        result.errors[0].message
+        == "Syntax Error: Document contains more than 13 tokens. Parsing aborted."
+    )
+
+
+def test_no_errors_exactly_max_number_of_tokens():
+    query = """
+    {
+      matt: user(name: "matt") {
+        name
+      }
+    }
+    """
+
+    result = _execute_with_max_tokens(query, 13)
+
+    assert not result.errors
+    assert result.data
+
+
+def _execute_with_max_tokens(query: str, max_token_count: int):
+    schema = strawberry.Schema(
+        Query, extensions=[MaxTokensLimiter(max_token_count=max_token_count)]
+    )
+
+    return schema.execute_sync(query)

--- a/tests/websockets/test_graphql_transport_ws.py
+++ b/tests/websockets/test_graphql_transport_ws.py
@@ -118,6 +118,7 @@ async def test_connection_init_timeout(request, http_client_class: Type[HttpClie
         ws.assert_reason("Connection initialisation timeout")
 
 
+@pytest.mark.flaky
 async def test_connection_init_timeout_cancellation(
     http_client_class: Type[HttpClient],
 ):


### PR DESCRIPTION
Limit the maximum number of tokens in a GraphQL document.

Implementation
----------------

* `ExecutionContext`: add `parse_options`
* pass `parse_options` to `graphql.language.parser.parse`

Docs
-------

* deployment docs: mention security extensions

Other
----------
max_aliases docstring: fix copy-paste error

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
