### PR TITLE
Adjust to deprecations for graphql_core v.3.2

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,3 @@
 Release type: patch
 
-Stop using functionality deprecated in graphql-core 3.2
+This release removes some usage of deprecated functions from GraphQL-core.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Stop using functionality deprecated in graphql-core 3.2

--- a/docs/integrations/aiohttp.md
+++ b/docs/integrations/aiohttp.md
@@ -120,8 +120,6 @@ from strawberry.aiohttp.views import GraphQLView
 from strawberry.http import GraphQLHTTPResponse
 from strawberry.types import ExecutionResult
 
-from graphql.error.graphql_error import format_error as format_graphql_error
-
 
 class MyGraphQLView(GraphQLView):
     async def process_result(
@@ -130,7 +128,7 @@ class MyGraphQLView(GraphQLView):
         data: GraphQLHTTPResponse = {"data": result.data}
 
         if result.errors:
-            data["errors"] = [format_graphql_error(err) for err in result.errors]
+            data["errors"] = [err.formatted for err in result.errors]
 
         return data
 ```

--- a/docs/integrations/asgi.md
+++ b/docs/integrations/asgi.md
@@ -146,8 +146,6 @@ and the execution results.
 from strawberry.http import GraphQLHTTPResponse
 from strawberry.types import ExecutionResult
 
-from graphql.error.graphql_error import format_error as format_graphql_error
-
 
 class MyGraphQL(GraphQL):
     async def process_result(
@@ -156,7 +154,7 @@ class MyGraphQL(GraphQL):
         data: GraphQLHTTPResponse = {"data": result.data}
 
         if result.errors:
-            data["errors"] = [format_graphql_error(err) for err in result.errors]
+            data["errors"] = [err.formatted for err in result.errors]
 
         return data
 ```

--- a/docs/integrations/chalice.md
+++ b/docs/integrations/chalice.md
@@ -135,15 +135,13 @@ result.
 from strawberry.http import GraphQLHTTPResponse
 from strawberry.types import ExecutionResult
 
-from graphql.error.graphql_error import format_error as format_graphql_error
-
 
 class MyGraphQLView(GraphQLView):
     def process_result(self, result: ExecutionResult) -> GraphQLHTTPResponse:
         data: GraphQLHTTPResponse = {"data": result.data}
 
         if result.errors:
-            data["errors"] = [format_graphql_error(err) for err in result.errors]
+            data["errors"] = [err.formatted for err in result.errors]
 
         return data
 ```

--- a/docs/integrations/django.md
+++ b/docs/integrations/django.md
@@ -126,8 +126,6 @@ and the execution results.
 from strawberry.http import GraphQLHTTPResponse
 from strawberry.types import ExecutionResult
 
-from graphql.error.graphql_error import format_error as format_graphql_error
-
 
 class MyGraphQLView(GraphQLView):
     def process_result(
@@ -136,7 +134,7 @@ class MyGraphQLView(GraphQLView):
         data: GraphQLHTTPResponse = {"data": result.data}
 
         if result.errors:
-            data["errors"] = [format_graphql_error(err) for err in result.errors]
+            data["errors"] = [err.formatted for err in result.errors]
 
         return data
 ```
@@ -244,8 +242,6 @@ and the execution results.
 from strawberry.http import GraphQLHTTPResponse
 from strawberry.types import ExecutionResult
 
-from graphql.error.graphql_error import format_error as format_graphql_error
-
 
 class MyGraphQLView(AsyncGraphQLView):
     async def process_result(
@@ -254,7 +250,7 @@ class MyGraphQLView(AsyncGraphQLView):
         data: GraphQLHTTPResponse = {"data": result.data}
 
         if result.errors:
-            data["errors"] = [format_graphql_error(err) for err in result.errors]
+            data["errors"] = [err.formatted for err in result.errors]
 
         return data
 ```

--- a/docs/integrations/fastapi.md
+++ b/docs/integrations/fastapi.md
@@ -272,8 +272,6 @@ from strawberry.fastapi import GraphQLRouter
 from strawberry.http import GraphQLHTTPResponse
 from strawberry.types import ExecutionResult
 
-from graphql.error.graphql_error import format_error as format_graphql_error
-
 
 class MyGraphQLRouter(GraphQLRouter):
     async def process_result(
@@ -282,7 +280,7 @@ class MyGraphQLRouter(GraphQLRouter):
         data: GraphQLHTTPResponse = {"data": result.data}
 
         if result.errors:
-            data["errors"] = [format_graphql_error(err) for err in result.errors]
+            data["errors"] = [err.formatted for err in result.errors]
 
         return data
 ```

--- a/docs/integrations/flask.md
+++ b/docs/integrations/flask.md
@@ -119,15 +119,13 @@ result.
 from strawberry.http import GraphQLHTTPResponse
 from strawberry.types import ExecutionResult
 
-from graphql.error.graphql_error import format_error as format_graphql_error
-
 
 class MyGraphQLView(GraphQLView):
     def process_result(self, result: ExecutionResult) -> GraphQLHTTPResponse:
         data: GraphQLHTTPResponse = {"data": result.data}
 
         if result.errors:
-            data["errors"] = [format_graphql_error(err) for err in result.errors]
+            data["errors"] = [err.formatted for err in result.errors]
 
         return data
 ```

--- a/docs/integrations/sanic.md
+++ b/docs/integrations/sanic.md
@@ -101,7 +101,6 @@ from strawberry.sanic.views import GraphQLView
 from strawberry.http import GraphQLHTTPResponse, process_result
 from strawberry.types import ExecutionResult
 from sanic.request import Request
-from graphql.error.graphql_error import format_error as format_graphql_error
 
 
 class MyGraphQLView(GraphQLView):
@@ -109,7 +108,7 @@ class MyGraphQLView(GraphQLView):
         self, request: Request, result: ExecutionResult
     ) -> GraphQLHTTPResponse:
         if result.errors:
-            result.errors = [format_graphql_error(err) for err in result.errors]
+            result.errors = [err.formatted for err in result.errors]
 
         return process_result(data)
 ```

--- a/strawberry/http/__init__.py
+++ b/strawberry/http/__init__.py
@@ -5,8 +5,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional
 from typing_extensions import TypedDict
 
-from graphql.error.graphql_error import format_error as format_graphql_error
-
 if TYPE_CHECKING:
     from strawberry.types import ExecutionResult
 
@@ -21,7 +19,7 @@ def process_result(result: ExecutionResult) -> GraphQLHTTPResponse:
     data: GraphQLHTTPResponse = {"data": result.data}
 
     if result.errors:
-        data["errors"] = [format_graphql_error(err) for err in result.errors]
+        data["errors"] = [err.formatted for err in result.errors]
     if result.extensions:
         data["extensions"] = result.extensions
 

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -23,7 +23,7 @@ from graphql import (
     parse,
     validate_schema,
 )
-from graphql.subscription import subscribe
+from graphql.execution import subscribe
 from graphql.type.directives import specified_directives
 
 from strawberry import relay

--- a/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Any, AsyncGenerator, Callable, Dict, List, Opt
 
 from graphql import ExecutionResult as GraphQLExecutionResult
 from graphql import GraphQLError, GraphQLSyntaxError, parse
-from graphql.error.graphql_error import format_error as format_graphql_error
 
 from strawberry.subscriptions.protocols.graphql_transport_ws.types import (
     CompleteMessage,
@@ -250,7 +249,7 @@ class BaseGraphQLTransportWSHandler(ABC):
         # Handle initial validation errors
         if isinstance(result_source, GraphQLExecutionResult):
             assert result_source.errors
-            payload = [format_graphql_error(result_source.errors[0])]
+            payload = [err.formatted for err in result_source.errors]
             await self.send_message(ErrorMessage(id=message.id, payload=payload))
             self.schema.process_errors(result_source.errors)
             return
@@ -296,7 +295,7 @@ class BaseGraphQLTransportWSHandler(ABC):
         try:
             async for result in result_source:
                 if result.errors:
-                    error_payload = [format_graphql_error(err) for err in result.errors]
+                    error_payload = [err.formatted for err in result.errors]
                     error_message = ErrorMessage(id=operation.id, payload=error_payload)
                     await operation.send_message(error_message)
                     self.schema.process_errors(result.errors)
@@ -312,7 +311,7 @@ class BaseGraphQLTransportWSHandler(ABC):
             # GraphQLErrors are handled by graphql-core and included in the
             # ExecutionResult
             error = GraphQLError(str(error), original_error=error)
-            error_payload = [format_graphql_error(error)]
+            error_payload = [error.formatted]
             error_message = ErrorMessage(id=operation.id, payload=error_payload)
             await operation.send_message(error_message)
             self.schema.process_errors([error])

--- a/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
@@ -307,7 +307,7 @@ class BaseGraphQLTransportWSHandler(ABC):
                     next_payload = {"data": result.data}
                     if result.errors:
                         next_payload["errors"] = [
-                            format_graphql_error(err) for err in result.errors
+                            err.formatted for err in result.errors
                         ]
                     next_message = NextMessage(id=operation.id, payload=next_payload)
                     await operation.send_message(next_message)

--- a/tests/schema/extensions/test_mask_errors.py
+++ b/tests/schema/extensions/test_mask_errors.py
@@ -1,7 +1,6 @@
 from unittest.mock import Mock
 
 from graphql.error import GraphQLError
-from graphql.error.graphql_error import format_error as format_graphql_error
 
 import strawberry
 from strawberry.extensions import MaskErrors
@@ -20,7 +19,7 @@ def test_mask_all_errors():
 
     result = schema.execute_sync(query)
     assert result.errors is not None
-    formatted_errors = [format_graphql_error(err) for err in result.errors]
+    formatted_errors = [err.formatted for err in result.errors]
     assert formatted_errors == [
         {
             "locations": [{"column": 9, "line": 1}],
@@ -58,7 +57,7 @@ def test_mask_some_errors():
 
     result = schema.execute_sync(query)
     assert result.errors is not None
-    formatted_errors = [format_graphql_error(err) for err in result.errors]
+    formatted_errors = [err.formatted for err in result.errors]
     assert formatted_errors == [
         {
             "locations": [{"column": 9, "line": 1}],
@@ -71,7 +70,7 @@ def test_mask_some_errors():
 
     result = schema.execute_sync(query)
     assert result.errors is not None
-    formatted_errors = [format_graphql_error(err) for err in result.errors]
+    formatted_errors = [err.formatted for err in result.errors]
     assert formatted_errors == [
         {
             "locations": [{"column": 9, "line": 1}],
@@ -101,7 +100,7 @@ def test_process_errors_original_error():
 
     result = schema.execute_sync(query)
     assert result.errors is not None
-    formatted_errors = [format_graphql_error(err) for err in result.errors]
+    formatted_errors = [err.formatted for err in result.errors]
     assert formatted_errors == [
         {
             "locations": [{"column": 9, "line": 1}],
@@ -129,7 +128,7 @@ def test_graphql_error_masking():
 
     result = schema.execute_sync(query)
     assert result.errors is not None
-    formatted_errors = [format_graphql_error(err) for err in result.errors]
+    formatted_errors = [err.formatted for err in result.errors]
     assert formatted_errors == [
         {
             "locations": [{"column": 9, "line": 1}],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

the `format_error()` function to turn `GraphQLError` into `GraphQLFormattedError` is deprecated
for `graphql-core` 3.2 and will be removed for version 3.3.

`graphql.subscription` module is deprecated, its contents moved to `graphql.execution`

No other deprecated features seem to be in use in strawberry.

Current version in strawberry is "~3.2.0"
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
