### PR TITLE
Failing test for lazy lists

### DIFF
--- a/tests/a.py
+++ b/tests/a.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, List, Optional
 from typing_extensions import Annotated
 
 import strawberry
 
 if TYPE_CHECKING:
     from tests.b import B
+    from tests.c import C
 
 
 @strawberry.type
@@ -18,6 +19,18 @@ class A:
         from tests.b import B
 
         return B(id=self.id)
+
+    @strawberry.field
+    async def b_list(self) -> Annotated[List[B], strawberry.lazy("tests.b")]:
+        from tests.b import B
+
+        return [B(id=self.id)]
+
+    @strawberry.field
+    async def c_list(self) -> Annotated[List[C], strawberry.lazy("tests.c")]:
+        from tests.c import C
+
+        return [C(id=self.id)]
 
     @strawberry.field
     async def optional_b(self) -> Annotated[B, strawberry.lazy("tests.b")] | None:

--- a/tests/b.py
+++ b/tests/b.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, List, Optional
 from typing_extensions import Annotated
 
 import strawberry
@@ -18,6 +18,12 @@ class B:
         from tests.a import A
 
         return A(id=self.id)
+
+    @strawberry.field
+    async def a_list(self) -> Annotated[List[A], strawberry.lazy("tests.a")]:
+        from tests.a import A
+
+        return [A(id=self.id)]
 
     @strawberry.field
     async def optional_a(

--- a/tests/c.py
+++ b/tests/c.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import strawberry
+
+
+@strawberry.type
+class C:
+    id: strawberry.ID

--- a/tests/schema/test_lazy/test_lazy.py
+++ b/tests/schema/test_lazy/test_lazy.py
@@ -26,6 +26,12 @@ def test_cyclic_import():
 
     type TypeB {
       typeA: TypeA!
+      typeAList: [TypeA!]!
+      typeCList: [TypeC!]!
+    }
+
+    type TypeC {
+      name: String!
     }
     """
 

--- a/tests/schema/test_lazy/test_lazy_generic.py
+++ b/tests/schema/test_lazy/test_lazy_generic.py
@@ -66,10 +66,16 @@ def test_no_generic_type_duplication_with_lazy():
 
         type TypeB {
           typeA: TypeA!
+          typeAList: [TypeA!]!
+          typeCList: [TypeC!]!
         }
 
         type TypeBEdge {
           node: TypeB!
+        }
+
+        type TypeC {
+          name: String!
         }
         """
     ).strip()

--- a/tests/schema/test_lazy/type_b.py
+++ b/tests/schema/test_lazy/type_b.py
@@ -1,12 +1,22 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List
 from typing_extensions import Annotated
 
 import strawberry
 
 if TYPE_CHECKING:
     from .type_a import TypeA
+    from .type_c import TypeC
+
+    ListTypeA = List[TypeA]
+    ListTypeC = List[TypeC]
 else:
     TypeA = Annotated["TypeA", strawberry.lazy("tests.schema.test_lazy.type_a")]
+    ListTypeA = Annotated[
+        List["TypeA"], strawberry.lazy("tests.schema.test_lazy.type_a")
+    ]
+    ListTypeC = Annotated[
+        List["TypeC"], strawberry.lazy("tests.schema.test_lazy.type_c")
+    ]
 
 
 @strawberry.type
@@ -18,3 +28,19 @@ class TypeB:
         from .type_a import TypeA
 
         return TypeA()
+
+    @strawberry.field()
+    def type_a_list(
+        self,
+    ) -> ListTypeA:
+        from .type_a import TypeA
+
+        return [TypeA()]
+
+    @strawberry.field()
+    def type_c_list(
+        self,
+    ) -> ListTypeC:
+        from .type_c import TypeC
+
+        return [TypeC()]

--- a/tests/test_forward_references.py
+++ b/tests/test_forward_references.py
@@ -67,6 +67,8 @@ def test_lazy_forward_reference():
     type A {
       id: ID!
       b: B!
+      bList: [B!]!
+      cList: [C!]!
       optionalB: B
       optionalB2: B
     }
@@ -74,8 +76,13 @@ def test_lazy_forward_reference():
     type B {
       id: ID!
       a: A!
+      aList: [A!]!
       optionalA: A
       optionalA2: A
+    }
+
+    type C {
+      id: ID!
     }
 
     type Query {


### PR DESCRIPTION
A bunch of failing test cases for lazy annotations combined with lists.

## Description

I added a few test cases that I expect to pass, resulting in schemas with list types, but they fail to resolve the types in some cases:
- old-school annotations (`Annotated[List["SomeType", lazy(...)]]`) fail in any case
- new annotations (`from __future__ import annotations; Annotated[List[SomeType, lazy(...)]]`, #2744) don't fail when both `Annotated[Type, lazy(...)]` and `Annotated[List[Type], lazy(...)]` are defined in the schema, but fail when there's _only_ `Annotated[List[Type], lazy(...)]`.

## Types of Changes

- [x] Tests

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
