### PR TITLE
Fix codegen missing fields

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,8 @@
+Release type: patch
+
+This release fixes a codegen bug.  Prior to this fix,
+inline fragments would only include the last field defined
+within its scope and all fields common with its siblings.
+
+After this fix, all fields will be included in the
+generated types.

--- a/strawberry/codegen/query_codegen.py
+++ b/strawberry/codegen/query_codegen.py
@@ -504,7 +504,9 @@ class QueryCodegen:
         selected_field = self.schema.get_field_for_type(
             selection.name.value, parent_type.name
         )
-        assert selected_field
+        assert (
+            selected_field
+        ), f"Couldn't find {parent_type.name}.{selection.name.value}"
 
         selected_field_type, wrapper = self._unwrap_type(selected_field.type)
         name = capitalize_first(to_camel_case(selection.name.value))

--- a/strawberry/codegen/query_codegen.py
+++ b/strawberry/codegen/query_codegen.py
@@ -640,13 +640,12 @@ class QueryCodegen:
 
         for fragment in fragments:
             fragment_class_name = class_name + fragment.type_condition.name.value
-            current_type = GraphQLObjectType(fragment_class_name, [])
+
+            current_type = GraphQLObjectType(fragment_class_name, list(common_fields))
 
             for sub_selection in fragment.selection_set.selections:
                 # TODO: recurse, use existing method ?
                 assert isinstance(sub_selection, FieldNode)
-
-                current_type.fields = list(common_fields)
 
                 parent_type = cast(
                     TypeDefinition,

--- a/tests/codegen/conftest.py
+++ b/tests/codegen/conftest.py
@@ -104,7 +104,7 @@ class Query:
     @strawberry.field
     def get_person_or_animal(self) -> Union[Person, Animal]:
         """Randomly get a person or an animal."""
-        p_or_a = random.choice([Person, Animal])()
+        p_or_a = random.choice([Person, Animal])()  # noqa: S311
         p_or_a.name = "Howard"
         p_or_a.age = 7
         return p_or_a

--- a/tests/codegen/conftest.py
+++ b/tests/codegen/conftest.py
@@ -1,7 +1,8 @@
 import datetime
 import decimal
 import enum
-from typing import TYPE_CHECKING, List, NewType, Optional
+import random
+from typing import TYPE_CHECKING, List, NewType, Optional, Union
 from typing_extensions import Annotated
 from uuid import UUID
 
@@ -99,6 +100,14 @@ class Query:
     @strawberry.field
     def with_inputs(self, id: Optional[strawberry.ID], input: ExampleInput) -> bool:
         return True
+
+    @strawberry.field
+    def get_person_or_animal(self) -> Union[Person, Animal]:
+        """Randomly get a person or an animal."""
+        p_or_a = random.choice([Person, Animal])()
+        p_or_a.name = "Howard"
+        p_or_a.age = 7
+        return p_or_a
 
 
 @strawberry.type

--- a/tests/codegen/queries/union_return.graphql
+++ b/tests/codegen/queries/union_return.graphql
@@ -1,0 +1,8 @@
+query OperationName {
+  getPersonOrAnimal {
+    ... on Person {
+      name
+      age
+    }
+  }
+}

--- a/tests/codegen/queries/union_with_one_type.graphql
+++ b/tests/codegen/queries/union_with_one_type.graphql
@@ -2,6 +2,7 @@ query OperationName {
   union {
     ... on Animal {
       age
+      name
     }
   }
 }

--- a/tests/codegen/snapshots/python/union_return.py
+++ b/tests/codegen/snapshots/python/union_return.py
@@ -1,0 +1,5 @@
+class OperationNameResultGetPersonOrAnimalPerson:
+    age: int
+
+class OperationNameResult:
+    get_person_or_animal: OperationNameResultGetPersonOrAnimalPerson

--- a/tests/codegen/snapshots/python/union_return.py
+++ b/tests/codegen/snapshots/python/union_return.py
@@ -1,4 +1,5 @@
 class OperationNameResultGetPersonOrAnimalPerson:
+    name: str
     age: int
 
 class OperationNameResult:

--- a/tests/codegen/snapshots/python/union_with_one_type.py
+++ b/tests/codegen/snapshots/python/union_with_one_type.py
@@ -1,4 +1,5 @@
 class OperationNameResultUnionAnimal:
+    age: int
     name: str
 
 class OperationNameResult:

--- a/tests/codegen/snapshots/python/union_with_one_type.py
+++ b/tests/codegen/snapshots/python/union_with_one_type.py
@@ -1,5 +1,5 @@
 class OperationNameResultUnionAnimal:
-    age: int
+    name: str
 
 class OperationNameResult:
     union: OperationNameResultUnionAnimal

--- a/tests/codegen/snapshots/typescript/union_return.ts
+++ b/tests/codegen/snapshots/typescript/union_return.ts
@@ -1,4 +1,5 @@
 type OperationNameResultGetPersonOrAnimalPerson = {
+    name: string
     age: number
 }
 

--- a/tests/codegen/snapshots/typescript/union_return.ts
+++ b/tests/codegen/snapshots/typescript/union_return.ts
@@ -1,0 +1,7 @@
+type OperationNameResultGetPersonOrAnimalPerson = {
+    age: number
+}
+
+type OperationNameResult = {
+    get_person_or_animal: OperationNameResultGetPersonOrAnimalPerson
+}

--- a/tests/codegen/snapshots/typescript/union_with_one_type.ts
+++ b/tests/codegen/snapshots/typescript/union_with_one_type.ts
@@ -1,5 +1,5 @@
 type OperationNameResultUnionAnimal = {
-    age: number
+    name: string
 }
 
 type OperationNameResult = {

--- a/tests/codegen/snapshots/typescript/union_with_one_type.ts
+++ b/tests/codegen/snapshots/typescript/union_with_one_type.ts
@@ -1,4 +1,5 @@
 type OperationNameResultUnionAnimal = {
+    age: number
     name: string
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

When we want to add a field to an inline fragment `GraphQLObjectType` (e.g. `current_type`), the first thing we do is set the `current_type.fields` to a list that contains the common-types between _this_ inline fragment and any sibling inline fragments.  This has the effect of stomping on any fields which have already been added and only the last field makes it into the result `GraphQLObjectType`.

Instead, we should just add the common fields in the beginning before adding any additional fields and then we don't ever need to do it again.

It's still important that we make a copy of the list in the `GraphQLObjectType` construction to make sure that we aren't sharing that list between multiple `GraphQLObjectType`.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fix #2818

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
