### PR TITLE
Allow passing metadata to Strawberry arguments

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,6 +7,7 @@ Example:
 ```python
 import strawberry
 
+
 @strawberry.type
 class Query:
     @strawberry.field

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,22 @@
+Release type: minor
+
+This PR allows passing metadata to Strawberry arguments.
+
+Example:
+
+```python
+import strawberry
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def hello(
+        self,
+        info,
+        input: Annotated[str, strawberry.argument(metadata={"test": "foo"})],
+    ) -> str:
+        argument_definition = info.get_argument_definition("input")
+        assert argument_definition.metadata["test"] == "foo"
+
+        return f"Hi {input}"
+```

--- a/strawberry/arguments.py
+++ b/strawberry/arguments.py
@@ -46,6 +46,7 @@ class StrawberryArgumentAnnotation:
     name: Optional[str]
     deprecation_reason: Optional[str]
     directives: Iterable[object]
+    metadata: Mapping[Any, Any]
 
     def __init__(
         self,
@@ -53,11 +54,13 @@ class StrawberryArgumentAnnotation:
         name: Optional[str] = None,
         deprecation_reason: Optional[str] = None,
         directives: Iterable[object] = (),
+        metadata: Optional[Mapping[Any, Any]] = None,
     ):
         self.description = description
         self.name = name
         self.deprecation_reason = deprecation_reason
         self.directives = directives
+        self.metadata = metadata or {}
 
 
 class StrawberryArgument:
@@ -71,6 +74,7 @@ class StrawberryArgument:
         default: object = _deprecated_UNSET,
         deprecation_reason: Optional[str] = None,
         directives: Iterable[object] = (),
+        metadata: Optional[Mapping[Any, Any]] = None,
     ) -> None:
         self.python_name = python_name
         self.graphql_name = graphql_name
@@ -80,6 +84,7 @@ class StrawberryArgument:
         self.type_annotation = type_annotation
         self.deprecation_reason = deprecation_reason
         self.directives = directives
+        self.metadata = metadata or {}
 
         # TODO: Consider moving this logic to a function
         self.default = (
@@ -121,6 +126,7 @@ class StrawberryArgument:
                 self.graphql_name = arg.name
                 self.deprecation_reason = arg.deprecation_reason
                 self.directives = arg.directives
+                self.metadata = arg.metadata
 
             if isinstance(arg, StrawberryLazyReference):
                 self.type_annotation = StrawberryAnnotation(
@@ -224,12 +230,14 @@ def argument(
     name: Optional[str] = None,
     deprecation_reason: Optional[str] = None,
     directives: Iterable[object] = (),
+    metadata: Optional[Mapping[Any, Any]] = None,
 ) -> StrawberryArgumentAnnotation:
     return StrawberryArgumentAnnotation(
         description=description,
         name=name,
         deprecation_reason=deprecation_reason,
         directives=directives,
+        metadata=metadata,
     )
 
 

--- a/tests/schema/extensions/test_field_extensions.py
+++ b/tests/schema/extensions/test_field_extensions.py
@@ -288,7 +288,7 @@ def test_extension_access_argument_metadata():
             nonlocal field_kwargs
             field_kwargs = kwargs
 
-            for key in kwargs.keys():
+            for key in kwargs:
                 argument_def = info.get_argument_definition(key)
                 assert argument_def is not None
                 argument_metadata[key] = argument_def.metadata

--- a/tests/schema/extensions/test_field_extensions.py
+++ b/tests/schema/extensions/test_field_extensions.py
@@ -1,5 +1,6 @@
 import re
-from typing import Any, Callable
+from typing import Any, Callable, Optional
+from typing_extensions import Annotated
 
 import pytest
 
@@ -276,3 +277,46 @@ def test_extension_mutate_arguments():
     result = schema.execute_sync(query)
     assert result.data, result.errors
     assert result.data["string"] == "This is a test!! 13"
+
+
+def test_extension_access_argument_metadata():
+    field_kwargs = {}
+    argument_metadata = {}
+
+    class CustomExtension(FieldExtension):
+        def resolve(self, next_: Callable[..., Any], source: Any, info: Info, **kwargs):
+            nonlocal field_kwargs
+            field_kwargs = kwargs
+
+            for key in kwargs.keys():
+                argument_def = info.get_argument_definition(key)
+                assert argument_def is not None
+                argument_metadata[key] = argument_def.metadata
+
+            result = next_(source, info, **kwargs)
+            return result
+
+    @strawberry.type
+    class Query:
+        @strawberry.field(extensions=[CustomExtension()])
+        def string(
+            self,
+            some_input: Annotated[str, strawberry.argument(metadata={"test": "foo"})],
+            another_input: Optional[str] = None,
+        ) -> str:
+            return f"This is a test!! {some_input}"
+
+    schema = strawberry.Schema(query=Query)
+    query = 'query { string(someInput: "foo") }'
+
+    result = schema.execute_sync(query)
+    assert result.data, result.errors
+    assert result.data["string"] == "This is a test!! foo"
+
+    assert isinstance(field_kwargs["some_input"], str)
+    assert argument_metadata == {
+        "some_input": {
+            "test": "foo",
+        },
+        "another_input": {},
+    }

--- a/tests/schema/test_arguments.py
+++ b/tests/schema/test_arguments.py
@@ -166,3 +166,36 @@ def test_optional_input_field_unset():
     )
     assert not result.errors
     assert result.data == {"hello": "Hi there"}
+
+
+def test_setting_metadata_on_argument():
+    field_definition = None
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def hello(
+            self,
+            info,
+            input: Annotated[str, strawberry.argument(metadata={"test": "foo"})],
+        ) -> str:
+            nonlocal field_definition
+            field_definition = info._field
+            return f"Hi {input}"
+
+    schema = strawberry.Schema(query=Query)
+
+    result = schema.execute_sync(
+        """
+        query {
+            hello(input: "there")
+        }
+    """
+    )
+    assert not result.errors
+    assert result.data == {"hello": "Hi there"}
+
+    assert field_definition
+    assert field_definition.arguments[0].metadata == {
+        "test": "foo",
+    }


### PR DESCRIPTION
## Description

This is groundwork to allow implementation of a validation extensions that uses field and argument metadata to define validators.

Example:

```python
import strawberry

@strawberry.type
class Query:
    @strawberry.field
    def hello(
        self,
        info,
        input: Annotated[str, strawberry.argument(metadata={"test": "foo"})],
    ) -> str:
        argument_definition = info.get_argument_definition("input")
        assert argument_definition.metadata["test"] == "foo"
        return f"Hi {input}"
```

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
