### PR TITLE
fix: fix optional scalars using the "or" notation on python 3.10

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,18 @@
+Release type: patch
+
+This release fixes an issue with optional scalars using the `or`
+notation with forward references on python 3.10.
+
+The following code would previously raise `TypeError` on python 3.10:
+
+```python
+from __future__ import annotations
+
+import strawberry
+from strawberry.scalars import JSON
+
+
+@strawberry.type
+class SomeType:
+    an_optional_json: JSON | None
+```

--- a/strawberry/custom_scalar.py
+++ b/strawberry/custom_scalar.py
@@ -17,7 +17,7 @@ from typing import (
 )
 
 from strawberry.exceptions import InvalidUnionTypeError
-from strawberry.type import StrawberryOptional, StrawberryType
+from strawberry.type import StrawberryType
 
 from .utils.str_converters import to_camel_case
 
@@ -76,7 +76,7 @@ class ScalarWrapper:
     def __or__(self, other: Union[StrawberryType, type]) -> StrawberryType:
         if other is None:
             # Return the correct notation when using `StrawberryUnion | None`.
-            return StrawberryOptional(of_type=self)
+            return Optional[self]
 
         # Raise an error in any other case.
         # There is Work in progress to deal with more merging cases, see:

--- a/tests/test_forward_references.py
+++ b/tests/test_forward_references.py
@@ -10,6 +10,7 @@ import pytest
 
 import strawberry
 from strawberry.printer import print_schema
+from strawberry.scalars import JSON
 from strawberry.type import StrawberryList, StrawberryOptional
 
 
@@ -23,16 +24,25 @@ def test_forward_reference():
     @strawberry.type
     class MyType:
         id: strawberry.ID
+        scalar: JSON
+        optional_scalar: JSON | None
 
-    expected_representation = """
+    expected_representation = '''
+    """
+    The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+    """
+    scalar JSON @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
+
     type MyType {
       id: ID!
+      scalar: JSON!
+      optionalScalar: JSON
     }
 
     type Query {
       myself: MyType!
     }
-    """
+    '''
 
     schema = strawberry.Schema(Query)
 

--- a/tests/utils/test_typing_forward_refs.py
+++ b/tests/utils/test_typing_forward_refs.py
@@ -5,6 +5,7 @@ from typing import ForwardRef, List, Optional, Union
 
 import pytest
 
+from strawberry.scalars import JSON
 from strawberry.utils.typing import eval_type
 
 
@@ -26,6 +27,7 @@ def test_eval_type():
         eval_type(ForwardRef("List[Foo | str] | None | int"), globals(), locals())
         == Union[List[Union[Foo, str]], int, None]
     )
+    assert eval_type(ForwardRef("JSON | None"), globals(), locals()) == Optional[JSON]
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Fix #2465
