### PR TITLE
Fix: don't require NodeId if resolve_id is overwritten

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+relay: don't require NodeId annotation when resolve_id is overwritten

--- a/strawberry/relay/types.py
+++ b/strawberry/relay/types.py
@@ -374,6 +374,11 @@ class Node:
         ]
 
         if len(candidates) == 0:
+            # resolve_id is overwritten, allow unset _id_attr
+            for mro_cls in cls.__mro__:
+                if mro_cls != Node:
+                    if "resolve_id" in cls.__dict__:
+                        return
             raise NodeIDAnnotationError(
                 f'No field annotated with `nodeid` found in "{cls.__name__}"', cls
             )

--- a/strawberry/relay/types.py
+++ b/strawberry/relay/types.py
@@ -376,9 +376,8 @@ class Node:
         if len(candidates) == 0:
             # resolve_id is overwritten, allow unset _id_attr
             for mro_cls in cls.__mro__:
-                if mro_cls != Node:
-                    if "resolve_id" in cls.__dict__:
-                        return
+                if mro_cls is not Node and "resolve_id" in cls.__dict__:
+                    return
             raise NodeIDAnnotationError(
                 f'No field annotated with `nodeid` found in "{cls.__name__}"', cls
             )

--- a/strawberry/relay/types.py
+++ b/strawberry/relay/types.py
@@ -220,7 +220,6 @@ class GlobalID:
             The resolved GraphQL type for the execution info
 
         """
-        schema = info.schema
         type_def = info.schema.get_type_by_name(self.type_name)
         assert isinstance(type_def, TypeDefinition)
 

--- a/strawberry/relay/types.py
+++ b/strawberry/relay/types.py
@@ -376,7 +376,10 @@ class Node:
         if len(candidates) == 0:
             # resolve_id is overwritten, allow unset _id_attr
             for mro_cls in cls.__mro__:
-                if mro_cls is not Node and "resolve_id" in cls.__dict__:
+                # stop when Node is reached
+                if mro_cls is Node:
+                    break
+                if "resolve_id" in cls.__dict__:
                     return
             raise NodeIDAnnotationError(
                 f'No field annotated with `nodeid` found in "{cls.__name__}"', cls

--- a/tests/relay/test_exceptions.py
+++ b/tests/relay/test_exceptions.py
@@ -26,16 +26,6 @@ def test_raises_error_on_missing_node_id_annotation():
         code: str
 
 
-def test_not_raises_error_on_missing_node_id_annotation_but_resolve_id():
-    @strawberry.type
-    class Fruit(relay.Node):
-        code: str
-
-        @classmethod
-        def resolve_id(cls, root) -> str:
-            return "test"
-
-
 @pytest.mark.raises_strawberry_exception(
     NodeIDAnnotationError,
     match='More than one field annotated with `NodeID` found in "Fruit"',

--- a/tests/relay/test_exceptions.py
+++ b/tests/relay/test_exceptions.py
@@ -26,6 +26,16 @@ def test_raises_error_on_missing_node_id_annotation():
         code: str
 
 
+def test_not_raises_error_on_missing_node_id_annotation_but_resolve_id():
+    @strawberry.type
+    class Fruit(relay.Node):
+        code: str
+
+        @classmethod
+        def resolve_id(cls, root) -> str:
+            return "test"
+
+
 @pytest.mark.raises_strawberry_exception(
     NodeIDAnnotationError,
     match='More than one field annotated with `NodeID` found in "Fruit"',

--- a/tests/relay/test_types.py
+++ b/tests/relay/test_types.py
@@ -3,6 +3,7 @@ from typing_extensions import assert_type
 
 import pytest
 
+import strawberry
 from strawberry import relay
 from strawberry.types.info import Info
 
@@ -148,3 +149,13 @@ async def test_global_id_resolve_node_ensure_type_wrong_type():
     gid = relay.GlobalID(type_name="FruitAsync", node_id="1")
     with pytest.raises(TypeError):
         fruit = await gid.resolve_node(fake_info, ensure_type=Foo)
+
+
+def test_not_raises_error_on_missing_node_id_annotation_but_resolve_id():
+    @strawberry.type
+    class Fruit(relay.Node):
+        code: str
+
+        @classmethod
+        def resolve_id(cls, root) -> str:
+            return "test"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
If resolve_id is overwritten it is valid that no NodeId annotation is found (custom logic). Don't fail in this case

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #2816

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
