### PR TITLE
Add `get_argument_definition` helper to info object

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,28 @@
+Release type: patch
+
+Add `get_argument_definition` helper function on the Info object to get
+a StrawberryArgument definition by argument name from inside a resolver or
+Field Extension.
+
+Example:
+
+```python
+import strawberry
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def field(
+        self,
+        info,
+        my_input: Annotated[
+          str,
+          strawberry.argument(description="Some description"),
+        ],
+    ) -> str:
+        my_input_def = info.get_argument_definition("my_input")
+        assert my_input_def.type is str
+        assert my_input_def.description == "Some description"
+
+        return my_input
+```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,6 +9,7 @@ Example:
 ```python
 import strawberry
 
+
 @strawberry.type
 class Query:
     @strawberry.field
@@ -16,8 +17,8 @@ class Query:
         self,
         info,
         my_input: Annotated[
-          str,
-          strawberry.argument(description="Some description"),
+            str,
+            strawberry.argument(description="Some description"),
         ],
     ) -> str:
         my_input_def = info.get_argument_definition("my_input")

--- a/strawberry/types/info.py
+++ b/strawberry/types/info.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from graphql.language import FieldNode
     from graphql.pyutils.path import Path
 
+    from strawberry.arguments import StrawberryArgument
     from strawberry.field import StrawberryField
     from strawberry.schema import Schema
     from strawberry.type import StrawberryType
@@ -82,3 +83,13 @@ class Info(Generic[ContextType, RootValueType]):
         return self._raw_info.path
 
     # TODO: parent_type as strawberry types
+
+    # Helper functions
+    def get_argument_definition(self, name: str) -> Optional[StrawberryArgument]:
+        """
+        Get the StrawberryArgument definition for the current field by name.
+        """
+        try:
+            return next(arg for arg in self._field.arguments if arg.python_name == name)
+        except StopIteration:
+            return None

--- a/tests/schema/test_info.py
+++ b/tests/schema/test_info.py
@@ -1,14 +1,14 @@
 import dataclasses
 import json
-from typing import List, Optional, Annotated
+from typing import Annotated, List, Optional
 
 import pytest
 
 import strawberry
+from strawberry.type import StrawberryOptional
 from strawberry.types import Info
 from strawberry.types.nodes import FragmentSpread, InlineFragment, SelectedField
 from strawberry.unset import UNSET
-from strawberry.type import StrawberryOptional
 
 
 def test_info_has_the_correct_shape():

--- a/tests/schema/test_info.py
+++ b/tests/schema/test_info.py
@@ -1,6 +1,7 @@
 import dataclasses
 import json
-from typing import Annotated, List, Optional
+from typing import List, Optional
+from typing_extensions import Annotated
 
 import pytest
 
@@ -357,6 +358,7 @@ def test_get_argument_defintion_helper():
 
     arg_1_def = None
     arg_2_def = None
+    missing_arg_def = None
 
     @strawberry.type
     class Query:
@@ -367,9 +369,10 @@ def test_get_argument_defintion_helper():
             arg_1: Annotated[str, strawberry.argument(description="Some description")],
             arg_2: Optional[TestInput] = None,
         ) -> str:
-            nonlocal arg_1_def, arg_2_def
+            nonlocal arg_1_def, arg_2_def, missing_arg_def
             arg_1_def = info.get_argument_definition("arg_1")
             arg_2_def = info.get_argument_definition("arg_2")
+            missing_arg_def = info.get_argument_definition("missing_arg_def")
 
             return "bar"
 
@@ -387,3 +390,5 @@ def test_get_argument_defintion_helper():
     assert arg_2_def.default is None
     assert isinstance(arg_2_def.type, StrawberryOptional)
     assert arg_2_def.type.of_type is TestInput
+
+    assert missing_arg_def is None


### PR DESCRIPTION
## Description

Ground work for implementing some common field extensions that can validate field arguments.

Example:

```python
import strawberry

@strawberry.type
class Query:
    @strawberry.field
    def field(
        self,
        info,
        my_input: Annotated[
          str,
          strawberry.argument(description="Some description"),
        ],
    ) -> str:
        my_input_def = info.get_argument_definition("my_input")
        assert my_input_def.type is str
        assert my_input_def.description == "Some description"

        return my_input
```

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
