### PR TITLE
Convert input arguments into Strawberry types for Field Extensions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,25 @@
+Release type: minor
+
+This release parses the input arguments to a field earlier so that Field
+Extensions recieve instances of Input types rather than plain dictionaries.
+
+Example:
+
+```python
+import strawberry
+from strawberry.extensions import FieldExtension
+
+@strawberry.input
+class MyInput:
+    foo: str
+
+class MyFieldExtension(FieldExtension):
+    def resolve(self, next_: Callable[..., Any], source: Any, info: Info, **kwargs):
+        # kwargs["my_input"] is instance of MyInput
+        ...
+
+@strawberry.type
+class Query:
+    def field(self, my_input: MyInput) -> str:
+        return "hi"
+```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -23,6 +23,7 @@ class MyFieldExtension(FieldExtension):
 
 @strawberry.type
 class Query:
+    @strawberry.field
     def field(self, my_input: MyInput) -> str:
         return "hi"
 ```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,14 +9,17 @@ Example:
 import strawberry
 from strawberry.extensions import FieldExtension
 
+
 @strawberry.input
 class MyInput:
     foo: str
+
 
 class MyFieldExtension(FieldExtension):
     def resolve(self, next_: Callable[..., Any], source: Any, info: Info, **kwargs):
         # kwargs["my_input"] is instance of MyInput
         ...
+
 
 @strawberry.type
 class Query:

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -59,8 +59,6 @@ from strawberry.utils.await_maybe import await_maybe
 
 from ..extensions.field_extension import (
     build_field_extension_resolvers,
-    SyncExtensionResolver,
-    AsyncExtensionResolver,
 )
 from . import compat
 from .types.concrete_type import ConcreteType

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -561,12 +561,24 @@ class GraphQLCoreConverter:
                     source=_source, info=info, kwargs=kwargs
                 )
 
+                resolver_requested_info = False
+                if "info" in field_kwargs:
+                    resolver_requested_info = True
+                    # remove info from field_kwargs because we're passing it
+                    # explicitly to the extensions
+                    field_kwargs.pop("info")
+
                 # `_get_result` expects `field_args` and `field_kwargs` as
                 # separate arguments so we have to wrap the function so that we
                 # can pass them in
                 def wrapped_get_result(_source, info, **kwargs):
+                    # if the resolver function requested the info object info
+                    # then put it back in the kwargs dictionary
+                    if resolver_requested_info:
+                        kwargs["info"] = info
+
                     return _get_result(
-                        _source, info, field_args=field_args, field_kwargs=field_kwargs
+                        _source, info, field_args=field_args, field_kwargs=kwargs
                     )
 
                 # combine all the extension resolvers

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -57,7 +57,11 @@ from strawberry.union import StrawberryUnion
 from strawberry.unset import UNSET
 from strawberry.utils.await_maybe import await_maybe
 
-from ..extensions.field_extension import build_field_extension_resolvers
+from ..extensions.field_extension import (
+    build_field_extension_resolvers,
+    SyncExtensionResolver,
+    AsyncExtensionResolver,
+)
 from . import compat
 from .types.concrete_type import ConcreteType
 
@@ -530,11 +534,12 @@ class GraphQLCoreConverter:
                 _field=field,
             )
 
-        def _get_result(_source: Any, info: Info, **kwargs):
-            field_args, field_kwargs = _get_arguments(
-                source=_source, info=info, kwargs=kwargs
-            )
-
+        def _get_result(
+            _source: Any,
+            info: Info,
+            field_args: List[Any],
+            field_kwargs: Dict[str, Any],
+        ):
             return field.get_result(
                 _source, info=info, args=field_args, kwargs=field_kwargs
             )
@@ -542,18 +547,38 @@ class GraphQLCoreConverter:
         def wrap_field_extensions() -> Callable[..., Any]:
             """Wrap the provided field resolver with the middleware."""
 
-            if not field.extensions:
-                return _get_result
-
             for extension in field.extensions:
                 extension.apply(field)
 
             extension_functions = build_field_extension_resolvers(field)
-            return reduce(
-                lambda chained_fns, next_fn: partial(next_fn, chained_fns),
-                extension_functions,
-                _get_result,
-            )
+
+            def extension_resolver(
+                _source: Any,
+                info: Info,
+                **kwargs,
+            ):
+                # parse field arguments into Strawberry input types and convert
+                # field names to Python equivalents
+                field_args, field_kwargs = _get_arguments(
+                    source=_source, info=info, kwargs=kwargs
+                )
+
+                # `_get_result` expects `field_args` and `field_kwargs` as
+                # separate arguments so we have to wrap the function so that we
+                # can pass them in
+                def wrapped_get_result(_source, info, **kwargs):
+                    return _get_result(
+                        _source, info, field_args=field_args, field_kwargs=field_kwargs
+                    )
+
+                # combine all the extension resolvers
+                return reduce(
+                    lambda chained_fn, next_fn: partial(next_fn, chained_fn),
+                    extension_functions,
+                    wrapped_get_result,
+                )(_source, info, **field_kwargs)
+
+            return extension_resolver
 
         _get_result_with_extensions = wrap_field_extensions()
 
@@ -561,14 +586,22 @@ class GraphQLCoreConverter:
             strawberry_info = _strawberry_info_from_graphql(info)
             _check_permissions(_source, strawberry_info, kwargs)
 
-            return _get_result_with_extensions(_source, strawberry_info, **kwargs)
+            return _get_result_with_extensions(
+                _source,
+                strawberry_info,
+                **kwargs,
+            )
 
         async def _async_resolver(_source: Any, info: GraphQLResolveInfo, **kwargs):
             strawberry_info = _strawberry_info_from_graphql(info)
             await _check_permissions_async(_source, strawberry_info, kwargs)
 
             return await await_maybe(
-                _get_result_with_extensions(_source, strawberry_info, **kwargs)
+                _get_result_with_extensions(
+                    _source,
+                    strawberry_info,
+                    **kwargs,
+                )
             )
 
         if field.is_async:


### PR DESCRIPTION
## Description

This PR parses the input arguments to a field early so that Field Extensions receive instances of Input types rather than just plain dictionaries.

Example:

```python
import strawberry
from strawberry.extensions import FieldExtension

@strawberry.input
class MyInput:
    foo: str

class MyFieldExtension(FieldExtension):
    def resolve(self, next_: Callable[..., Any], source: Any, info: Info, **kwargs):
        # kwargs["my_input"] is instance of MyInput
        ...

@strawberry.type
class Query:
	@strawberry.field
    def field(self, my_input: MyInput) -> str:
        return "hi"
```

Note: I think the whole resolver function in the schema converter is
getting pretty messy and probably needs a refactor.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
