### PR TITLE
Allow custom classes for Span attribute

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+Release type: patch
+
+This release adds support for custom classes for span to be able to set attributes.
+With this, we shouldn't see errors like this anymore:
+
+```Invalid type dict for attribute 'graphql.param.paginator' value. Expected one of ['bool', 'str', 'bytes', 'int', 'float'] or a sequence of those types.```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
 Release type: patch
 
-This release adds support for custom classes for span to be able to set attributes.
+This release adds support for custom classes inside the OpenTelemetry integration.
 With this, we shouldn't see errors like this anymore:
 
 ```Invalid type dict for attribute 'graphql.param.paginator' value. Expected one of ['bool', 'str', 'bytes', 'int', 'float'] or a sequence of those types.```

--- a/strawberry/extensions/tracing/opentelemetry.py
+++ b/strawberry/extensions/tracing/opentelemetry.py
@@ -113,12 +113,23 @@ class OpenTelemetryExtension(SchemaExtension):
     def convert_to_allowed_types(self, value: Any) -> Any:
         if isinstance(value, (bool, str, bytes, int, float)):
             return value
-        elif isinstance(value, (list, tuple)):
+        elif isinstance(value, complex):
+            return str(value)  # Convert complex numbers to strings
+        elif isinstance(value, (list, tuple, range)):
             return self.convert_list_or_tuple_to_allowed_types(value)
         elif isinstance(value, dict):
             return self.convert_dict_to_allowed_types(value)
+        elif isinstance(value, (set, frozenset)):
+            return self.convert_set_to_allowed_types(value)
+        elif isinstance(value, (bytearray, memoryview)):
+            return bytes(value)  # Convert bytearray and memoryview to bytes
         else:
             return str(value)
+
+    def convert_set_to_allowed_types(self, value: set or frozenset) -> str:
+        return (
+            "{" + ", ".join(str(self.convert_to_allowed_types(x)) for x in value) + "}"
+        )
 
     def convert_list_or_tuple_to_allowed_types(self, value: list or tuple) -> str:
         return ", ".join(map(str, map(self.convert_to_allowed_types, value)))

--- a/strawberry/extensions/tracing/opentelemetry.py
+++ b/strawberry/extensions/tracing/opentelemetry.py
@@ -110,7 +110,7 @@ class OpenTelemetryExtension(SchemaExtension):
             return str(value)
 
     def convert_list_or_tuple_to_allowed_types(self, value: list or tuple) -> str:
-        return ', '.join(map(self.convert_to_allowed_types, value))
+        return ", ".join(map(str, map(self.convert_to_allowed_types, value)))
 
     def add_tags(self, span: Span, info: GraphQLResolveInfo, kwargs: Any) -> None:
         graphql_path = ".".join(map(str, get_path_from_info(info)))

--- a/strawberry/extensions/tracing/opentelemetry.py
+++ b/strawberry/extensions/tracing/opentelemetry.py
@@ -111,16 +111,17 @@ class OpenTelemetryExtension(SchemaExtension):
         )
 
     def convert_to_allowed_types(self, value: Any) -> Any:
+        # Put these in decreasing order of use-cases to exit as soon as possible
         if isinstance(value, (bool, str, bytes, int, float)):
             return value
-        elif isinstance(value, complex):
-            return str(value)  # Convert complex numbers to strings
         elif isinstance(value, (list, tuple, range)):
             return self.convert_list_or_tuple_to_allowed_types(value)
         elif isinstance(value, dict):
             return self.convert_dict_to_allowed_types(value)
         elif isinstance(value, (set, frozenset)):
             return self.convert_set_to_allowed_types(value)
+        elif isinstance(value, complex):
+            return str(value)  # Convert complex numbers to strings
         elif isinstance(value, (bytearray, memoryview)):
             return bytes(value)  # Convert bytearray and memoryview to bytes
         else:

--- a/strawberry/extensions/tracing/opentelemetry.py
+++ b/strawberry/extensions/tracing/opentelemetry.py
@@ -101,11 +101,22 @@ class OpenTelemetryExtension(SchemaExtension):
             return args
         return self._arg_filter(deepcopy(args), info)
 
+    def convert_dict_to_allowed_types(self, value: dict) -> str:
+        return (
+            "{"
+            + ", ".join(
+                f"{k}: {self.convert_to_allowed_types(v)}" for k, v in value.items()
+            )
+            + "}"
+        )
+
     def convert_to_allowed_types(self, value: Any) -> Any:
         if isinstance(value, (bool, str, bytes, int, float)):
             return value
         elif isinstance(value, (list, tuple)):
             return self.convert_list_or_tuple_to_allowed_types(value)
+        elif isinstance(value, dict):
+            return self.convert_dict_to_allowed_types(value)
         else:
             return str(value)
 

--- a/strawberry/extensions/tracing/opentelemetry.py
+++ b/strawberry/extensions/tracing/opentelemetry.py
@@ -3,7 +3,18 @@ from __future__ import annotations
 import enum
 from copy import deepcopy
 from inspect import isawaitable
-from typing import TYPE_CHECKING, Any, Callable, Dict, Generator, Optional
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    FrozenSet,
+    Generator,
+    Iterable,
+    Optional,
+    Set,
+    Union,
+)
 
 from opentelemetry import trace
 from opentelemetry.trace import SpanKind
@@ -127,12 +138,12 @@ class OpenTelemetryExtension(SchemaExtension):
         else:
             return str(value)
 
-    def convert_set_to_allowed_types(self, value: set or frozenset) -> str:
+    def convert_set_to_allowed_types(self, value: Union[Set, FrozenSet]) -> str:
         return (
             "{" + ", ".join(str(self.convert_to_allowed_types(x)) for x in value) + "}"
         )
 
-    def convert_list_or_tuple_to_allowed_types(self, value: list or tuple) -> str:
+    def convert_list_or_tuple_to_allowed_types(self, value: Iterable) -> str:
         return ", ".join(map(str, map(self.convert_to_allowed_types, value)))
 
     def add_tags(self, span: Span, info: GraphQLResolveInfo, kwargs: Any) -> None:

--- a/tests/extensions/test_custom_objects_for_setting_attribute.py
+++ b/tests/extensions/test_custom_objects_for_setting_attribute.py
@@ -34,6 +34,30 @@ def test_convert_complex_object_with_simple_object(otel_ext):
     )
 
 
+def test_convert_dictionary(otel_ext):
+    value = {
+        "int": 1,
+        "float": 3.14,
+        "bool": True,
+        "str": "hello",
+        "list": [1, 2, 3],
+        "tuple": (4, 5, 6),
+        "simple_object": SimpleObject(42),
+    }
+
+    expected = (
+        "{int: 1, "
+        "float: 3.14, "
+        "bool: True, "
+        "str: hello, "
+        "list: 1, 2, 3, "
+        "tuple: 4, 5, 6, "
+        "simple_object: SimpleObject(42)}"
+    )
+
+    assert otel_ext.convert_to_allowed_types(value) == expected
+
+
 def test_convert_bool(otel_ext):
     assert otel_ext.convert_to_allowed_types(True) is True
     assert otel_ext.convert_to_allowed_types(False) is False

--- a/tests/extensions/test_custom_objects_for_setting_attribute.py
+++ b/tests/extensions/test_custom_objects_for_setting_attribute.py
@@ -1,0 +1,84 @@
+import pytest
+
+from strawberry.extensions.tracing.opentelemetry import OpenTelemetryExtension
+
+
+@pytest.fixture
+def otel_ext():
+    return OpenTelemetryExtension()
+
+
+class SimpleObject:
+    def __init__(self, value):
+        self.value = value
+
+    def __str__(self):
+        return f"SimpleObject({self.value})"
+
+
+class ComplexObject:
+    def __init__(self, simple_object, value):
+        self.simple_object = simple_object
+        self.value = value
+
+    def __str__(self):
+        return f"ComplexObject({str(self.simple_object)}, {self.value})"
+
+
+def test_convert_complex_object_with_simple_object(otel_ext):
+    simple_obj = SimpleObject(42)
+    complex_obj = ComplexObject(simple_obj, 99)
+    assert (
+        otel_ext.convert_to_allowed_types(complex_obj)
+        == "ComplexObject(SimpleObject(42), 99)"
+    )
+
+
+def test_convert_bool(otel_ext):
+    assert otel_ext.convert_to_allowed_types(True) is True
+    assert otel_ext.convert_to_allowed_types(False) is False
+
+
+def test_convert_str(otel_ext):
+    assert otel_ext.convert_to_allowed_types("hello") == "hello"
+
+
+def test_convert_bytes(otel_ext):
+    assert otel_ext.convert_to_allowed_types(b"hello") == b"hello"
+
+
+def test_convert_int(otel_ext):
+    assert otel_ext.convert_to_allowed_types(42) == 42
+
+
+def test_convert_float(otel_ext):
+    assert otel_ext.convert_to_allowed_types(3.14) == 3.14
+
+
+def test_convert_simple_object(otel_ext):
+    obj = SimpleObject(42)
+    assert otel_ext.convert_to_allowed_types(obj) == "SimpleObject(42)"
+
+
+def test_convert_list_of_basic_types(otel_ext):
+    value = [1, "hello", 3.14, True, False]
+    assert otel_ext.convert_to_allowed_types(value) == "1, hello, 3.14, True, False"
+
+
+def test_convert_list_of_mixed_types(otel_ext):
+    value = [1, "hello", 3.14, SimpleObject(42)]
+    assert (
+        otel_ext.convert_to_allowed_types(value) == "1, hello, 3.14, SimpleObject(42)"
+    )
+
+
+def test_convert_tuple_of_basic_types(otel_ext):
+    value = (1, "hello", 3.14, True, False)
+    assert otel_ext.convert_to_allowed_types(value) == "1, hello, 3.14, True, False"
+
+
+def test_convert_tuple_of_mixed_types(otel_ext):
+    value = (1, "hello", 3.14, SimpleObject(42))
+    assert (
+        otel_ext.convert_to_allowed_types(value) == "1, hello, 3.14, SimpleObject(42)"
+    )

--- a/tests/extensions/test_custom_objects_for_setting_attribute.py
+++ b/tests/extensions/test_custom_objects_for_setting_attribute.py
@@ -25,6 +25,38 @@ class ComplexObject:
         return f"ComplexObject({str(self.simple_object)}, {self.value})"
 
 
+def test_convert_complex_number(otel_ext):
+    value = 3 + 4j
+    assert otel_ext.convert_to_allowed_types(value) == "(3+4j)"
+
+
+def test_convert_range(otel_ext):
+    value = range(3)
+    assert otel_ext.convert_to_allowed_types(value) == "0, 1, 2"
+
+
+def test_convert_bytearray(otel_ext):
+    value = bytearray(b"hello world")
+    assert otel_ext.convert_to_allowed_types(value) == b"hello world"
+
+
+def test_convert_memoryview(otel_ext):
+    value = memoryview(b"hello world")
+    assert otel_ext.convert_to_allowed_types(value) == b"hello world"
+
+
+def test_convert_set(otel_ext):
+    value = {1, 2, 3, 4}
+    converted_value = otel_ext.convert_to_allowed_types(value)
+    assert set(converted_value.strip("{}").split(", ")) == {"1", "2", "3", "4"}
+
+
+def test_convert_frozenset(otel_ext):
+    value = frozenset([1, 2, 3, 4])
+    converted_value = otel_ext.convert_to_allowed_types(value)
+    assert set(converted_value.strip("{}").split(", ")) == {"1", "2", "3", "4"}
+
+
 def test_convert_complex_object_with_simple_object(otel_ext):
     simple_obj = SimpleObject(42)
     complex_obj = ComplexObject(simple_obj, 99)


### PR DESCRIPTION
## Description

This PR solves the problem to allow custom classes to not clog the logs as follows
```
Invalid type dict for attribute 'graphql.param.paginator' value. Expected one of ['bool', 'str', 'bytes', 'int', 'float'] or a sequence of those types
Invalid type DisplayType for attribute 'graphql.param.displayType' value. Expected one of ['bool', 'str', 'bytes', 'int', 'float'] or a sequence of those types
```
This happens as part of `span.set_attribute`, which only expects limited types

So what we do is we check the basic types and if it is one of them then proceed.
In case its a list or tuple we convert it into a string recursively
And it if it an object type, like BaseModel or Strawberry type(Most probably this case) then it would just use its string version

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #2752 

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
