### PR TITLE
Docs: Ensure syntax highlighting is present (and consistent)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,7 @@ Poetry.
 You will first need to clone the repository using `git` and place yourself in
 its directory:
 
-```bash
+```shell
 $ git clone git@github.com:strawberry-graphql/strawberry.git
 $ cd strawberry
 ```
@@ -116,7 +116,7 @@ $ cd strawberry
 Now, you will need to install the required dependencies for Strawberry and be sure
 that the current tests are passing on your machine:
 
-```bash
+```shell
 $ poetry install
 $ poetry run pytest tests -n auto
 $ poetry run mypy
@@ -131,7 +131,7 @@ To make sure that you don't accidentally commit code that does not follow the
 coding style, you can install a pre-commit hook that will check that everything
 is in order:
 
-```bash
+```shell
 $ poetry run pre-commit install
 ```
 
@@ -153,7 +153,7 @@ So as soon as your PR is merged, a release will be made.
 
 Here's an example of RELEASE.md:
 
-```
+```text
 Release type: patch
 
 Description of the changes, ideally with some examples, if adding a new feature.

--- a/docs/codegen/query-codegen.md
+++ b/docs/codegen/query-codegen.md
@@ -69,7 +69,7 @@ query MyQuery {
 
 With the following command:
 
-```bash
+```shell
 strawberry codegen --schema schema --output-dir ./output -p python query.graphql
 ```
 
@@ -103,7 +103,7 @@ Strawberry's codegen supports plugins, in the example above for example, we are
 using the `python` plugin. To pass more plugins to the codegen tool, you can use
 the `-p` flag, for example:
 
-```bash
+```shell
 strawberry codegen --schema schema --output-dir ./output -p python -p typescript query.graphql
 ```
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -48,7 +48,7 @@ will show the following exception on the command line:
 These errors are only enabled when `rich` and `libcst` are installed. You can
 install Strawberry with errors enabled by running:
 
-```bash
+```shell
 pip install "strawberry-graphql[cli]"
 ```
 

--- a/docs/extensions/datadog.md
+++ b/docs/extensions/datadog.md
@@ -12,7 +12,7 @@ This extension adds support for tracing with Datadog.
 
 Make sure you have `ddtrace` installed before using this extension.
 
-```
+```shell
 pip install ddtrace
 ```
 

--- a/docs/extensions/opentelemetry.md
+++ b/docs/extensions/opentelemetry.md
@@ -13,7 +13,7 @@ This extension adds tracing information that is compatible with
 
 This extension requires additional requirements:
 
-```
+```shell
 pip install 'strawberry-graphql[opentelemetry]'
 ```
 

--- a/docs/guides/dataloaders.md
+++ b/docs/guides/dataloaders.md
@@ -423,12 +423,12 @@ You can now run the example above with any ASGI server, you can read
 [ASGI](../integrations/asgi.md)) to get more details on how to run the app. In
 case you choose uvicorn you can install it wih
 
-```bash
+```shell
 pip install uvicorn
 ```
 
 and then, assuming we named our file above `schema.py` we start the app with
 
-```
+```shell
 uvicorn schema:app
 ```

--- a/docs/guides/federation.md
+++ b/docs/guides/federation.md
@@ -218,12 +218,12 @@ services.
 
 In two terminal windows, run the following commands:
 
-```bash
+```shell
 cd books
 strawberry server --port 3500 app
 ```
 
-```bash
+```shell
 cd reviews
 strawberry server --port 3000 app
 ```
@@ -266,14 +266,14 @@ subgraphs:
 This file will be used by rover to compose the schema, which can be done with
 the following command:
 
-```bash
+```shell
 # Creates prod-schema.graphql or overwrites if it already exists
 rover supergraph compose --config ./supergraph.yaml > supergraph-schema.graphql
 ```
 
 Now that we have the composed schema, we can start the router.
 
-```bash
+```shell
 ./router --supergraph supergraph-schema.graphql
 ```
 

--- a/docs/guides/file-upload.md
+++ b/docs/guides/file-upload.md
@@ -117,7 +117,7 @@ Assuming you have your schema up and running, here there are some requests examp
 
 ### Sending one file
 
-```bash
+```shell
 curl localhost:8000/graphql \
   -F operations='{ "query": "mutation($file: Upload!){ readFile(file: $file) }", "variables": { "file": null } }' \
   -F map='{ "file": ["variables.file"] }' \
@@ -126,7 +126,7 @@ curl localhost:8000/graphql \
 
 ### Sending a list of files
 
-```bash
+```shell
 curl localhost:8000/graphql \
   -F operations='{ "query": "mutation($files: [Upload!]!) { readFiles(files: $files) }", "variables": { "files": [null, null] } }' \
   -F map='{"file1": ["variables.files.0"], "file2": ["variables.files.1"]}' \
@@ -136,7 +136,7 @@ curl localhost:8000/graphql \
 
 ### Sending nested files
 
-```bash
+```shell
 curl localhost:8000/graphql \
   -F operations='{ "query": "mutation($folder: FolderInput!) { readFolder(folder: $folder) }", "variables": {"folder": {"files": [null, null]}} }' \
   -F map='{"file1": ["variables.folder.files.0"], "file2": ["variables.folder.files.1"]}' \

--- a/docs/guides/pagination/connections.md
+++ b/docs/guides/pagination/connections.md
@@ -603,7 +603,7 @@ schema = strawberry.Schema(query=Query)
 
 you can start the debug server with the following command:
 
-```
+```shell
 strawberry server example:schema
 ```
 

--- a/docs/guides/pagination/cursor-based.md
+++ b/docs/guides/pagination/cursor-based.md
@@ -503,7 +503,7 @@ the cursor initially, when it makes the first request.
 
 Now, let us start a debug server with our schema!
 
-```text
+```shell
 strawberry server example:schema
 ```
 

--- a/docs/guides/pagination/offset-based.md
+++ b/docs/guides/pagination/offset-based.md
@@ -209,7 +209,7 @@ strawberry server example:schema
 
 You will get the following message:
 
-```shell
+```text
 Running strawberry on http://0.0.0.0:8000/graphql 🍓
 ```
 

--- a/docs/guides/pagination/offset-based.md
+++ b/docs/guides/pagination/offset-based.md
@@ -232,7 +232,7 @@ ordered by name:
 
 The result should look like this:
 
-```graphql
+```json
 {
   "data": {
     "users": {
@@ -287,7 +287,7 @@ contains the substring "ie".
 
 This is the result:
 
-```
+```json
 {
   "data": {
     "users": {

--- a/docs/guides/pagination/offset-based.md
+++ b/docs/guides/pagination/offset-based.md
@@ -203,13 +203,13 @@ Django pagination API. You can check it out [here](https://docs.djangoproject.co
 
 Now, let us start the server and see offset-based pagination in action!
 
-```
+```shell
 strawberry server example:schema
 ```
 
 You will get the following message:
 
-```
+```shell
 Running strawberry on http://0.0.0.0:8000/graphql 🍓
 ```
 

--- a/docs/guides/server.md
+++ b/docs/guides/server.md
@@ -10,7 +10,7 @@ framework like Flask or Django.
 Strawberry’s built in server helps with this use case. It allows to quickly have
 a development server by running the following command:
 
-```bash
+```shell
 strawberry server package.module:schema
 ```
 
@@ -36,6 +36,6 @@ prototyping.
 To disable operation logging you can use the `--log-operations` configuration
 flag:
 
-```bash
+```shell
 strawberry server package.module:schema --log-operations False
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,20 +21,20 @@ Strawberry is built on top of Python’s
 
 Let’s create a new folder:
 
-```bash
+```shell
 mkdir strawberry-demo
 cd strawberry-demo
 ```
 
 After that we need a new virtualenv:
 
-```bash
+```shell
 python -m venv virtualenv
 ```
 
 Activate the virtualenv and then install strawberry plus the debug server.
 
-```bash
+```shell
 source virtualenv/bin/activate
 pip install 'strawberry-graphql[debug-server]'
 ```
@@ -125,13 +125,13 @@ schema = strawberry.Schema(query=Query)
 
 Then run the following command
 
-```bash
+```shell
 strawberry server schema
 ```
 
 This will start a debug server, you should see the following output:
 
-```bash
+```shell
 Running strawberry on http://0.0.0.0:8000/graphql 🍓
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -131,7 +131,7 @@ strawberry server schema
 
 This will start a debug server, you should see the following output:
 
-```shell
+```text
 Running strawberry on http://0.0.0.0:8000/graphql 🍓
 ```
 

--- a/docs/integrations/asgi.md
+++ b/docs/integrations/asgi.md
@@ -8,7 +8,7 @@ Strawberry comes with a basic ASGI integration. It provides an app that you can
 use to serve your GraphQL schema. Before using Strawberry's ASGI support make
 sure you install all the required dependencies by running:
 
-```
+```shell
 pip install 'strawberry-graphql[asgi]'
 ```
 

--- a/docs/integrations/channels.md
+++ b/docs/integrations/channels.md
@@ -453,7 +453,7 @@ Implementation.
 
 Example usage:
 
-```
+```python
 from strawberry.channels import GraphQLProtocolTypeRouter
 from django.core.asgi import get_asgi_application
 

--- a/docs/integrations/fastapi.md
+++ b/docs/integrations/fastapi.md
@@ -12,7 +12,7 @@ called `GraphQLRouter`.
 Before using Strawberry's FastAPI support make sure you install all the required
 dependencies by running:
 
-```
+```shell
 pip install 'strawberry-graphql[fastapi]'
 ```
 

--- a/docs/operations/tracing.md
+++ b/docs/operations/tracing.md
@@ -51,7 +51,7 @@ In addition to Datadog and Apollo Tracing we also support
 
 You also need to install the extras for opentelemetry by doing:
 
-```
+```shell
 pip install 'strawberry-graphql[opentelemetry]'
 ```
 
@@ -222,7 +222,7 @@ service:
 
 Spin this docker-compose up with (this will take a while, give it a minute):
 
-```
+```shell
 docker-compose up --force-recreate --build
 ```
 

--- a/docs/types/object-types.md
+++ b/docs/types/object-types.md
@@ -4,7 +4,7 @@ title: Object types
 
 # Object types
 
-Object types are the fundamentals of any GraphQL schema, the are used to defined the kind of objects that exist in a schema. Object types are created by defining a name and a list of fields, here’s an example object type defined using the GraphQL schema language:
+Object types are the fundamentals of any GraphQL schema, they are used to define the kind of objects that exist in a schema. Object types are created by defining a name and a list of fields, here’s an example object type defined using the GraphQL schema language:
 
 ```graphql
 type Character {
@@ -15,7 +15,7 @@ type Character {
 
 ## A note on Query, Mutation and Subscription
 
-While reading about GraphQL you might have encountered 3 special object types: `Query`, `Mutation` and `Subscription`. They are defined as standard object types, with the difference that they are also used as entry point for your schema (also referred as root types).
+While reading about GraphQL you might have encountered 3 special object types: `Query`, `Mutation` and `Subscription`. They are defined as standard object types, with the difference that they are also used as entry points for your schema (also referred as root types).
 
 - `Query` is the entry point for all the query operations
 - `Mutation` is the entry point for all the mutations

--- a/docs/types/private.md
+++ b/docs/types/private.md
@@ -23,7 +23,7 @@ internal and not for GraphQL.
 Consider the following type, which can accept any Python object and handle
 converting it to string, representation, or templated output:
 
-```
+```python
 
 @strawberry.type
 class Stringable:
@@ -47,7 +47,7 @@ The `Private[...]` type lets Strawberry know that this field is not
 a GraphQL field. "value" is a regular field on the class, but it is not
 exposed on the GraphQL API.
 
-```
+```python
 
 @strawberry.type
 class Query:

--- a/docs/types/private.md
+++ b/docs/types/private.md
@@ -24,7 +24,6 @@ Consider the following type, which can accept any Python object and handle
 converting it to string, representation, or templated output:
 
 ```python
-
 @strawberry.type
 class Stringable:
     value: strawberry.Private[object]
@@ -40,7 +39,6 @@ class Stringable:
     @strawberry.field
     def format(self, template: str) -> str:
         return template.format(my=self.value)
-
 ```
 
 The `Private[...]` type lets Strawberry know that this field is not
@@ -48,13 +46,11 @@ a GraphQL field. "value" is a regular field on the class, but it is not
 exposed on the GraphQL API.
 
 ```python
-
 @strawberry.type
 class Query:
     @strawberry.field
     def now(self) -> Stringable:
         return Stringable(value=datetime.datetime.now())
-
 ```
 
 Queries can then select the fields and formats desired, but formatting only


### PR DESCRIPTION
## Description

I noticed some code fences weren't being syntax highlighted, so I did a quick inventory and made sure they were present and consistent.

Question: is it worth standardizing the naked code fences with shell code to `bash` or `shell`? I noticed this inconsistency, but did not include those wider changes here.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [X] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
