### PR TITLE
refactor: add a `strict` keyword for get_object_definition

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+Release type: patch
+
+This release removes `get_object_definition_strict` and instead
+overloads `get_object_definition` to accept an extra `strct` keyword.
+
+This is a new feature so it is unlikely to break anything.

--- a/strawberry/codegen/query_codegen.py
+++ b/strawberry/codegen/query_codegen.py
@@ -47,7 +47,7 @@ from strawberry.type import (
     StrawberryList,
     StrawberryOptional,
     StrawberryType,
-    get_object_definition_strict,
+    get_object_definition,
     has_object_definition,
 )
 from strawberry.types.types import StrawberryObjectDefinition
@@ -629,7 +629,7 @@ class QueryCodegen:
                 selection, parent_type, class_name
             )
         else:
-            parent_type = get_object_definition_strict(selected_field_type)
+            parent_type = get_object_definition(selected_field_type, strict=True)
             field_type = self._collect_types(selection, parent_type, class_name)
 
         if wrapper:

--- a/strawberry/type.py
+++ b/strawberry/type.py
@@ -11,9 +11,9 @@ from typing import (
     Type,
     TypeVar,
     Union,
-    cast,
+    overload,
 )
-from typing_extensions import Protocol
+from typing_extensions import Literal, Protocol
 
 from strawberry.utils.typing import is_concrete_generic
 
@@ -202,13 +202,30 @@ def has_object_definition(
     return False
 
 
+@overload
 def get_object_definition(
     obj: Any,
+    *,
+    strict: Literal[True],
+) -> StrawberryObjectDefinition:
+    ...
+
+
+@overload
+def get_object_definition(
+    obj: Any,
+    *,
+    strict: bool = False,
 ) -> Optional[StrawberryObjectDefinition]:
-    if has_object_definition(obj):
-        return obj.__strawberry_definition__
-    return None
+    ...
 
 
-def get_object_definition_strict(obj: Any) -> StrawberryObjectDefinition:
-    return cast(WithStrawberryObjectDefinition, obj).__strawberry_definition__
+def get_object_definition(
+    obj: Any,
+    *,
+    strict: bool = False,
+) -> Optional[StrawberryObjectDefinition]:
+    definition = obj.__strawberry_definition__ if has_object_definition(obj) else None
+    if strict and definition is None:
+        raise TypeError(f"{obj!r} does not have a StrawberryObjectDefinition")
+    return definition

--- a/tests/relay/test_utils.py
+++ b/tests/relay/test_utils.py
@@ -3,7 +3,7 @@ from typing import Any
 import pytest
 
 from strawberry.relay.utils import from_base64, to_base64
-from strawberry.type import get_object_definition_strict
+from strawberry.type import get_object_definition
 
 from .schema import Fruit
 
@@ -44,7 +44,7 @@ def test_to_base64_with_type():
 
 def test_to_base64_with_typedef():
     value = to_base64(
-        get_object_definition_strict(Fruit),
+        get_object_definition(Fruit, strict=True),
         "1",
     )
     assert value == "RnJ1aXQ6MQ=="

--- a/tests/schema/test_directives.py
+++ b/tests/schema/test_directives.py
@@ -8,7 +8,7 @@ import strawberry
 from strawberry.directive import DirectiveLocation, DirectiveValue
 from strawberry.extensions import SchemaExtension
 from strawberry.schema.config import StrawberryConfig
-from strawberry.type import get_object_definition_strict
+from strawberry.type import get_object_definition
 from strawberry.types.info import Info
 from strawberry.utils.await_maybe import await_maybe
 
@@ -410,7 +410,7 @@ def info_directive_schema() -> strawberry.Schema:
         def greetingTemplate(self, locale: Locale = Locale.EN) -> str:
             return greetings[locale]
 
-    field = get_object_definition_strict(Query).fields[0]
+    field = get_object_definition(Query, strict=True).fields[0]
 
     @strawberry.directive(
         locations=[DirectiveLocation.FIELD],

--- a/tests/schema/test_extensions.py
+++ b/tests/schema/test_extensions.py
@@ -13,7 +13,7 @@ import strawberry
 from strawberry.scalars import JSON
 from strawberry.schema.schema_converter import GraphQLCoreConverter
 from strawberry.schema_directive import Location
-from strawberry.type import get_object_definition_strict
+from strawberry.type import get_object_definition
 
 DEFINITION_BACKREF = GraphQLCoreConverter.DEFINITION_BACKREF
 
@@ -38,8 +38,10 @@ def test_extensions_schema_directive():
     #        but aren't added to graphql_schema.directives
     # maybe graphql_schema_directive = graphql_schema.get_directive("schemaDirective")
 
+    directives = get_object_definition(Query, strict=True).directives
+    assert directives is not None
     graphql_schema_directive = schema.schema_converter.from_schema_directive(
-        get_object_definition_strict(Query).directives[0]
+        directives[0]
     )
     assert (
         graphql_schema_directive.extensions[DEFINITION_BACKREF]

--- a/tests/test_type.py
+++ b/tests/test_type.py
@@ -1,0 +1,51 @@
+import dataclasses
+from typing import Optional
+from typing_extensions import assert_type
+
+import pytest
+
+import strawberry
+from strawberry.type import get_object_definition
+from strawberry.types.types import StrawberryObjectDefinition
+
+
+def test_get_object_definition():
+    @strawberry.type
+    class Fruit:
+        name: str
+
+    obj_definition = get_object_definition(Fruit)
+    assert_type(obj_definition, Optional[StrawberryObjectDefinition])
+    assert obj_definition is not None
+    assert isinstance(obj_definition, StrawberryObjectDefinition)
+
+
+def test_get_object_definition_non_strawberry_type():
+    @dataclasses.dataclass
+    class Fruit:
+        name: str
+
+    assert get_object_definition(Fruit) is None
+
+    class OtherFruit:
+        ...
+
+    assert get_object_definition(OtherFruit) is None
+
+
+def test_get_object_definition_strict():
+    @strawberry.type
+    class Fruit:
+        name: str
+
+    obj_definition = get_object_definition(Fruit, strict=True)
+    assert_type(obj_definition, StrawberryObjectDefinition)
+
+    class OtherFruit:
+        name: str
+
+    with pytest.raises(
+        TypeError,
+        match=".* does not have a StrawberryObjectDefinition",
+    ):
+        get_object_definition(OtherFruit, strict=True)


### PR DESCRIPTION
Instead of having an extra function for strict, use get_object_definition
only but overload it with a `strict` keyword argument.
