### PR TITLE
Do not choke on __typename in codegen.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+codegen no longer chokes on queries that have a `__typename` in them.
+Python generated types will not have the `__typename` included in the fields.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,4 @@
 Release type: patch
 
-codegen no longer chokes on queries that have a `__typename` in them.
+In this release codegen no longer chokes on queries that have a `__typename` in them.
 Python generated types will not have the `__typename` included in the fields.

--- a/strawberry/codegen/plugins/python.py
+++ b/strawberry/codegen/plugins/python.py
@@ -110,7 +110,7 @@ class PythonPlugin(QueryCodegenPlugin):
         return f'{value} = "{value}"'
 
     def _print_object_type(self, type_: GraphQLObjectType) -> str:
-        fields = "\n".join(self._print_field(field) for field in type_.fields)
+        fields = "\n".join(self._print_field(field) for field in type_.fields if field.name != "__typename")
 
         return "\n".join(
             [

--- a/strawberry/codegen/plugins/python.py
+++ b/strawberry/codegen/plugins/python.py
@@ -110,7 +110,11 @@ class PythonPlugin(QueryCodegenPlugin):
         return f'{value} = "{value}"'
 
     def _print_object_type(self, type_: GraphQLObjectType) -> str:
-        fields = "\n".join(self._print_field(field) for field in type_.fields if field.name != "__typename")
+        fields = "\n".join(
+            self._print_field(field)
+            for field in type_.fields
+            if field.name != "__typename"
+        )
 
         return "\n".join(
             [

--- a/strawberry/codegen/query_codegen.py
+++ b/strawberry/codegen/query_codegen.py
@@ -416,6 +416,8 @@ class QueryCodegen:
     def _field_from_selection(
         self, selection: FieldNode, parent_type: TypeDefinition
     ) -> GraphQLField:
+        if selection.name.value == "__typename":
+            return GraphQLField("__typename", None, GraphQLScalar("String", None))
         field = self.schema.get_field_for_type(selection.name.value, parent_type.name)
         assert field
 

--- a/tests/codegen/queries/union_with_typename.graphql
+++ b/tests/codegen/queries/union_with_typename.graphql
@@ -1,0 +1,19 @@
+query OperationName {
+  __typename
+  union {
+    ... on Animal {
+      age
+    }
+    ... on Person {
+      name
+    }
+  }
+  optionalUnion {
+    ... on Animal {
+      age
+    }
+    ... on Person {
+      name
+    }
+  }
+}

--- a/tests/codegen/snapshots/python/union_with_typename.py
+++ b/tests/codegen/snapshots/python/union_with_typename.py
@@ -1,0 +1,21 @@
+from typing import Optional, Union
+
+class OperationNameResultUnionAnimal:
+    age: int
+
+class OperationNameResultUnionPerson:
+    name: str
+
+OperationNameResultUnion = Union[OperationNameResultUnionAnimal, OperationNameResultUnionPerson]
+
+class OperationNameResultOptionalUnionAnimal:
+    age: int
+
+class OperationNameResultOptionalUnionPerson:
+    name: str
+
+OperationNameResultOptionalUnion = Union[OperationNameResultOptionalUnionAnimal, OperationNameResultOptionalUnionPerson]
+
+class OperationNameResult:
+    union: OperationNameResultUnion
+    optional_union: Optional[OperationNameResultOptionalUnion]

--- a/tests/codegen/snapshots/typescript/union_with_typename.ts
+++ b/tests/codegen/snapshots/typescript/union_with_typename.ts
@@ -1,0 +1,25 @@
+type OperationNameResultUnionAnimal = {
+    age: number
+}
+
+type OperationNameResultUnionPerson = {
+    name: string
+}
+
+type OperationNameResultUnion = OperationNameResultUnionAnimal | OperationNameResultUnionPerson
+
+type OperationNameResultOptionalUnionAnimal = {
+    age: number
+}
+
+type OperationNameResultOptionalUnionPerson = {
+    name: string
+}
+
+type OperationNameResultOptionalUnion = OperationNameResultOptionalUnionAnimal | OperationNameResultOptionalUnionPerson
+
+type OperationNameResult = {
+    __typename: string
+    union: OperationNameResultUnion
+    optional_union: OperationNameResultOptionalUnion | undefined
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Current, `strawberry codegen` will raise an `AssertionError` if a `__typename` field is included in the query.  This change causes `__typename` to be emitted as a `GraphQLField("__typename", None, GraphQLScalar("String", None))`.  The python plugin filters this field out of the emitted objects because the leading double underscore would invoke name mangling so it probably wouldn't be terribly useful.

For now, it is include in the typescript plugin.  Custom plugins can do whatever they want (obviously)

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #2796

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
