### PR TITLE
Add support for `IntEnum`

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,19 @@
+Release type: patch
+
+This release adds support for using `enum_value` with `IntEnum`s, like this:
+
+```python
+import strawberry
+
+from enum import IntEnum
+
+
+@strawberry.enum
+class Color(IntEnum):
+    OTHER = strawberry.enum_value(
+        -1, description="Other: The color is not red, blue, or green."
+    )
+    RED = strawberry.enum_value(0, description="Red: The color red.")
+    BLUE = strawberry.enum_value(1, description="Blue: The color blue.")
+    GREEN = strawberry.enum_value(2, description="Green: The color green.")
+```

--- a/strawberry/enum.py
+++ b/strawberry/enum.py
@@ -57,6 +57,9 @@ class EnumValueDefinition:
     directives: Iterable[object] = ()
     description: Optional[str] = None
 
+    def __int__(self) -> int:
+        return self.value
+
 
 def enum_value(
     value: Any,

--- a/tests/enums/test_enum.py
+++ b/tests/enums/test_enum.py
@@ -1,4 +1,4 @@
-from enum import Enum
+from enum import Enum, IntEnum
 
 import pytest
 
@@ -153,3 +153,19 @@ def test_can_use_enum_values():
         "B",
         "Coconut",
     ]
+
+
+def test_int_enums():
+    @strawberry.enum
+    class TestEnum(IntEnum):
+        A = 1
+        B = 2
+        C = 3
+        D = strawberry.enum_value(4, description="D")
+
+    assert TestEnum.A.value == 1
+    assert TestEnum.B.value == 2
+    assert TestEnum.C.value == 3
+    assert TestEnum.D.value == 4
+
+    assert [x.value for x in TestEnum.__members__.values()] == [1, 2, 3, 4]


### PR DESCRIPTION
This PR adds support for `IntEnum`s by adding a `__int__` method on `EnumValueDefinition` :)

Closes #2385