### PR TITLE
fix: StrawberryContainer can receive types other than strawberry types

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+Release type: patch
+
+This release fixes a typing regression on `StraberryContainer` subclasses
+where type checkers would not allow non `WithStrawberryObjectDefinition` types
+to be passed for its `of_type` argument (e.g. `StrawberryOptional(str)`)

--- a/strawberry/type.py
+++ b/strawberry/type.py
@@ -79,7 +79,7 @@ class StrawberryType(ABC):
 
 class StrawberryContainer(StrawberryType):
     def __init__(
-        self, of_type: Union[StrawberryType, Type[WithStrawberryObjectDefinition]]
+        self, of_type: Union[StrawberryType, Type[WithStrawberryObjectDefinition], type]
     ):
         self.of_type = of_type
 

--- a/tests/pyright/test_type.py
+++ b/tests/pyright/test_type.py
@@ -1,0 +1,84 @@
+from .utils import Result, requires_pyright, run_pyright, skip_on_windows
+
+pytestmark = [skip_on_windows, requires_pyright]
+
+
+CODE = """
+import strawberry
+from strawberry.type import StrawberryOptional, StrawberryList
+
+
+@strawberry.type
+class Fruit:
+    name: str
+
+
+reveal_type(StrawberryOptional(Fruit))
+reveal_type(StrawberryList(Fruit))
+reveal_type(StrawberryOptional(StrawberryList(Fruit)))
+reveal_type(StrawberryList(StrawberryOptional(Fruit)))
+
+reveal_type(StrawberryOptional(str))
+reveal_type(StrawberryList(str))
+reveal_type(StrawberryOptional(StrawberryList(str)))
+reveal_type(StrawberryList(StrawberryOptional(str)))
+"""
+
+
+def test_pyright():
+    results = run_pyright(CODE)
+
+    assert results == [
+        Result(
+            type="information",
+            message='Type of "StrawberryOptional(Fruit)" is "StrawberryOptional"',
+            line=11,
+            column=13,
+        ),
+        Result(
+            type="information",
+            message='Type of "StrawberryList(Fruit)" is "StrawberryList"',
+            line=12,
+            column=13,
+        ),
+        Result(
+            type="information",
+            message='Type of "StrawberryOptional(StrawberryList(Fruit))" is '
+            '"StrawberryOptional"',
+            line=13,
+            column=13,
+        ),
+        Result(
+            type="information",
+            message='Type of "StrawberryList(StrawberryOptional(Fruit))" is '
+            '"StrawberryList"',
+            line=14,
+            column=13,
+        ),
+        Result(
+            type="information",
+            message='Type of "StrawberryOptional(str)" is "StrawberryOptional"',
+            line=16,
+            column=13,
+        ),
+        Result(
+            type="information",
+            message='Type of "StrawberryList(str)" is "StrawberryList"',
+            line=17,
+            column=13,
+        ),
+        Result(
+            type="information",
+            message='Type of "StrawberryOptional(StrawberryList(str))" is '
+            '"StrawberryOptional"',
+            line=18,
+            column=13,
+        ),
+        Result(
+            type="information",
+            message='Type of "StrawberryList(StrawberryOptional(str))" is '
+            '"StrawberryList"',
+            line=19,
+            column=13,
+        ),
+    ]


### PR DESCRIPTION
This fixes a typing issue when doing something like `StrawberryOptional(str)`
