### PR TITLE
Do not block `graphql_transport_ws` operations while creating context or validating a single request operation

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+Operations over `graphql-transport-ws` now create the Context and perform validation on
+the worker `Task`, thus not blocking the websocket from accepting messages.

--- a/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
@@ -43,7 +43,6 @@ if TYPE_CHECKING:
     from strawberry.subscriptions.protocols.graphql_transport_ws.types import (
         GraphQLTransportMessage,
     )
-    
 
 
 class BaseGraphQLTransportWSHandler(ABC):
@@ -294,9 +293,9 @@ class BaseGraphQLTransportWSHandler(ABC):
         self.operations[message.id] = operation
 
     async def operation_task(self, operation: Operation) -> None:
-        """
-        The operation task's top level method. Cleans-up and de-registers the operation
-        once it is done.
+        """The operation task's top level method.
+
+        Cleans-up and de-registers the operation once it is done.
         """
         task = asyncio.current_task()
         assert task is not None  # for type checkers

--- a/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
@@ -301,13 +301,14 @@ class BaseGraphQLTransportWSHandler(ABC):
         except asyncio.CancelledError:
             raise
         except Exception as error:
+            # Log any unhandled exceptions in the operation task
             await self.handle_task_exception(error)
-            # cleanup in case of something really unexpected
         finally:
-            # add this task to a list to be reaped later
+            # Clenaup.  Remove the operation from the list of active operations
             if operation.id in self.operations:
                 del self.operations[operation.id]
             # TODO: Stop collecting background tasks, not necessary.
+            # Add this task to a list to be reaped later
             self.completed_tasks.append(task)
 
     async def handle_operation(

--- a/tests/http/clients/aiohttp.py
+++ b/tests/http/clients/aiohttp.py
@@ -17,7 +17,7 @@ from strawberry.http.ides import GraphQL_IDE
 from strawberry.types import ExecutionResult
 from tests.views.schema import Query, schema
 
-from ..context import get_context
+from ..context import get_context_async as get_context
 from .base import (
     JSON,
     DebuggableGraphQLTransportWSMixin,
@@ -50,7 +50,7 @@ class GraphQLView(BaseGraphQLView):
     ) -> object:
         context = await super().get_context(request, response)
 
-        return get_context(context)
+        return await get_context(context)
 
     async def get_root_value(self, request: web.Request) -> Query:
         await super().get_root_value(request)  # for coverage

--- a/tests/http/clients/asgi.py
+++ b/tests/http/clients/asgi.py
@@ -18,7 +18,7 @@ from strawberry.http.ides import GraphQL_IDE
 from strawberry.types import ExecutionResult
 from tests.views.schema import Query, schema
 
-from ..context import get_context
+from ..context import get_context_async as get_context
 from .base import (
     JSON,
     DebuggableGraphQLTransportWSMixin,
@@ -56,7 +56,7 @@ class GraphQLView(BaseGraphQLView):
     ) -> object:
         context = await super().get_context(request, response)
 
-        return get_context(context)
+        return await get_context(context)
 
     async def process_result(
         self, request: Request, result: ExecutionResult

--- a/tests/http/clients/channels.py
+++ b/tests/http/clients/channels.py
@@ -20,7 +20,7 @@ from strawberry.http.ides import GraphQL_IDE
 from strawberry.http.typevars import Context, RootValue
 from tests.views.schema import Query, schema
 
-from ..context import get_context
+from ..context import get_context, get_context_async
 from .base import (
     JSON,
     HttpClient,
@@ -77,7 +77,7 @@ class DebuggableGraphQLTransportWSConsumer(GraphQLWSConsumer):
         context["connectionInitTimeoutTask"] = getattr(
             self._handler, "connection_init_timeout_task", None
         )
-        for key, val in get_context({}).items():
+        for key, val in (await get_context_async({})).items():
             context[key] = val
         return context
 
@@ -95,7 +95,7 @@ class DebuggableGraphQLHTTPConsumer(GraphQLHTTPConsumer):
     async def get_context(self, request: ChannelsConsumer, response: Any) -> Context:
         context = await super().get_context(request, response)
 
-        return get_context(context)
+        return await get_context_async(context)
 
     async def process_result(
         self, request: ChannelsConsumer, result: Any

--- a/tests/http/clients/fastapi.py
+++ b/tests/http/clients/fastapi.py
@@ -17,7 +17,7 @@ from strawberry.http.ides import GraphQL_IDE
 from strawberry.types import ExecutionResult
 from tests.views.schema import Query, schema
 
-from ..context import get_context
+from ..context import get_context_async as get_context
 from .asgi import AsgiWebSocketClient
 from .base import (
     JSON,
@@ -50,7 +50,7 @@ async def fastapi_get_context(
     ws: WebSocket = None,  # type: ignore
     custom_value: str = Depends(custom_context_dependency),
 ) -> Dict[str, object]:
-    return get_context(
+    return await get_context(
         {
             "request": request or ws,
             "background_tasks": background_tasks,

--- a/tests/http/clients/litestar.py
+++ b/tests/http/clients/litestar.py
@@ -17,7 +17,7 @@ from strawberry.litestar.controller import GraphQLTransportWSHandler, GraphQLWSH
 from strawberry.types import ExecutionResult
 from tests.views.schema import Query, schema
 
-from ..context import get_context
+from ..context import get_context_async as get_context
 from .base import (
     JSON,
     DebuggableGraphQLTransportWSMixin,
@@ -35,7 +35,7 @@ def custom_context_dependency() -> str:
 
 
 async def litestar_get_context(request: Request = None):
-    return get_context({"request": request})
+    return await get_context({"request": request})
 
 
 async def get_root_value(request: Request = None):

--- a/tests/http/clients/litestar.py
+++ b/tests/http/clients/litestar.py
@@ -30,10 +30,6 @@ from .base import (
 )
 
 
-def custom_context_dependency() -> str:
-    return "Hi!"
-
-
 async def litestar_get_context(request: Request = None):
     return await get_context({"request": request})
 

--- a/tests/http/context.py
+++ b/tests/http/context.py
@@ -2,6 +2,21 @@ from typing import Dict
 
 
 def get_context(context: object) -> Dict[str, object]:
-    assert isinstance(context, dict)
+    return get_context_inner(context)
 
+
+# a patchable method for unittests
+def get_context_inner(context: object) -> Dict[str, object]:
+    assert isinstance(context, dict)
+    return {**context, "custom_value": "a value from context"}
+
+
+# async version for async frameworks
+async def get_context_async(context: object) -> Dict[str, object]:
+    return await get_context_async_inner(context)
+
+
+# a patchable method for unittests
+async def get_context_async_inner(context: object) -> Dict[str, object]:
+    assert isinstance(context, dict)
     return {**context, "custom_value": "a value from context"}

--- a/tests/views/schema.py
+++ b/tests/views/schema.py
@@ -77,7 +77,7 @@ class DebugInfo:
 @strawberry.type
 class Query:
     @strawberry.field
-    def greetings(self) -> str:
+    def greetings(self) -> str:  # pragma: no cover
         return "hello"
 
     @strawberry.field
@@ -108,7 +108,7 @@ class Query:
         raise ValueError(message)
 
     @strawberry.field
-    def teapot(self, info: strawberry.Info[Any, None]) -> str:
+    def teapot(self, info: strawberry.Info[Any, None]) -> str:  # pragma: no cover
         info.context["response"].status_code = 418
 
         return "🫖"
@@ -142,7 +142,7 @@ class Query:
 @strawberry.type
 class Mutation:
     @strawberry.mutation
-    def echo(self, string_to_echo: str) -> str:
+    def echo(self, string_to_echo: str) -> str:  # pragma: no cover
         return string_to_echo
 
     @strawberry.mutation
@@ -162,7 +162,7 @@ class Mutation:
         return list(map(_read_file, folder.files))
 
     @strawberry.mutation
-    def match_text(self, text_file: Upload, pattern: str) -> str:
+    def match_text(self, text_file: Upload, pattern: str) -> str:  # pragma: no cover
         text = text_file.read().decode()
         return pattern if pattern in text else ""
 
@@ -199,7 +199,7 @@ class Subscription:
         raise ValueError(message)
 
         # Without this yield, the method is not recognised as an async generator
-        yield "Hi"
+        yield "Hi"  # pragma: no cover
 
     @strawberry.subscription
     async def flavors(self) -> AsyncGenerator[Flavor, None]:

--- a/tests/views/schema.py
+++ b/tests/views/schema.py
@@ -91,13 +91,13 @@ class Query:
 
     @strawberry.field(permission_classes=[AlwaysFailPermission])
     def always_fail(self) -> Optional[str]:
-        return "Hey"
+        return "Hey"  # pragma: no cover
 
     @strawberry.field(permission_classes=[ConditionalFailPermission])
     def conditional_fail(
         self, sleep: Optional[float] = None, fail: bool = False
     ) -> str:
-        return "Hey"
+        return "Hey"  # pragma: no cover
 
     @strawberry.field
     async def error(self, message: str) -> AsyncGenerator[str, None]:
@@ -285,7 +285,7 @@ class Subscription:
     async def conditional_fail(
         self, sleep: Optional[float] = None, fail: bool = False
     ) -> AsyncGenerator[str, None]:
-        yield "Hey"
+        yield "Hey"  # pragma: no cover
 
 
 class Schema(strawberry.Schema):

--- a/tests/views/schema.py
+++ b/tests/views/schema.py
@@ -20,6 +20,19 @@ class AlwaysFailPermission(BasePermission):
         return False
 
 
+class ConditionalFailPermission(BasePermission):
+    @property
+    def message(self):
+        return f"failed after sleep {self.sleep}"
+
+    async def has_permission(self, source, info, **kwargs: Any) -> bool:
+        self.sleep = kwargs.get("sleep", None)
+        self.fail = kwargs.get("fail", True)
+        if self.sleep is not None:
+            await asyncio.sleep(kwargs["sleep"])
+        return not self.fail
+
+
 class MyExtension(SchemaExtension):
     def get_results(self) -> Dict[str, str]:
         return {"example": "example"}
@@ -78,6 +91,12 @@ class Query:
 
     @strawberry.field(permission_classes=[AlwaysFailPermission])
     def always_fail(self) -> Optional[str]:
+        return "Hey"
+
+    @strawberry.field(permission_classes=[ConditionalFailPermission])
+    def conditional_fail(
+        self, sleep: Optional[float] = None, fail: bool = False
+    ) -> str:
         return "Hey"
 
     @strawberry.field
@@ -261,6 +280,12 @@ class Subscription:
                 await asyncio.sleep(0.01)
         finally:
             await asyncio.sleep(delay)
+
+    @strawberry.subscription(permission_classes=[ConditionalFailPermission])
+    async def conditional_fail(
+        self, sleep: Optional[float] = None, fail: bool = False
+    ) -> AsyncGenerator[str, None]:
+        yield "Hey"
 
 
 class Schema(strawberry.Schema):

--- a/tests/websockets/test_graphql_transport_ws.py
+++ b/tests/websockets/test_graphql_transport_ws.py
@@ -6,12 +6,7 @@ import json
 import time
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any, AsyncGenerator, Type
-from unittest.mock import Mock, patch
-
-try:
-    from unittest.mock import AsyncMock
-except ImportError:
-    AsyncMock = None
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 import pytest_asyncio
@@ -926,9 +921,6 @@ async def test_error_handler_for_timeout(http_client: HttpClient):
 
         if isinstance(http_client, ChannelsHttpClient):
             pytest.skip("Can't patch on_init for this client")
-
-    if not AsyncMock:
-        pytest.skip("Don't have AsyncMock")
 
     ws = ws_raw
     handler = None

--- a/tests/websockets/test_graphql_transport_ws.py
+++ b/tests/websockets/test_graphql_transport_ws.py
@@ -1094,3 +1094,60 @@ async def test_long_validation_concurrent_subscription(ws: WebSocketClient):
             id="sub2", payload={"data": {"conditionalFail": "Hey"}}
         ).as_dict()
     )
+
+
+@pytest.mark.xfail
+async def test_long_custom_context(ws: WebSocketClient):
+    """
+    Test that the websocket is not blocked evaluating the context
+    """
+
+    counter = 0
+
+    async def slow_get_context(ctxt):
+        nonlocal counter
+        old = counter
+        counter += 1
+        if old == 0:
+            await asyncio.sleep(0.1)
+            ctxt["custom_value"] = "slow"
+        else:
+            ctxt["custom_value"] = "fast"
+        return ctxt
+
+    with patch("tests.http.context.get_context_async_inner", slow_get_context):
+        await ws.send_json(
+            SubscribeMessage(
+                id="sub1",
+                payload=SubscribeMessagePayload(query="query { valueFromContext }"),
+            ).as_dict()
+        )
+
+        await ws.send_json(
+            SubscribeMessage(
+                id="sub2",
+                payload=SubscribeMessagePayload(
+                    query="query { valueFromContext }",
+                ),
+            ).as_dict()
+        )
+
+        # we expect the second query to arrive first, because the
+        # first operation is stuck getting context
+        response = await ws.receive_json()
+        assert (
+            response
+            == NextMessage(
+                id="sub2", payload={"data": {"valueFromContext": "fast"}}
+            ).as_dict()
+        )
+
+        response = await ws.receive_json()
+        if response == CompleteMessage(id="sub2").as_dict():
+            response = await ws.receive_json()  # ignore the complete message
+        assert (
+            response
+            == NextMessage(
+                id="sub1", payload={"data": {"valueFromContext": "slow"}}
+            ).as_dict()
+        )

--- a/tests/websockets/test_graphql_transport_ws.py
+++ b/tests/websockets/test_graphql_transport_ws.py
@@ -997,7 +997,6 @@ async def test_long_validation_concurrent_query(ws: WebSocketClient):
     )
 
 
-@pytest.mark.xfail
 async def test_long_validation_concurrent_subscription(ws: WebSocketClient):
     """
     Test that the websocket is not blocked while validating a

--- a/tests/websockets/test_graphql_transport_ws.py
+++ b/tests/websockets/test_graphql_transport_ws.py
@@ -40,6 +40,10 @@ try:
     from ..http.clients.starlite import StarliteHttpClient
 except ImportError:
     StarliteHttpClient = None
+try:
+    from ..http.clients.litestar import LitestarHttpClient
+except ImportError:
+    LitestarHttpClient = None
 
 if TYPE_CHECKING:
     from ..http.clients.base import HttpClient
@@ -1108,7 +1112,7 @@ async def test_long_custom_context(
     """
     Test that the websocket is not blocked evaluating the context
     """
-    if http_client_class in (FastAPIHttpClient, StarliteHttpClient):
+    if http_client_class in (FastAPIHttpClient, StarliteHttpClient, LitestarHttpClient):
         pytest.skip("Client evaluates the context only once per connection")
 
     counter = 0

--- a/tests/websockets/test_graphql_transport_ws.py
+++ b/tests/websockets/test_graphql_transport_ws.py
@@ -34,15 +34,15 @@ from ..http.clients.base import WebSocketClient
 
 try:
     from ..http.clients.fastapi import FastAPIHttpClient
-except ImportError:
+except ImportError:  # pragma: no cover
     FastAPIHttpClient = None
 try:
     from ..http.clients.starlite import StarliteHttpClient
-except ImportError:
+except ImportError:  # pragma: no cover
     StarliteHttpClient = None
 try:
     from ..http.clients.litestar import LitestarHttpClient
-except ImportError:
+except ImportError:  # pragma: no cover
     LitestarHttpClient = None
 
 if TYPE_CHECKING:

--- a/tests/websockets/test_graphql_transport_ws.py
+++ b/tests/websockets/test_graphql_transport_ws.py
@@ -962,3 +962,70 @@ async def test_subscription_errors_continue(ws: WebSocketClient):
         response = await ws.receive_json()
         assert response["type"] == CompleteMessage.type
         assert response["id"] == "sub1"
+
+
+async def test_long_validation_concurrent_query(ws: WebSocketClient):
+    """
+    Test that the websocket is not blocked while validating a
+    single-result-operation
+    """
+    await ws.send_json(
+        SubscribeMessage(
+            id="sub1",
+            payload=SubscribeMessagePayload(
+                query="query { conditionalFail(sleep:0.1) }"
+            ),
+        ).as_dict()
+    )
+    await ws.send_json(
+        SubscribeMessage(
+            id="sub2",
+            payload=SubscribeMessagePayload(
+                query="query { conditionalFail(fail:false) }"
+            ),
+        ).as_dict()
+    )
+
+    # we expect the second query to arrive first, because the
+    # first query is stuck in validation
+    response = await ws.receive_json()
+    assert (
+        response
+        == NextMessage(
+            id="sub2", payload={"data": {"conditionalFail": "Hey"}}
+        ).as_dict()
+    )
+
+
+@pytest.mark.xfail
+async def test_long_validation_concurrent_subscription(ws: WebSocketClient):
+    """
+    Test that the websocket is not blocked while validating a
+    subscription
+    """
+    await ws.send_json(
+        SubscribeMessage(
+            id="sub1",
+            payload=SubscribeMessagePayload(
+                query="subscription { conditionalFail(sleep:0.1) }"
+            ),
+        ).as_dict()
+    )
+    await ws.send_json(
+        SubscribeMessage(
+            id="sub2",
+            payload=SubscribeMessagePayload(
+                query="query { conditionalFail(fail:false) }"
+            ),
+        ).as_dict()
+    )
+
+    # we expect the second query to arrive first, because the
+    # first operation is stuck in validation
+    response = await ws.receive_json()
+    assert (
+        response
+        == NextMessage(
+            id="sub2", payload={"data": {"conditionalFail": "Hey"}}
+        ).as_dict()
+    )

--- a/tests/websockets/test_graphql_transport_ws.py
+++ b/tests/websockets/test_graphql_transport_ws.py
@@ -1192,8 +1192,8 @@ async def test_task_error_handler(ws: WebSocketClient):
                 ).as_dict()
             )
 
-            # wait for the error to be logged
-            while not wakeup:
+            # wait for the error to be logged.  Must use timed loop and not event.
+            while not wakeup:  # noqa: ASYNC110
                 await asyncio.sleep(0.01)
             # and another little bit, for the thread to finish
             await asyncio.sleep(0.01)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

Now both `Context` creation and validation of an operation (subscripton or single-result operation) are performed
on the worker task, freeing up the Websocket for other requests.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Previously both creating the context, and validating the request, were done on the same task which handles
incoming messages for the Websocket.  Both of these operations are async and can potentially take a long time.
Now they are performed on the worker background `Task` which is created to handle the operation.

We add tests to make sure that long operations in context and validation don't block the websocket connection.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
