### PR TITLE
Support schema extensions for subsctriptions - Alternative

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: minor
+
+Subscriptions now support Schema Extensions.

--- a/docs/guides/custom-extensions.md
+++ b/docs/guides/custom-extensions.md
@@ -36,8 +36,6 @@ resolvers.
 If you need to wrap only certain field resolvers with additional logic, please
 check out [field extensions](field-extensions.md).
 
-Note that `resolve` can also be implemented asynchronously.
-
 ```python
 from strawberry.types import Info
 from strawberry.extensions import SchemaExtension
@@ -46,6 +44,21 @@ from strawberry.extensions import SchemaExtension
 class MyExtension(SchemaExtension):
     def resolve(self, _next, root, info: Info, *args, **kwargs):
         return _next(root, info, *args, **kwargs)
+```
+
+Note that `resolve` can also be implemented asynchronously, in which
+case the result from `_next` must be optionally awaited:
+
+```python
+from inspect import isawaitable
+from strawberry.types import Info
+from strawberry.extensions import SchemaExtension
+
+
+class MyExtension(SchemaExtension):
+    async def resolve(self, _next, root, info: Info, *args, **kwargs):
+        result = _next(root, info, *args, **kwargs)
+        return await result if isawaitable(result) else result
 ```
 
 ### Get results

--- a/strawberry/schema/base.py
+++ b/strawberry/schema/base.py
@@ -2,7 +2,17 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Type, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    AsyncGenerator,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Type,
+    Union,
+)
 from typing_extensions import Protocol
 
 from strawberry.utils.logging import StrawberryLogger
@@ -62,7 +72,7 @@ class BaseSchema(Protocol):
         context_value: Optional[Any] = None,
         root_value: Optional[Any] = None,
         operation_name: Optional[str] = None,
-    ) -> Any:
+    ) -> Union[ExecutionResult, AsyncGenerator[ExecutionResult, None]]:
         raise NotImplementedError
 
     @abstractmethod

--- a/strawberry/schema/execute.py
+++ b/strawberry/schema/execute.py
@@ -4,6 +4,8 @@ from asyncio import ensure_future
 from inspect import isawaitable
 from typing import (
     TYPE_CHECKING,
+    AsyncGenerator,
+    AsyncIterable,
     Awaitable,
     Callable,
     Iterable,
@@ -16,8 +18,10 @@ from typing import (
     cast,
 )
 
+from graphql import ExecutionResult as GraphQLExecutionResult
 from graphql import GraphQLError, parse
 from graphql import execute as original_execute
+from graphql import subscribe as original_subscribe
 from graphql.validation import validate
 
 from strawberry.exceptions import MissingQueryError
@@ -30,7 +34,6 @@ if TYPE_CHECKING:
     from typing_extensions import Unpack
 
     from graphql import ExecutionContext as GraphQLExecutionContext
-    from graphql import ExecutionResult as GraphQLExecutionResult
     from graphql import GraphQLSchema
     from graphql.language import DocumentNode
     from graphql.validation import ASTValidationRule
@@ -55,6 +58,100 @@ def validate_document(
         document,
         validation_rules,
     )
+
+
+async def _parse_and_validate_async(
+    execution_context: ExecutionContext,
+    process_errors: Callable[[List[GraphQLError], Optional[ExecutionContext]], None],
+    extensions_runner: SchemaExtensionsRunner,
+    allowed_operation_types: Optional[Iterable[OperationType]] = None,
+):
+    assert execution_context.query
+    async with extensions_runner.parsing():
+        try:
+            if not execution_context.graphql_document:
+                execution_context.graphql_document = parse_document(
+                    execution_context.query, **execution_context.parse_options
+                )
+
+        except GraphQLError as error:
+            execution_context.errors = [error]
+            process_errors([error], execution_context)
+            return ExecutionResult(
+                data=None,
+                errors=[error],
+                extensions=await extensions_runner.get_extensions_results(),
+            )
+
+        except Exception as error:  # pragma: no cover
+            error = GraphQLError(str(error), original_error=error)
+
+            execution_context.errors = [error]
+            process_errors([error], execution_context)
+
+            return ExecutionResult(
+                data=None,
+                errors=[error],
+                extensions=await extensions_runner.get_extensions_results(),
+            )
+
+    if (
+        allowed_operation_types is not None
+        and execution_context.operation_type not in allowed_operation_types
+    ):
+        raise InvalidOperationTypeError(execution_context.operation_type)
+
+    async with extensions_runner.validation():
+        _run_validation(execution_context)
+        if execution_context.errors:
+            process_errors(execution_context.errors, execution_context)
+            return ExecutionResult(data=None, errors=execution_context.errors)
+
+
+def _parse_and_validate_sync(
+    execution_context: ExecutionContext,
+    process_errors: Callable[[List[GraphQLError], Optional[ExecutionContext]], None],
+    extensions_runner: SchemaExtensionsRunner,
+    allowed_operation_types: Iterable[OperationType],
+) -> Optional[ExecutionResult]:
+    assert execution_context.query
+    with extensions_runner.parsing():
+        try:
+            if not execution_context.graphql_document:
+                execution_context.graphql_document = parse_document(
+                    execution_context.query, **execution_context.parse_options
+                )
+
+        except GraphQLError as error:
+            execution_context.errors = [error]
+            process_errors([error], execution_context)
+            return ExecutionResult(
+                data=None,
+                errors=[error],
+                extensions=extensions_runner.get_extensions_results_sync(),
+            )
+
+        except Exception as error:  # pragma: no cover
+            error = GraphQLError(str(error), original_error=error)
+
+            execution_context.errors = [error]
+            process_errors([error], execution_context)
+
+            return ExecutionResult(
+                data=None,
+                errors=[error],
+                extensions=extensions_runner.get_extensions_results_sync(),
+            )
+
+    if execution_context.operation_type not in allowed_operation_types:
+        raise InvalidOperationTypeError(execution_context.operation_type)
+
+    with extensions_runner.validation():
+        _run_validation(execution_context)
+        if execution_context.errors:
+            process_errors(execution_context.errors, execution_context)
+            return ExecutionResult(data=None, errors=execution_context.errors)
+    return None
 
 
 def _run_validation(execution_context: ExecutionContext) -> None:
@@ -89,45 +186,18 @@ async def execute(
         if not execution_context.query:
             raise MissingQueryError()
 
-        async with extensions_runner.parsing():
-            try:
-                if not execution_context.graphql_document:
-                    execution_context.graphql_document = parse_document(
-                        execution_context.query, **execution_context.parse_options
-                    )
-
-            except GraphQLError as error:
-                execution_context.errors = [error]
-                process_errors([error], execution_context)
-                return ExecutionResult(
-                    data=None,
-                    errors=[error],
-                    extensions=await extensions_runner.get_extensions_results(),
-                )
-
-            except Exception as error:  # pragma: no cover
-                error = GraphQLError(str(error), original_error=error)
-
-                execution_context.errors = [error]
-                process_errors([error], execution_context)
-
-                return ExecutionResult(
-                    data=None,
-                    errors=[error],
-                    extensions=await extensions_runner.get_extensions_results(),
-                )
-
-        if execution_context.operation_type not in allowed_operation_types:
-            raise InvalidOperationTypeError(execution_context.operation_type)
-
-        async with extensions_runner.validation():
-            _run_validation(execution_context)
-            if execution_context.errors:
-                process_errors(execution_context.errors, execution_context)
-                return ExecutionResult(data=None, errors=execution_context.errors)
+        error_result = await _parse_and_validate_async(
+            execution_context,
+            process_errors,
+            extensions_runner,
+            allowed_operation_types,
+        )
+        if error_result is not None:
+            return error_result
 
         async with extensions_runner.executing():
             if not execution_context.result:
+                assert execution_context.graphql_document
                 result = original_execute(
                     schema,
                     execution_context.graphql_document,
@@ -182,44 +252,18 @@ def execute_sync(
         if not execution_context.query:
             raise MissingQueryError()
 
-        with extensions_runner.parsing():
-            try:
-                if not execution_context.graphql_document:
-                    execution_context.graphql_document = parse_document(
-                        execution_context.query, **execution_context.parse_options
-                    )
-
-            except GraphQLError as error:
-                execution_context.errors = [error]
-                process_errors([error], execution_context)
-                return ExecutionResult(
-                    data=None,
-                    errors=[error],
-                    extensions=extensions_runner.get_extensions_results_sync(),
-                )
-
-            except Exception as error:  # pragma: no cover
-                error = GraphQLError(str(error), original_error=error)
-
-                execution_context.errors = [error]
-                process_errors([error], execution_context)
-                return ExecutionResult(
-                    data=None,
-                    errors=[error],
-                    extensions=extensions_runner.get_extensions_results_sync(),
-                )
-
-        if execution_context.operation_type not in allowed_operation_types:
-            raise InvalidOperationTypeError(execution_context.operation_type)
-
-        with extensions_runner.validation():
-            _run_validation(execution_context)
-            if execution_context.errors:
-                process_errors(execution_context.errors, execution_context)
-                return ExecutionResult(data=None, errors=execution_context.errors)
+        error_result = _parse_and_validate_sync(
+            execution_context,
+            process_errors,
+            extensions_runner,
+            allowed_operation_types,
+        )
+        if error_result is not None:
+            return error_result
 
         with extensions_runner.executing():
             if not execution_context.result:
+                assert execution_context.graphql_document
                 result = original_execute(
                     schema,
                     execution_context.graphql_document,
@@ -255,4 +299,142 @@ def execute_sync(
         data=execution_context.result.data,
         errors=execution_context.result.errors,
         extensions=extensions_runner.get_extensions_results_sync(),
+    )
+
+
+async def subscribe(
+    schema: GraphQLSchema,
+    *,
+    extensions: Sequence[Union[Type[SchemaExtension], SchemaExtension]],
+    execution_context: ExecutionContext,
+    process_errors: Callable[[List[GraphQLError], Optional[ExecutionContext]], None],
+) -> Union[ExecutionResult, AsyncGenerator[ExecutionResult, None]]:
+    # The graphql-core subscribe function returns either an ExecutionResult or an
+    # AsyncGenerator[ExecutionResult, None].  The former is returned in case of an error
+    # during parsing or validation.
+    # We repeat that pattern here, but to maintain the context of the extensions
+    # context manager, we must delegate to an inner async generator.  The inner
+    # generator yields an initial result, either a None, or an ExecutionResult,
+    # to indicate the two different cases.
+
+    asyncgen = _subscribe(
+        schema,
+        extensions=extensions,
+        execution_context=execution_context,
+        process_errors=process_errors,
+    )
+    # start the generator
+    first = await asyncgen.__anext__()
+    if first is not None:
+        # Single result.  Close the generator to exit any context managers
+        await asyncgen.aclose()
+        return first
+    else:
+        # return the started generator. Cast away the Optional[] type
+        return cast(AsyncGenerator[ExecutionResult, None], asyncgen)
+
+
+async def _subscribe(
+    schema: GraphQLSchema,
+    *,
+    extensions: Sequence[Union[Type[SchemaExtension], SchemaExtension]],
+    execution_context: ExecutionContext,
+    process_errors: Callable[[List[GraphQLError], Optional[ExecutionContext]], None],
+) -> AsyncGenerator[Optional[ExecutionResult], None]:
+    # This Async generator first yields either a single ExecutionResult or None.
+    # If None is yielded, then the subscription has failed and the generator should
+    # be closed.
+    # Otherwise, if None is yielded, the subscription can continue.
+
+    extensions_runner = SchemaExtensionsRunner(
+        execution_context=execution_context,
+        extensions=list(extensions),
+    )
+
+    # unlike execute(), the entire operation, including the results hooks,
+    # is run within the operation() hook.
+    async with extensions_runner.operation():
+        # Note: In graphql-core the schema would be validated here but in
+        # Strawberry we are validating it at initialisation time instead
+
+        error_result = await _parse_and_validate_async(
+            execution_context, process_errors, extensions_runner
+        )
+        if error_result is not None:
+            yield error_result
+            return  # pragma: no cover
+
+        async with extensions_runner.executing():
+            # currently original_subscribe is an async function.  A future release
+            # of graphql-core will make it optionally awaitable
+            assert execution_context.graphql_document
+            result: Union[AsyncIterable[GraphQLExecutionResult], GraphQLExecutionResult]
+            result_or_awaitable = original_subscribe(
+                schema,
+                execution_context.graphql_document,
+                root_value=execution_context.root_value,
+                context_value=execution_context.context,
+                variable_values=execution_context.variables,
+                operation_name=execution_context.operation_name,
+            )
+            if isawaitable(result_or_awaitable):
+                result = await cast(
+                    Awaitable[
+                        Union[
+                            AsyncIterable["GraphQLExecutionResult"],
+                            "GraphQLExecutionResult",
+                        ]
+                    ],
+                    result_or_awaitable,
+                )
+            else:  # pragma: no cover
+                result = cast(
+                    Union[
+                        AsyncIterable["GraphQLExecutionResult"],
+                        "GraphQLExecutionResult",
+                    ],
+                    result_or_awaitable,
+                )
+
+            if isinstance(result, GraphQLExecutionResult):
+                yield await process_subscribe_result(
+                    execution_context, process_errors, extensions_runner, result
+                )
+                return  # pragma: no cover
+
+            yield None  # signal that we are returning an async generator
+            aiterator = result.__aiter__()
+            try:
+                async for result in aiterator:
+                    yield await process_subscribe_result(
+                        execution_context, process_errors, extensions_runner, result
+                    )
+            finally:
+                # grapql-core's iterator may or may not have an aclose() method
+                if hasattr(aiterator, "aclose"):
+                    await aiterator.aclose()
+
+
+async def process_subscribe_result(
+    execution_context: ExecutionContext,
+    process_errors: Callable[[List[GraphQLError], Optional[ExecutionContext]], None],
+    extensions_runner: SchemaExtensionsRunner,
+    result: GraphQLExecutionResult,
+) -> ExecutionResult:
+    execution_context.result = result
+    # Also set errors on the execution_context so that it's easier
+    # to access in extensions
+    if result.errors:
+        execution_context.errors = result.errors
+
+        # Run the `Schema.process_errors` function here before
+        # extensions have a chance to modify them (see the MaskErrors
+        # extension). That way we can log the original errors but
+        # only return a sanitised version to the client.
+        process_errors(result.errors, execution_context)
+
+    return ExecutionResult(
+        data=execution_context.result.data,
+        errors=execution_context.result.errors,
+        extensions=await extensions_runner.get_extensions_results(),
     )

--- a/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
@@ -256,7 +256,6 @@ class BaseGraphQLTransportWSHandler(ABC):
             assert result_source.errors
             payload = [err.formatted for err in result_source.errors]
             await self.send_message(ErrorMessage(id=message.id, payload=payload))
-            self.schema.process_errors(result_source.errors)
             return
 
         # Create task to handle this subscription, reserve the operation ID
@@ -306,13 +305,10 @@ class BaseGraphQLTransportWSHandler(ABC):
                     error_payload = [err.formatted for err in result.errors]
                     error_message = ErrorMessage(id=operation.id, payload=error_payload)
                     await operation.send_message(error_message)
-                    # don't need to call schema.process_errors() here because
-                    # it was already done by schema.execute()
                     return
                 else:
                     next_payload = {"data": result.data}
                     if result.errors:
-                        self.schema.process_errors(result.errors)
                         next_payload["errors"] = [
                             err.formatted for err in result.errors
                         ]

--- a/strawberry/subscriptions/protocols/graphql_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_ws/handlers.py
@@ -135,7 +135,6 @@ class BaseGraphQLWSHandler(ABC):
             assert result_source.errors
             error_payload = result_source.errors[0].formatted
             await self.send_message(GQL_ERROR, operation_id, error_payload)
-            self.schema.process_errors(result_source.errors)
             return
 
         self.subscriptions[operation_id] = result_source
@@ -165,10 +164,6 @@ class BaseGraphQLWSHandler(ABC):
                 if result.extensions:
                     payload["extensions"] = result.extensions
                 await self.send_message(GQL_DATA, operation_id, payload)
-                # log errors after send_message to prevent potential
-                # slowdown of sending result
-                if result.errors:
-                    self.schema.process_errors(result.errors)
         except asyncio.CancelledError:
             # CancelledErrors are expected during task cleanup.
             pass

--- a/strawberry/subscriptions/protocols/graphql_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_ws/handlers.py
@@ -123,19 +123,13 @@ class BaseGraphQLWSHandler(ABC):
         if self.debug:
             pretty_print_graphql_operation(operation_name, query, variables)
 
-        try:
-            result_source = await self.schema.subscribe(
-                query=query,
-                variable_values=variables,
-                operation_name=operation_name,
-                context_value=context,
-                root_value=root_value,
-            )
-        except GraphQLError as error:
-            error_payload = error.formatted
-            await self.send_message(GQL_ERROR, operation_id, error_payload)
-            self.schema.process_errors([error])
-            return
+        result_source = await self.schema.subscribe(
+            query=query,
+            variable_values=variables,
+            operation_name=operation_name,
+            context_value=context,
+            root_value=root_value,
+        )
 
         if isinstance(result_source, ExecutionResult):
             assert result_source.errors

--- a/tests/channels/test_layers.py
+++ b/tests/channels/test_layers.py
@@ -91,6 +91,7 @@ async def test_channel_listen(ws: WebsocketCommunicator):
     )
 
     response = await ws.receive_json_from()
+    del response["payload"]["extensions"]
     assert (
         response
         == NextMessage(
@@ -315,6 +316,7 @@ async def test_channel_listen_group(ws: WebsocketCommunicator):
         },
     )
     response = await ws.receive_json_from()
+    del response["payload"]["extensions"]
     assert (
         response
         == NextMessage(
@@ -331,6 +333,7 @@ async def test_channel_listen_group(ws: WebsocketCommunicator):
     )
 
     response = await ws.receive_json_from()
+    del response["payload"]["extensions"]
     assert (
         response
         == NextMessage(

--- a/tests/channels/test_layers.py
+++ b/tests/channels/test_layers.py
@@ -91,7 +91,7 @@ async def test_channel_listen(ws: WebsocketCommunicator):
     )
 
     response = await ws.receive_json_from()
-    del response["payload"]["extensions"]
+    response["payload"].pop("extensions", None)
     assert (
         response
         == NextMessage(
@@ -138,6 +138,7 @@ async def test_channel_listen_with_confirmation(ws: WebsocketCommunicator):
     )
 
     response = await ws.receive_json_from()
+    response["payload"].pop("extensions", None)
     assert (
         response
         == NextMessage(
@@ -316,7 +317,7 @@ async def test_channel_listen_group(ws: WebsocketCommunicator):
         },
     )
     response = await ws.receive_json_from()
-    del response["payload"]["extensions"]
+    response["payload"].pop("extensions", None)
     assert (
         response
         == NextMessage(
@@ -333,7 +334,7 @@ async def test_channel_listen_group(ws: WebsocketCommunicator):
     )
 
     response = await ws.receive_json_from()
-    del response["payload"]["extensions"]
+    response["payload"].pop("extensions", None)
     assert (
         response
         == NextMessage(
@@ -380,6 +381,7 @@ async def test_channel_listen_group_cm(ws: WebsocketCommunicator):
         },
     )
     response = await ws.receive_json_from()
+    response["payload"].pop("extensions", None)
     assert (
         response
         == NextMessage(
@@ -396,6 +398,7 @@ async def test_channel_listen_group_cm(ws: WebsocketCommunicator):
     )
 
     response = await ws.receive_json_from()
+    response["payload"].pop("extensions", None)
     assert (
         response
         == NextMessage(

--- a/tests/http/clients/aiohttp.py
+++ b/tests/http/clients/aiohttp.py
@@ -14,7 +14,8 @@ from strawberry.aiohttp.handlers import GraphQLTransportWSHandler, GraphQLWSHand
 from strawberry.aiohttp.views import GraphQLView as BaseGraphQLView
 from strawberry.http import GraphQLHTTPResponse
 from strawberry.types import ExecutionResult
-from tests.views.schema import Query, schema
+from tests.views.schema import Query
+from tests.views.schema import async_schema as schema
 
 from ..context import get_context
 from .base import (

--- a/tests/http/clients/asgi.py
+++ b/tests/http/clients/asgi.py
@@ -15,7 +15,8 @@ from strawberry.asgi import GraphQL as BaseGraphQLView
 from strawberry.asgi.handlers import GraphQLTransportWSHandler, GraphQLWSHandler
 from strawberry.http import GraphQLHTTPResponse
 from strawberry.types import ExecutionResult
-from tests.views.schema import Query, schema
+from tests.views.schema import Query
+from tests.views.schema import async_schema as schema
 
 from ..context import get_context
 from .base import (

--- a/tests/http/clients/channels.py
+++ b/tests/http/clients/channels.py
@@ -17,7 +17,8 @@ from strawberry.channels import (
 from strawberry.channels.handlers.base import ChannelsConsumer
 from strawberry.http import GraphQLHTTPResponse
 from strawberry.http.typevars import Context, RootValue
-from tests.views.schema import Query, schema
+from tests.views.schema import Query, async_schema
+from tests.views.schema import schema as sync_schema
 
 from ..context import get_context
 from .base import (
@@ -141,12 +142,12 @@ class ChannelsHttpClient(HttpClient):
         result_override: ResultOverrideFunction = None,
     ):
         self.ws_app = DebuggableGraphQLTransportWSConsumer.as_asgi(
-            schema=schema,
+            schema=async_schema,
             keep_alive=False,
         )
 
         self.http_app = DebuggableGraphQLHTTPConsumer.as_asgi(
-            schema=schema,
+            schema=async_schema,
             graphiql=graphiql,
             allow_queries_via_get=allow_queries_via_get,
             result_override=result_override,
@@ -154,7 +155,7 @@ class ChannelsHttpClient(HttpClient):
 
     def create_app(self, **kwargs: Any) -> None:
         self.ws_app = DebuggableGraphQLTransportWSConsumer.as_asgi(
-            schema=schema, **kwargs
+            schema=async_schema, **kwargs
         )
 
     async def _graphql_request(
@@ -260,7 +261,7 @@ class SyncChannelsHttpClient(ChannelsHttpClient):
         result_override: ResultOverrideFunction = None,
     ):
         self.http_app = DebuggableSyncGraphQLHTTPConsumer.as_asgi(
-            schema=schema,
+            schema=sync_schema,
             graphiql=graphiql,
             allow_queries_via_get=allow_queries_via_get,
             result_override=result_override,

--- a/tests/http/clients/fastapi.py
+++ b/tests/http/clients/fastapi.py
@@ -14,7 +14,8 @@ from strawberry.fastapi import GraphQLRouter as BaseGraphQLRouter
 from strawberry.fastapi.handlers import GraphQLTransportWSHandler, GraphQLWSHandler
 from strawberry.http import GraphQLHTTPResponse
 from strawberry.types import ExecutionResult
-from tests.views.schema import Query, schema
+from tests.views.schema import Query
+from tests.views.schema import async_schema as schema
 
 from ..context import get_context
 from .asgi import AsgiWebSocketClient

--- a/tests/http/clients/starlite.py
+++ b/tests/http/clients/starlite.py
@@ -14,7 +14,8 @@ from strawberry.http import GraphQLHTTPResponse
 from strawberry.starlite import make_graphql_controller
 from strawberry.starlite.controller import GraphQLTransportWSHandler, GraphQLWSHandler
 from strawberry.types import ExecutionResult
-from tests.views.schema import Query, schema
+from tests.views.schema import Query
+from tests.views.schema import async_schema as schema
 
 from ..context import get_context
 from .base import (

--- a/tests/views/schema.py
+++ b/tests/views/schema.py
@@ -404,7 +404,7 @@ schema = Schema(
     extensions=[MyExtension],
 )
 
-async_schema = strawberry.Schema(
+async_schema = Schema(
     query=Query,
     mutation=Mutation,
     subscription=Subscription,

--- a/tests/websockets/test_graphql_transport_ws.py
+++ b/tests/websockets/test_graphql_transport_ws.py
@@ -24,6 +24,7 @@ from strawberry.subscriptions.protocols.graphql_transport_ws.types import (
     ConnectionAckMessage,
     ConnectionInitMessage,
     ErrorMessage,
+    NextMessage,
     PingMessage,
     PongMessage,
     SubscribeMessage,
@@ -374,7 +375,7 @@ async def test_subscription_field_errors(ws: WebSocketClient):
         assert response["payload"][0]["locations"] == [{"line": 1, "column": 16}]
         assert (
             response["payload"][0]["message"]
-            == "The subscription field 'notASubscriptionField' is not defined."
+            == "Cannot query field 'notASubscriptionField' on type 'Subscription'."
         )
         process_errors.assert_called_once()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

Subscriptions are now executed like queries and mutations, and extension hooks are called.
Result extension hooks are called for each result yielded by the subscription

Note, This is a separate PR from #2784, because it contains an alternative, less intrusive, way to do this.
It avoids changing the signature of `schema.subscribe` which now, like `graphql-core`, continues to return __either__
an `ExcecutionResult` or an `AsyncGenerator`.


<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

the `Schema.subscribe()`, when _awaited_ returns a `Union[ExeuctionResult, AsyncGenerator[ExecutionResult,None]]`.
This is similar to before, but previously it would return a raw `GraphQLExecutionResult` object, or an `AsyncIterator` over said type, directly from `graphql-core`.

Internally, an `AsyncGenerator` is created which yields an extra _initial result_, which is either a `ExecutionResult` in case
the inner subscribe method failed and no iterator is forthcoming, or a `None` if subscription is about to proceed.  An
outer method examines this initially yielded value and either returns that to the caller, or the already started `AsyncGenerator`, which the caller then continues to iterate from, maintaining all context which that iterator had already established.

Tests are added to tests for result extensions.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

* #2097

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as we