### PR TITLE
fix: relay.Node with overwritten resolve_id and without NodeId 

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,3 @@
 Release type: patch
 
-relay: don't require NodeId annotation if resolve_id is overwritten
-relay: add tests for resolve_id overwrites
+Don't require `NodeId` annotation if resolve_id is overwritten on `Node` implemented types

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+relay: don't require NodeId annotation if resolve_id is overwritten
+relay: add tests for resolve_id overwrites

--- a/strawberry/relay/types.py
+++ b/strawberry/relay/types.py
@@ -217,7 +217,6 @@ class GlobalID:
             The resolved GraphQL type for the execution info
 
         """
-        schema = info.schema
         type_def = info.schema.get_type_by_name(self.type_name)
         assert isinstance(type_def, StrawberryObjectDefinition)
 

--- a/strawberry/relay/types.py
+++ b/strawberry/relay/types.py
@@ -360,21 +360,6 @@ class Node:
 
     _id_attr: ClassVar[Optional[str]] = None
 
-    def __init_subclass__(cls, **kwargs: Any):
-        super().__init_subclass__(**kwargs)
-        # Call resolve_id_attr in here to make sure we raise provide
-        # early feedback for missing NodeID annotations
-        has_custom_resolve_id = False
-        for base in cls.__mro__:
-            if base is Node:
-                break
-            if "resolve_id" in base.__dict__:
-                has_custom_resolve_id = True
-                break
-
-        if not has_custom_resolve_id:
-            cls.resolve_id_attr()
-
     @field(name="id", description="The Globally Unique ID of this object")
     @classmethod
     def _id(cls, root: Node, info: Info) -> GlobalID:

--- a/strawberry/relay/types.py
+++ b/strawberry/relay/types.py
@@ -360,6 +360,21 @@ class Node:
 
     _id_attr: ClassVar[Optional[str]] = None
 
+    def __init_subclass__(cls, **kwargs: Any):
+        super().__init_subclass__(**kwargs)
+        # Call resolve_id_attr in here to make sure we raise provide
+        # early feedback for missing NodeID annotations
+        has_custom_resolve_id = False
+        for base in cls.__mro__:
+            if base is Node:
+                break
+            if "resolve_id" in base.__dict__:
+                has_custom_resolve_id = True
+                break
+
+        if not has_custom_resolve_id:
+            cls.resolve_id_attr()
+
     @field(name="id", description="The Globally Unique ID of this object")
     @classmethod
     def _id(cls, root: Node, info: Info) -> GlobalID:

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -334,7 +334,16 @@ class Schema(BaseSchema):
             # early feedback for missing NodeID annotations
             origin = type_def.origin
             if issubclass(origin, relay.Node):
-                origin.resolve_id_attr()
+                has_custom_resolve_id = False
+                for base in origin.__mro__:
+                    if base is relay.Node:
+                        break
+                    if "resolve_id" in base.__dict__:
+                        has_custom_resolve_id = True
+                        break
+
+                if not has_custom_resolve_id:
+                    origin.resolve_id_attr()
 
     def _warn_for_federation_directives(self):
         """Raises a warning if the schema has any federation directives."""

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -26,7 +26,6 @@ from graphql import (
 from graphql.execution import subscribe
 from graphql.type.directives import specified_directives
 
-from strawberry import relay
 from strawberry.annotation import StrawberryAnnotation
 from strawberry.extensions.directives import (
     DirectivesExtension,
@@ -329,21 +328,6 @@ class Schema(BaseSchema):
             # them needs to do that.
             if type_def.is_interface:
                 continue
-
-            # Call resolve_id_attr in here to make sure we raise provide
-            # early feedback for missing NodeID annotations
-            origin = type_def.origin
-            if issubclass(origin, relay.Node):
-                has_custom_resolve_id = False
-                for base in origin.__mro__:
-                    if base is relay.Node:
-                        break
-                    if "resolve_id" in base.__dict__:
-                        has_custom_resolve_id = True
-                        break
-
-                if not has_custom_resolve_id:
-                    origin.resolve_id_attr()
 
     def _warn_for_federation_directives(self):
         """Raises a warning if the schema has any federation directives."""

--- a/tests/relay/test_schema.py
+++ b/tests/relay/test_schema.py
@@ -379,25 +379,26 @@ def test_overwrite_resolve_id_and_no_node_id(mocker: MockerFixture):
 
     expected_type = textwrap.dedent(
         '''
-        type Fruit implements Node {
-        """The Globally Unique ID of this object"""
-        id: GlobalID!
-        color: String!
-      }
+          type Fruit implements Node {
+          """The Globally Unique ID of this object"""
+          id: GlobalID!
+          color: String!
+        }
 
-      """__GLOBAL_ID_DESC__"""
-      scalar GlobalID @specifiedBy(url: "https://relay.dev/graphql/objectidentification.htm")
+        """__GLOBAL_ID_DESC__"""
+        scalar GlobalID @specifiedBy(url: "https://relay.dev/graphql/objectidentification.htm")
 
-      """An object with a Globally Unique ID"""
-      interface Node {
-        """The Globally Unique ID of this object"""
-        id: GlobalID!
-      }
+        """An object with a Globally Unique ID"""
+        interface Node {
+          """The Globally Unique ID of this object"""
+          id: GlobalID!
+        }
 
-      type Query {
-        fruit: Fruit!
-      }
-      '''
+        type Query {
+          fruit: Fruit!
+        }
+        '''
+    )
 
     schema = strawberry.Schema(query=Query)
 

--- a/tests/relay/test_schema.py
+++ b/tests/relay/test_schema.py
@@ -367,11 +367,11 @@ def test_overwrite_resolve_id_and_no_node_id(mocker: MockerFixture):
 
     @strawberry.type
     class Fruit(relay.Node):
-        code: str
+        color: str
 
         @classmethod
         def resolve_id(cls, root) -> str:
-            return "test"
+            return "test"  # pragma: no cover
 
     @strawberry.type
     class Query:
@@ -380,7 +380,7 @@ def test_overwrite_resolve_id_and_no_node_id(mocker: MockerFixture):
     expected_type = '''type Fruit implements Node {
   """The Globally Unique ID of this object"""
   id: GlobalID!
-  code: String!
+  color: String!
 }
 
 """__GLOBAL_ID_DESC__"""

--- a/tests/relay/test_schema.py
+++ b/tests/relay/test_schema.py
@@ -356,3 +356,47 @@ def test_node_id_annotation_in_superclass_and_subclass(mocker: MockerFixture):
             "edges": [{"node": {"id": to_base64("Fruit", i)}} for i in range(10)]
         }
     }
+
+
+def test_overwrite_resolve_id_and_no_node_id(mocker: MockerFixture):
+    mocker.patch.object(
+        DEFAULT_SCALAR_REGISTRY[relay.GlobalID],
+        "description",
+        "__GLOBAL_ID_DESC__",
+    )
+
+    @strawberry.type
+    class Fruit(relay.Node):
+        code: str
+
+        @classmethod
+        def resolve_id(cls, root) -> str:
+            return "test"
+
+    @strawberry.type
+    class Query:
+        fruit: Fruit
+
+    expected_type = '''type Fruit implements Node {
+  """The Globally Unique ID of this object"""
+  id: GlobalID!
+  code: String!
+}
+
+"""__GLOBAL_ID_DESC__"""
+scalar GlobalID @specifiedBy(url: "https://relay.dev/graphql/objectidentification.htm")
+
+"""An object with a Globally Unique ID"""
+interface Node {
+  """The Globally Unique ID of this object"""
+  id: GlobalID!
+}
+
+type Query {
+  fruit: Fruit!
+}
+    '''
+
+    schema = strawberry.Schema(query=Query)
+
+    assert str(schema) == textwrap.dedent(expected_type).strip()

--- a/tests/relay/test_schema.py
+++ b/tests/relay/test_schema.py
@@ -377,25 +377,27 @@ def test_overwrite_resolve_id_and_no_node_id(mocker: MockerFixture):
     class Query:
         fruit: Fruit
 
-    expected_type = '''type Fruit implements Node {
-  """The Globally Unique ID of this object"""
-  id: GlobalID!
-  color: String!
-}
+    expected_type = textwrap.dedent(
+        '''
+        type Fruit implements Node {
+        """The Globally Unique ID of this object"""
+        id: GlobalID!
+        color: String!
+      }
 
-"""__GLOBAL_ID_DESC__"""
-scalar GlobalID @specifiedBy(url: "https://relay.dev/graphql/objectidentification.htm")
+      """__GLOBAL_ID_DESC__"""
+      scalar GlobalID @specifiedBy(url: "https://relay.dev/graphql/objectidentification.htm")
 
-"""An object with a Globally Unique ID"""
-interface Node {
-  """The Globally Unique ID of this object"""
-  id: GlobalID!
-}
+      """An object with a Globally Unique ID"""
+      interface Node {
+        """The Globally Unique ID of this object"""
+        id: GlobalID!
+      }
 
-type Query {
-  fruit: Fruit!
-}
-    '''
+      type Query {
+        fruit: Fruit!
+      }
+      '''
 
     schema = strawberry.Schema(query=Query)
 

--- a/tests/relay/test_types.py
+++ b/tests/relay/test_types.py
@@ -1,7 +1,7 @@
 from typing import Any, AsyncGenerator, AsyncIterable, Optional, Union, cast
-from typing_extensions import assert_type
 
 import pytest
+from typing_extensions import assert_type
 
 import strawberry
 from strawberry import relay
@@ -241,3 +241,21 @@ async def test_resolve_async_list_connection_but_sync_after_sliced():
             ],
         }
     }
+
+
+def test_overwrite_resolve_id_and_no_node_id():
+    @strawberry.type
+    class Fruit(relay.Node):
+        color: str
+
+        @classmethod
+        def resolve_id(cls, root) -> str:
+            return "test"
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def fruit(self) -> Fruit:
+            return Fruit(color="red")
+
+    strawberry.Schema(query=Query)

--- a/tests/relay/test_types.py
+++ b/tests/relay/test_types.py
@@ -1,7 +1,7 @@
 from typing import Any, AsyncGenerator, AsyncIterable, Optional, Union, cast
+from typing_extensions import assert_type
 
 import pytest
-from typing_extensions import assert_type
 
 import strawberry
 from strawberry import relay
@@ -250,12 +250,12 @@ def test_overwrite_resolve_id_and_no_node_id():
 
         @classmethod
         def resolve_id(cls, root) -> str:
-            return "test"
+            return "test"  # pragma: no cover
 
     @strawberry.type
     class Query:
         @strawberry.field
         def fruit(self) -> Fruit:
-            return Fruit(color="red")
+            return Fruit(color="red")  # pragma: no cover
 
     strawberry.Schema(query=Query)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Using a Node without a NodeId annotation should be possible in case of the resolve_id method is overwritten

Fix a remaining bug and add tests for this case


<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #2816
* #2834


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
