### PR TITLE
Fix duplicated type when using generics and lazy types

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,8 @@
+Release type: patch
+
+This release fixes an issue where Strawberry would make copies
+of types that were using specialized generics that were not
+Strawerry types.
+
+This issue combined with the use of lazy types was resulting
+in duplicated type errors.

--- a/strawberry/types/types.py
+++ b/strawberry/types/types.py
@@ -16,7 +16,6 @@ from typing import (
 from typing_extensions import Self
 
 from strawberry.type import StrawberryType, StrawberryTypeVar
-from strawberry.utils.inspect import get_specialized_type_var_map
 from strawberry.utils.typing import is_generic as is_type_generic
 
 if TYPE_CHECKING:
@@ -116,12 +115,7 @@ class TypeDefinition(StrawberryType):
 
     @property
     def is_specialized_generic(self) -> bool:
-        if not self.is_generic:
-            return False
-
-        type_var_map = get_specialized_type_var_map(self.origin)
-
-        return not type_var_map and not getattr(self.origin, "__parameters__", None)
+        return self.is_generic and not getattr(self.origin, "__parameters__", None)
 
     @property
     def type_params(self) -> List[TypeVar]:

--- a/strawberry/types/types.py
+++ b/strawberry/types/types.py
@@ -119,10 +119,9 @@ class TypeDefinition(StrawberryType):
         if not self.is_generic:
             return False
 
-        type_var_map = get_specialized_type_var_map(self.origin, include_type_vars=True)
-        return type_var_map is None or not any(
-            isinstance(arg, TypeVar) for arg in type_var_map.values()
-        )
+        type_var_map = get_specialized_type_var_map(self.origin)
+
+        return not type_var_map and not getattr(self.origin, "__parameters__", None)
 
     @property
     def type_params(self) -> List[TypeVar]:

--- a/strawberry/utils/inspect.py
+++ b/strawberry/utils/inspect.py
@@ -1,7 +1,17 @@
 import asyncio
 import inspect
 from functools import lru_cache
-from typing import Any, Callable, Dict, List, Optional, TypeVar, Union, overload
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    TypeVar,
+    Union,
+    _GenericAlias,
+    overload,
+)
 from typing_extensions import Literal, get_args
 
 
@@ -104,7 +114,13 @@ def get_specialized_type_var_map(cls: type, *, include_type_vars: bool = False):
 
     type_var_map = {}
 
-    orig_bases = [b for b in orig_bases if hasattr(b, "_type_definition")]
+    # only get type vars for base generics (ie. Generic[T]) and for strawberry types
+
+    orig_bases = [
+        b
+        for b in orig_bases
+        if hasattr(b, "_type_definition") or type(b) is _GenericAlias
+    ]
 
     for base in orig_bases:
         # Recursively get type var map from base classes

--- a/strawberry/utils/inspect.py
+++ b/strawberry/utils/inspect.py
@@ -1,7 +1,7 @@
 import asyncio
 import inspect
 from functools import lru_cache
-from typing import (  # type: ignore
+from typing import (
     Any,
     Callable,
     Dict,

--- a/strawberry/utils/inspect.py
+++ b/strawberry/utils/inspect.py
@@ -104,6 +104,8 @@ def get_specialized_type_var_map(cls: type, *, include_type_vars: bool = False):
 
     type_var_map = {}
 
+    orig_bases = [b for b in orig_bases if hasattr(b, "_type_definition")]
+
     for base in orig_bases:
         # Recursively get type var map from base classes
         base_type_var_map = get_specialized_type_var_map(base)

--- a/tests/schema/test_lazy/test_lazy_generic.py
+++ b/tests/schema/test_lazy/test_lazy_generic.py
@@ -162,3 +162,27 @@ def test_lazy_types_declared_within_optional():
     ).strip()
 
     assert str(schema) == expected_schema
+
+
+def test_lazy_with_already_specialized_generic():
+    from tests.schema.test_lazy.type_d import Query
+
+    schema = strawberry.Schema(query=Query)
+    expected_schema = textwrap.dedent(
+        """
+        type Query {
+          normalEdges: [TypeCOptionalEdge!]!
+          lazyEdges: [TypeCOptionalEdge!]!
+        }
+
+        type TypeC {
+          name: String!
+        }
+
+        type TypeCOptionalEdge {
+          node: TypeC
+        }
+        """
+    ).strip()
+
+    assert str(schema) == expected_schema

--- a/tests/schema/test_lazy/test_lazy_generic.py
+++ b/tests/schema/test_lazy/test_lazy_generic.py
@@ -171,16 +171,12 @@ def test_lazy_with_already_specialized_generic():
     expected_schema = textwrap.dedent(
         """
         type Query {
-          normalEdges: [TypeCOptionalEdge!]!
-          lazyEdges: [TypeCOptionalEdge!]!
+          typeD1: TypeD!
+          typeD: TypeD!
         }
 
-        type TypeC {
+        type TypeD {
           name: String!
-        }
-
-        type TypeCOptionalEdge {
-          node: TypeC
         }
         """
     ).strip()

--- a/tests/schema/test_lazy/type_d.py
+++ b/tests/schema/test_lazy/type_d.py
@@ -1,0 +1,27 @@
+import sys
+from typing import Generic, TypeVar
+from typing_extensions import Annotated
+
+import strawberry
+
+T = TypeVar("T")
+
+
+class Mixin(Generic[T]):
+    node: T
+
+
+@strawberry.type
+class TypeD(Mixin[int]):
+    name: str
+
+
+@strawberry.type
+class Query:
+    type_d_1: TypeD
+    type_d: Annotated["TypeD", strawberry.lazy("tests.schema.test_lazy.type_d")]
+
+
+if __name__ == "__main__":
+    schema = strawberry.Schema(query=Query)
+    sys.stdout.write(f"{schema.as_str()}\n")

--- a/tests/utils/test_inspect.py
+++ b/tests/utils/test_inspect.py
@@ -20,11 +20,9 @@ def test_get_specialized_type_var_map_generic_not_specialized():
         ...
 
     assert get_specialized_type_var_map(Foo) == {}
-    assert get_specialized_type_var_map(Foo, include_type_vars=True) == {_T: _T}
 
 
-@pytest.mark.parametrize("include_type_vars", [True, False])
-def test_get_specialized_type_var_map_generic(include_type_vars: bool):
+def test_get_specialized_type_var_map_generic():
     @strawberry.type
     class Foo(Generic[_T]):
         ...
@@ -33,13 +31,10 @@ def test_get_specialized_type_var_map_generic(include_type_vars: bool):
     class Bar(Foo[int]):
         ...
 
-    assert get_specialized_type_var_map(Bar, include_type_vars=include_type_vars) == {
-        _T: int
-    }
+    assert get_specialized_type_var_map(Bar) == {_T: int}
 
 
-@pytest.mark.parametrize("include_type_vars", [True, False])
-def test_get_specialized_type_var_map_generic_subclass(include_type_vars: bool):
+def test_get_specialized_type_var_map_generic_subclass():
     @strawberry.type
     class Foo(Generic[_T]):
         ...
@@ -52,13 +47,10 @@ def test_get_specialized_type_var_map_generic_subclass(include_type_vars: bool):
     class BarSubclass(Bar):
         ...
 
-    assert get_specialized_type_var_map(
-        BarSubclass, include_type_vars=include_type_vars
-    ) == {_T: int}
+    assert get_specialized_type_var_map(BarSubclass) == {_T: int}
 
 
-@pytest.mark.parametrize("include_type_vars", [True, False])
-def test_get_specialized_type_var_map_double_generic(include_type_vars: bool):
+def test_get_specialized_type_var_map_double_generic():
     @strawberry.type
     class Foo(Generic[_T]):
         ...
@@ -71,13 +63,10 @@ def test_get_specialized_type_var_map_double_generic(include_type_vars: bool):
     class Bin(Bar[int]):
         ...
 
-    assert get_specialized_type_var_map(Bin, include_type_vars=include_type_vars) == {
-        _T: int
-    }
+    assert get_specialized_type_var_map(Bin) == {_T: int}
 
 
-@pytest.mark.parametrize("include_type_vars", [True, False])
-def test_get_specialized_type_var_map_double_generic_subclass(include_type_vars: bool):
+def test_get_specialized_type_var_map_double_generic_subclass():
     @strawberry.type
     class Foo(Generic[_T]):
         ...
@@ -94,13 +83,10 @@ def test_get_specialized_type_var_map_double_generic_subclass(include_type_vars:
     class BinSubclass(Bin):
         ...
 
-    assert get_specialized_type_var_map(Bin, include_type_vars=include_type_vars) == {
-        _T: int
-    }
+    assert get_specialized_type_var_map(Bin) == {_T: int}
 
 
-@pytest.mark.parametrize("include_type_vars", [True, False])
-def test_get_specialized_type_var_map_multiple_inheritance(include_type_vars: bool):
+def test_get_specialized_type_var_map_multiple_inheritance():
     @strawberry.type
     class Foo(Generic[_T]):
         ...
@@ -117,16 +103,13 @@ def test_get_specialized_type_var_map_multiple_inheritance(include_type_vars: bo
     class Baz(Bin, Bar[str]):
         ...
 
-    assert get_specialized_type_var_map(Baz, include_type_vars=include_type_vars) == {
+    assert get_specialized_type_var_map(Baz) == {
         _T: int,
         _K: str,
     }
 
 
-@pytest.mark.parametrize("include_type_vars", [True, False])
-def test_get_specialized_type_var_map_multiple_inheritance_subclass(
-    include_type_vars: bool,
-):
+def test_get_specialized_type_var_map_multiple_inheritance_subclass():
     @strawberry.type
     class Foo(Generic[_T]):
         ...
@@ -147,9 +130,7 @@ def test_get_specialized_type_var_map_multiple_inheritance_subclass(
     class BazSubclass(Baz):
         ...
 
-    assert get_specialized_type_var_map(
-        BazSubclass, include_type_vars=include_type_vars
-    ) == {
+    assert get_specialized_type_var_map(BazSubclass) == {
         _T: int,
         _K: str,
     }

--- a/tests/utils/test_inspect.py
+++ b/tests/utils/test_inspect.py
@@ -2,6 +2,7 @@ from typing import Generic, TypeVar
 
 import pytest
 
+import strawberry
 from strawberry.utils.inspect import get_specialized_type_var_map
 
 _T = TypeVar("_T")
@@ -14,6 +15,7 @@ def test_get_specialized_type_var_map_non_generic(value: type):
 
 
 def test_get_specialized_type_var_map_generic_not_specialized():
+    @strawberry.type
     class Foo(Generic[_T]):
         ...
 
@@ -23,9 +25,11 @@ def test_get_specialized_type_var_map_generic_not_specialized():
 
 @pytest.mark.parametrize("include_type_vars", [True, False])
 def test_get_specialized_type_var_map_generic(include_type_vars: bool):
+    @strawberry.type
     class Foo(Generic[_T]):
         ...
 
+    @strawberry.type
     class Bar(Foo[int]):
         ...
 
@@ -36,12 +40,15 @@ def test_get_specialized_type_var_map_generic(include_type_vars: bool):
 
 @pytest.mark.parametrize("include_type_vars", [True, False])
 def test_get_specialized_type_var_map_generic_subclass(include_type_vars: bool):
+    @strawberry.type
     class Foo(Generic[_T]):
         ...
 
+    @strawberry.type
     class Bar(Foo[int]):
         ...
 
+    @strawberry.type
     class BarSubclass(Bar):
         ...
 
@@ -52,12 +59,15 @@ def test_get_specialized_type_var_map_generic_subclass(include_type_vars: bool):
 
 @pytest.mark.parametrize("include_type_vars", [True, False])
 def test_get_specialized_type_var_map_double_generic(include_type_vars: bool):
+    @strawberry.type
     class Foo(Generic[_T]):
         ...
 
+    @strawberry.type
     class Bar(Foo[_T]):
         ...
 
+    @strawberry.type
     class Bin(Bar[int]):
         ...
 
@@ -68,15 +78,19 @@ def test_get_specialized_type_var_map_double_generic(include_type_vars: bool):
 
 @pytest.mark.parametrize("include_type_vars", [True, False])
 def test_get_specialized_type_var_map_double_generic_subclass(include_type_vars: bool):
+    @strawberry.type
     class Foo(Generic[_T]):
         ...
 
+    @strawberry.type
     class Bar(Foo[_T]):
         ...
 
+    @strawberry.type
     class Bin(Bar[int]):
         ...
 
+    @strawberry.type
     class BinSubclass(Bin):
         ...
 
@@ -87,15 +101,19 @@ def test_get_specialized_type_var_map_double_generic_subclass(include_type_vars:
 
 @pytest.mark.parametrize("include_type_vars", [True, False])
 def test_get_specialized_type_var_map_multiple_inheritance(include_type_vars: bool):
+    @strawberry.type
     class Foo(Generic[_T]):
         ...
 
+    @strawberry.type
     class Bar(Generic[_K]):
         ...
 
+    @strawberry.type
     class Bin(Foo[int]):
         ...
 
+    @strawberry.type
     class Baz(Bin, Bar[str]):
         ...
 
@@ -109,18 +127,23 @@ def test_get_specialized_type_var_map_multiple_inheritance(include_type_vars: bo
 def test_get_specialized_type_var_map_multiple_inheritance_subclass(
     include_type_vars: bool,
 ):
+    @strawberry.type
     class Foo(Generic[_T]):
         ...
 
+    @strawberry.type
     class Bar(Generic[_K]):
         ...
 
+    @strawberry.type
     class Bin(Foo[int]):
         ...
 
+    @strawberry.type
     class Baz(Bin, Bar[str]):
         ...
 
+    @strawberry.type
     class BazSubclass(Baz):
         ...
 


### PR DESCRIPTION
This PR changes how `get_specialized_type_var_map` to only work on strawberry types, this prevents us thinking that types extending specialized generics that aren't types should be copied :)

It also removes support for `include_type_vars` as this was used in only one place