### PR TITLE
Add missing arguments to create_type

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+Release type: minor
+
+This release updates `create_type` to add support for all arguments
+that `strawberry.type` supports. This includes: `description`, `extend`,
+`directives`, `is_input` and `is_interface`.

--- a/docs/guides/tools.md
+++ b/docs/guides/tools.md
@@ -14,7 +14,15 @@ server. All tools can be imported from `strawberry.tools`
 Create a Strawberry type from a list of fields.
 
 ```python
-def create_type(name: str, fields: List[StrawberryField]) -> Type:
+def create_type(
+    name: str,
+    fields: List[StrawberryField],
+    is_input: bool = False,
+    is_interface: bool = False,
+    description: Optional[str] = None,
+    directives: Optional[Sequence[object]] = (),
+    extend: bool = False,
+) -> Type:
     ...
 ```
 

--- a/strawberry/tools/create_type.py
+++ b/strawberry/tools/create_type.py
@@ -1,11 +1,19 @@
 import types
-from typing import List, Type
+from typing import List, Optional, Sequence, Type
 
 import strawberry
 from strawberry.field import StrawberryField
 
 
-def create_type(name: str, fields: List[StrawberryField]) -> Type:
+def create_type(
+    name: str,
+    fields: List[StrawberryField],
+    is_input: bool = False,
+    is_interface: bool = False,
+    description: Optional[str] = None,
+    directives: Optional[Sequence[object]] = (),
+    extend: bool = False,
+) -> Type:
     """Create a Strawberry type from a list of StrawberryFields
 
     >>> @strawberry.field
@@ -39,4 +47,11 @@ def create_type(name: str, fields: List[StrawberryField]) -> Type:
 
     cls = types.new_class(name, (), {}, lambda ns: ns.update(namespace))
 
-    return strawberry.type(cls)
+    return strawberry.type(
+        cls,
+        is_input=is_input,
+        is_interface=is_interface,
+        description=description,
+        directives=directives,
+        extend=extend,
+    )

--- a/tests/tools/test_create_type.py
+++ b/tests/tools/test_create_type.py
@@ -141,7 +141,7 @@ def test_create_mutation_type():
         return User(username=username)
 
     Mutation = create_type("Mutation", [make_user])
-    definition = Mutation.__strawberry_definition__
+    definition = get_object_definition(Mutation, strict=True)
 
     assert len(definition.fields) == 1
 
@@ -160,7 +160,7 @@ def test_create_mutation_type_with_params():
         return User(username=username)
 
     Mutation = create_type("Mutation", [make_user])
-    definition = Mutation.__strawberry_definition__
+    definition = get_object_definition(Mutation, strict=True)
 
     assert len(definition.fields) == 1
 

--- a/tests/tools/test_create_type.py
+++ b/tests/tools/test_create_type.py
@@ -3,16 +3,93 @@ from textwrap import dedent
 import pytest
 
 import strawberry
+from strawberry.annotation import StrawberryAnnotation
+from strawberry.field import StrawberryField
 from strawberry.tools import create_type
+from strawberry.type import get_object_definition
 
 
-def test_create_decorator_type():
+def test_create_type():
     @strawberry.field
     def name() -> str:
         return "foo"
 
-    MyType = create_type("MyType", [name])
-    definition = MyType.__strawberry_definition__
+    MyType = create_type("MyType", [name], description="This is a description")
+    definition = get_object_definition(MyType, strict=True)
+
+    assert definition.name == "MyType"
+    assert definition.description == "This is a description"
+    assert definition.is_input is False
+
+    assert len(definition.fields) == 1
+
+    assert definition.fields[0].python_name == "name"
+    assert definition.fields[0].graphql_name is None
+    assert definition.fields[0].type == str
+
+
+def test_create_type_extend_and_directives():
+    @strawberry.field
+    def name() -> str:
+        return "foo"
+
+    MyType = create_type(
+        "MyType",
+        [name],
+        description="This is a description",
+        extend=True,
+        directives=[object()],
+    )
+    definition = get_object_definition(MyType, strict=True)
+
+    assert definition.name == "MyType"
+    assert definition.description == "This is a description"
+    assert definition.is_input is False
+    assert definition.extend is True
+    assert len(list(definition.directives)) == 1
+
+    assert len(definition.fields) == 1
+
+    assert definition.fields[0].python_name == "name"
+    assert definition.fields[0].graphql_name is None
+    assert definition.fields[0].type == str
+
+
+def test_create_input_type():
+    name = StrawberryField(
+        python_name="name", type_annotation=StrawberryAnnotation(str)
+    )
+
+    MyType = create_type(
+        "MyType", [name], is_input=True, description="This is a description"
+    )
+    definition = get_object_definition(MyType, strict=True)
+
+    assert definition.name == "MyType"
+    assert definition.description == "This is a description"
+    assert definition.is_input
+
+    assert len(definition.fields) == 1
+
+    assert definition.fields[0].python_name == "name"
+    assert definition.fields[0].graphql_name is None
+    assert definition.fields[0].type == str
+
+
+def test_create_interface_type():
+    name = StrawberryField(
+        python_name="name", type_annotation=StrawberryAnnotation(str)
+    )
+
+    MyType = create_type(
+        "MyType", [name], is_interface=True, description="This is a description"
+    )
+    definition = get_object_definition(MyType, strict=True)
+
+    assert definition.name == "MyType"
+    assert definition.description == "This is a description"
+    assert definition.is_input is False
+    assert definition.is_interface
 
     assert len(definition.fields) == 1
 
@@ -28,7 +105,7 @@ def test_create_variable_type():
     name = strawberry.field(name="name", resolver=get_name)
 
     MyType = create_type("MyType", [name])
-    definition = MyType.__strawberry_definition__
+    definition = get_object_definition(MyType, strict=True)
 
     assert len(definition.fields) == 1
 


### PR DESCRIPTION
This PR adds missing arguments to `create_type` so people don't need to create
their own utility: https://github.com/dagger/dagger/blob/68cfddb53730cd3ec132bd115d6717013dd60062/sdk/python/src/dagger/server/_commands.py#L52-L58
