### PR TITLE
make graphql_ws test less timing-sensitive.

### DIFF
--- a/tests/websockets/test_graphql_transport_ws.py
+++ b/tests/websockets/test_graphql_transport_ws.py
@@ -787,6 +787,9 @@ async def test_rejects_connection_params_not_unset(ws_raw: WebSocketClient):
     ws.assert_reason("Invalid connection init payload")
 
 
+# timings can sometimes fail currently.  Until this test is rewritten when
+# generator based subscriptions are implemented, mark it as flaky
+@pytest.mark.flaky
 async def test_subsciption_cancel_finalization_delay(ws: WebSocketClient):
     # Test that when we cancel a subscription, the websocket isn't blocked
     # while some complex finalization takes place.

--- a/tests/websockets/test_graphql_ws.py
+++ b/tests/websockets/test_graphql_ws.py
@@ -119,13 +119,17 @@ async def test_sends_keep_alive(aiohttp_app_client: HttpClient):
         response = await ws.receive_json()
         assert response["type"] == GQL_CONNECTION_ACK
 
-        response = await ws.receive_json()
-        assert response["type"] == GQL_CONNECTION_KEEP_ALIVE
+        # we can't be sure how many keep-alives exactly we
+        # get but they should be more than one.
+        keepalive_count = 0
+        while True:
+            response = await ws.receive_json()
+            if response["type"] == GQL_CONNECTION_KEEP_ALIVE:
+                keepalive_count += 1
+            else:
+                break
+        assert keepalive_count >= 1
 
-        response = await ws.receive_json()
-        assert response["type"] == GQL_CONNECTION_KEEP_ALIVE
-
-        response = await ws.receive_json()
         assert response["type"] == GQL_DATA
         assert response["id"] == "demo"
         assert response["payload"]["data"] == {"echo": "Hi"}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
A fix to intermittent test failure in graphql_ws

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Due to timing issues on test runners, the exact number of Keepalive messages sent can vary.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
