### PR TITLE
Support subscription errors without terminating

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+Release type: patch
+
+The `graphql-transport-ws` protocol allows for subscriptions to error during execution without terminating
+the subscription.  Non-fatal errors produced by subscriptions now produce `Next` messages containing
+an `ExecutionResult` with an `error` field and don't necessarily terminate the subscription.
+This is in accordance to the behaviour of Apollo server.

--- a/strawberry/channels/testing.py
+++ b/strawberry/channels/testing.py
@@ -140,9 +140,6 @@ class GraphQLWebsocketCommunicator(WebsocketCommunicator):
 
 def process_errors(errors: List[GraphQLFormattedError]) -> List[GraphQLError]:
     return [
-        GraphQLError(
-            message=error["message"],
-            extensions=error.get("extensions", None),
-        )
+        GraphQLError(str(error), original_error=error)
         for error in errors
     ]

--- a/strawberry/channels/testing.py
+++ b/strawberry/channels/testing.py
@@ -127,19 +127,17 @@ class GraphQLWebsocketCommunicator(WebsocketCommunicator):
                 payload = NextMessage(**response).payload
                 ret = ExecutionResult(payload["data"], None)
                 if "errors" in payload:
-                    ret.errors = process_errors(payload["errors"])
+                    ret.errors = self.process_errors(payload["errors"])
                 ret.extensions = payload.get("extensions", None)
                 yield ret
             elif message_type == ErrorMessage.type:
                 error_payload = ErrorMessage(**response).payload
-                yield ExecutionResult(data=None, errors=process_errors(error_payload))
+                yield ExecutionResult(
+                    data=None, errors=self.process_errors(error_payload)
+                )
                 return  # an error message is the last message for a subscription
             else:
                 return
 
-
-def process_errors(errors: List[GraphQLFormattedError]) -> List[GraphQLError]:
-    return [
-        GraphQLError(str(error), original_error=error)
-        for error in errors
-    ]
+    def process_errors(self, errors: List[GraphQLFormattedError]) -> List[GraphQLError]:
+        return [GraphQLError(str(error), original_error=error) for error in errors]

--- a/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
@@ -245,7 +245,7 @@ class BaseGraphQLTransportWSHandler(ABC):
 
             result_source = get_result_source()
 
-        operation = Operation(self, message.id)
+        operation = Operation(self, message.id, operation_type)
 
         # Handle initial validation errors
         if isinstance(result_source, GraphQLExecutionResult):
@@ -295,7 +295,10 @@ class BaseGraphQLTransportWSHandler(ABC):
     ) -> None:
         try:
             async for result in result_source:
-                if result.errors:
+                if (
+                    result.errors
+                    and operation.operation_type != OperationType.SUBSCRIPTION
+                ):
                     error_payload = [format_graphql_error(err) for err in result.errors]
                     error_message = ErrorMessage(id=operation.id, payload=error_payload)
                     await operation.send_message(error_message)
@@ -303,6 +306,10 @@ class BaseGraphQLTransportWSHandler(ABC):
                     return
                 else:
                     next_payload = {"data": result.data}
+                    if result.errors:
+                        next_payload["errors"] = [
+                            format_graphql_error(err) for err in result.errors
+                        ]
                     next_message = NextMessage(id=operation.id, payload=next_payload)
                     await operation.send_message(next_message)
         except asyncio.CancelledError:
@@ -358,11 +365,17 @@ class Operation:
     Helps enforce protocol state transition.
     """
 
-    __slots__ = ["handler", "id", "completed", "task"]
+    __slots__ = ["handler", "id", "operation_type", "completed", "task"]
 
-    def __init__(self, handler: BaseGraphQLTransportWSHandler, id: str):
+    def __init__(
+        self,
+        handler: BaseGraphQLTransportWSHandler,
+        id: str,
+        operation_type: OperationType,
+    ):
         self.handler = handler
         self.id = id
+        self.operation_type = operation_type
         self.completed = False
         self.task: Optional[asyncio.Task] = None
 

--- a/strawberry/subscriptions/protocols/graphql_transport_ws/types.py
+++ b/strawberry/subscriptions/protocols/graphql_transport_ws/types.py
@@ -85,7 +85,7 @@ class NextMessage(GraphQLTransportMessage):
     """
 
     id: str
-    payload: Dict[str, Any]  # TODO: shape like ExecutionResult
+    payload: Dict[str, Any]  # TODO: shape like FormattedExecutionResult
     type: str = "next"
 
     def as_dict(self) -> dict:

--- a/tests/views/schema.py
+++ b/tests/views/schema.py
@@ -80,6 +80,10 @@ class Query:
         return "Hey"
 
     @strawberry.field
+    async def error(self, message: str) -> AsyncGenerator[str, None]:
+        yield GraphQLError(message)  # type: ignore
+
+    @strawberry.field
     async def exception(self, message: str) -> str:
         raise ValueError(message)
 

--- a/tests/views/schema.py
+++ b/tests/views/schema.py
@@ -184,6 +184,12 @@ class Subscription:
         yield Flavor.CHOCOLATE
 
     @strawberry.subscription
+    async def flavors_invalid(self) -> AsyncGenerator[Flavor, None]:
+        yield Flavor.VANILLA
+        yield "invalid type"  # type: ignore
+        yield Flavor.CHOCOLATE
+
+    @strawberry.subscription
     async def debug(self, info: Info[Any, Any]) -> AsyncGenerator[DebugInfo, None]:
         active_result_handlers = [
             task for task in info.context["get_tasks"]() if not task.done()

--- a/tests/websockets/test_graphql_transport_ws.py
+++ b/tests/websockets/test_graphql_transport_ws.py
@@ -873,7 +873,6 @@ async def test_error_handler_for_timeout(http_client: HttpClient):
     assert "total_seconds" in str(args[0][0])
 
 
-@pytest.mark.xfail
 async def test_subscription_errors_continue(ws: WebSocketClient):
     """
     Verify that an ExecutionResult with errors during subscription does not terminate

--- a/tests/websockets/test_graphql_transport_ws.py
+++ b/tests/websockets/test_graphql_transport_ws.py
@@ -430,14 +430,14 @@ async def test_subscription_errors(ws: WebSocketClient):
     )
 
     response = await ws.receive_json()
-    assert response["type"] == ErrorMessage.type
+    assert response["type"] == NextMessage.type
     assert response["id"] == "sub1"
-    assert len(response["payload"]) == 1
-    assert response["payload"][0].get("path") == ["error"]
-    assert response["payload"][0]["message"] == "TEST ERR"
+    assert len(response["payload"]["errors"]) == 1
+    assert response["payload"]["errors"][0].get("path") == ["error"]
+    assert response["payload"]["errors"][0]["message"] == "TEST ERR"
 
 
-async def test_subscription_error_no_complete(ws: WebSocketClient):
+async def test_operation_error_no_complete(ws: WebSocketClient):
     """
     Test that an "error" message is not followed by "complete"
     """
@@ -446,7 +446,7 @@ async def test_subscription_error_no_complete(ws: WebSocketClient):
         SubscribeMessage(
             id="sub1",
             payload=SubscribeMessagePayload(
-                query='subscription { error(message: "TEST ERR") }',
+                query='query { error(message: "TEST ERR") }',
             ),
         ).as_dict()
     )
@@ -461,7 +461,7 @@ async def test_subscription_error_no_complete(ws: WebSocketClient):
         SubscribeMessage(
             id="sub2",
             payload=SubscribeMessagePayload(
-                query='subscription { error(message: "TEST ERR") }',
+                query='query { error(message: "TEST ERR") }',
             ),
         ).as_dict()
     )

--- a/tests/websockets/test_graphql_transport_ws.py
+++ b/tests/websockets/test_graphql_transport_ws.py
@@ -433,7 +433,7 @@ async def test_subscription_errors(ws: WebSocketClient):
     assert response["type"] == NextMessage.type
     assert response["id"] == "sub1"
     assert len(response["payload"]["errors"]) == 1
-    assert response["payload"]["errors"][0].get("path") == ["error"]
+    assert response["payload"]["errors"][0]["path"] == ["error"]
     assert response["payload"]["errors"][0]["message"] == "TEST ERR"
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

`strawberry-transport-graphql` protocol now creates a `Next` message and doesn't terminate the operation
if a non-fatal error is generated during execution of a `subscribe` request.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The graphql `ExecutionResult` struct contained in an `Next` message contains both  `data` and `errors` members.
When a non-fatal error occurs when producing a result, such an `ExecutionResult` is produced by Appollo server,
a `Next` message is created, and the subscription continues.    This PR replicates that behaviour.

Single result operations (`query`, `mutate`) which cause errors during execution, continue to produce `Error` messages
as before, again, similar to Appollo.

<!--- Describe your changes in detail here. -->

## Note:

this PR builds on top of #2699, so we may consider merging that first, to reduce the footprint of the change.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x]  I have tested the changes and verified that they work and don't break anything (as well as I can manage).
