### PR TITLE
Allow the usage of fragment directives in codegen.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,39 @@
+Release type: patch
+
+In this release codegen no longer chokes on queries that use a fragment.
+
+There is one significant limitation at the present.  When a fragment is included via the spread operator in an object, it must be the only field present.  Attempts to include more fields will result in a ``ValueError``.
+
+However, there are some real benefits.  When a fragment is included in multiple places in the query, only a single class will be made to represent that fragment:
+
+```
+fragment Point on Bar {
+   id
+   x
+   y
+}
+
+query GetPoints {
+  circlePoints {
+    ...Point
+  }
+  squarePoints {
+    ...Point
+  }
+}
+```
+
+Might generate the following types
+
+```py
+class Point:
+    id: str
+    x: float
+    y: float
+
+class GetPointsResult:
+    circle_points: List[Point]
+    square_points: List[Point]
+```
+
+The previous behavior would generate duplicate classes for for the `GetPointsCirclePoints` and `GetPointsSquarePoints` even though they are really identical classes.

--- a/strawberry/codegen/plugins/print_operation.py
+++ b/strawberry/codegen/plugins/print_operation.py
@@ -7,11 +7,15 @@ from strawberry.codegen import CodegenFile, QueryCodegenPlugin
 from strawberry.codegen.types import (
     GraphQLBoolValue,
     GraphQLEnumValue,
+    GraphQLField,
     GraphQLFieldSelection,
+    GraphQLFragmentSpread,
+    GraphQLFragmentType,
     GraphQLInlineFragment,
     GraphQLIntValue,
     GraphQLList,
     GraphQLListValue,
+    GraphQLObjectType,
     GraphQLOptional,
     GraphQLStringValue,
     GraphQLVariableReference,
@@ -32,8 +36,15 @@ class PrintOperationPlugin(QueryCodegenPlugin):
     def generate_code(
         self, types: List[GraphQLType], operation: GraphQLOperation
     ) -> List[CodegenFile]:
+        code_lines = []
+        for t in types:
+            if not isinstance(t, GraphQLFragmentType):
+                continue
+            code_lines.append(self._print_fragment(t))
+
         code = "\n".join(
             [
+                *code_lines,
                 (
                     f"{operation.kind} {operation.name}"
                     f"{self._print_operation_variables(operation)}"
@@ -44,6 +55,28 @@ class PrintOperationPlugin(QueryCodegenPlugin):
             ]
         )
         return [CodegenFile("query.graphql", code)]
+
+    def _print_fragment_field(self, field: GraphQLField, indent: str = "") -> str:
+        code_lines = []
+        if isinstance(field.type, GraphQLObjectType):
+            code_lines.append(f"{indent}{field.name} {{")
+            for subfield in field.type.fields:
+                code_lines.append(
+                    self._print_fragment_field(subfield, indent=indent + "  ")
+                )
+            code_lines.append(f"{indent}}}")
+        else:
+            code_lines.append(f"{indent}{field.name}")
+        return "\n".join(code_lines)
+
+    def _print_fragment(self, fragment: GraphQLFragmentType) -> str:
+        code_lines = []
+        code_lines.append(f"fragment {fragment.name} on {fragment.on} {{")
+        for field in fragment.fields:
+            code_lines.append(self._print_fragment_field(field, indent="  "))
+        code_lines.append("}")
+        code_lines.append("")
+        return "\n".join(code_lines)
 
     def _print_operation_variables(self, operation: GraphQLOperation) -> str:
         if not operation.variables:
@@ -143,12 +176,18 @@ class PrintOperationPlugin(QueryCodegenPlugin):
             ]
         )
 
+    def _print_fragment_spread(self, fragment: GraphQLFragmentSpread) -> str:
+        return f"...{fragment.name}"
+
     def _print_selection(self, selection: GraphQLSelection) -> str:
         if isinstance(selection, GraphQLFieldSelection):
             return self._print_field_selection(selection)
 
         if isinstance(selection, GraphQLInlineFragment):
             return self._print_inline_fragment(selection)
+
+        if isinstance(selection, GraphQLFragmentSpread):
+            return self._print_fragment_spread(selection)
 
         raise ValueError(f"Unsupported selection: {selection}")  # pragma: no cover
 

--- a/strawberry/codegen/query_codegen.py
+++ b/strawberry/codegen/query_codegen.py
@@ -18,6 +18,8 @@ from graphql import (
     BooleanValueNode,
     EnumValueNode,
     FieldNode,
+    FragmentDefinitionNode,
+    FragmentSpreadNode,
     InlineFragmentNode,
     IntValueNode,
     ListTypeNode,
@@ -51,6 +53,8 @@ from .types import (
     GraphQLEnumValue,
     GraphQLField,
     GraphQLFieldSelection,
+    GraphQLFragmentSpread,
+    GraphQLFragmentType,
     GraphQLInlineFragment,
     GraphQLIntValue,
     GraphQLList,
@@ -169,6 +173,10 @@ class QueryCodegen:
         if operation.name is None:
             raise NoOperationNameProvidedError()
 
+        # Look for any free-floating fragments and create types out of them
+        # These types can then be referenced and included later via the
+        # fragment spread operator.
+        self._populate_fragment_types(ast)
         self.operation = self._convert_operation(operation)
 
         result = self.generate_code()
@@ -181,6 +189,26 @@ class QueryCodegen:
             return
 
         self.types.append(type_)
+
+    def _populate_fragment_types(self, ast: DocumentNode) -> None:
+        fragment_definitions = (
+            definition
+            for definition in ast.definitions
+            if isinstance(definition, FragmentDefinitionNode)
+        )
+        for fd in fragment_definitions:
+            query_type = self.schema.get_type_by_name("Query")
+            assert isinstance(query_type, TypeDefinition)
+            self._collect_types(
+                # The FragmentDefinitionNode has a non-Optional `SelectionSetNode` but the Protocol
+                # wants an `Optional[SelectionSetNode]` so this doesn't quite conform.
+                cast(HasSelectionSet, fd),
+                parent_type=query_type,
+                class_name=fd.name.value,
+                graph_ql_object_type_factory=lambda name: GraphQLFragmentType(
+                    name, on=fd.type_condition.name.value
+                ),
+            )
 
     def _convert_selection(self, selection: SelectionNode) -> GraphQLSelection:
         if isinstance(selection, FieldNode):
@@ -197,6 +225,9 @@ class QueryCodegen:
                 selection.type_condition.name.value,
                 self._convert_selection_set(selection.selection_set),
             )
+
+        if isinstance(selection, FragmentSpreadNode):
+            return GraphQLFragmentSpread(selection.name.value)
 
         raise ValueError(f"Unsupported type: {type(selection)}")  # pragma: no cover
 
@@ -525,6 +556,9 @@ class QueryCodegen:
         selection: HasSelectionSet,
         parent_type: TypeDefinition,
         class_name: str,
+        graph_ql_object_type_factory: Callable[
+            [str], GraphQLObjectType
+        ] = GraphQLObjectType,
     ) -> GraphQLType:
         assert selection.selection_set is not None
         selection_set = selection.selection_set
@@ -537,14 +571,32 @@ class QueryCodegen:
                 selection, parent_type, class_name
             )
 
-        current_type = GraphQLObjectType(class_name, [])
+        current_type = graph_ql_object_type_factory(class_name)
+        fields: List[Union[GraphQLFragmentSpread, GraphQLField]] = []
 
         for sub_selection in selection_set.selections:
+            if isinstance(sub_selection, FragmentSpreadNode):
+                fields.append(GraphQLFragmentSpread(sub_selection.name.value))
+                continue
             assert isinstance(sub_selection, FieldNode)
-
             field = self._get_field(sub_selection, class_name, parent_type)
 
-            current_type.fields.append(field)
+            fields.append(field)
+
+        if any(isinstance(f, GraphQLFragmentSpread) for f in fields):
+            if len(fields) > 1:
+                raise ValueError(
+                    "Queries with Fragments cannot currently include separate fields."
+                )
+            spread_field = fields[0]
+            assert isinstance(spread_field, GraphQLFragmentSpread)
+            return next(
+                t
+                for t in self.types
+                if isinstance(t, GraphQLObjectType) and t.name == spread_field.name
+            )
+
+        current_type.fields = cast(List[GraphQLField], fields)
 
         self._collect_type(current_type)
 

--- a/strawberry/codegen/types.py
+++ b/strawberry/codegen/types.py
@@ -53,7 +53,9 @@ class GraphQLFragmentType(GraphQLObjectType):
 
     def __post_init__(self) -> None:
         if not self.on:
-            raise ValueError("GraphQLFragmentType must be constructed with a valid 'on'")
+            raise ValueError(
+                "GraphQLFragmentType must be constructed with a valid 'on'"
+            )
 
 
 @dataclass

--- a/strawberry/codegen/types.py
+++ b/strawberry/codegen/types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, List, Optional, Type, Union
 
 if TYPE_CHECKING:
@@ -32,9 +32,28 @@ class GraphQLField:
 
 
 @dataclass
+class GraphQLFragmentSpread:
+    name: str
+
+
+@dataclass
 class GraphQLObjectType:
     name: str
-    fields: List[GraphQLField]
+    fields: List[GraphQLField] = field(default_factory=list)
+
+
+# Subtype of GraphQLObjectType.
+# Because dataclass inheritance is a little odd, the fields are
+# repeated here.
+@dataclass
+class GraphQLFragmentType(GraphQLObjectType):
+    name: str
+    fields: List[GraphQLField] = field(default_factory=list)
+    on: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.on:
+            raise ValueError("GraphQLFragmentType must be constructed with a valid 'on'")
 
 
 @dataclass
@@ -75,7 +94,9 @@ class GraphQLInlineFragment:
     selections: List[GraphQLSelection]
 
 
-GraphQLSelection = Union[GraphQLFieldSelection, GraphQLInlineFragment]
+GraphQLSelection = Union[
+    GraphQLFieldSelection, GraphQLInlineFragment, GraphQLFragmentSpread
+]
 
 
 @dataclass

--- a/tests/codegen/queries/fragment.graphql
+++ b/tests/codegen/queries/fragment.graphql
@@ -1,0 +1,18 @@
+fragment Fields on Query {
+  id
+  integer
+  float
+  boolean
+  uuid
+  date
+  datetime
+  time
+  decimal
+  lazy {
+    something
+  }
+}
+
+query OperationName {
+  ...Fields
+}

--- a/tests/codegen/queries/mutation-fragment.graphql
+++ b/tests/codegen/queries/mutation-fragment.graphql
@@ -1,0 +1,9 @@
+fragment IdFragment on BlogPost {
+  id
+}
+
+mutation addBook($input: String!) {
+  addBook(input: $input) {
+    ...IdFragment
+  }
+}

--- a/tests/codegen/snapshots/python/fragment.py
+++ b/tests/codegen/snapshots/python/fragment.py
@@ -1,0 +1,18 @@
+from uuid import UUID
+from datetime import date, datetime, time
+from decimal import Decimal
+
+class FieldsLazy:
+    something: bool
+
+class Fields:
+    id: str
+    integer: int
+    float: float
+    boolean: bool
+    uuid: UUID
+    date: date
+    datetime: datetime
+    time: time
+    decimal: Decimal
+    lazy: FieldsLazy

--- a/tests/codegen/snapshots/python/mutation-fragment.py
+++ b/tests/codegen/snapshots/python/mutation-fragment.py
@@ -1,0 +1,8 @@
+class IdFragment:
+    id: str
+
+class addBookResult:
+    add_book: IdFragment
+
+class addBookVariables:
+    input: str

--- a/tests/codegen/snapshots/typescript/fragment.ts
+++ b/tests/codegen/snapshots/typescript/fragment.ts
@@ -1,0 +1,16 @@
+type FieldsLazy = {
+    something: boolean
+}
+
+type Fields = {
+    id: string
+    integer: number
+    float: number
+    boolean: boolean
+    uuid: string
+    date: string
+    datetime: string
+    time: string
+    decimal: string
+    lazy: FieldsLazy
+}

--- a/tests/codegen/snapshots/typescript/mutation-fragment.ts
+++ b/tests/codegen/snapshots/typescript/mutation-fragment.ts
@@ -1,0 +1,11 @@
+type IdFragment = {
+    id: string
+}
+
+type addBookResult = {
+    add_book: IdFragment
+}
+
+type addBookVariables = {
+    input: string
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This PR enables the use of non-inline `fragment` in client generation.

The limitations/behaviors so far are that:

* fragments can only be included by themselves (they cannot be used with other fields)
* fragments are emitted as new types in the generated types files and they replace the types that would have been generated in that position otherwise.

See the associated issue for more details.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* fixes #2801

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
