### PR TITLE
Plumb the GraphQL typename through to clients if known.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+Release type: minor
+
+This release gives codegen clients the ability to inquire about the `__typename`
+of a `GraphQLObjectType`.  This information can be used to automatically select
+the proper type to hydrate when working with a union type in the response.

--- a/strawberry/codegen/plugins/python.py
+++ b/strawberry/codegen/plugins/python.py
@@ -155,12 +155,17 @@ class PythonPlugin(QueryCodegenPlugin):
             if field.name != "__typename"
         )
 
-        return "\n".join(
-            [
-                f"class {type_.name}:",
-                textwrap.indent(fields, " " * 4),
-            ]
-        )
+        indent = 4 * " "
+        lines = [
+            f"class {type_.name}:",
+        ]
+        if type_.graphql_typename:
+            lines.append(
+                textwrap.indent(f"# typename: {type_.graphql_typename}", indent)
+            )
+        lines.append(textwrap.indent(fields, indent))
+
+        return "\n".join(lines)
 
     def _print_enum_type(self, type_: GraphQLEnum) -> str:
         values = "\n".join(self._print_enum_value(value) for value in type_.values)

--- a/strawberry/codegen/types.py
+++ b/strawberry/codegen/types.py
@@ -41,6 +41,7 @@ class GraphQLFragmentSpread:
 class GraphQLObjectType:
     name: str
     fields: List[GraphQLField] = field(default_factory=list)
+    graphql_typename: Optional[str] = None
 
 
 # Subtype of GraphQLObjectType.
@@ -50,6 +51,7 @@ class GraphQLObjectType:
 class GraphQLFragmentType(GraphQLObjectType):
     name: str
     fields: List[GraphQLField] = field(default_factory=list)
+    graphql_typename: Optional[str] = None
     on: str = ""
 
     def __post_init__(self) -> None:

--- a/tests/codegen/snapshots/python/fragment.py
+++ b/tests/codegen/snapshots/python/fragment.py
@@ -1,4 +1,5 @@
 class PersonName:
+    # typename: Person
     name: str
 
 class OperationNameResult:

--- a/tests/codegen/snapshots/python/interface_fragments.py
+++ b/tests/codegen/snapshots/python/interface_fragments.py
@@ -1,10 +1,12 @@
 from typing import Union
 
 class OperationNameResultInterfaceBlogPost:
+    # typename: BlogPost
     id: str
     title: str
 
 class OperationNameResultInterfaceImage:
+    # typename: Image
     id: str
     url: str
 

--- a/tests/codegen/snapshots/python/interface_single_fragment.py
+++ b/tests/codegen/snapshots/python/interface_single_fragment.py
@@ -1,4 +1,5 @@
 class OperationNameResultInterfaceBlogPost:
+    # typename: BlogPost
     id: str
     title: str
 

--- a/tests/codegen/snapshots/python/mutation-fragment.py
+++ b/tests/codegen/snapshots/python/mutation-fragment.py
@@ -1,4 +1,5 @@
 class IdFragment:
+    # typename: BlogPost
     id: str
 
 class addBookResult:

--- a/tests/codegen/snapshots/python/union.py
+++ b/tests/codegen/snapshots/python/union.py
@@ -1,17 +1,21 @@
 from typing import Optional, Union
 
 class OperationNameResultUnionAnimal:
+    # typename: Animal
     age: int
 
 class OperationNameResultUnionPerson:
+    # typename: Person
     name: str
 
 OperationNameResultUnion = Union[OperationNameResultUnionAnimal, OperationNameResultUnionPerson]
 
 class OperationNameResultOptionalUnionAnimal:
+    # typename: Animal
     age: int
 
 class OperationNameResultOptionalUnionPerson:
+    # typename: Person
     name: str
 
 OperationNameResultOptionalUnion = Union[OperationNameResultOptionalUnionAnimal, OperationNameResultOptionalUnionPerson]

--- a/tests/codegen/snapshots/python/union_return.py
+++ b/tests/codegen/snapshots/python/union_return.py
@@ -1,4 +1,5 @@
 class OperationNameResultGetPersonOrAnimalPerson:
+    # typename: Person
     name: str
     age: int
 

--- a/tests/codegen/snapshots/python/union_with_one_type.py
+++ b/tests/codegen/snapshots/python/union_with_one_type.py
@@ -1,4 +1,5 @@
 class OperationNameResultUnionAnimal:
+    # typename: Animal
     age: int
     name: str
 

--- a/tests/codegen/snapshots/python/union_with_typename.py
+++ b/tests/codegen/snapshots/python/union_with_typename.py
@@ -1,17 +1,21 @@
 from typing import Optional, Union
 
 class OperationNameResultUnionAnimal:
+    # typename: Animal
     age: int
 
 class OperationNameResultUnionPerson:
+    # typename: Person
     name: str
 
 OperationNameResultUnion = Union[OperationNameResultUnionAnimal, OperationNameResultUnionPerson]
 
 class OperationNameResultOptionalUnionAnimal:
+    # typename: Animal
     age: int
 
 class OperationNameResultOptionalUnionPerson:
+    # typename: Person
     name: str
 
 OperationNameResultOptionalUnion = Union[OperationNameResultOptionalUnionAnimal, OperationNameResultOptionalUnionPerson]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Issue #2874 does a pretty good job explaining what I'm trying to accomplish here, but the tl;dr is that GraphQL often makes response objects that look like:

```py
OperationNameResultUnion = Union[OperationNameResultUnionAnimal, OperationNameResultUnionPerson]

class OperationNameResult:
    union: OperationNameResultUnion
```

The query result JSON might have a `__typename` field that indicates whether the response is for an `Animal` or a `Person`, however, it isn't easy for a client to know whether `Animal` maps to `OperationNameResultUnionAnimal` or `OperationNameResultUnionPerson`.  (In principle, you _could_ look at the suffix in the class name and try to figure it out that way, but that feels flaky).

This change just adds the typename to the `GraphQLObjectType` that is passed to the client generator plugins.  The plugin can then choose to use this information or to disregard it.

The python plugin has been updated to include the typename in a comment in the class body -- this information might be useful for humans looking at the generated classes, but it is also a convenient way to test that the new functionality is working.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [x] **Enhancement**/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #2874 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
