### PR TITLE
Fix deprecation warning

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: minor
+
+This release fixes a deprecation warning generated inside our codebase and
+adds support for using `Info` when declared in a `if TYPE_CHECKING` block

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,0 @@
-Release type: minor
-
-This release fixes a deprecation warning generated inside our codebase and
-adds support for using `Info` when declared in a `if TYPE_CHECKING` block

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+This release fixes a depreaction warning being triggered
+by the relay integration.

--- a/strawberry/relay/types.py
+++ b/strawberry/relay/types.py
@@ -38,6 +38,7 @@ from strawberry.object_type import interface, type
 from strawberry.private import StrawberryPrivate
 from strawberry.relay.exceptions import NodeIDAnnotationError
 from strawberry.type import StrawberryContainer
+from strawberry.types.info import Info  # noqa: TCH001
 from strawberry.types.types import TypeDefinition
 from strawberry.utils.aio import aenumerate, aislice, resolve_awaitable
 from strawberry.utils.inspect import in_async_context
@@ -47,7 +48,6 @@ from .utils import from_base64, to_base64
 
 if TYPE_CHECKING:
     from strawberry.scalars import ID
-    from strawberry.types.info import Info
     from strawberry.utils.await_maybe import AwaitableOrValue
 
 _T = TypeVar("_T")

--- a/strawberry/relay/types.py
+++ b/strawberry/relay/types.py
@@ -38,7 +38,6 @@ from strawberry.object_type import interface, type
 from strawberry.private import StrawberryPrivate
 from strawberry.relay.exceptions import NodeIDAnnotationError
 from strawberry.type import StrawberryContainer
-from strawberry.types.info import Info  # noqa: TCH001
 from strawberry.types.types import TypeDefinition
 from strawberry.utils.aio import aenumerate, aislice, resolve_awaitable
 from strawberry.utils.inspect import in_async_context
@@ -48,6 +47,7 @@ from .utils import from_base64, to_base64
 
 if TYPE_CHECKING:
     from strawberry.scalars import ID
+    from strawberry.types.info import Info
     from strawberry.utils.await_maybe import AwaitableOrValue
 
 _T = TypeVar("_T")

--- a/strawberry/types/fields/resolver.py
+++ b/strawberry/types/fields/resolver.py
@@ -135,14 +135,6 @@ class ReservedType(NamedTuple):
         if origin is Annotated:
             # Handle annotated arguments such as Private[str] and DirectiveValue[str]
             return any(isinstance(argument, self.type) for argument in get_args(other))
-        elif type(origin) is str:
-            # Handle forward references, there might be conflicts with the name,
-            # for example is someone makes an input type called "Info", but this
-            # is a rare case and we can ignore it for now
-            # another option would be to check if strawberry.types.info.Info is
-            # imported in a `if TYPE_CHECKING:` block, but that feels like too much
-            # work for a rare case
-            return origin == self.type.__name__
         else:
             # Handle both concrete and generic types (i.e Info, and Info[Any, Any])
             return (

--- a/strawberry/types/fields/resolver.py
+++ b/strawberry/types/fields/resolver.py
@@ -135,6 +135,14 @@ class ReservedType(NamedTuple):
         if origin is Annotated:
             # Handle annotated arguments such as Private[str] and DirectiveValue[str]
             return any(isinstance(argument, self.type) for argument in get_args(other))
+        elif type(origin) is str:
+            # Handle forward references, there might be conflicts with the name,
+            # for example is someone makes an input type called "Info", but this
+            # is a rare case and we can ignore it for now
+            # another option would be to check if strawberry.types.info.Info is
+            # imported in a `if TYPE_CHECKING:` block, but that feels like too much
+            # work for a rare case
+            return origin == self.type.__name__
         else:
             # Handle both concrete and generic types (i.e Info, and Info[Any, Any])
             return (

--- a/tests/relay/schema.py
+++ b/tests/relay/schema.py
@@ -30,7 +30,7 @@ class Fruit(relay.Node):
     def resolve_nodes(
         cls,
         *,
-        info: Info,
+        info: Info[None, None],
         node_ids: Iterable[str],
         required: bool = False,
     ) -> Iterable[Optional[Self]]:
@@ -40,7 +40,7 @@ class Fruit(relay.Node):
         return fruits.values()
 
     @classmethod
-    def is_type_of(cls, obj, _info) -> bool:
+    def is_type_of(cls, obj: Any, _info: Info[None, None]) -> bool:
         # This is here to support FruitConcrete, which is mimicing an integration
         # object which would return an object alike Fruit (e.g. the django integration)
         return isinstance(obj, (cls, FruitConcrete))
@@ -63,7 +63,7 @@ class FruitAsync(relay.Node):
     async def resolve_nodes(
         cls,
         *,
-        info: Optional[Info] = None,
+        info: Optional[Info[None, None]] = None,
         node_ids: Iterable[str],
         required: bool = False,
     ) -> Iterable[Optional[Self]]:
@@ -76,7 +76,7 @@ class FruitAsync(relay.Node):
         return fruits_async.values()
 
     @classmethod
-    async def resolve_id(cls, root: Self, *, info: Info) -> str:
+    async def resolve_id(cls, root: Self, *, info: Info[None, None]) -> str:
         return str(root.id)
 
 
@@ -91,7 +91,7 @@ class FruitCustomPaginationConnection(relay.Connection[Fruit]):
         cls,
         nodes: Iterable[Fruit],
         *,
-        info: Optional[Info] = None,
+        info: Optional[Info[None, None]] = None,
         total_count: Optional[int] = None,
         before: Optional[str] = None,
         after: Optional[str] = None,
@@ -160,7 +160,9 @@ FruitAlike = namedtuple("FruitAlike", ["id", "name", "color"])
 @strawberry.type
 class FruitAlikeConnection(relay.ListConnection[Fruit]):
     @classmethod
-    def resolve_node(cls, node: FruitAlike, *, info: Info, **kwargs: Any) -> Fruit:
+    def resolve_node(
+        cls, node: FruitAlike, *, info: Info[None, None], **kwargs: Any
+    ) -> Fruit:
         return Fruit(
             id=node.id,
             name=node.name,
@@ -196,7 +198,7 @@ class Query:
     @relay.connection(relay.ListConnection[Fruit])
     def fruits_concrete_resolver(
         self,
-        info: Info,
+        info: Info[None, None],
         name_endswith: Optional[str] = None,
     ) -> List[Fruit]:
         # This is mimicing integrations, like Django
@@ -216,7 +218,7 @@ class Query:
     @relay.connection(relay.ListConnection[Fruit])
     def fruits_custom_resolver(
         self,
-        info: Info,
+        info: Info[None, None],
         name_endswith: Optional[str] = None,
     ) -> List[Fruit]:
         return [
@@ -228,7 +230,7 @@ class Query:
     @relay.connection(relay.ListConnection[Fruit])
     def fruits_custom_resolver_lazy(
         self,
-        info: Info,
+        info: Info[None, None],
         name_endswith: Optional[str] = None,
     ) -> List[Annotated["Fruit", strawberry.lazy("tests.relay.schema")]]:
         return [
@@ -240,7 +242,7 @@ class Query:
     @relay.connection(relay.ListConnection[Fruit])
     def fruits_custom_resolver_iterator(
         self,
-        info: Info,
+        info: Info[None, None],
         name_endswith: Optional[str] = None,
     ) -> Iterator[Fruit]:
         for f in fruits.values():
@@ -250,7 +252,7 @@ class Query:
     @relay.connection(relay.ListConnection[Fruit])
     def fruits_custom_resolver_iterable(
         self,
-        info: Info,
+        info: Info[None, None],
         name_endswith: Optional[str] = None,
     ) -> Iterator[Fruit]:
         for f in fruits.values():
@@ -260,7 +262,7 @@ class Query:
     @relay.connection(relay.ListConnection[Fruit])
     def fruits_custom_resolver_generator(
         self,
-        info: Info,
+        info: Info[None, None],
         name_endswith: Optional[str] = None,
     ) -> Generator[Fruit, None, None]:
         for f in fruits.values():
@@ -270,7 +272,7 @@ class Query:
     @relay.connection(relay.ListConnection[Fruit])
     async def fruits_custom_resolver_async_iterable(
         self,
-        info: Info,
+        info: Info[None, None],
         name_endswith: Optional[str] = None,
     ) -> AsyncIterable[Fruit]:
         for f in fruits.values():
@@ -280,7 +282,7 @@ class Query:
     @relay.connection(relay.ListConnection[Fruit])
     async def fruits_custom_resolver_async_iterator(
         self,
-        info: Info,
+        info: Info[None, None],
         name_endswith: Optional[str] = None,
     ) -> AsyncIterator[Fruit]:
         for f in fruits.values():
@@ -290,7 +292,7 @@ class Query:
     @relay.connection(relay.ListConnection[Fruit])
     async def fruits_custom_resolver_async_generator(
         self,
-        info: Info,
+        info: Info[None, None],
         name_endswith: Optional[str] = None,
     ) -> AsyncGenerator[Fruit, None]:
         for f in fruits.values():
@@ -300,7 +302,7 @@ class Query:
     @relay.connection(FruitAlikeConnection)
     def fruit_alike_connection_custom_resolver(
         self,
-        info: Info,
+        info: Info[None, None],
         name_endswith: Optional[str] = None,
     ) -> List[FruitAlike]:
         return [
@@ -320,7 +322,7 @@ class Mutation:
     @strawberry.mutation
     def create_fruit(
         self,
-        info: Info,
+        info: Info[None, None],
         name: str,
         color: str,
     ) -> CreateFruitPayload:

--- a/tests/relay/test_schema.py
+++ b/tests/relay/test_schema.py
@@ -16,11 +16,9 @@ def test_schema():
     schema_output = str(schema).strip("\n").strip(" ")
     output = pathlib.Path(__file__).parent / "schema.gql"
     if not output.exists():
-        with output.open("w") as f:
-            f.write(schema_output + "\n")
+        output.write_text(schema_output + "\n")
 
-    with output.open() as f:
-        expected = f.read().strip("\n").strip(" ")
+    expected = output.read_text().strip("\n").strip(" ")
 
     assert schema_output == expected
 


### PR DESCRIPTION
Closes #2857

This is probably not the best way to fix this deprecation warning, as I think the code that checks for `Info` doesn't support forward refs when `Info` is not defined. I think we could fix it by checking the name of the type, but this is probably an ok workaround for the time being

~EDIT:~

~I've updates the PR to check the name of the class 😊~


/cc @bellini666 @skilkis 