### PR TITLE
Fields copy their directives.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Fields with generics support directives.

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -331,6 +331,7 @@ class StrawberryField(dataclasses.Field):
             # ignored because of https://github.com/python/mypy/issues/6910
             default_factory=self.default_factory,
             deprecation_reason=self.deprecation_reason,
+            directives=self.directives,
         )
 
     @property

--- a/tests/objects/generics/test_generic_objects.py
+++ b/tests/objects/generics/test_generic_objects.py
@@ -11,9 +11,11 @@ T = TypeVar("T")
 
 
 def test_basic_generic():
+    directive = object()
+
     @strawberry.type
     class Edge(Generic[T]):
-        node_field: T
+        node_field: T = strawberry.field(directives=[directive])
 
     definition = Edge._type_definition
     assert definition.is_generic
@@ -35,6 +37,7 @@ def test_basic_generic():
     [field_copy] = definition_copy.fields
     assert field_copy.python_name == "node_field"
     assert field_copy.type is str
+    assert field_copy.directives == [directive]
 
 
 def test_generics_nested():


### PR DESCRIPTION
## Description
Directives were omitted in the `copy_with` operation, affecting fields with generics.

## Types of Changes
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #2641

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
