### PR TITLE
fix: fix a regression on StrawberryAnnotation.__eq__ method

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,10 @@
+Release type: patch
+
+This release fixes a regression when comparing a `StrawberryAnnotation`
+instance with anything that is not also a `StrawberryAnnotation` instance,
+which caused it to raise a `NotImplementedError`.
+
+This reverts its behavior back to how it worked before, where it returns
+`NotImplemented` instead, meaning that the comparison can be delegated to
+the type being compared against or return `False` in case it doesn't define
+an `__eq__` method.

--- a/strawberry/annotation.py
+++ b/strawberry/annotation.py
@@ -62,10 +62,7 @@ class StrawberryAnnotation:
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, StrawberryAnnotation):
-            raise NotImplementedError(
-                f"Comparing {StrawberryAnnotation.__name__} "
-                f"with {type(other)} is not supported."
-            )
+            return NotImplemented
 
         return self.resolve() == other.resolve()
 

--- a/tests/types/test_annotation.py
+++ b/tests/types/test_annotation.py
@@ -50,6 +50,20 @@ def test_annotation_hash(type1: Union[object, str], type2: Union[object, str]):
     ), "Equal type must imply equal hash"
 
 
+def test_eq_on_other_type():
+    class Foo:
+        def __eq__(self, other):
+            # Anything that is a strawberry annotation is equal to Foo
+            return isinstance(other, StrawberryAnnotation)
+
+    assert Foo() != object()
+    assert object() != Foo()
+    assert Foo() != 123 != Foo()
+    assert 123 != Foo()
+    assert Foo() == StrawberryAnnotation(int)
+    assert StrawberryAnnotation(int) == Foo()
+
+
 def test_eq_on_non_annotation():
-    with pytest.raises(NotImplementedError):
-        StrawberryAnnotation(int) == 2  # noqa: B015
+    assert StrawberryAnnotation(int) != int
+    assert StrawberryAnnotation(int) != 123


### PR DESCRIPTION
Fix a regression when comparing a `StrawberryAnnotation` instance with
anything that is not also a `StrawberryAnnotation` instance, which
caused it to raise a `NotImplementedError`.
