### PR TITLE
Allow a mutation query to utilize object arguments in codegen

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+Release type: patch
+
+This release fixes a bug where codegen would fail on mutations that have object arguments in the query.
+
+Additionally, it does a topological sort of the types before passing it to the plugins to ensure that
+dependent types are defined after their dependencies.

--- a/strawberry/codegen/plugins/print_operation.py
+++ b/strawberry/codegen/plugins/print_operation.py
@@ -16,6 +16,7 @@ from strawberry.codegen.types import (
     GraphQLList,
     GraphQLListValue,
     GraphQLObjectType,
+    GraphQLObjectValue,
     GraphQLOptional,
     GraphQLStringValue,
     GraphQLVariableReference,
@@ -123,6 +124,16 @@ class PrintOperationPlugin(QueryCodegenPlugin):
 
         if isinstance(value, GraphQLBoolValue):
             return str(value.value).lower()
+
+        if isinstance(value, GraphQLObjectValue):
+            return (
+                "{"
+                + ", ".join(
+                    f"{name}: {self._print_argument_value(v)}"
+                    for name, v in value.values.items()
+                )
+                + "}"
+            )
 
         raise ValueError(f"not supported: {type(value)}")  # pragma: no cover
 

--- a/strawberry/codegen/query_codegen.py
+++ b/strawberry/codegen/query_codegen.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from functools import cmp_to_key, lru_cache, partial
+from functools import cmp_to_key, partial
 from typing import (
     TYPE_CHECKING,
     Callable,

--- a/strawberry/codegen/types.py
+++ b/strawberry/codegen/types.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, List, Optional, Type, Union
+from typing import TYPE_CHECKING, List, Mapping, Optional, Type, Union
 
 if TYPE_CHECKING:
     from enum import EnumMeta
@@ -127,6 +127,11 @@ class GraphQLListValue:
 
 
 @dataclass
+class GraphQLObjectValue:
+    values: Mapping[str, GraphQLArgumentValue]
+
+
+@dataclass
 class GraphQLVariableReference:
     value: str
 
@@ -138,6 +143,7 @@ GraphQLArgumentValue = Union[
     GraphQLListValue,
     GraphQLEnumValue,
     GraphQLBoolValue,
+    GraphQLObjectValue,
 ]
 
 

--- a/tests/codegen/conftest.py
+++ b/tests/codegen/conftest.py
@@ -110,11 +110,34 @@ class Query:
         return p_or_a
 
 
+@strawberry.input
+class BlogPostInput:
+    title: str
+
+
+@strawberry.input
+class AddBlogPostsInput:
+    posts: List[BlogPostInput]
+
+
+@strawberry.type
+class AddBlogPostsOutput:
+    posts: List[BlogPost]
+
+
 @strawberry.type
 class Mutation:
     @strawberry.mutation
     def add_book(self, name: str) -> BlogPost:
         return BlogPost(id="c6f1c3ce-5249-4570-9182-c2836b836d14", name=name)
+
+    @strawberry.mutation
+    def add_blog_posts(self, input: AddBlogPostsInput) -> AddBlogPostsOutput:
+        output = AddBlogPostsOutput()
+        output.posts = []
+        for i, title in enumerate(input.posts):
+            output.posts.append(BlogPost(str(i), title))
+        return output
 
 
 @pytest.fixture

--- a/tests/codegen/queries/mutation_with_object.graphql
+++ b/tests/codegen/queries/mutation_with_object.graphql
@@ -1,0 +1,7 @@
+mutation addBlogPosts($input: [BlogPostInput!]!) {
+  addBlogPosts(input: {posts: $input}) {
+    posts {
+      title
+    }
+  }
+}

--- a/tests/codegen/queries/mutation_with_object.graphql
+++ b/tests/codegen/queries/mutation_with_object.graphql
@@ -1,4 +1,4 @@
-mutation addBlogPosts($input: [BlogPostInput!]!) {
+mutation AddBlogPosts($input: [BlogPostInput!]!) {
   addBlogPosts(input: {posts: $input}) {
     posts {
       title

--- a/tests/codegen/snapshots/python/mutation_with_object.py
+++ b/tests/codegen/snapshots/python/mutation_with_object.py
@@ -1,0 +1,16 @@
+from typing import List
+
+class addBlogPostsResultAddBlogPostsPosts:
+    title: str
+
+class addBlogPostsResultAddBlogPosts:
+    posts: List[addBlogPostsResultAddBlogPostsPosts]
+
+class addBlogPostsResult:
+    add_blog_posts: addBlogPostsResultAddBlogPosts
+
+class addBlogPostsVariables:
+    input: List[BlogPostInput]
+
+class BlogPostInput:
+    title: str

--- a/tests/codegen/snapshots/python/mutation_with_object.py
+++ b/tests/codegen/snapshots/python/mutation_with_object.py
@@ -9,8 +9,8 @@ class addBlogPostsResultAddBlogPosts:
 class addBlogPostsResult:
     add_blog_posts: addBlogPostsResultAddBlogPosts
 
-class addBlogPostsVariables:
-    input: List[BlogPostInput]
-
 class BlogPostInput:
     title: str
+
+class addBlogPostsVariables:
+    input: List[BlogPostInput]

--- a/tests/codegen/snapshots/python/mutation_with_object.py
+++ b/tests/codegen/snapshots/python/mutation_with_object.py
@@ -1,16 +1,16 @@
 from typing import List
 
-class addBlogPostsResultAddBlogPostsPosts:
+class AddBlogPostsResultAddBlogPostsPosts:
     title: str
 
-class addBlogPostsResultAddBlogPosts:
-    posts: List[addBlogPostsResultAddBlogPostsPosts]
+class AddBlogPostsResultAddBlogPosts:
+    posts: List[AddBlogPostsResultAddBlogPostsPosts]
 
-class addBlogPostsResult:
-    add_blog_posts: addBlogPostsResultAddBlogPosts
+class AddBlogPostsResult:
+    add_blog_posts: AddBlogPostsResultAddBlogPosts
 
 class BlogPostInput:
     title: str
 
-class addBlogPostsVariables:
+class AddBlogPostsVariables:
     input: List[BlogPostInput]

--- a/tests/codegen/snapshots/python/variables.py
+++ b/tests/codegen/snapshots/python/variables.py
@@ -3,13 +3,6 @@ from typing import List, Optional
 class OperationNameResult:
     with_inputs: bool
 
-class OperationNameVariables:
-    id: Optional[str]
-    input: ExampleInput
-    ids: List[str]
-    ids2: Optional[List[Optional[str]]]
-    ids3: Optional[List[Optional[List[Optional[str]]]]]
-
 class PersonInput:
     name: str
 
@@ -20,3 +13,10 @@ class ExampleInput:
     person: Optional[PersonInput]
     people: Optional[PersonInput]
     optional_people: Optional[Optional[PersonInput]]
+
+class OperationNameVariables:
+    id: Optional[str]
+    input: ExampleInput
+    ids: List[str]
+    ids2: Optional[List[Optional[str]]]
+    ids3: Optional[List[Optional[List[Optional[str]]]]]

--- a/tests/codegen/snapshots/typescript/mutation_with_object.ts
+++ b/tests/codegen/snapshots/typescript/mutation_with_object.ts
@@ -1,19 +1,19 @@
-type addBlogPostsResultAddBlogPostsPosts = {
+type AddBlogPostsResultAddBlogPostsPosts = {
     title: string
 }
 
-type addBlogPostsResultAddBlogPosts = {
-    posts: addBlogPostsResultAddBlogPostsPosts[]
+type AddBlogPostsResultAddBlogPosts = {
+    posts: AddBlogPostsResultAddBlogPostsPosts[]
 }
 
-type addBlogPostsResult = {
-    add_blog_posts: addBlogPostsResultAddBlogPosts
+type AddBlogPostsResult = {
+    add_blog_posts: AddBlogPostsResultAddBlogPosts
 }
 
 type BlogPostInput = {
     title: string
 }
 
-type addBlogPostsVariables = {
+type AddBlogPostsVariables = {
     input: BlogPostInput[]
 }

--- a/tests/codegen/snapshots/typescript/mutation_with_object.ts
+++ b/tests/codegen/snapshots/typescript/mutation_with_object.ts
@@ -10,10 +10,10 @@ type addBlogPostsResult = {
     add_blog_posts: addBlogPostsResultAddBlogPosts
 }
 
-type addBlogPostsVariables = {
-    input: BlogPostInput[]
-}
-
 type BlogPostInput = {
     title: string
+}
+
+type addBlogPostsVariables = {
+    input: BlogPostInput[]
 }

--- a/tests/codegen/snapshots/typescript/mutation_with_object.ts
+++ b/tests/codegen/snapshots/typescript/mutation_with_object.ts
@@ -1,0 +1,19 @@
+type addBlogPostsResultAddBlogPostsPosts = {
+    title: string
+}
+
+type addBlogPostsResultAddBlogPosts = {
+    posts: addBlogPostsResultAddBlogPostsPosts[]
+}
+
+type addBlogPostsResult = {
+    add_blog_posts: addBlogPostsResultAddBlogPosts
+}
+
+type addBlogPostsVariables = {
+    input: BlogPostInput[]
+}
+
+type BlogPostInput = {
+    title: string
+}

--- a/tests/codegen/snapshots/typescript/variables.ts
+++ b/tests/codegen/snapshots/typescript/variables.ts
@@ -2,14 +2,6 @@ type OperationNameResult = {
     with_inputs: boolean
 }
 
-type OperationNameVariables = {
-    id: string | undefined
-    input: ExampleInput
-    ids: string[]
-    ids2: (string | undefined)[] | undefined
-    ids3: ((string | undefined)[] | undefined)[] | undefined
-}
-
 type PersonInput = {
     name: string
 }
@@ -21,4 +13,12 @@ type ExampleInput = {
     person: PersonInput | undefined
     people: PersonInput | undefined
     optional_people: PersonInput | undefined | undefined
+}
+
+type OperationNameVariables = {
+    id: string | undefined
+    input: ExampleInput
+    ids: string[]
+    ids2: (string | undefined)[] | undefined
+    ids3: ((string | undefined)[] | undefined)[] | undefined
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The current codegen chokes on the following query with a `ValueError`:

```
mutation addBlogPosts($input: [BlogPostInput!]!) {
  addBlogPosts(input: {posts: $input}) {
    posts {
      title
    }
  }
}
```

It doesn't know how to handle the `Object` in the input position.

This PR fixes that.

Additionally, I noticed that the emitted types sometimes are not ordered properly.  (basically, they would fail to import without `from __future__ import annotations` due to forward references).  The plugin _could_ just add that import and things would likely be fine, but it seems easy enough to do a topological sort of the types before passing them to the plugins, so I figured that I would implement that as well.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #2830

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
