### PR TITLE
Support Schema Extensions in subscriptions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: minor
+
+Subscriptions now support Schema Extensions.

--- a/docs/guides/custom-extensions.md
+++ b/docs/guides/custom-extensions.md
@@ -45,8 +45,8 @@ class MyExtension(SchemaExtension):
         return _next(root, info, *args, **kwargs)
 ```
 
-Note that `resolve` can also be implemented asynchronously, in which
-case the result from `_next` must be optionally awaited:
+Note that `resolve` can also be implemented asynchronously, in which case the
+result from `_next` must be optionally awaited:
 
 ```python
 from inspect import isawaitable

--- a/docs/guides/custom-extensions.md
+++ b/docs/guides/custom-extensions.md
@@ -36,8 +36,6 @@ resolvers.
 If you need to wrap only certain field resolvers with additional logic, please
 check out [field extensions](field-extensions.md).
 
-Note that `resolve` can also be implemented asynchronously.
-
 ```python
 from strawberry.extensions import SchemaExtension
 
@@ -45,6 +43,21 @@ from strawberry.extensions import SchemaExtension
 class MyExtension(SchemaExtension):
     def resolve(self, _next, root, info: strawberry.Info, *args, **kwargs):
         return _next(root, info, *args, **kwargs)
+```
+
+Note that `resolve` can also be implemented asynchronously, in which
+case the result from `_next` must be optionally awaited:
+
+```python
+from inspect import isawaitable
+from strawberry.types import Info
+from strawberry.extensions import SchemaExtension
+
+
+class MyExtension(SchemaExtension):
+    async def resolve(self, _next, root, info: Info, *args, **kwargs):
+        result = _next(root, info, *args, **kwargs)
+        return await result if isawaitable(result) else result
 ```
 
 ### Get results

--- a/docs/operations/testing.md
+++ b/docs/operations/testing.md
@@ -136,10 +136,9 @@ async def test_subscription():
     	}
     """
 
-    sub = await schema.subscribe(query)
-
     index = 0
-    async for result in sub:
+    async for ok, result in schema.subscribe(query):
+        assert ok
         assert not result.errors
         assert result.data == {"count": index}
 

--- a/docs/operations/testing.md
+++ b/docs/operations/testing.md
@@ -137,8 +137,7 @@ async def test_subscription():
     """
 
     index = 0
-    async for ok, result in schema.subscribe(query):
-        assert ok
+    async for result in schema.subscribe(query):
         assert not result.errors
         assert result.data == {"count": index}
 

--- a/strawberry/schema/__init__.py
+++ b/strawberry/schema/__init__.py
@@ -1,4 +1,4 @@
-from .base import BaseSchema
+from .base import BaseSchema, SubscribeSingleResult
 from .schema import Schema
 
-__all__ = ["BaseSchema", "Schema"]
+__all__ = ["BaseSchema", "Schema", "SubscribeSingleResult"]

--- a/strawberry/schema/base.py
+++ b/strawberry/schema/base.py
@@ -32,6 +32,15 @@ if TYPE_CHECKING:
     from .config import StrawberryConfig
 
 
+class SubscribeSingleResult(RuntimeError):
+    """Raised when Schema.subscribe() returns a single execution result, instead of a
+    subscription generator, typically as a result of validation errors.
+    """
+
+    def __init__(self, value: ExecutionResult) -> None:
+        self.value = value
+
+
 class BaseSchema(Protocol):
     config: StrawberryConfig
     schema_converter: GraphQLCoreConverter
@@ -72,7 +81,7 @@ class BaseSchema(Protocol):
         context_value: Optional[Any] = None,
         root_value: Optional[Any] = None,
         operation_name: Optional[str] = None,
-    ) -> AsyncGenerator[Any, None]:
+    ) -> AsyncGenerator[ExecutionResult, None]:
         raise NotImplementedError
 
     @abstractmethod

--- a/strawberry/schema/base.py
+++ b/strawberry/schema/base.py
@@ -2,7 +2,17 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Type, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    AsyncGenerator,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Type,
+    Union,
+)
 from typing_extensions import Protocol
 
 from strawberry.utils.logging import StrawberryLogger
@@ -55,14 +65,14 @@ class BaseSchema(Protocol):
         raise NotImplementedError
 
     @abstractmethod
-    async def subscribe(
+    def subscribe(
         self,
         query: str,
         variable_values: Optional[Dict[str, Any]] = None,
         context_value: Optional[Any] = None,
         root_value: Optional[Any] = None,
         operation_name: Optional[str] = None,
-    ) -> Any:
+    ) -> AsyncGenerator[Any, None]:
         raise NotImplementedError
 
     @abstractmethod

--- a/strawberry/schema/execute.py
+++ b/strawberry/schema/execute.py
@@ -282,7 +282,6 @@ async def subscribe(
     *,
     extensions: Sequence[Union[Type[SchemaExtension], SchemaExtension]],
     execution_context: ExecutionContext,
-    execution_context_class: Optional[Type[GraphQLExecutionContext]] = None,
     process_errors: Callable[[List[GraphQLError], Optional[ExecutionContext]], None],
 ) -> AsyncGenerator[Tuple[bool, ExecutionResult], None]:
     """
@@ -308,8 +307,7 @@ async def subscribe(
     async with extensions_runner.operation():
         # Note: In graphql-core the schema would be validated here but in
         # Strawberry we are validating it at initialisation time instead
-        if not execution_context.query:
-            raise MissingQueryError()
+        assert execution_context.query is not None
 
         async with extensions_runner.parsing():
             try:

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -320,7 +320,6 @@ class Schema(BaseSchema):
         async for result in subscribe(
             self._schema,
             extensions=self.get_extensions(),
-            execution_context_class=self.execution_context_class,
             execution_context=execution_context,
             process_errors=self.process_errors,
         ):

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -307,7 +307,7 @@ class Schema(BaseSchema):
         context_value: Optional[Any] = None,
         root_value: Optional[Any] = None,
         operation_name: Optional[str] = None,
-    ) -> AsyncGenerator[tuple[bool, ExecutionResult], None]:
+    ) -> AsyncGenerator[ExecutionResult, None]:
         execution_context = ExecutionContext(
             query=query,
             schema=self,

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -5,7 +5,7 @@ from functools import lru_cache
 from typing import (
     TYPE_CHECKING,
     Any,
-    AsyncIterator,
+    AsyncGenerator,
     Dict,
     Iterable,
     List,
@@ -20,10 +20,8 @@ from graphql import (
     GraphQLNonNull,
     GraphQLSchema,
     get_introspection_query,
-    parse,
     validate_schema,
 )
-from graphql.execution import subscribe
 from graphql.type.directives import specified_directives
 
 from strawberry import relay
@@ -43,11 +41,10 @@ from ..printer import print_schema
 from . import compat
 from .base import BaseSchema
 from .config import StrawberryConfig
-from .execute import execute, execute_sync
+from .execute import execute, execute_sync, subscribe
 
 if TYPE_CHECKING:
     from graphql import ExecutionContext as GraphQLExecutionContext
-    from graphql import ExecutionResult as GraphQLExecutionResult
 
     from strawberry.custom_scalar import ScalarDefinition, ScalarWrapper
     from strawberry.directive import StrawberryDirective
@@ -305,21 +302,29 @@ class Schema(BaseSchema):
 
     async def subscribe(
         self,
-        # TODO: make this optional when we support extensions
-        query: str,
+        query: Optional[str],
         variable_values: Optional[Dict[str, Any]] = None,
         context_value: Optional[Any] = None,
         root_value: Optional[Any] = None,
         operation_name: Optional[str] = None,
-    ) -> Union[AsyncIterator[GraphQLExecutionResult], GraphQLExecutionResult]:
-        return await subscribe(
-            self._schema,
-            parse(query),
+    ) -> AsyncGenerator[tuple[bool, ExecutionResult], None]:
+        execution_context = ExecutionContext(
+            query=query,
+            schema=self,
+            context=context_value,
             root_value=root_value,
-            context_value=context_value,
-            variable_values=variable_values,
-            operation_name=operation_name,
+            variables=variable_values,
+            provided_operation_name=operation_name,
         )
+
+        async for result in subscribe(
+            self._schema,
+            extensions=self.get_extensions(),
+            execution_context_class=self.execution_context_class,
+            execution_context=execution_context,
+            process_errors=self.process_errors,
+        ):
+            yield result
 
     def _resolve_node_ids(self):
         for concrete_type in self.schema_converter.type_map.values():

--- a/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
@@ -8,7 +8,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     AsyncGenerator,
-    AsyncIterator,
     Callable,
     Dict,
     List,
@@ -255,7 +254,7 @@ class BaseGraphQLTransportWSHandler(ABC):
             )
         else:
             # create AsyncGenerator returning a single result
-            async def get_result_source() -> AsyncIterator[ExecutionResult]:
+            async def get_result_source() -> AsyncGenerator[ExecutionResult, None]:
                 raise SubscribeSingleResult(
                     await self.schema.execute(
                         query=message.payload.query,

--- a/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
@@ -318,6 +318,8 @@ class BaseGraphQLTransportWSHandler(ABC):
                         next_payload["errors"] = [
                             err.formatted for err in result.errors
                         ]
+                    if result.extensions:
+                        next_payload["extensions"] = result.extensions
                     next_message = NextMessage(id=operation.id, payload=next_payload)
                     await operation.send_message(next_message)
         except Exception as error:

--- a/strawberry/subscriptions/protocols/graphql_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_ws/handlers.py
@@ -122,19 +122,13 @@ class BaseGraphQLWSHandler(ABC):
         if self.debug:
             pretty_print_graphql_operation(operation_name, query, variables)
 
-        try:
-            result_source = self.schema.subscribe(
-                query=query,
-                variable_values=variables,
-                operation_name=operation_name,
-                context_value=context,
-                root_value=root_value,
-            )
-        except GraphQLError as error:
-            error_payload = error.formatted
-            await self.send_message(GQL_ERROR, operation_id, error_payload)
-            self.schema.process_errors([error])
-            return
+        result_source = self.schema.subscribe(
+            query=query,
+            variable_values=variables,
+            operation_name=operation_name,
+            context_value=context,
+            root_value=root_value,
+        )
 
         self.subscriptions[operation_id] = result_source
         result_handler = self.handle_async_results(result_source, operation_id)

--- a/strawberry/subscriptions/protocols/graphql_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_ws/handlers.py
@@ -190,13 +190,12 @@ class BaseGraphQLWSHandler(ABC):
         await self.send_message(GQL_COMPLETE, operation_id, None)
 
     async def cleanup_operation(self, operation_id: str) -> None:
-        await self.subscriptions[operation_id].aclose()
-        del self.subscriptions[operation_id]
-
-        self.tasks[operation_id].cancel()
+        iterator = self.subscriptions.pop(operation_id)
+        task = self.tasks.pop(operation_id)
+        task.cancel()
         with suppress(BaseException):
-            await self.tasks[operation_id]
-        del self.tasks[operation_id]
+            await task
+        await iterator.aclose()
 
     async def send_message(
         self,

--- a/strawberry/subscriptions/protocols/graphql_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_ws/handlers.py
@@ -160,6 +160,8 @@ class BaseGraphQLWSHandler(ABC):
                 payload = {"data": result.data}
                 if result.errors:
                     payload["errors"] = [err.formatted for err in result.errors]
+                if result.extensions:
+                    payload["extensions"] = result.extensions
                 await self.send_message(GQL_DATA, operation_id, payload)
                 # log errors after send_message to prevent potential
                 # slowdown of sending result

--- a/strawberry/subscriptions/protocols/graphql_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_ws/handlers.py
@@ -5,7 +5,6 @@ from abc import ABC, abstractmethod
 from contextlib import suppress
 from typing import TYPE_CHECKING, Any, AsyncGenerator, Dict, Optional, cast
 
-from graphql import ExecutionResult as GraphQLExecutionResult
 from graphql import GraphQLError
 
 from strawberry.subscriptions.protocols.graphql_ws import (
@@ -124,7 +123,7 @@ class BaseGraphQLWSHandler(ABC):
             pretty_print_graphql_operation(operation_name, query, variables)
 
         try:
-            result_source = await self.schema.subscribe(
+            result_source = self.schema.subscribe(
                 query=query,
                 variable_values=variables,
                 operation_name=operation_name,
@@ -135,13 +134,6 @@ class BaseGraphQLWSHandler(ABC):
             error_payload = error.formatted
             await self.send_message(GQL_ERROR, operation_id, error_payload)
             self.schema.process_errors([error])
-            return
-
-        if isinstance(result_source, GraphQLExecutionResult):
-            assert result_source.errors
-            error_payload = result_source.errors[0].formatted
-            await self.send_message(GQL_ERROR, operation_id, error_payload)
-            self.schema.process_errors(result_source.errors)
             return
 
         self.subscriptions[operation_id] = result_source
@@ -164,7 +156,13 @@ class BaseGraphQLWSHandler(ABC):
         operation_id: str,
     ) -> None:
         try:
-            async for result in result_source:
+            async for success, result in result_source:
+                if not success:
+                    assert result.errors
+                    error_payload = result.errors[0].formatted
+                    await self.send_message(GQL_ERROR, operation_id, error_payload)
+                    self.schema.process_errors(result.errors)
+                    return
                 payload = {"data": result.data}
                 if result.errors:
                     payload["errors"] = [err.formatted for err in result.errors]
@@ -186,6 +184,8 @@ class BaseGraphQLWSHandler(ABC):
                 {"data": None, "errors": [error.formatted]},
             )
             self.schema.process_errors([error])
+        finally:
+            await result_source.aclose()
 
         await self.send_message(GQL_COMPLETE, operation_id, None)
 

--- a/strawberry/subscriptions/protocols/graphql_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_ws/handlers.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, AsyncGenerator, Dict, Optional, cast
 
 from graphql import GraphQLError
 
+from strawberry.schema import SubscribeSingleResult
 from strawberry.subscriptions.protocols.graphql_ws import (
     GQL_COMPLETE,
     GQL_CONNECTION_ACK,
@@ -150,23 +151,22 @@ class BaseGraphQLWSHandler(ABC):
         operation_id: str,
     ) -> None:
         try:
-            async for success, result in result_source:
-                if not success:
-                    assert result.errors
-                    error_payload = result.errors[0].formatted
-                    await self.send_message(GQL_ERROR, operation_id, error_payload)
-                    self.schema.process_errors(result.errors)
-                    return
-                payload = {"data": result.data}
-                if result.errors:
-                    payload["errors"] = [err.formatted for err in result.errors]
-                if result.extensions:
-                    payload["extensions"] = result.extensions
-                await self.send_message(GQL_DATA, operation_id, payload)
-                # log errors after send_message to prevent potential
-                # slowdown of sending result
-                if result.errors:
-                    self.schema.process_errors(result.errors)
+            try:
+                async for result in result_source:
+                    payload = {"data": result.data}
+                    if result.errors:
+                        payload["errors"] = [err.formatted for err in result.errors]
+                    if result.extensions:
+                        payload["extensions"] = result.extensions
+                    await self.send_message(GQL_DATA, operation_id, payload)
+            except SubscribeSingleResult as single_result:
+                result = single_result.value
+                assert result.errors
+                error_payload = result.errors[0].formatted
+                await self.send_message(GQL_ERROR, operation_id, error_payload)
+                return
+            finally:
+                await result_source.aclose()
         except asyncio.CancelledError:
             # CancelledErrors are expected during task cleanup.
             pass
@@ -180,8 +180,6 @@ class BaseGraphQLWSHandler(ABC):
                 {"data": None, "errors": [error.formatted]},
             )
             self.schema.process_errors([error])
-        finally:
-            await result_source.aclose()
 
         await self.send_message(GQL_COMPLETE, operation_id, None)
 

--- a/tests/benchmarks/test_subscriptions.py
+++ b/tests/benchmarks/test_subscriptions.py
@@ -16,11 +16,8 @@ def test_subscription(benchmark: BenchmarkFixture):
 
     async def _run():
         for _ in range(100):
-            iterator = await schema.subscribe(s)
-
-            value = await iterator.__anext__()  # type: ignore[union-attr]
-
-            assert value.data is not None
-            assert value.data["something"] == "Hello World!"
+            async for value in schema.subscribe(s):
+                assert value.data is not None
+                assert value.data["something"] == "Hello World!"
 
     benchmark(lambda: asyncio.run(_run()))

--- a/tests/channels/test_layers.py
+++ b/tests/channels/test_layers.py
@@ -91,6 +91,7 @@ async def test_channel_listen(ws: WebsocketCommunicator):
     )
 
     response = await ws.receive_json_from()
+    response["payload"].pop("extensions", None)
     assert (
         response
         == NextMessage(
@@ -137,6 +138,7 @@ async def test_channel_listen_with_confirmation(ws: WebsocketCommunicator):
     )
 
     response = await ws.receive_json_from()
+    response["payload"].pop("extensions", None)
     assert (
         response
         == NextMessage(
@@ -315,6 +317,7 @@ async def test_channel_listen_group(ws: WebsocketCommunicator):
         },
     )
     response = await ws.receive_json_from()
+    response["payload"].pop("extensions", None)
     assert (
         response
         == NextMessage(
@@ -331,6 +334,7 @@ async def test_channel_listen_group(ws: WebsocketCommunicator):
     )
 
     response = await ws.receive_json_from()
+    response["payload"].pop("extensions", None)
     assert (
         response
         == NextMessage(
@@ -377,6 +381,7 @@ async def test_channel_listen_group_cm(ws: WebsocketCommunicator):
         },
     )
     response = await ws.receive_json_from()
+    response["payload"].pop("extensions", None)
     assert (
         response
         == NextMessage(
@@ -393,6 +398,7 @@ async def test_channel_listen_group_cm(ws: WebsocketCommunicator):
     )
 
     response = await ws.receive_json_from()
+    response["payload"].pop("extensions", None)
     assert (
         response
         == NextMessage(

--- a/tests/http/clients/aiohttp.py
+++ b/tests/http/clients/aiohttp.py
@@ -15,7 +15,8 @@ from strawberry.aiohttp.views import GraphQLView as BaseGraphQLView
 from strawberry.http import GraphQLHTTPResponse
 from strawberry.http.ides import GraphQL_IDE
 from strawberry.types import ExecutionResult
-from tests.views.schema import Query, schema
+from tests.views.schema import Query
+from tests.views.schema import async_schema as schema
 
 from ..context import get_context
 from .base import (

--- a/tests/http/clients/asgi.py
+++ b/tests/http/clients/asgi.py
@@ -16,7 +16,8 @@ from strawberry.asgi.handlers import GraphQLTransportWSHandler, GraphQLWSHandler
 from strawberry.http import GraphQLHTTPResponse
 from strawberry.http.ides import GraphQL_IDE
 from strawberry.types import ExecutionResult
-from tests.views.schema import Query, schema
+from tests.views.schema import Query
+from tests.views.schema import async_schema as schema
 
 from ..context import get_context
 from .base import (

--- a/tests/http/clients/channels.py
+++ b/tests/http/clients/channels.py
@@ -18,7 +18,8 @@ from strawberry.channels.handlers.base import ChannelsConsumer
 from strawberry.http import GraphQLHTTPResponse
 from strawberry.http.ides import GraphQL_IDE
 from strawberry.http.typevars import Context, RootValue
-from tests.views.schema import Query, async_schema as schema
+from tests.views.schema import Query, async_schema
+from tests.views.schema import schema as sync_schema
 
 from ..context import get_context
 from .base import (
@@ -143,12 +144,12 @@ class ChannelsHttpClient(HttpClient):
         result_override: ResultOverrideFunction = None,
     ):
         self.ws_app = DebuggableGraphQLTransportWSConsumer.as_asgi(
-            schema=schema,
+            schema=async_schema,
             keep_alive=False,
         )
 
         self.http_app = DebuggableGraphQLHTTPConsumer.as_asgi(
-            schema=schema,
+            schema=async_schema,
             graphiql=graphiql,
             graphql_ide=graphql_ide,
             allow_queries_via_get=allow_queries_via_get,
@@ -157,7 +158,7 @@ class ChannelsHttpClient(HttpClient):
 
     def create_app(self, **kwargs: Any) -> None:
         self.ws_app = DebuggableGraphQLTransportWSConsumer.as_asgi(
-            schema=schema, **kwargs
+            schema=async_schema, **kwargs
         )
 
     async def _graphql_request(
@@ -264,7 +265,7 @@ class SyncChannelsHttpClient(ChannelsHttpClient):
         result_override: ResultOverrideFunction = None,
     ):
         self.http_app = DebuggableSyncGraphQLHTTPConsumer.as_asgi(
-            schema=schema,
+            schema=sync_schema,
             graphiql=graphiql,
             graphql_ide=graphql_ide,
             allow_queries_via_get=allow_queries_via_get,

--- a/tests/http/clients/channels.py
+++ b/tests/http/clients/channels.py
@@ -18,7 +18,7 @@ from strawberry.channels.handlers.base import ChannelsConsumer
 from strawberry.http import GraphQLHTTPResponse
 from strawberry.http.ides import GraphQL_IDE
 from strawberry.http.typevars import Context, RootValue
-from tests.views.schema import Query, schema
+from tests.views.schema import Query, async_schema as schema
 
 from ..context import get_context
 from .base import (

--- a/tests/http/clients/fastapi.py
+++ b/tests/http/clients/fastapi.py
@@ -15,7 +15,8 @@ from strawberry.fastapi.handlers import GraphQLTransportWSHandler, GraphQLWSHand
 from strawberry.http import GraphQLHTTPResponse
 from strawberry.http.ides import GraphQL_IDE
 from strawberry.types import ExecutionResult
-from tests.views.schema import Query, schema
+from tests.views.schema import Query
+from tests.views.schema import async_schema as schema
 
 from ..context import get_context
 from .asgi import AsgiWebSocketClient

--- a/tests/http/clients/starlite.py
+++ b/tests/http/clients/starlite.py
@@ -15,7 +15,8 @@ from strawberry.http.ides import GraphQL_IDE
 from strawberry.starlite import make_graphql_controller
 from strawberry.starlite.controller import GraphQLTransportWSHandler, GraphQLWSHandler
 from strawberry.types import ExecutionResult
-from tests.views.schema import Query, schema
+from tests.views.schema import Query
+from tests.views.schema import async_schema as schema
 
 from ..context import get_context
 from .base import (

--- a/tests/schema/test_permission.py
+++ b/tests/schema/test_permission.py
@@ -13,6 +13,7 @@ from strawberry.exceptions.permission_fail_silently_requires_optional import (
 from strawberry.permission import BasePermission, PermissionExtension
 from strawberry.printer import print_schema
 from strawberry.schema import SubscribeSingleResult
+from strawberry.types import Info
 
 
 def test_raises_graphql_error_when_permission_method_is_missing():

--- a/tests/schema/test_permission.py
+++ b/tests/schema/test_permission.py
@@ -12,6 +12,7 @@ from strawberry.exceptions.permission_fail_silently_requires_optional import (
 )
 from strawberry.permission import BasePermission, PermissionExtension
 from strawberry.printer import print_schema
+from strawberry.schema import SubscribeSingleResult
 
 
 def test_raises_graphql_error_when_permission_method_is_missing():
@@ -80,9 +81,11 @@ async def test_raises_permission_error_for_subscription():
 
     query = "subscription { user }"
 
-    async for ok, result in schema.subscribe(query):
-        assert not ok
-        assert result.errors[0].message == "You are not authorized"
+    with pytest.raises(SubscribeSingleResult) as err:
+        async for result in schema.subscribe(query):
+            pass
+    result = err.value.value
+    assert result.errors[0].message == "You are not authorized"
 
 
 @pytest.mark.asyncio

--- a/tests/schema/test_permission.py
+++ b/tests/schema/test_permission.py
@@ -83,7 +83,7 @@ async def test_raises_permission_error_for_subscription():
     query = "subscription { user }"
 
     with pytest.raises(SubscribeSingleResult) as err:
-        async for result in schema.subscribe(query):
+        async for _ in schema.subscribe(query):
             pass
     result = err.value.value
     assert result.errors[0].message == "You are not authorized"

--- a/tests/schema/test_permission.py
+++ b/tests/schema/test_permission.py
@@ -80,9 +80,9 @@ async def test_raises_permission_error_for_subscription():
 
     query = "subscription { user }"
 
-    result = await schema.subscribe(query)
-
-    assert result.errors[0].message == "You are not authorized"
+    async for ok, result in schema.subscribe(query):
+        assert not ok
+        assert result.errors[0].message == "You are not authorized"
 
 
 @pytest.mark.asyncio

--- a/tests/schema/test_permission.py
+++ b/tests/schema/test_permission.py
@@ -13,7 +13,6 @@ from strawberry.exceptions.permission_fail_silently_requires_optional import (
 from strawberry.permission import BasePermission, PermissionExtension
 from strawberry.printer import print_schema
 from strawberry.schema import SubscribeSingleResult
-from strawberry.types import Info
 
 
 def test_raises_graphql_error_when_permission_method_is_missing():

--- a/tests/schema/test_subscription.py
+++ b/tests/schema/test_subscription.py
@@ -33,11 +33,10 @@ async def test_subscription():
 
     query = "subscription { example }"
 
-    sub = await schema.subscribe(query)
-    result = await sub.__anext__()
-
-    assert not result.errors
-    assert result.data["example"] == "Hi"
+    async for ok, result in schema.subscribe(query):
+        assert ok
+        assert not result.errors
+        assert result.data["example"] == "Hi"
 
 
 @pytest.mark.asyncio
@@ -89,11 +88,10 @@ async def test_subscription_with_arguments():
 
     query = 'subscription { example(name: "Nina") }'
 
-    sub = await schema.subscribe(query)
-    result = await sub.__anext__()
-
-    assert not result.errors
-    assert result.data["example"] == "Hi Nina"
+    async for ok, result in schema.subscribe(query):
+        assert ok
+        assert not result.errors
+        assert result.data["example"] == "Hi Nina"
 
 
 requires_builtin_generics = pytest.mark.skipif(
@@ -132,11 +130,10 @@ async def test_subscription_return_annotations(return_annotation: str):
 
     query = "subscription { example }"
 
-    sub = await schema.subscribe(query)
-    result = await sub.__anext__()
-
-    assert not result.errors
-    assert result.data["example"] == "Hi"
+    async for ok, result in schema.subscribe(query):
+        assert ok
+        assert not result.errors
+        assert result.data["example"] == "Hi"
 
 
 @pytest.mark.asyncio
@@ -165,11 +162,10 @@ async def test_subscription_with_unions():
 
     query = "subscription { exampleWithUnion { ... on A { a } } }"
 
-    sub = await schema.subscribe(query)
-    result = await sub.__anext__()
-
-    assert not result.errors
-    assert result.data["exampleWithUnion"]["a"] == "Hi"
+    async for ok, result in schema.subscribe(query):
+        assert ok
+        assert not result.errors
+        assert result.data["exampleWithUnion"]["a"] == "Hi"
 
     del A, B
 
@@ -204,11 +200,10 @@ async def test_subscription_with_unions_and_annotated():
 
     query = "subscription { exampleWithAnnotatedUnion { ... on C { c } } }"
 
-    sub = await schema.subscribe(query)
-    result = await sub.__anext__()
-
-    assert not result.errors
-    assert result.data["exampleWithAnnotatedUnion"]["c"] == "Hi"
+    async for ok, result in schema.subscribe(query):
+        assert ok
+        assert not result.errors
+        assert result.data["exampleWithAnnotatedUnion"]["c"] == "Hi"
 
     del C, D
 
@@ -231,8 +226,7 @@ async def test_subscription_with_annotated():
 
     query = "subscription { example }"
 
-    sub = await schema.subscribe(query)
-    result = await sub.__anext__()
-
-    assert not result.errors
-    assert result.data["example"] == "Hi"
+    async for ok, result in schema.subscribe(query):
+        assert ok
+        assert not result.errors
+        assert result.data["example"] == "Hi"

--- a/tests/schema/test_subscription.py
+++ b/tests/schema/test_subscription.py
@@ -159,8 +159,7 @@ async def test_subscription_with_unions():
 
     query = "subscription { exampleWithUnion { ... on A { a } } }"
 
-    async for ok, result in schema.subscribe(query):
-        assert ok
+    async for result in schema.subscribe(query):
         assert not result.errors
         assert result.data["exampleWithUnion"]["a"] == "Hi"
 
@@ -197,8 +196,7 @@ async def test_subscription_with_unions_and_annotated():
 
     query = "subscription { exampleWithAnnotatedUnion { ... on C { c } } }"
 
-    async for ok, result in schema.subscribe(query):
-        assert ok
+    async for result in schema.subscribe(query):
         assert not result.errors
         assert result.data["exampleWithAnnotatedUnion"]["c"] == "Hi"
 
@@ -223,7 +221,6 @@ async def test_subscription_with_annotated():
 
     query = "subscription { example }"
 
-    async for ok, result in schema.subscribe(query):
-        assert ok
+    async for result in schema.subscribe(query):
         assert not result.errors
         assert result.data["example"] == "Hi"

--- a/tests/schema/test_subscription.py
+++ b/tests/schema/test_subscription.py
@@ -33,8 +33,7 @@ async def test_subscription():
 
     query = "subscription { example }"
 
-    async for ok, result in schema.subscribe(query):
-        assert ok
+    async for result in schema.subscribe(query):
         assert not result.errors
         assert result.data["example"] == "Hi"
 
@@ -88,8 +87,7 @@ async def test_subscription_with_arguments():
 
     query = 'subscription { example(name: "Nina") }'
 
-    async for ok, result in schema.subscribe(query):
-        assert ok
+    async for result in schema.subscribe(query):
         assert not result.errors
         assert result.data["example"] == "Hi Nina"
 
@@ -130,8 +128,7 @@ async def test_subscription_return_annotations(return_annotation: str):
 
     query = "subscription { example }"
 
-    async for ok, result in schema.subscribe(query):
-        assert ok
+    async for result in schema.subscribe(query):
         assert not result.errors
         assert result.data["example"] == "Hi"
 

--- a/tests/schema/test_subscription.py
+++ b/tests/schema/test_subscription.py
@@ -64,11 +64,9 @@ async def test_subscription_with_permission():
 
     query = "subscription { example }"
 
-    sub = await schema.subscribe(query)
-    result = await sub.__anext__()
-
-    assert not result.errors
-    assert result.data["example"] == "Hi"
+    async for result in schema.subscribe(query):
+        assert not result.errors
+        assert result.data["example"] == "Hi"
 
 
 @pytest.mark.asyncio

--- a/tests/views/schema.py
+++ b/tests/views/schema.py
@@ -41,7 +41,7 @@ class MyExtension(SchemaExtension):
     def get_results(self) -> Dict[str, str]:
         return {"example": "example"}
 
-    def resolve(self, _next, root, info: Info, *args: Any, **kwargs: Any):
+    def resolve(self, _next, root, info: strawberry.Info, *args: Any, **kwargs: Any):
         self.active_counter += 1
         try:
             self.resolve_called()
@@ -91,7 +91,7 @@ class MyAsyncExtension(SchemaExtension):
     def get_results(self) -> Dict[str, str]:
         return {"example": "example"}
 
-    async def resolve(self, _next, root, info: Info, *args: Any, **kwargs: Any):
+    async def resolve(self, _next, root, info: strawberry.Info, *args: Any, **kwargs: Any):
         self.resolve_called()
         self.active_counter += 1
         try:

--- a/tests/views/schema.py
+++ b/tests/views/schema.py
@@ -91,7 +91,9 @@ class MyAsyncExtension(SchemaExtension):
     def get_results(self) -> Dict[str, str]:
         return {"example": "example"}
 
-    async def resolve(self, _next, root, info: strawberry.Info, *args: Any, **kwargs: Any):
+    async def resolve(
+        self, _next, root, info: strawberry.Info, *args: Any, **kwargs: Any
+    ):
         self.resolve_called()
         self.active_counter += 1
         try:

--- a/tests/views/schema.py
+++ b/tests/views/schema.py
@@ -20,6 +20,19 @@ class AlwaysFailPermission(BasePermission):
         return False
 
 
+class ConditionalFailPermission(BasePermission):
+    @property
+    def message(self):
+        return f"failed after sleep {self.sleep}"
+
+    async def has_permission(self, source, info, **kwargs: Any) -> bool:
+        self.sleep = kwargs.get("sleep", None)
+        self.fail = kwargs.get("fail", True)
+        if self.sleep is not None:
+            await asyncio.sleep(kwargs["sleep"])
+        return not self.fail
+
+
 class MyExtension(SchemaExtension):
     def get_results(self) -> Dict[str, str]:
         return {"example": "example"}
@@ -84,6 +97,12 @@ class Query:
 
     @strawberry.field(permission_classes=[AlwaysFailPermission])
     def always_fail(self) -> Optional[str]:
+        return "Hey"
+
+    @strawberry.field(permission_classes=[ConditionalFailPermission])
+    def conditional_fail(
+        self, sleep: Optional[float] = None, fail: bool = False
+    ) -> str:
         return "Hey"
 
     @strawberry.field
@@ -267,6 +286,12 @@ class Subscription:
                 await asyncio.sleep(0.01)
         finally:
             await asyncio.sleep(delay)
+
+    @strawberry.subscription(permission_classes=[ConditionalFailPermission])
+    async def conditional_fail(
+        self, sleep: Optional[float] = None, fail: bool = False
+    ) -> AsyncGenerator[str, None]:
+        yield "Hey"
 
 
 class Schema(strawberry.Schema):

--- a/tests/websockets/test_graphql_transport_ws.py
+++ b/tests/websockets/test_graphql_transport_ws.py
@@ -250,11 +250,8 @@ async def test_can_send_payload_with_additional_things(ws_raw: WebSocketClient):
 
     data = await ws.receive(timeout=2)
 
-    assert json.loads(data.data) == {
-        "type": "next",
-        "id": "1",
-        "payload": {"data": {"echo": "Hi"}},
-    }
+    result = json.loads(data.data)
+    assert_next(result, "1", {"echo": "Hi"})
 
 
 async def test_server_sent_ping(ws: WebSocketClient):

--- a/tests/websockets/test_graphql_transport_ws.py
+++ b/tests/websockets/test_graphql_transport_ws.py
@@ -403,7 +403,7 @@ async def test_subscription_field_errors(ws: WebSocketClient):
         assert response["payload"][0]["locations"] == [{"line": 1, "column": 16}]
         assert (
             response["payload"][0]["message"]
-            == "The subscription field 'notASubscriptionField' is not defined."
+            == "Cannot query field 'notASubscriptionField' on type 'Subscription'."
         )
         process_errors.assert_called_once()
 

--- a/tests/websockets/test_graphql_transport_ws.py
+++ b/tests/websockets/test_graphql_transport_ws.py
@@ -54,6 +54,20 @@ async def ws(ws_raw: WebSocketClient) -> WebSocketClient:
     return ws_raw
 
 
+def assert_next(response, id, data, extensions=None):
+    """
+    Assert that the NextMessage payload contains the provided data.
+    If extensions is provided, it will also assert that the
+    extensions are present
+    """
+    assert response["type"] == "next"
+    assert response["id"] == id
+    assert set(response["payload"].keys()) <= {"data", "errors", "extensions"}
+    assert response["payload"]["data"] == data
+    if extensions is not None:
+        assert response["payload"]["extensions"] == extensions
+
+
 async def test_unknown_message_type(ws_raw: WebSocketClient):
     ws = ws_raw
 
@@ -158,13 +172,7 @@ async def test_connection_init_timeout_cancellation(
     )
 
     response = await ws.receive_json()
-    assert (
-        response
-        == NextMessage(
-            id="sub1",
-            payload={"data": {"debug": {"isConnectionInitTimeoutTaskDone": True}}},
-        ).as_dict()
-    )
+    assert_next(response, "sub1", {"debug": {"isConnectionInitTimeoutTaskDone": True}})
 
 
 @pytest.mark.xfail(reason="This test is flaky")
@@ -260,10 +268,7 @@ async def test_server_sent_ping(ws: WebSocketClient):
     await ws.send_json(PongMessage().as_dict())
 
     response = await ws.receive_json()
-    assert (
-        response
-        == NextMessage(id="sub1", payload={"data": {"requestPing": True}}).as_dict()
-    )
+    assert_next(response, "sub1", {"requestPing": True})
 
     response = await ws.receive_json()
     assert response == CompleteMessage(id="sub1").as_dict()
@@ -327,9 +332,7 @@ async def test_reused_operation_ids(ws: WebSocketClient):
     )
 
     response = await ws.receive_json()
-    assert (
-        response == NextMessage(id="sub1", payload={"data": {"echo": "Hi"}}).as_dict()
-    )
+    assert_next(response, "sub1", {"echo": "Hi"})
 
     response = await ws.receive_json()
     assert response == CompleteMessage(id="sub1").as_dict()
@@ -346,9 +349,7 @@ async def test_reused_operation_ids(ws: WebSocketClient):
     )
 
     response = await ws.receive_json()
-    assert (
-        response == NextMessage(id="sub1", payload={"data": {"echo": "Hi"}}).as_dict()
-    )
+    assert_next(response, "sub1", {"echo": "Hi"})
 
 
 async def test_simple_subscription(ws: WebSocketClient):
@@ -362,9 +363,7 @@ async def test_simple_subscription(ws: WebSocketClient):
     )
 
     response = await ws.receive_json()
-    assert (
-        response == NextMessage(id="sub1", payload={"data": {"echo": "Hi"}}).as_dict()
-    )
+    assert_next(response, "sub1", {"echo": "Hi"})
 
     await ws.send_json(CompleteMessage(id="sub1").as_dict())
 
@@ -428,12 +427,7 @@ async def test_subscription_cancellation(ws: WebSocketClient):
     )
 
     response = await ws.receive_json()
-    assert (
-        response
-        == NextMessage(
-            id="sub2", payload={"data": {"debug": {"numActiveResultHandlers": 2}}}
-        ).as_dict()
-    )
+    assert_next(response, "sub2", {"debug": {"numActiveResultHandlers": 2}})
 
     response = await ws.receive_json()
     assert response == CompleteMessage(id="sub2").as_dict()
@@ -450,12 +444,7 @@ async def test_subscription_cancellation(ws: WebSocketClient):
     )
 
     response = await ws.receive_json()
-    assert (
-        response
-        == NextMessage(
-            id="sub3", payload={"data": {"debug": {"numActiveResultHandlers": 1}}}
-        ).as_dict()
-    )
+    assert_next(response, "sub3", {"debug": {"numActiveResultHandlers": 1}})
 
     response = await ws.receive_json()
     assert response == CompleteMessage(id="sub3").as_dict()
@@ -543,10 +532,7 @@ async def test_single_result_query_operation(ws: WebSocketClient):
     )
 
     response = await ws.receive_json()
-    assert (
-        response
-        == NextMessage(id="sub1", payload={"data": {"hello": "Hello world"}}).as_dict()
-    )
+    assert_next(response, "sub1", {"hello": "Hello world"})
 
     response = await ws.receive_json()
     assert response == CompleteMessage(id="sub1").as_dict()
@@ -568,12 +554,7 @@ async def test_single_result_query_operation_async(ws: WebSocketClient):
     )
 
     response = await ws.receive_json()
-    assert (
-        response
-        == NextMessage(
-            id="sub1", payload={"data": {"asyncHello": "Hello Dolly"}}
-        ).as_dict()
-    )
+    assert_next(response, "sub1", {"asyncHello": "Hello Dolly"})
 
     response = await ws.receive_json()
     assert response == CompleteMessage(id="sub1").as_dict()
@@ -607,12 +588,7 @@ async def test_single_result_query_operation_overlapped(ws: WebSocketClient):
 
     # we expect the response to the second query to arrive first
     response = await ws.receive_json()
-    assert (
-        response
-        == NextMessage(
-            id="sub2", payload={"data": {"asyncHello": "Hello Dolly"}}
-        ).as_dict()
-    )
+    assert_next(response, "sub2", {"asyncHello": "Hello Dolly"})
     response = await ws.receive_json()
     assert response == CompleteMessage(id="sub2").as_dict()
 
@@ -626,10 +602,7 @@ async def test_single_result_mutation_operation(ws: WebSocketClient):
     )
 
     response = await ws.receive_json()
-    assert (
-        response
-        == NextMessage(id="sub1", payload={"data": {"hello": "strawberry"}}).as_dict()
-    )
+    assert_next(response, "sub1", {"hello": "strawberry"})
 
     response = await ws.receive_json()
     assert response == CompleteMessage(id="sub1").as_dict()
@@ -653,12 +626,7 @@ async def test_single_result_operation_selection(ws: WebSocketClient):
     )
 
     response = await ws.receive_json()
-    assert (
-        response
-        == NextMessage(
-            id="sub1", payload={"data": {"hello": "Hello Strawberry"}}
-        ).as_dict()
-    )
+    assert_next(response, "sub1", {"hello": "Hello Strawberry"})
 
     response = await ws.receive_json()
     assert response == CompleteMessage(id="sub1").as_dict()
@@ -808,12 +776,7 @@ async def test_injects_connection_params(ws_raw: WebSocketClient):
     )
 
     response = await ws.receive_json()
-    assert (
-        response
-        == NextMessage(
-            id="sub1", payload={"data": {"connectionParams": "rocks"}}
-        ).as_dict()
-    )
+    assert_next(response, "sub1", {"connectionParams": "rocks"})
 
     await ws.send_json(CompleteMessage(id="sub1").as_dict())
 
@@ -862,12 +825,7 @@ async def test_subsciption_cancel_finalization_delay(ws: WebSocketClient):
     )
 
     response = await ws.receive_json()
-    assert (
-        response
-        == NextMessage(
-            id="sub1", payload={"data": {"longFinalizer": "hello"}}
-        ).as_dict()
-    )
+    assert_next(response, "sub1", {"longFinalizer": "hello"})
 
     # now cancel the stubscription and send a new query.  We expect the response
     # to the new query to arrive immediately, without waiting for the finalizer
@@ -952,9 +910,7 @@ async def test_subscription_errors_continue(ws: WebSocketClient):
         )
 
         response = await ws.receive_json()
-        assert response["type"] == NextMessage.type
-        assert response["id"] == "sub1"
-        assert response["payload"]["data"] == {"flavorsInvalid": "VANILLA"}
+        assert_next(response, "sub1", {"flavorsInvalid": "VANILLA"})
 
         response = await ws.receive_json()
         assert response["type"] == NextMessage.type
@@ -965,10 +921,24 @@ async def test_subscription_errors_continue(ws: WebSocketClient):
         process_errors.assert_called_once()
 
         response = await ws.receive_json()
-        assert response["type"] == NextMessage.type
-        assert response["id"] == "sub1"
-        assert response["payload"]["data"] == {"flavorsInvalid": "CHOCOLATE"}
+        assert_next(response, "sub1", {"flavorsInvalid": "CHOCOLATE"})
 
         response = await ws.receive_json()
         assert response["type"] == CompleteMessage.type
         assert response["id"] == "sub1"
+
+
+async def test_extensions(ws: WebSocketClient):
+    await ws.send_json(
+        SubscribeMessage(
+            id="sub1",
+            payload=SubscribeMessagePayload(
+                query='subscription { echo(message: "Hi") }'
+            ),
+        ).as_dict()
+    )
+
+    response = await ws.receive_json()
+    assert_next(response, "sub1", {"echo": "Hi"}, extensions={"example": "example"})
+
+    await ws.send_json(CompleteMessage(id="sub1").as_dict())

--- a/tests/websockets/test_graphql_transport_ws.py
+++ b/tests/websockets/test_graphql_transport_ws.py
@@ -957,6 +957,11 @@ async def test_extensions(ws: WebSocketClient):
     resolve_called = Mock()
     lifecycle_called = Mock()
 
+    # we must make sure that earlier requests and drained before we start
+    # so that their execution events don't interfere with our events
+    while MyAsyncExtension.active_counter > 0:
+        await asyncio.sleep(0.01)
+
     with patch.object(MyAsyncExtension, "resolve_called", resolve_called):
         with patch.object(MyAsyncExtension, "lifecycle_called", lifecycle_called):
             await ws.send_json(

--- a/tests/websockets/test_graphql_transport_ws.py
+++ b/tests/websockets/test_graphql_transport_ws.py
@@ -407,6 +407,28 @@ async def test_subscription_field_errors(ws: WebSocketClient):
         process_errors.assert_called_once()
 
 
+async def test_query_field_errors(ws: WebSocketClient):
+    await ws.send_json(
+        SubscribeMessage(
+            id="sub1",
+            payload=SubscribeMessagePayload(
+                query="query { notASubscriptionField }",
+            ),
+        ).as_dict()
+    )
+
+    response = await ws.receive_json()
+    assert response["type"] == ErrorMessage.type
+    assert response["id"] == "sub1"
+    assert len(response["payload"]) == 1
+    assert response["payload"][0].get("path") is None
+    assert response["payload"][0]["locations"] == [{"line": 1, "column": 9}]
+    assert (
+        response["payload"][0]["message"]
+        == "Cannot query field 'notASubscriptionField' on type 'Query'."
+    )
+
+
 async def test_subscription_cancellation(ws: WebSocketClient):
     await ws.send_json(
         SubscribeMessage(
@@ -942,6 +964,50 @@ async def test_extensions(ws: WebSocketClient):
     assert_next(response, "sub1", {"echo": "Hi"}, extensions={"example": "example"})
 
     await ws.send_json(CompleteMessage(id="sub1").as_dict())
+
+
+async def test_validation_query(ws: WebSocketClient):
+    """
+    Test validation for query
+    """
+    await ws.send_json(
+        SubscribeMessage(
+            id="sub1",
+            payload=SubscribeMessagePayload(
+                query="query { conditionalFail(fail:true) }"
+            ),
+        ).as_dict()
+    )
+
+    # We expect an error message directly
+    response = await ws.receive_json()
+    assert response["type"] == ErrorMessage.type
+    assert response["id"] == "sub1"
+    assert len(response["payload"]) == 1
+    assert response["payload"][0].get("path") == ["conditionalFail"]
+    assert response["payload"][0]["message"] == "failed after sleep None"
+
+
+async def test_validation_subscription(ws: WebSocketClient):
+    """
+    Test validation for subscription
+    """
+    await ws.send_json(
+        SubscribeMessage(
+            id="sub1",
+            payload=SubscribeMessagePayload(
+                query="subscription { conditionalFail(fail:true) }"
+            ),
+        ).as_dict()
+    )
+
+    # We expect an error message directly
+    response = await ws.receive_json()
+    assert response["type"] == ErrorMessage.type
+    assert response["id"] == "sub1"
+    assert len(response["payload"]) == 1
+    assert response["payload"][0].get("path") == ["conditionalFail"]
+    assert response["payload"][0]["message"] == "failed after sleep None"
 
 
 async def test_long_validation_concurrent_query(ws: WebSocketClient):

--- a/tests/websockets/test_graphql_ws.py
+++ b/tests/websockets/test_graphql_ws.py
@@ -254,7 +254,9 @@ async def test_subscription_field_error(ws: WebSocketClient):
     assert response["id"] == "invalid-field"
     assert response["payload"] == {
         "locations": [{"line": 1, "column": 16}],
-        "message": ("The subscription field 'notASubscriptionField' is not defined."),
+        "message": (
+            "Cannot query field 'notASubscriptionField' on type 'Subscription'."
+        ),
     }
 
 

--- a/tests/websockets/test_graphql_ws.py
+++ b/tests/websockets/test_graphql_ws.py
@@ -558,3 +558,26 @@ async def test_rejects_connection_params(aiohttp_app_client: HttpClient):
         # make sure the WebSocket is disconnected now
         await ws.receive(timeout=2)  # receive close
         assert ws.closed
+
+
+async def test_extensions(ws: WebSocketClient):
+    await ws.send_json(
+        {
+            "type": GQL_START,
+            "id": "demo",
+            "payload": {
+                "query": 'subscription { echo(message: "Hi") }',
+            },
+        }
+    )
+
+    response = await ws.receive_json()
+    assert response["type"] == GQL_DATA
+    assert response["id"] == "demo"
+    assert response["payload"]["data"] == {"echo": "Hi"}
+    assert response["payload"]["extensions"] == {"example": "example"}
+
+    await ws.send_json({"type": GQL_STOP, "id": "demo"})
+    response = await ws.receive_json()
+    assert response["type"] == GQL_COMPLETE
+    assert response["id"] == "demo"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Subscriptions are now executed like queries and mutations, and extension hooks are called.
Result extension hooks are called for each result yielded by the subscription

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

__NOTE:__ #2825 is an updated version of this, with a less intrusive change to the `schema` API.

## Description

the `Schema.subscribe()` is turned into an `AsyncGenerator` yielding `ExecutionResult` objects.
In case the validation of the requests results in a single result instead of a subscription,  e.g. when the inner
`graphql-core.subscribe()` does not return an iterator, a special exception is thrown, `SubscribeSingleResult` which' `value`
attribute contains the single `ExecutionResult`.

This pattern, always being a `AsyncGenerator` which aborts under certain circumstances, makes for a cleaner interface
and allows for much simpler use of context managers.  Following the pattern of `graphql-core` which either returns
an iterator __or__ an object, makes it unnecessarily tricky to implement with the Extensions context managers.

The `payload` part of the returned messages in both protocols is augmented with an `extensions` member if added by the corresponding hooks.

Tests are added to tests for result extensions.

A side effect of this change is that initial validation now happens on a worker task.  This feature was a part of a separate PR in progress, so corresponding tests are also added to verify that functionality.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

* #2097

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
