### PR TITLE
fix(relay): allow NodeExtension to be used together with other async extensions/permissions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+This release adds resolve_async to NodeExtension to allow it to
+be used together with other field async extensions/permissions.

--- a/strawberry/relay/fields.py
+++ b/strawberry/relay/fields.py
@@ -72,6 +72,16 @@ class NodeExtension(FieldExtension):
     ) -> Any:
         return next_(source, info, **kwargs)
 
+    async def resolve_async(
+        self, next_: SyncExtensionResolver, source: Any, info: Info, **kwargs: Any
+    ) -> Any:
+        retval = next_(source, info, **kwargs)
+        # If the resolve_nodes method is not async, retval will not actually
+        # be awaitable. We still need the `resolve_async` in here because
+        # otherwise this extension can't be used together with other
+        # async extensions.
+        return await retval if inspect.isawaitable(retval) else retval
+
     def get_node_resolver(self, field: StrawberryField):  # noqa: ANN201
         type_ = field.type
         is_optional = isinstance(type_, StrawberryOptional)

--- a/tests/relay/schema.gql
+++ b/tests/relay/schema.gql
@@ -104,6 +104,10 @@ type Query {
     """The ID of the object."""
     id: GlobalID!
   ): Node!
+  nodeWithAsyncPermissions(
+    """The ID of the object."""
+    id: GlobalID!
+  ): Node!
   nodes(
     """The IDs of the objects."""
     ids: [GlobalID!]!

--- a/tests/relay/schema.py
+++ b/tests/relay/schema.py
@@ -16,6 +16,7 @@ from typing_extensions import Annotated, Self
 
 import strawberry
 from strawberry import relay
+from strawberry.permission import BasePermission
 from strawberry.relay.utils import to_base64
 from strawberry.types import Info
 
@@ -176,9 +177,19 @@ async def fruits_async_resolver() -> Iterable[FruitAsync]:
     return fruits_async.values()
 
 
+class DummyPermission(BasePermission):
+    message = "Dummy message"
+
+    async def has_permission(self, source: Any, info: Info, **kwargs: Any) -> bool:
+        return True
+
+
 @strawberry.type
 class Query:
     node: relay.Node = relay.node()
+    node_with_async_permissions: relay.Node = relay.node(
+        permission_classes=[DummyPermission]
+    )
     nodes: List[relay.Node] = relay.node()
     node_optional: Optional[relay.Node] = relay.node()
     nodes_optional: List[Optional[relay.Node]] = relay.node()

--- a/tests/relay/test_fields.py
+++ b/tests/relay/test_fields.py
@@ -34,6 +34,35 @@ def test_query_node():
     }
 
 
+async def test_query_node_with_async_permissions():
+    result = await schema.execute(
+        """
+        query TestQuery ($id: GlobalID!) {
+            nodeWithAsyncPermissions (id: $id) {
+                ... on Node {
+                    id
+                }
+                ... on Fruit {
+                    name
+                    color
+                }
+            }
+        }
+        """,
+        variable_values={
+            "id": to_base64("Fruit", 2),
+        },
+    )
+    assert result.errors is None
+    assert result.data == {
+        "nodeWithAsyncPermissions": {
+            "id": to_base64("Fruit", 2),
+            "color": "red",
+            "name": "Apple",
+        },
+    }
+
+
 def test_query_node_optional():
     result = schema.execute_sync(
         """


### PR DESCRIPTION
This fixes an issue where NodeExtension could not be used together with
other async extensions/permissions.

Fix #2862
