### PR TITLE
Fix GraphiQL Explorer Plugin styling and update GraphiQL to the latest 2.4.7 version

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+This release updates the built-in GraphiQL to the current latest version 2.4.7 and improves styling for the GraphiQL Explorer Plugin.

--- a/strawberry/static/graphiql.html
+++ b/strawberry/static/graphiql.html
@@ -54,15 +54,15 @@
 
     <script
       crossorigin
-      src="https://unpkg.com/js-cookie@3.0.1/dist/js.cookie.min.js"
-      integrity="sha384-ETDm/j6COkRSUfVFsGNM5WYE4WjyRgfDhy4Pf4Fsc8eNw/eYEMqYZWuxTzMX6FBa"
+      src="https://unpkg.com/js-cookie@3.0.5/dist/js.cookie.min.js"
+      integrity="sha384-/vxhYfM1LENRhdpZ8dwEsQn/X4VhpbEZSiU4m/FwR+PVpzar4fkEOw8FP9Y+OfQN"
     ></script>
 
     <link
       crossorigin
       rel="stylesheet"
-      href="https://unpkg.com/graphiql@2.2.0/graphiql.min.css"
-      integrity="sha384-4a2fCKkum7OnFcO9Qae5NAO7bYHTeolCix2FOnzhz8L42NP6+2Q1cTH7p/xr4Pfg"
+      href="https://unpkg.com/graphiql@2.4.7/graphiql.min.css"
+      integrity="sha384-486GcFFVcFN0yj7LIp/vn7DVsuf2CTytJlNuqjHg0zF2g72zra2gWCNV2HBxJgC6"
     />
   </head>
 
@@ -70,13 +70,13 @@
     <div id="graphiql" class="graphiql-container">Loading...</div>
     <script
       crossorigin
-      src="https://unpkg.com/graphiql@2.2.0/graphiql.min.js"
-      integrity="sha384-JHFGCFTH/jUGV6uL38eHuw/3kb0aUiF0EzWPP68NQxvz7ldZXEoCv9RBGtsFHM86"
+      src="https://unpkg.com/graphiql@2.4.7/graphiql.min.js"
+      integrity="sha384-8da92RVD56z/pbOOnJ4Ud5qlhqEzDtJI6qVZjN88SCbOatpo4xVDeP3T0nmfTf+9"
     ></script>
     <script
       crossorigin
-      src="https://unpkg.com/@graphiql/plugin-explorer@0.1.0/dist/graphiql-plugin-explorer.umd.js"
-      integrity="sha384-XyAmNqmxnLsRHkMhQYTqC0ub7uXpNbwdkhjn70ZF3J3XSb7bouSdRVfzDojimcMd"
+      src="https://unpkg.com/@graphiql/plugin-explorer@0.1.15/dist/graphiql-plugin-explorer.umd.js"
+      integrity="sha384-730PslzMVMN3EMJOKuh/WVRaRwhaBbWE43IOXyR+DMDlQiYx0BjiPmoPZ+6qEa0C"
     ></script>
     <script>
       const EXAMPLE_QUERY = `# Welcome to GraphiQL 🍓

--- a/strawberry/static/graphiql.html
+++ b/strawberry/static/graphiql.html
@@ -64,6 +64,13 @@
       href="https://unpkg.com/graphiql@2.4.7/graphiql.min.css"
       integrity="sha384-486GcFFVcFN0yj7LIp/vn7DVsuf2CTytJlNuqjHg0zF2g72zra2gWCNV2HBxJgC6"
     />
+
+    <link
+      crossorigin
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/@graphiql/plugin-explorer@0.1.15/dist/style.css"
+      integrity="sha384-kOrlMT58B3t0hTVIPFqWyg1oL4DKvxHNcC1X2qugv4fXd9ehKULhhjDLvBi3HoEK"
+    />
   </head>
 
   <body>


### PR DESCRIPTION
## Description

- Update GraphiQL to the latest 2.4.7 version
- Improve the styling for GraphiQL Explorer Plugin by including the CSS that comes with it
- Also fix the pre-commit errors produced in #2802

Before
<img width="430" alt="Screenshot 2023-06-02 at 4 12 01 AM" src="https://github.com/strawberry-graphql/strawberry/assets/6521018/da9c1ef2-9658-4d02-b1ce-746c360127e9">

After
<img width="426" alt="Screenshot 2023-06-02 at 4 11 01 AM" src="https://github.com/strawberry-graphql/strawberry/assets/6521018/be7ec691-939b-4d67-8b8c-0b362de6329d">

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
