### PR TITLE
added url sharing for graphiql

### DIFF
--- a/strawberry/static/graphiql.html
+++ b/strawberry/static/graphiql.html
@@ -113,6 +113,35 @@
 #   Auto Complete:  Ctrl-Space (or just start typing)
 #
 `;
+      const parameters = {};
+
+      for (const entry of window.location.search.slice(1).split('&')) {
+        const eq = entry.indexOf('=');
+        if (eq >= 0) {
+          parameters[decodeURIComponent(entry.slice(0, eq))] = decodeURIComponent(
+            entry.slice(eq + 1),
+          );
+        }
+      }
+
+      function updateURL(data) {
+
+        Object.assign(parameters, data);
+
+        const newSearch =
+          '?' +
+          Object.keys(parameters)
+            .filter(function (key) {
+              return Boolean(parameters[key]);
+            })
+            .map(function (key) {
+              return (
+                encodeURIComponent(key) + '=' + encodeURIComponent(parameters[key])
+              );
+            })
+            .join('&');
+        history.replaceState(null, null, newSearch);
+      }
 
       const fetchURL = window.location.href;
 
@@ -142,19 +171,57 @@
         subscriptionUrl,
       });
 
+
       function GraphiQLWithExplorer() {
-        const [query, setQuery] = React.useState(EXAMPLE_QUERY);
+        const [query, setQuery] = React.useState(parameters.q || EXAMPLE_QUERY);
+        const [variables, setVariables] = React.useState(null);
+        const activeTab = React.useRef(null);
+        const [headers, setHeaders] = React.useState(null);
+
+        function onEditQuery(query) {
+          setQuery(query)
+          updateURL({ q: query });
+        }
+
+        function onEditVariables(variables) {
+          updateURL({ variables });
+        }
+
+        function onEditHeaders(headers) {
+          updateURL({ headers });
+        }
+
+        function onTabChange(tabsState) {
+          if (activeTab.current !== tabsState.activeTabIndex) {
+            activeTab.current = tabsState.activeTabIndex;
+
+            const query = tabsState.tabs[tabsState.activeTabIndex].query
+            setQuery(query);
+            updateURL({q: query});
+          }
+        }
+
         const explorerPlugin = GraphiQLPluginExplorer.useExplorerPlugin({
           query: query,
-          onEdit: setQuery,
+          onEdit: onEditQuery,
         });
+
         return React.createElement(GraphiQL, {
           fetcher: fetcher,
           defaultEditorToolsVisibility: true,
+          headers: headers,
           plugins: [explorerPlugin],
           query: query,
-          onEditQuery: setQuery,
+          variables: variables,
+          onEditQuery: onEditQuery,
+          onEditHeaders: onEditHeaders,
+          onEditVariables: onEditVariables,
+          onTabChange: onTabChange,
           inputValueDeprecation: true,
+          defaultEditorToolsVisibility: true,
+          isHeadersEditorEnabled: true,
+          shouldPersistHeaders: true,
+          defaultHeaders: parameters.defaultHeaders,
         });
       }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

After each page reload, a new tab is created and I am unable to share my query via URL. In Apollo or Graphene, this functionality is available, so it would be great to have the same behavior implemented in Strawberry as well.

Inspired by [renderExample.js](https://github.com/graphql/graphiql/blob/d9e5089f78f85cd50c3e3e3ba8510f7dda3d06f5/packages/graphiql/resources/renderExample.js#L30). 

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist


<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

<img width="1728" alt="Screenshot 2023-06-12 at 20 49 46" src="https://github.com/strawberry-graphql/strawberry/assets/10367100/4517f7bf-510f-4330-b63e-656d5452d617">
<img width="1728" alt="Screenshot 2023-06-12 at 20 50 16" src="https://github.com/strawberry-graphql/strawberry/assets/10367100/2fcc8b84-0dcf-4455-9f19-765775def5b2">
