### PR TITLE
feat: support lazy references with forward references

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,22 @@
+Release type: minor
+
+This release adds support for properly resolving lazy references
+when using forward refs.
+
+For example, this code should now work without any issues:
+
+```python
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Annotated
+
+if TYPE_CHECKING:
+    from some.module import OtherType
+
+
+@strawberry.type
+class MyType:
+    @strawberry.field
+    async def other_type(self) -> Annotated[OtherType, strawberry.lazy("some.module")]:
+        ...
+```

--- a/strawberry/utils/typing.py
+++ b/strawberry/utils/typing.py
@@ -223,7 +223,7 @@ def _ast_replace_union_operation(
 
 
 _annotated_re = re.compile(
-    r"(typing\.Annotated|Annotated\[)(?P<type>\w*),(?P<args>.*)(\])",
+    r"(Annotated\[)(?P<type>\w*),(?P<args>.*)(\])",
 )
 
 
@@ -260,30 +260,31 @@ def eval_type(
         # and trying to _eval_type on it will fail. Take a different approach
         # here to resolve lazy types by execing the annotated args and resolving
         # the type directly.
-        annotated_match = _annotated_re.match(type_.__forward_arg__)
+        annotated_match = _annotated_re.search(type_.__forward_arg__)
         if annotated_match:
             gdict = annotated_match.groupdict()
-            ldict = (localns or {}).copy()
-            # Exec the remaining annotated args to get their real values and
-            # put the result in ldict["args"]
-            exec(f'args = ({gdict["args"]}, )', globalns, ldict)
-            args = ldict["args"]
+            # FIXME: Eval the remaining annotated args to get their real values
+            # We might want to refactor how we import lazy modules to avoid having
+            # to eval the code in here
+            args = eval(f'({gdict["args"]}, )', globalns, localns)  # noqa: PGH001
+            lazy_ref = next(
+                (arg for arg in args if isinstance(arg, StrawberryLazyReference)),
+                None,
+            )
+            if lazy_ref is not None:
+                remaining = [
+                    a for a in args if not isinstance(a, StrawberryLazyReference)
+                ]
+                type_ = lazy_ref.resolve_forward_ref(ForwardRef(gdict["type"]))
+                # If we only had a StrawberryLazyReference, we can return the type
+                # directly. It already did its job!
+                if not remaining:
+                    return type_
 
-            for arg in args:
-                if isinstance(arg, StrawberryLazyReference):
-                    remaining = [
-                        a for a in args if not isinstance(a, StrawberryLazyReference)
-                    ]
-                    type_ = arg.resolve_forward_ref(ForwardRef(gdict["type"]))
-                    # If we only had a StrawberryLazyReference, we can return the type
-                    # directly. It already did its job!
-                    if not remaining:
-                        return type_
-
-                    # Otherwise return the type annotated with the remaining annotations
-                    return Annotated.__class_getitem__(  # type: ignore
-                        (type_, *remaining),
-                    )
+                # Otherwise return the type annotated with the remaining annotations
+                return Annotated.__class_getitem__(  # type: ignore
+                    (type_, *remaining),
+                )
 
         return _eval_type(type_, globalns, localns)
 

--- a/tests/a.py
+++ b/tests/a.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from typing_extensions import Annotated
+
+import strawberry
+
+if TYPE_CHECKING:
+    from tests.b import B
+
+
+@strawberry.type
+class A:
+    id: strawberry.ID
+
+    @strawberry.field
+    async def b(self) -> Annotated[B, strawberry.lazy("tests.b")]:
+        from tests.b import B
+
+        return B(id=self.id)

--- a/tests/b.py
+++ b/tests/b.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from typing_extensions import Annotated
+
+import strawberry
+
+if TYPE_CHECKING:
+    from tests.a import A
+
+
+@strawberry.type
+class B:
+    id: strawberry.ID
+
+    @strawberry.field
+    async def a(self) -> Annotated[A, strawberry.lazy("tests.a"), object()]:
+        from tests.a import A
+
+        return A(id=self.id)

--- a/tests/test_forward_references.py
+++ b/tests/test_forward_references.py
@@ -11,6 +11,7 @@ import pytest
 import strawberry
 from strawberry.printer import print_schema
 from strawberry.type import StrawberryList, StrawberryOptional
+from tests.a import A
 
 
 def test_forward_reference():
@@ -39,6 +40,33 @@ def test_forward_reference():
     assert print_schema(schema) == textwrap.dedent(expected_representation).strip()
 
     del MyType
+
+
+def test_lazy_forward_reference():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        async def a(self) -> A:
+            return A(id=strawberry.ID("1"))
+
+    expected_representation = """
+    type A {
+      id: ID!
+      b: B!
+    }
+
+    type B {
+      id: ID!
+      a: A!
+    }
+
+    type Query {
+      a: A!
+    }
+    """
+
+    schema = strawberry.Schema(query=Query)
+    assert print_schema(schema) == textwrap.dedent(expected_representation).strip()
 
 
 def test_with_resolver():

--- a/tests/test_forward_references.py
+++ b/tests/test_forward_references.py
@@ -43,6 +43,9 @@ def test_forward_reference():
 
 
 def test_lazy_forward_reference():
+    if sys.version_info < (3, 9):
+        pytest.skip("Python 3.8 and previous can't properly resolve this. ")
+
     @strawberry.type
     class Query:
         @strawberry.field

--- a/tests/test_forward_references.py
+++ b/tests/test_forward_references.py
@@ -42,10 +42,11 @@ def test_forward_reference():
     del MyType
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 9),
+    reason="Python 3.8 and previous can't properly resolve this.",
+)
 def test_lazy_forward_reference():
-    if sys.version_info < (3, 9):
-        pytest.skip("Python 3.8 and previous can't properly resolve this. ")
-
     @strawberry.type
     class Query:
         @strawberry.field


### PR DESCRIPTION
This should make resolving `Annotated[SomeType, strawberry.lazy("some.module")]` work when using `from __future__ import annotations`.

This also means that it is important for supporting python 3.12, which will work with future annotations by default.

Fix #2504
