### PR TITLE
Make StrawberryAnnotation hashable.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Make StrawberryAnnotation hashable, to make it compatible to newer versions of dacite.

--- a/strawberry/annotation.py
+++ b/strawberry/annotation.py
@@ -61,6 +61,9 @@ class StrawberryAnnotation:
 
         return self.resolve() == other.resolve()
 
+    def __hash__(self) -> int:
+        return hash(self.resolve())
+
     @staticmethod
     def from_annotation(
         annotation: object, namespace: Optional[Dict] = None

--- a/strawberry/type.py
+++ b/strawberry/type.py
@@ -148,3 +148,6 @@ class StrawberryTypeVar(StrawberryType):
             return self.type_var == other
 
         return super().__eq__(other)
+
+    def __hash__(self):
+        return hash(self.type_var)

--- a/strawberry/union.py
+++ b/strawberry/union.py
@@ -69,8 +69,7 @@ class StrawberryUnion(StrawberryType):
         return super().__eq__(other)
 
     def __hash__(self) -> int:
-        # TODO: Is this a bad idea? __eq__ objects are supposed to have the same hash
-        return id(self)
+        return hash((self.graphql_name, self.type_annotations, self.description))
 
     def __or__(self, other: Union[StrawberryType, type]) -> StrawberryType:
         if other is None:

--- a/tests/types/test_annotation.py
+++ b/tests/types/test_annotation.py
@@ -1,0 +1,42 @@
+import itertools
+from enum import Enum
+from typing import Optional, TypeVar, Union
+
+import strawberry
+from strawberry.annotation import StrawberryAnnotation
+from strawberry.unset import UnsetType
+
+
+def test_annotation_hash():
+    T = TypeVar("T")
+
+    class Bleh:
+        pass
+
+    @strawberry.enum
+    class NumaNuma(Enum):
+        MA = "ma"
+        I = "i"  # noqa: E741
+        A = "a"
+        HI = "hi"
+
+    types = [
+        int,
+        str,
+        None,
+        Optional[str],
+        UnsetType,
+        Union[int, str],
+        "int",
+        T,
+        Bleh,
+        NumaNuma,
+    ]
+    for type1, type2 in itertools.combinations_with_replacement(types, 2):
+        annotation1 = StrawberryAnnotation(type1)
+        annotation2 = StrawberryAnnotation(type2)
+        assert (
+            hash(annotation1) == hash(annotation2)
+            if annotation1 == annotation2
+            else hash(annotation1) != hash(annotation2)
+        ), "Equal type must imply equal hash"

--- a/tests/types/test_annotation.py
+++ b/tests/types/test_annotation.py
@@ -2,41 +2,49 @@ import itertools
 from enum import Enum
 from typing import Optional, TypeVar, Union
 
+import pytest
+
 import strawberry
 from strawberry.annotation import StrawberryAnnotation
 from strawberry.unset import UnsetType
 
 
-def test_annotation_hash():
-    T = TypeVar("T")
+class Bleh:
+    pass
 
-    class Bleh:
-        pass
 
-    @strawberry.enum
-    class NumaNuma(Enum):
-        MA = "ma"
-        I = "i"  # noqa: E741
-        A = "a"
-        HI = "hi"
+@strawberry.enum
+class NumaNuma(Enum):
+    MA = "ma"
+    I = "i"  # noqa: E741
+    A = "a"
+    HI = "hi"
 
-    types = [
-        int,
-        str,
-        None,
-        Optional[str],
-        UnsetType,
-        Union[int, str],
-        "int",
-        T,
-        Bleh,
-        NumaNuma,
-    ]
-    for type1, type2 in itertools.combinations_with_replacement(types, 2):
-        annotation1 = StrawberryAnnotation(type1)
-        annotation2 = StrawberryAnnotation(type2)
-        assert (
-            hash(annotation1) == hash(annotation2)
-            if annotation1 == annotation2
-            else hash(annotation1) != hash(annotation2)
-        ), "Equal type must imply equal hash"
+
+T = TypeVar("T")
+
+types = [
+    int,
+    str,
+    None,
+    Optional[str],
+    UnsetType,
+    Union[int, str],
+    "int",
+    T,
+    Bleh,
+    NumaNuma,
+]
+
+
+@pytest.mark.parametrize(
+    ("type1", "type2"), itertools.combinations_with_replacement(types, 2)
+)
+def test_annotation_hash(type1: Union[object, str], type2: Union[object, str]):
+    annotation1 = StrawberryAnnotation(type1)
+    annotation2 = StrawberryAnnotation(type2)
+    assert (
+        hash(annotation1) == hash(annotation2)
+        if annotation1 == annotation2
+        else hash(annotation1) != hash(annotation2)
+    ), "Equal type must imply equal hash"


### PR DESCRIPTION
Hi!

As mentioned in:
https://github.com/strawberry-graphql/strawberry/issues/2509
Non-hashable StrawberryAnnotations are incompatible with `dacite.from_dict` function, used to instantiate the models using dicts.
This PR makes StrawberryAnnotations hashable to fix this issue.

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/strawberry-graphql/strawberry/issues/2509

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
