### PR TITLE
refactor: resolve `relay.NodeID` annotations when creating the schema itself

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,3 @@
 Release type: minor
 
-This release changes the way we check for `relay.NodeID` annotations to be done
-later instead of in class initialization. This solves problems with trying to
-evaluate type annotations before they are totally defined, and also allows
-integrations to inject code for it in the type.
+This release improves the ﻿`relay.NodeID` annotation check by delaying it until after class initialization. This resolves issues with evaluating type annotations before they are fully defined and enables integrations to inject code for it in the type.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+Release type: minor
+
+This release changes the way we check for `relay.NodeID` annotations to be done
+later instead of in class initialization. This solves problems with trying to
+evaluate type annotations before they are totally defined, and also allows
+integrations to inject code for it in the type.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -334,6 +334,7 @@ src = ["strawberry", "tests"]
 "tests/http/clients/__init__.py" = ["F401"]
 "tests/schema/test_scalars.py" = ["E501"]
 "tests/schema/test_basic.py" = ["E501"]
+"tests/relay/test_schema.py" = ["E501"]
 
 [tool.ruff.isort]
 known-first-party = ["strawberry"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -334,7 +334,6 @@ src = ["strawberry", "tests"]
 "tests/http/clients/__init__.py" = ["F401"]
 "tests/schema/test_scalars.py" = ["E501"]
 "tests/schema/test_basic.py" = ["E501"]
-"tests/relay/test_schema.py" = ["E501"]
 
 [tool.ruff.isort]
 known-first-party = ["strawberry"]

--- a/strawberry/relay/types.py
+++ b/strawberry/relay/types.py
@@ -30,7 +30,6 @@ from typing_extensions import (
     TypeAlias,
     get_args,
     get_origin,
-    get_type_hints,
 )
 
 from strawberry.field import field
@@ -42,6 +41,7 @@ from strawberry.type import StrawberryContainer
 from strawberry.types.types import TypeDefinition
 from strawberry.utils.aio import aenumerate, aislice, resolve_awaitable
 from strawberry.utils.inspect import in_async_context
+from strawberry.utils.typing import eval_type
 
 from .utils import from_base64, to_base64
 
@@ -358,36 +358,7 @@ class Node:
 
     """
 
-    _id_attr: ClassVar[str]
-
-    def __init_subclass__(cls, **kwargs: Any):
-        annotations = get_type_hints(cls, include_extras=True)
-        candidates = [
-            attr
-            for attr, annotation in annotations.items()
-            if (
-                get_origin(annotation) is Annotated
-                and any(
-                    isinstance(argument, NodeIDPrivate)
-                    for argument in get_args(annotation)
-                )
-            )
-        ]
-
-        if len(candidates) == 0:
-            raise NodeIDAnnotationError(
-                f'No field annotated with `nodeid` found in "{cls.__name__}"', cls
-            )
-        if len(candidates) > 1:
-            raise NodeIDAnnotationError(
-                (
-                    "More than one field annotated with `NodeID` "
-                    f'found in "{cls.__name__}"'
-                ),
-                cls,
-            )
-
-        cls._id_attr = candidates[0]
+    _id_attr: ClassVar[Optional[str]] = None
 
     @field(name="id", description="The Globally Unique ID of this object")
     @classmethod
@@ -427,6 +398,44 @@ class Node:
         return GlobalID(type_name=type_name, node_id=str(node_id))
 
     @classmethod
+    def resolve_id_attr(cls) -> str:
+        if cls._id_attr is None:
+            candidates: list[str] = []
+            for base in cls.__mro__:
+                base_namespace = sys.modules[base.__module__].__dict__
+
+                for attr_name, attr in getattr(base, "__annotations__", {}).items():
+                    evaled = eval_type(attr, globalns=base_namespace)
+
+                    if get_origin(evaled) is Annotated and any(
+                        isinstance(a, NodeIDPrivate) for a in get_args(evaled)
+                    ):
+                        candidates.append(attr_name)
+
+                # If we found candidates in this base, stop looking for more
+                # This is to support subclasses to define something else than
+                # its superclass as a NodeID
+                if candidates:
+                    break
+
+            if len(candidates) == 0:
+                raise NodeIDAnnotationError(
+                    f'No field annotated with `NodeID` found in "{cls.__name__}"', cls
+                )
+            if len(candidates) > 1:
+                raise NodeIDAnnotationError(
+                    (
+                        "More than one field annotated with `NodeID` "
+                        f'found in "{cls.__name__}"'
+                    ),
+                    cls,
+                )
+
+            cls._id_attr = candidates[0]
+
+        return cls._id_attr
+
+    @classmethod
     def resolve_id(
         cls,
         root: Self,
@@ -450,7 +459,7 @@ class Node:
             The resolved id (which is expected to be str)
 
         """
-        return getattr(root, cls._id_attr)
+        return getattr(root, cls.resolve_id_attr())
 
     @classmethod
     def resolve_typename(cls, root: Self, info: Info) -> str:

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -164,17 +164,7 @@ class Schema(BaseSchema):
         self._schema._strawberry_schema = self  # type: ignore
 
         self._warn_for_federation_directives()
-
-        for concrete_type in self.schema_converter.type_map.values():
-            type_def = concrete_type.definition
-            if (
-                isinstance(type_def, TypeDefinition)
-                and issubclass(type_def.origin, relay.Node)
-                and type_def.origin is not relay.Node
-            ):
-                # Call resolve_id_attr in here to make sure we raise provide
-                # early feedback for missing NodeID annotations
-                type_def.origin.resolve_id_attr()
+        self._validate_types_node_id_attr()
 
         # Validate schema early because we want developers to know about
         # possible issues as soon as possible
@@ -317,6 +307,28 @@ class Schema(BaseSchema):
             variable_values=variable_values,
             operation_name=operation_name,
         )
+
+    def _validate_types_node_id_attr(self):
+        for concrete_type in self.schema_converter.type_map.values():
+            type_def = concrete_type.definition
+
+            # This can be a TypeDefinition, EnumDefinition, ScalarDefinition
+            # or UnionDefinition
+            if not isinstance(type_def, TypeDefinition):
+                continue
+
+            # Do not validate id_attr for interfaces. relay.Node itself and
+            # any other interfdace that implements it are not required to
+            # provide a NodeID annotation, only the concrete type implementing
+            # them needs to do that.
+            if type_def.is_interface:
+                continue
+
+            # Call resolve_id_attr in here to make sure we raise provide
+            # early feedback for missing NodeID annotations
+            origin = type_def.origin
+            if issubclass(origin, relay.Node):
+                origin.resolve_id_attr()
 
     def _warn_for_federation_directives(self):
         """Raises a warning if the schema has any federation directives."""

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -164,7 +164,7 @@ class Schema(BaseSchema):
         self._schema._strawberry_schema = self  # type: ignore
 
         self._warn_for_federation_directives()
-        self._validate_types_node_id_attr()
+        self._resolve_node_ids()
 
         # Validate schema early because we want developers to know about
         # possible issues as soon as possible
@@ -308,7 +308,7 @@ class Schema(BaseSchema):
             operation_name=operation_name,
         )
 
-    def _validate_types_node_id_attr(self):
+    def _resolve_node_ids(self):
         for concrete_type in self.schema_converter.type_map.values():
             type_def = concrete_type.definition
 

--- a/tests/relay/test_exceptions.py
+++ b/tests/relay/test_exceptions.py
@@ -18,12 +18,20 @@ class NonNodeType:
 
 @pytest.mark.raises_strawberry_exception(
     NodeIDAnnotationError,
-    match='No field annotated with `nodeid` found in "Fruit"',
+    match='No field annotated with `NodeID` found in "Fruit"',
 )
 def test_raises_error_on_missing_node_id_annotation():
     @strawberry.type
     class Fruit(relay.Node):
         code: str
+
+    @strawberry.type
+    class Query:
+        @relay.connection(relay.ListConnection[Fruit])
+        def fruits(self) -> List[Fruit]:
+            ...
+
+    strawberry.Schema(query=Query)
 
 
 @pytest.mark.raises_strawberry_exception(
@@ -35,6 +43,14 @@ def test_raises_error_on_multiple_node_id_annotation():
     class Fruit(relay.Node):
         pk: relay.NodeID[str]
         code: relay.NodeID[str]
+
+    @strawberry.type
+    class Query:
+        @relay.connection(relay.ListConnection[Fruit])
+        def fruits(self) -> List[Fruit]:
+            ...
+
+    strawberry.Schema(query=Query)
 
 
 @pytest.mark.raises_strawberry_exception(

--- a/tests/relay/test_schema.py
+++ b/tests/relay/test_schema.py
@@ -2,9 +2,12 @@ import pathlib
 import textwrap
 from typing import List
 
+from pytest_mock import MockerFixture
+
 import strawberry
 from strawberry import relay
 from strawberry.relay.utils import to_base64
+from strawberry.schema.types.scalar import DEFAULT_SCALAR_REGISTRY
 
 from .schema import schema
 
@@ -22,7 +25,14 @@ def test_schema():
     assert schema_output == expected
 
 
-def test_node_id_annotation():
+def test_node_id_annotation(mocker: MockerFixture):
+    # Avoid E501 errors
+    mocker.patch.object(
+        DEFAULT_SCALAR_REGISTRY[relay.GlobalID],
+        "description",
+        "__GLOBAL_ID_DESC__",
+    )
+
     @strawberry.type
     class Fruit(relay.Node):
         code: relay.NodeID[int]
@@ -59,9 +69,7 @@ def test_node_id_annotation():
           node: Fruit!
         }
 
-        """
-        The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `"4"`) or integer (such as `4`) input value will be accepted as an ID.
-        """
+        """__GLOBAL_ID_DESC__"""
         scalar GlobalID @specifiedBy(url: "https://relay.dev/graphql/objectidentification.htm")
 
         """An object with a Globally Unique ID"""
@@ -124,7 +132,14 @@ def test_node_id_annotation():
     }
 
 
-def test_node_id_annotation_in_superclass():
+def test_node_id_annotation_in_superclass(mocker: MockerFixture):
+    # Avoid E501 errors
+    mocker.patch.object(
+        DEFAULT_SCALAR_REGISTRY[relay.GlobalID],
+        "description",
+        "__GLOBAL_ID_DESC__",
+    )
+
     @strawberry.type
     class BaseFruit(relay.Node):
         code: relay.NodeID[int]
@@ -165,9 +180,7 @@ def test_node_id_annotation_in_superclass():
           node: Fruit!
         }
 
-        """
-        The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `"4"`) or integer (such as `4`) input value will be accepted as an ID.
-        """
+        """__GLOBAL_ID_DESC__"""
         scalar GlobalID @specifiedBy(url: "https://relay.dev/graphql/objectidentification.htm")
 
         """An object with a Globally Unique ID"""
@@ -230,7 +243,14 @@ def test_node_id_annotation_in_superclass():
     }
 
 
-def test_node_id_annotation_in_superclass_and_subclass():
+def test_node_id_annotation_in_superclass_and_subclass(mocker: MockerFixture):
+    # Avoid E501 errors
+    mocker.patch.object(
+        DEFAULT_SCALAR_REGISTRY[relay.GlobalID],
+        "description",
+        "__GLOBAL_ID_DESC__",
+    )
+
     @strawberry.type
     class BaseFruit(relay.Node):
         code: relay.NodeID[int]
@@ -271,9 +291,7 @@ def test_node_id_annotation_in_superclass_and_subclass():
           node: Fruit!
         }
 
-        """
-        The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `"4"`) or integer (such as `4`) input value will be accepted as an ID.
-        """
+        """__GLOBAL_ID_DESC__"""
         scalar GlobalID @specifiedBy(url: "https://relay.dev/graphql/objectidentification.htm")
 
         """An object with a Globally Unique ID"""

--- a/tests/relay/test_schema.py
+++ b/tests/relay/test_schema.py
@@ -1,4 +1,10 @@
 import pathlib
+import textwrap
+from typing import List
+
+import strawberry
+from strawberry import relay
+from strawberry.relay.utils import to_base64
 
 from .schema import schema
 
@@ -14,3 +20,317 @@ def test_schema():
         expected = f.read().strip("\n").strip(" ")
 
     assert schema_output == expected
+
+
+def test_node_id_annotation():
+    @strawberry.type
+    class Fruit(relay.Node):
+        code: relay.NodeID[int]
+
+    @strawberry.type
+    class Query:
+        @relay.connection(relay.ListConnection[Fruit])
+        def fruits(self) -> List[Fruit]:
+            return [Fruit(code=i) for i in range(10)]
+
+    schema = strawberry.Schema(query=Query)
+    expected = textwrap.dedent(
+        '''
+        type Fruit implements Node {
+          """The Globally Unique ID of this object"""
+          id: GlobalID!
+        }
+
+        """A connection to a list of items."""
+        type FruitConnection {
+          """Pagination data for this connection"""
+          pageInfo: PageInfo!
+
+          """Contains the nodes in this connection"""
+          edges: [FruitEdge!]!
+        }
+
+        """An edge in a connection."""
+        type FruitEdge {
+          """A cursor for use in pagination"""
+          cursor: String!
+
+          """The item at the end of the edge"""
+          node: Fruit!
+        }
+
+        """
+        The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `"4"`) or integer (such as `4`) input value will be accepted as an ID.
+        """
+        scalar GlobalID @specifiedBy(url: "https://relay.dev/graphql/objectidentification.htm")
+
+        """An object with a Globally Unique ID"""
+        interface Node {
+          """The Globally Unique ID of this object"""
+          id: GlobalID!
+        }
+
+        """Information to aid in pagination."""
+        type PageInfo {
+          """When paginating forwards, are there more items?"""
+          hasNextPage: Boolean!
+
+          """When paginating backwards, are there more items?"""
+          hasPreviousPage: Boolean!
+
+          """When paginating backwards, the cursor to continue."""
+          startCursor: String
+
+          """When paginating forwards, the cursor to continue."""
+          endCursor: String
+        }
+
+        type Query {
+          fruits(
+            """Returns the items in the list that come before the specified cursor."""
+            before: String = null
+
+            """Returns the items in the list that come after the specified cursor."""
+            after: String = null
+
+            """Returns the first n items from the list."""
+            first: Int = null
+
+            """Returns the items in the list that come after the specified cursor."""
+            last: Int = null
+          ): FruitConnection!
+        }
+        '''
+    ).strip()
+    assert str(schema) == expected
+    result = schema.execute_sync(
+        """
+        query {
+          fruits {
+            edges {
+              node {
+                id
+              }
+            }
+          }
+        }
+        """
+    )
+    assert result.errors is None
+    assert result.data == {
+        "fruits": {
+            "edges": [{"node": {"id": to_base64("Fruit", i)}} for i in range(10)]
+        }
+    }
+
+
+def test_node_id_annotation_in_superclass():
+    @strawberry.type
+    class BaseFruit(relay.Node):
+        code: relay.NodeID[int]
+
+    @strawberry.type
+    class Fruit(BaseFruit):
+        ...
+
+    @strawberry.type
+    class Query:
+        @relay.connection(relay.ListConnection[Fruit])
+        def fruits(self) -> List[Fruit]:
+            return [Fruit(code=i) for i in range(10)]
+
+    schema = strawberry.Schema(query=Query)
+    expected = textwrap.dedent(
+        '''
+        type Fruit implements Node {
+          """The Globally Unique ID of this object"""
+          id: GlobalID!
+        }
+
+        """A connection to a list of items."""
+        type FruitConnection {
+          """Pagination data for this connection"""
+          pageInfo: PageInfo!
+
+          """Contains the nodes in this connection"""
+          edges: [FruitEdge!]!
+        }
+
+        """An edge in a connection."""
+        type FruitEdge {
+          """A cursor for use in pagination"""
+          cursor: String!
+
+          """The item at the end of the edge"""
+          node: Fruit!
+        }
+
+        """
+        The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `"4"`) or integer (such as `4`) input value will be accepted as an ID.
+        """
+        scalar GlobalID @specifiedBy(url: "https://relay.dev/graphql/objectidentification.htm")
+
+        """An object with a Globally Unique ID"""
+        interface Node {
+          """The Globally Unique ID of this object"""
+          id: GlobalID!
+        }
+
+        """Information to aid in pagination."""
+        type PageInfo {
+          """When paginating forwards, are there more items?"""
+          hasNextPage: Boolean!
+
+          """When paginating backwards, are there more items?"""
+          hasPreviousPage: Boolean!
+
+          """When paginating backwards, the cursor to continue."""
+          startCursor: String
+
+          """When paginating forwards, the cursor to continue."""
+          endCursor: String
+        }
+
+        type Query {
+          fruits(
+            """Returns the items in the list that come before the specified cursor."""
+            before: String = null
+
+            """Returns the items in the list that come after the specified cursor."""
+            after: String = null
+
+            """Returns the first n items from the list."""
+            first: Int = null
+
+            """Returns the items in the list that come after the specified cursor."""
+            last: Int = null
+          ): FruitConnection!
+        }
+        '''
+    ).strip()
+    assert str(schema) == expected
+    result = schema.execute_sync(
+        """
+        query {
+          fruits {
+            edges {
+              node {
+                id
+              }
+            }
+          }
+        }
+        """
+    )
+    assert result.errors is None
+    assert result.data == {
+        "fruits": {
+            "edges": [{"node": {"id": to_base64("Fruit", i)}} for i in range(10)]
+        }
+    }
+
+
+def test_node_id_annotation_in_superclass_and_subclass():
+    @strawberry.type
+    class BaseFruit(relay.Node):
+        code: relay.NodeID[int]
+
+    @strawberry.type
+    class Fruit(BaseFruit):
+        other_code: relay.NodeID[int]
+
+    @strawberry.type
+    class Query:
+        @relay.connection(relay.ListConnection[Fruit])
+        def fruits(self) -> List[Fruit]:
+            return [Fruit(code=i, other_code=i) for i in range(10)]
+
+    schema = strawberry.Schema(query=Query)
+    expected = textwrap.dedent(
+        '''
+        type Fruit implements Node {
+          """The Globally Unique ID of this object"""
+          id: GlobalID!
+        }
+
+        """A connection to a list of items."""
+        type FruitConnection {
+          """Pagination data for this connection"""
+          pageInfo: PageInfo!
+
+          """Contains the nodes in this connection"""
+          edges: [FruitEdge!]!
+        }
+
+        """An edge in a connection."""
+        type FruitEdge {
+          """A cursor for use in pagination"""
+          cursor: String!
+
+          """The item at the end of the edge"""
+          node: Fruit!
+        }
+
+        """
+        The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `"4"`) or integer (such as `4`) input value will be accepted as an ID.
+        """
+        scalar GlobalID @specifiedBy(url: "https://relay.dev/graphql/objectidentification.htm")
+
+        """An object with a Globally Unique ID"""
+        interface Node {
+          """The Globally Unique ID of this object"""
+          id: GlobalID!
+        }
+
+        """Information to aid in pagination."""
+        type PageInfo {
+          """When paginating forwards, are there more items?"""
+          hasNextPage: Boolean!
+
+          """When paginating backwards, are there more items?"""
+          hasPreviousPage: Boolean!
+
+          """When paginating backwards, the cursor to continue."""
+          startCursor: String
+
+          """When paginating forwards, the cursor to continue."""
+          endCursor: String
+        }
+
+        type Query {
+          fruits(
+            """Returns the items in the list that come before the specified cursor."""
+            before: String = null
+
+            """Returns the items in the list that come after the specified cursor."""
+            after: String = null
+
+            """Returns the first n items from the list."""
+            first: Int = null
+
+            """Returns the items in the list that come after the specified cursor."""
+            last: Int = null
+          ): FruitConnection!
+        }
+        '''
+    ).strip()
+    assert str(schema) == expected
+    result = schema.execute_sync(
+        """
+        query {
+          fruits {
+            edges {
+              node {
+                id
+              }
+            }
+          }
+        }
+        """
+    )
+    assert result.errors is None
+    assert result.data == {
+        "fruits": {
+            "edges": [{"node": {"id": to_base64("Fruit", i)}} for i in range(10)]
+        }
+    }


### PR DESCRIPTION
Fix #2833