### PR TITLE
Do not display graphiql view in fastapi doc if graphiql parameter is …

### DIFF
--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -144,6 +144,7 @@ class GraphQLRouter(APIRouter):
                     "description": "Not found if GraphiQL is not enabled.",
                 },
             },
+            include_in_schema=graphiql,
         )
         async def handle_http_get(
             request: Request,


### PR DESCRIPTION
…deactivated

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* using `include_in_schema` parameter in fastapi router to disable/enable graphiql endpoint in swagger documentation.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
