### PR TITLE
2772 match annotations in pydantic schema

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,20 @@
 Release type: patch
 
 Fixing a bug in experimental.pydantic whereby Optional type annotations weren't exactly aligned between strawberry type and pydantic model.
+
+Previously this would have caused the series field to be non-nullable in graphql.
+```python
+from typing import Optional
+from pydantic import BaseModel, Field
+import strawberry
+
+
+class VehicleModel(BaseModel):
+    series: Optional[str] = Field(default='')
+
+
+@strawberry.experimental.pydantic.type(model=VehicleModel, all_fields=True)
+class VehicleModelType:
+    pass
+
+```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
 Release type: patch
 
-Fixing a bug in experimental.pydantic whereby Optional type annotations weren't exactly aligned between strawberry type and pydantic model.
+This release fixes a bug in experimental.pydantic whereby `Optional` type annotations weren't exactly aligned between strawberry type and pydantic model.
 
 Previously this would have caused the series field to be non-nullable in graphql.
 ```python

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,11 +10,10 @@ import strawberry
 
 
 class VehicleModel(BaseModel):
-    series: Optional[str] = Field(default='')
+    series: Optional[str] = Field(default="")
 
 
 @strawberry.experimental.pydantic.type(model=VehicleModel, all_fields=True)
 class VehicleModelType:
     pass
-
 ```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Fixing a bug in experimental.pydantic whereby Optional type annotations weren't exactly aligned between strawberry type and pydantic model.

--- a/strawberry/experimental/pydantic/object_type.py
+++ b/strawberry/experimental/pydantic/object_type.py
@@ -3,19 +3,33 @@ from __future__ import annotations
 import dataclasses
 import sys
 import warnings
-from typing import (TYPE_CHECKING, Any, Callable, Dict, List, Optional,
-                    Sequence, Set, Type, cast)
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Set,
+    Type,
+    cast,
+)
 
 from strawberry.annotation import StrawberryAnnotation
 from strawberry.auto import StrawberryAuto
 from strawberry.experimental.pydantic.conversion import (
     convert_pydantic_model_to_strawberry_class,
-    convert_strawberry_class_to_pydantic_model)
+    convert_strawberry_class_to_pydantic_model,
+)
 from strawberry.experimental.pydantic.exceptions import MissingFieldsListError
 from strawberry.experimental.pydantic.fields import replace_types_recursively
 from strawberry.experimental.pydantic.utils import (
-    DataclassCreationFields, ensure_all_auto_fields_in_pydantic,
-    get_default_factory_for_field, get_private_fields)
+    DataclassCreationFields,
+    ensure_all_auto_fields_in_pydantic,
+    get_default_factory_for_field,
+    get_private_fields,
+)
 from strawberry.field import StrawberryField
 from strawberry.object_type import _process_type, _wrap_dataclass
 from strawberry.types.type_resolver import _get_fields
@@ -91,7 +105,9 @@ def _build_dataclass_creation_fields(
 
 if TYPE_CHECKING:
     from strawberry.experimental.pydantic.conversion_types import (
-        PydanticModel, StrawberryTypeFromPydantic)
+        PydanticModel,
+        StrawberryTypeFromPydantic,
+    )
 
 
 def type(

--- a/strawberry/experimental/pydantic/object_type.py
+++ b/strawberry/experimental/pydantic/object_type.py
@@ -3,33 +3,19 @@ from __future__ import annotations
 import dataclasses
 import sys
 import warnings
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Dict,
-    List,
-    Optional,
-    Sequence,
-    Set,
-    Type,
-    cast,
-)
+from typing import (TYPE_CHECKING, Any, Callable, Dict, List, Optional,
+                    Sequence, Set, Type, cast)
 
 from strawberry.annotation import StrawberryAnnotation
 from strawberry.auto import StrawberryAuto
 from strawberry.experimental.pydantic.conversion import (
     convert_pydantic_model_to_strawberry_class,
-    convert_strawberry_class_to_pydantic_model,
-)
+    convert_strawberry_class_to_pydantic_model)
 from strawberry.experimental.pydantic.exceptions import MissingFieldsListError
 from strawberry.experimental.pydantic.fields import replace_types_recursively
 from strawberry.experimental.pydantic.utils import (
-    DataclassCreationFields,
-    ensure_all_auto_fields_in_pydantic,
-    get_default_factory_for_field,
-    get_private_fields,
-)
+    DataclassCreationFields, ensure_all_auto_fields_in_pydantic,
+    get_default_factory_for_field, get_private_fields)
 from strawberry.field import StrawberryField
 from strawberry.object_type import _process_type, _wrap_dataclass
 from strawberry.types.type_resolver import _get_fields
@@ -43,11 +29,7 @@ if TYPE_CHECKING:
 def get_type_for_field(field: ModelField, is_input: bool):  # noqa: ANN201
     outer_type = field.outer_type_
     replaced_type = replace_types_recursively(outer_type, is_input)
-
-    default_defined: bool = (
-        field.default_factory is not None or field.default is not None
-    )
-    should_add_optional: bool = not (field.required or default_defined)
+    should_add_optional: bool = field.allow_none
     if should_add_optional:
         return Optional[replaced_type]
     else:
@@ -109,9 +91,7 @@ def _build_dataclass_creation_fields(
 
 if TYPE_CHECKING:
     from strawberry.experimental.pydantic.conversion_types import (
-        PydanticModel,
-        StrawberryTypeFromPydantic,
-    )
+        PydanticModel, StrawberryTypeFromPydantic)
 
 
 def type(

--- a/tests/experimental/pydantic/schema/test_basic.py
+++ b/tests/experimental/pydantic/schema/test_basic.py
@@ -503,8 +503,7 @@ def test_basic_type_with_optional_and_default():
 
     assert not result.errors
     assert result.data["user"]["age"] == 1
-    assert result.data["user"]["password"] == 'ABC'
-
+    assert result.data["user"]["password"] == "ABC"
 
     @strawberry.type
     class QueryNone:
@@ -520,4 +519,4 @@ def test_basic_type_with_optional_and_default():
 
     assert not result.errors
     assert result.data["user"]["age"] == 1
-    assert result.data["user"]["password"] == None
+    assert result.data["user"]["password"] is None

--- a/tests/experimental/pydantic/schema/test_basic.py
+++ b/tests/experimental/pydantic/schema/test_basic.py
@@ -465,3 +465,59 @@ def test_basic_type_with_interface():
     assert not result.errors
     assert result.data["user"]["interfaceField"]["baseField"] == "abc"
     assert result.data["user"]["interfaceField"]["fieldB"] == 10
+
+
+def test_basic_type_with_optional_and_default():
+    class UserModel(pydantic.BaseModel):
+        age: int
+        password: Optional[str] = pydantic.Field(default="ABC")
+
+    @strawberry.experimental.pydantic.type(UserModel, all_fields=True)
+    class User:
+        pass
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def user(self) -> User:
+            return User(age=1)
+
+    schema = strawberry.Schema(query=Query)
+
+    expected_schema = """
+    type Query {
+      user: User!
+    }
+
+    type User {
+      age: Int!
+      password: String
+    }
+    """
+
+    assert str(schema) == textwrap.dedent(expected_schema).strip()
+
+    query = "{ user { age password } }"
+
+    result = schema.execute_sync(query)
+
+    assert not result.errors
+    assert result.data["user"]["age"] == 1
+    assert result.data["user"]["password"] == 'ABC'
+
+
+    @strawberry.type
+    class QueryNone:
+        @strawberry.field
+        def user(self) -> User:
+            return User(age=1, password=None)
+
+    schema = strawberry.Schema(query=QueryNone)
+
+    query = "{ user { age password } }"
+
+    result = schema.execute_sync(query)
+
+    assert not result.errors
+    assert result.data["user"]["age"] == 1
+    assert result.data["user"]["password"] == None

--- a/tests/experimental/pydantic/schema/test_defaults.py
+++ b/tests/experimental/pydantic/schema/test_defaults.py
@@ -10,7 +10,7 @@ from strawberry.printer import print_schema
 def test_field_type_default():
     class User(pydantic.BaseModel):
         name: str = "James"
-        nickname: Optional[str] = 'Jim'
+        nickname: Optional[str] = "Jim"
 
     @strawberry.experimental.pydantic.type(User, all_fields=True)
     class PydanticUser:

--- a/tests/experimental/pydantic/schema/test_defaults.py
+++ b/tests/experimental/pydantic/schema/test_defaults.py
@@ -10,6 +10,7 @@ from strawberry.printer import print_schema
 def test_field_type_default():
     class User(pydantic.BaseModel):
         name: str = "James"
+        nickname: Optional[str] = 'Jim'
 
     @strawberry.experimental.pydantic.type(User, all_fields=True)
     class PydanticUser:
@@ -35,6 +36,7 @@ def test_field_type_default():
     expected = """
     type PydanticUser {
       name: String!
+      nickname: String
     }
 
     type Query {

--- a/tests/experimental/pydantic/test_basic.py
+++ b/tests/experimental/pydantic/test_basic.py
@@ -352,7 +352,6 @@ def test_optional_and_default():
         some_list: Optional[List[str]] = pydantic.Field(default_factory=list)
         check: Optional[bool] = False
 
-
     @strawberry.experimental.pydantic.type(UserModel, all_fields=True)
     class User:
         pass
@@ -391,9 +390,6 @@ def test_optional_and_default():
     assert check_field.python_name == "check"
     assert isinstance(check_field.type, StrawberryOptional)
     assert check_field.type.of_type is bool
-
-
-
 
 
 def test_type_with_fields_mutable_default():

--- a/tests/experimental/pydantic/test_basic.py
+++ b/tests/experimental/pydantic/test_basic.py
@@ -343,6 +343,59 @@ def test_default_and_default_factory():
     assert UserType4().to_pydantic().friend is None
 
 
+def test_optional_and_default():
+    class UserModel(pydantic.BaseModel):
+        age: int
+        name: str = pydantic.Field("Michael", description="The user name")
+        password: Optional[str] = pydantic.Field(default="ABC")
+        passwordtwo: Optional[str] = None
+        some_list: Optional[List[str]] = pydantic.Field(default_factory=list)
+        check: Optional[bool] = False
+
+
+    @strawberry.experimental.pydantic.type(UserModel, all_fields=True)
+    class User:
+        pass
+
+    definition: TypeDefinition = User._type_definition
+    assert definition.name == "User"
+
+    [
+        age_field,
+        name_field,
+        password_field,
+        passwordtwo_field,
+        some_list_field,
+        check_field,
+    ] = definition.fields
+
+    assert age_field.python_name == "age"
+    assert age_field.type is int
+
+    assert name_field.python_name == "name"
+    assert name_field.type is str
+
+    assert password_field.python_name == "password"
+    assert isinstance(password_field.type, StrawberryOptional)
+    assert password_field.type.of_type is str
+
+    assert passwordtwo_field.python_name == "passwordtwo"
+    assert isinstance(passwordtwo_field.type, StrawberryOptional)
+    assert passwordtwo_field.type.of_type is str
+
+    assert some_list_field.python_name == "some_list"
+    assert isinstance(some_list_field.type, StrawberryOptional)
+    assert isinstance(some_list_field.type.of_type, StrawberryList)
+    assert some_list_field.type.of_type.of_type is str
+
+    assert check_field.python_name == "check"
+    assert isinstance(check_field.type, StrawberryOptional)
+    assert check_field.type.of_type is bool
+
+
+
+
+
 def test_type_with_fields_mutable_default():
     empty_list = []
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Changed the implementation of the strawberry inference of type annotations to make sure it matches the pydantic annotations. I.e. correctly returning if it is Optional or Not ,whilst also ensuring it uses strawberry compatible types 

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #2772 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
