### PR TITLE
fix: use ast to parse lazy types using forward refs to cover some corner cases

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,20 @@
+Release type: patch
+
+This release fixes an issue for parsing lazy types using forward references
+when they were enclosed in an `Optional[...]` type.
+
+The following now should work properly:
+
+```python
+from __future__ import annotations
+
+from typing import Optional, Annotated
+import strawberry
+
+
+@strawberry.type
+class MyType:
+    other_type: Optional[Annotated["OtherType", strawberry.lazy("some.module")]]
+    # or like this
+    other_type: Annotated["OtherType", strawberry.lazy("some.module")] | None
+```

--- a/strawberry/utils/typing.py
+++ b/strawberry/utils/typing.py
@@ -222,7 +222,7 @@ def _ast_replace_union_operation(
     return expr
 
 
-def _ast_extra_ns(
+def _get_namespace_from_ast(
     expr: Union[ast.Expr, ast.expr],
     globalns: Optional[Dict] = None,
     localns: Optional[Dict] = None,
@@ -234,10 +234,10 @@ def _ast_extra_ns(
     if isinstance(expr, ast.Expr) and isinstance(
         expr.value, (ast.BinOp, ast.Subscript)
     ):
-        extra.update(_ast_extra_ns(expr.value, globalns, localns))
+        extra.update(_get_namespace_from_ast(expr.value, globalns, localns))
     elif isinstance(expr, ast.BinOp):
         for elt in (expr.left, expr.right):
-            extra.update(_ast_extra_ns(elt, globalns, localns))
+            extra.update(_get_namespace_from_ast(elt, globalns, localns))
     elif (
         isinstance(expr, ast.Subscript)
         and isinstance(expr.value, ast.Name)
@@ -250,7 +250,7 @@ def _ast_extra_ns(
             expr_slice = expr.slice
 
         for elt in cast(ast.Tuple, expr_slice).elts:
-            extra.update(_ast_extra_ns(elt, globalns, localns))
+            extra.update(_get_namespace_from_ast(elt, globalns, localns))
     elif (
         isinstance(expr, ast.Subscript)
         and isinstance(expr.value, ast.Name)
@@ -266,7 +266,7 @@ def _ast_extra_ns(
 
         args: List[str] = []
         for elt in cast(ast.Tuple, expr_slice).elts:
-            extra.update(_ast_extra_ns(elt, globalns, localns))
+            extra.update(_get_namespace_from_ast(elt, globalns, localns))
             args.append(ast_unparse(elt))
 
         # When using forward refs, the whole
@@ -309,7 +309,7 @@ def eval_type(
             if "Union" not in globalns:
                 globalns["Union"] = Union
 
-        globalns.update(_ast_extra_ns(ast_obj, globalns, localns))
+        globalns.update(_get_namespace_from_ast(ast_obj, globalns, localns))
 
         assert ast_unparse
         type_ = ForwardRef(ast_unparse(ast_obj))

--- a/strawberry/utils/typing.py
+++ b/strawberry/utils/typing.py
@@ -270,7 +270,7 @@ def _ast_extra_ns(
             args.append(ast_unparse(elt))
 
         # When using forward refs, the whole
-        # Annotated[SomeType, strabwerry.lazy("type.module")] is a forward ref,
+        # Annotated[SomeType, strawberry.lazy("type.module")] is a forward ref,
         # and trying to _eval_type on it will fail. Take a different approach
         # here to resolve lazy types by execing the annotated args, resolving the
         # type directly and then adding it to extra namespace, so that _eval_type

--- a/strawberry/utils/typing.py
+++ b/strawberry/utils/typing.py
@@ -243,7 +243,13 @@ def _ast_extra_ns(
         and isinstance(expr.value, ast.Name)
         and expr.value.id == "Union"
     ):
-        for elt in cast(ast.Tuple, expr.slice).elts:
+        if hasattr(ast, "Index") and isinstance(expr.slice, ast.Index):
+            # The cast is required for mypy on python 3.7 and 3.8
+            expr_slice = cast(Any, expr.slice).value
+        else:
+            expr_slice = expr.slice
+
+        for elt in cast(ast.Tuple, expr_slice).elts:
             extra.update(_ast_extra_ns(elt, globalns, localns))
     elif (
         isinstance(expr, ast.Subscript)
@@ -252,8 +258,14 @@ def _ast_extra_ns(
     ):
         assert ast_unparse
 
+        if hasattr(ast, "Index") and isinstance(expr.slice, ast.Index):
+            # The cast is required for mypy on python 3.7 and 3.8
+            expr_slice = cast(Any, expr.slice).value
+        else:
+            expr_slice = expr.slice
+
         args: List[str] = []
-        for elt in cast(ast.Tuple, expr.slice).elts:
+        for elt in cast(ast.Tuple, expr_slice).elts:
             extra.update(_ast_extra_ns(elt, globalns, localns))
             args.append(ast_unparse(elt))
 

--- a/tests/a.py
+++ b/tests/a.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 from typing_extensions import Annotated
 
 import strawberry
@@ -15,6 +15,18 @@ class A:
 
     @strawberry.field
     async def b(self) -> Annotated[B, strawberry.lazy("tests.b")]:
+        from tests.b import B
+
+        return B(id=self.id)
+
+    @strawberry.field
+    async def optional_b(self) -> Annotated[B, strawberry.lazy("tests.b")] | None:
+        from tests.b import B
+
+        return B(id=self.id)
+
+    @strawberry.field
+    async def optional_b2(self) -> Optional[Annotated[B, strawberry.lazy("tests.b")]]:
         from tests.b import B
 
         return B(id=self.id)

--- a/tests/b.py
+++ b/tests/b.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 from typing_extensions import Annotated
 
 import strawberry
@@ -15,6 +15,22 @@ class B:
 
     @strawberry.field
     async def a(self) -> Annotated[A, strawberry.lazy("tests.a"), object()]:
+        from tests.a import A
+
+        return A(id=self.id)
+
+    @strawberry.field
+    async def optional_a(
+        self,
+    ) -> Annotated[A, strawberry.lazy("tests.a"), object()] | None:
+        from tests.a import A
+
+        return A(id=self.id)
+
+    @strawberry.field
+    async def optional_a2(
+        self,
+    ) -> Optional[Annotated[A, strawberry.lazy("tests.a"), object()]]:
         from tests.a import A
 
         return A(id=self.id)

--- a/tests/test_forward_references.py
+++ b/tests/test_forward_references.py
@@ -67,11 +67,15 @@ def test_lazy_forward_reference():
     type A {
       id: ID!
       b: B!
+      optionalB: B
+      optionalB2: B
     }
 
     type B {
       id: ID!
       a: A!
+      optionalA: A
+      optionalA2: A
     }
 
     type Query {


### PR DESCRIPTION
Using regexp is simple, but there are a lot of corner cases that it
cannot resolve easily.

This changes the approach to use ast to parse annotations and then
add the resolved type to the global namespace, allowing the `_eval_type`
function to properly handle those corner cases for us.
