### PR TITLE
Add support for setting cookies in TemporalResponse

### DIFF
--- a/strawberry/chalice/views.py
+++ b/strawberry/chalice/views.py
@@ -111,7 +111,9 @@ class GraphQLView(
         return Response(
             body=self.encode_json(response_data),
             status_code=status_code,
-            headers=sub_response.headers,
+            # The type definition of the headers field of the Response class is wrong,
+            # see https://github.com/aws/chalice/pull/2050
+            headers=sub_response.headers,  # type: ignore
         )
 
     def execute_request(self, request: Request) -> Response:

--- a/strawberry/channels/handlers/http_handler.py
+++ b/strawberry/channels/handlers/http_handler.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import dataclasses
 import json
 from io import BytesIO
-from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Union, Tuple
+from typing import TYPE_CHECKING, Any, List, Mapping, Optional, Tuple, Union
 from urllib.parse import parse_qs
 
 from django.conf import settings
@@ -39,9 +39,7 @@ class ChannelsResponse:
     content: bytes
     status: int = 200
     content_type: str = "application/json"
-    headers: List[Tuple[bytes, bytes]] = dataclasses.field(
-        default_factory=list
-    )
+    headers: List[Tuple[bytes, bytes]] = dataclasses.field(default_factory=list)
 
 
 @dataclasses.dataclass
@@ -169,7 +167,9 @@ class BaseGraphQLHTTPConsumer(ChannelsConsumer, AsyncHttpConsumer):
         headers = []
         for name, value in sub_response.headers.items():
             if isinstance(value, list):
-                multivalue_headers = [(name.encode(), element.encode()) for element in value]
+                multivalue_headers = [
+                    (name.encode(), element.encode()) for element in value
+                ]
                 headers.extend(multivalue_headers)
             else:
                 headers.append((name.encode(), value.encode()))

--- a/strawberry/http/cookie.py
+++ b/strawberry/http/cookie.py
@@ -1,0 +1,43 @@
+import datetime
+from http.cookies import SimpleCookie
+from typing import Optional, Union
+from typing_extensions import Literal
+
+SameSite = Union[Literal["strict"], Literal["lax"], Literal["none"]]
+
+
+def generate_cookie_header_value(
+    key: str,
+    value: str,
+    max_age: Optional[int] = None,
+    expires: Optional[datetime.datetime] = None,
+    path: str = "/",
+    domain: Optional[str] = None,
+    secure: bool = True,
+    httponly: bool = False,
+    samesite: Optional[SameSite] = None,
+) -> str:
+    cookie: SimpleCookie = SimpleCookie()
+
+    cookie[key] = value
+
+    if expires is not None:
+        if expires.tzinfo is None:
+            # We have a naive datetime
+            expires = expires.replace(tzinfo=datetime.timezone.utc)
+        delta = expires - datetime.datetime.now(tz=datetime.timezone.utc)
+        # We just use the max_age logic
+        max_age = max(0, delta.days * 86400 + delta.seconds)
+    if max_age is not None:
+        cookie[key]["max-age"] = max_age
+    if domain is not None:
+        cookie[key]["domain"] = domain
+
+    cookie[key]["path"] = path
+    cookie[key]["secure"] = secure
+    cookie[key]["httponly"] = httponly
+
+    if samesite is not None:
+        cookie[key]["samesite"] = samesite
+
+    return cookie.output(header="").strip()

--- a/strawberry/http/cookie.py
+++ b/strawberry/http/cookie.py
@@ -20,6 +20,9 @@ def generate_cookie_header_value(
     cookie: SimpleCookie = SimpleCookie()
 
     cookie[key] = value
+    cookie[key]["path"] = path
+    cookie[key]["secure"] = secure
+    cookie[key]["httponly"] = httponly
 
     if expires is not None:
         if expires.tzinfo is None:
@@ -32,11 +35,6 @@ def generate_cookie_header_value(
         cookie[key]["max-age"] = max_age
     if domain is not None:
         cookie[key]["domain"] = domain
-
-    cookie[key]["path"] = path
-    cookie[key]["secure"] = secure
-    cookie[key]["httponly"] = httponly
-
     if samesite is not None:
         cookie[key]["samesite"] = samesite
 

--- a/strawberry/http/temporal_response.py
+++ b/strawberry/http/temporal_response.py
@@ -1,8 +1,51 @@
+import datetime
 from dataclasses import dataclass, field
-from typing import Dict
+from typing import Dict, List, Optional, Union
+
+from .cookie import SameSite, generate_cookie_header_value
 
 
 @dataclass
 class TemporalResponse:
     status_code: int = 200
-    headers: Dict[str, str] = field(default_factory=dict)
+    headers: Dict[str, Union[str, List[str]]] = field(default_factory=dict)
+
+    def set_cookie(
+        self,
+        key: str,
+        value: str,
+        max_age: Optional[int] = None,
+        expires: Optional[datetime.datetime] = None,
+        path: str = "/",
+        domain: Optional[str] = None,
+        secure: bool = True,
+        httponly: bool = False,
+        samesite: Optional[SameSite] = None,
+    ) -> None:
+        header_value = generate_cookie_header_value(
+            key,
+            value,
+            max_age=max_age,
+            expires=expires,
+            path=path,
+            domain=domain,
+            secure=secure,
+            httponly=httponly,
+            samesite=samesite,
+        )
+
+        # It is possible to have multiple Set-Cookie headers
+        # so we need to support multiple values per key in the
+        # self.headers dictionary for this header.
+        if "Set-Cookie" in self.headers:
+            if isinstance(self.headers["Set-Cookie"], list):
+                self.headers["Set-Cookie"].append(header_value)
+            else:
+                self.headers["Set-Cookie"] = [self.headers["Set-Cookie"], header_value]
+        else:
+            self.headers["Set-Cookie"] = header_value
+
+    def delete_cookie(
+        self, key: str, path: str = "/", domain: Union[None, str] = None
+    ) -> None:
+        self.set_cookie(key, "", path=path, max_age=0, domain=domain)

--- a/strawberry/sanic/views.py
+++ b/strawberry/sanic/views.py
@@ -152,12 +152,20 @@ class GraphQLView(
 
         data = self.encode_json(response_data)
 
-        return HTTPResponse(
+        response = HTTPResponse(
             data,
             status=status_code,
             content_type="application/json",
-            headers=sub_response.headers,
         )
+
+        for k, v in sub_response.headers.items():
+            if isinstance(v, list):
+                for e in v:
+                    response.headers.add(k, e)
+            else:
+                response.headers.add(k, v)
+
+        return response
 
     async def post(self, request: Request) -> HTTPResponse:
         try:

--- a/strawberry/sanic/views.py
+++ b/strawberry/sanic/views.py
@@ -158,12 +158,12 @@ class GraphQLView(
             content_type="application/json",
         )
 
-        for k, v in sub_response.headers.items():
-            if isinstance(v, list):
-                for e in v:
-                    response.headers.add(k, e)
+        for name, value in sub_response.headers.items():
+            if isinstance(value, list):
+                for element in value:
+                    response.headers.add(name, element)
             else:
-                response.headers.add(k, v)
+                response.headers.add(name, value)
 
         return response
 

--- a/tests/http/clients/async_django.py
+++ b/tests/http/clients/async_django.py
@@ -46,16 +46,26 @@ class AsyncDjangoHttpClient(DjangoHttpClient):
         try:
             response = await view(request)
         except Http404:
-            return Response(
-                status_code=404, data=b"Not found", headers=response.headers
-            )
+            return Response(status_code=404, data=b"Not found", headers={})
         except (BadRequest, SuspiciousOperation) as e:
-            return Response(
-                status_code=400, data=e.args[0].encode(), headers=response.headers
-            )
+            return Response(status_code=400, data=e.args[0].encode(), headers={})
         else:
+            response_headers = {}
+            for k, v in response.headers.items():
+                response_headers[k] = v
+
+            if len(response.cookies) > 1:
+                response_headers["Set-Cookie"] = [
+                    cookie.output(header="").strip()
+                    for cookie in response.cookies.values()
+                ]
+            else:
+                response_headers["Set-Cookie"] = response.cookies.output(
+                    header=""
+                ).strip()
+
             return Response(
                 status_code=response.status_code,
                 data=response.content,
-                headers=response.headers,
+                headers=response_headers,
             )

--- a/tests/http/clients/base.py
+++ b/tests/http/clients/base.py
@@ -1,5 +1,6 @@
 import abc
 import json
+from ctypes import Union
 from dataclasses import dataclass
 from io import BytesIO
 from typing import (
@@ -25,7 +26,7 @@ ResultOverrideFunction = Optional[Callable[[ExecutionResult], GraphQLHTTPRespons
 class Response:
     status_code: int
     data: bytes
-    headers: Mapping[str, str]
+    headers: Mapping[str, "Union[str, List[str]]"]
 
     @property
     def text(self) -> str:

--- a/tests/http/clients/channels.py
+++ b/tests/http/clients/channels.py
@@ -208,10 +208,17 @@ class ChannelsHttpClient(HttpClient):
         )
         response = await communicator.get_response()
 
+        response_headers = {}
+        for key, value in response["headers"]:
+            if isinstance(value, list):
+                response_headers[key.decode()] = [e.decode() for e in value]
+            else:
+                response_headers[key.decode()] = value.decode()
+
         return Response(
             status_code=response["status"],
             data=response["body"],
-            headers={k.decode(): v.decode() for k, v in response["headers"]},
+            headers=response_headers,
         )
 
     async def get(

--- a/tests/http/clients/channels.py
+++ b/tests/http/clients/channels.py
@@ -219,7 +219,6 @@ class ChannelsHttpClient(HttpClient):
             else:
                 response_headers[name] = value.decode()
 
-
         return Response(
             status_code=response["status"],
             data=response["body"],

--- a/tests/http/clients/channels.py
+++ b/tests/http/clients/channels.py
@@ -210,10 +210,15 @@ class ChannelsHttpClient(HttpClient):
 
         response_headers = {}
         for key, value in response["headers"]:
-            if isinstance(value, list):
-                response_headers[key.decode()] = [e.decode() for e in value]
+            name = key.decode()
+            if name in response_headers:
+                if isinstance(response_headers[name], list):
+                    response_headers[name].append(value.decode())
+                else:
+                    response_headers[name] = [response_headers[name], value.decode()]
             else:
-                response_headers[key.decode()] = value.decode()
+                response_headers[name] = value.decode()
+
 
         return Response(
             status_code=response["status"],

--- a/tests/http/clients/django.py
+++ b/tests/http/clients/django.py
@@ -75,18 +75,28 @@ class DjangoHttpClient(HttpClient):
         try:
             response = view(request)
         except Http404:
-            return Response(
-                status_code=404, data=b"Not found", headers=response.headers
-            )
+            return Response(status_code=404, data=b"Not found", headers={})
         except (BadRequest, SuspiciousOperation) as e:
-            return Response(
-                status_code=400, data=e.args[0].encode(), headers=response.headers
-            )
+            return Response(status_code=400, data=e.args[0].encode(), headers={})
         else:
+            response_headers = {}
+            for k, v in response.headers.items():
+                response_headers[k] = v
+
+            if len(response.cookies) > 1:
+                response_headers["Set-Cookie"] = [
+                    cookie.output(header="").strip()
+                    for cookie in response.cookies.values()
+                ]
+            else:
+                response_headers["Set-Cookie"] = response.cookies.output(
+                    header=""
+                ).strip()
+
             return Response(
                 status_code=response.status_code,
                 data=response.content,
-                headers=response.headers,
+                headers=response_headers,
             )
 
     async def _graphql_request(

--- a/tests/http/test_cookie.py
+++ b/tests/http/test_cookie.py
@@ -1,0 +1,66 @@
+from datetime import datetime, timedelta
+
+import pytest
+from freezegun import freeze_time
+
+from strawberry.http.cookie import generate_cookie_header_value
+
+
+def test_set_cookie():
+    assert (
+        generate_cookie_header_value("strawberry", "rocks")
+        == "strawberry=rocks; Path=/; Secure"
+    )
+
+
+def test_set_cookie_secure_false():
+    assert (
+        generate_cookie_header_value("strawberry", "rocks", secure=False)
+        == "strawberry=rocks; Path=/"
+    )
+
+
+def test_set_cookie_httponly():
+    assert (
+        generate_cookie_header_value("strawberry", "rocks", httponly=True)
+        == "strawberry=rocks; HttpOnly; Path=/; Secure"
+    )
+
+
+def test_set_cookie_max_age():
+    assert (
+        generate_cookie_header_value("strawberry", "rocks", max_age=100)
+        == "strawberry=rocks; Max-Age=100; Path=/; Secure"
+    )
+
+
+def test_set_cookie_path():
+    assert (
+        generate_cookie_header_value("strawberry", "rocks", path="/graphql")
+        == "strawberry=rocks; Path=/graphql; Secure"
+    )
+
+
+def test_set_cookie_domain():
+    assert (
+        generate_cookie_header_value("strawberry", "rocks", domain="strawberry.rocks")
+        == "strawberry=rocks; Domain=strawberry.rocks; Path=/; Secure"
+    )
+
+
+@pytest.mark.parametrize("samesite", ["strict", "lax", "none"])
+def test_set_cookie_samesite(samesite):
+    assert (
+        generate_cookie_header_value("strawberry", "rocks", samesite=samesite)
+        == f"strawberry=rocks; Path=/; SameSite={samesite}; Secure"
+    )
+
+
+@freeze_time("20300101 00:00:00")
+def test_set_cookie_expires():
+    one_day_later = datetime.now() + timedelta(days=1)
+    seconds_in_a_day = 86400
+    assert (
+        generate_cookie_header_value("strawberry", "rocks", expires=one_day_later)
+        == f"strawberry=rocks; Max-Age={seconds_in_a_day}; Path=/; Secure"
+    )

--- a/tests/http/test_temporal_response.py
+++ b/tests/http/test_temporal_response.py
@@ -1,0 +1,37 @@
+
+
+from strawberry.http.temporal_response import TemporalResponse
+
+
+def test_set_cookie():
+    response = TemporalResponse()
+    response.set_cookie("strawberry", "rocks")
+    assert response.headers["Set-Cookie"] == "strawberry=rocks; Path=/; Secure"
+
+
+def test_set_two_cookies():
+    response = TemporalResponse()
+    response.set_cookie("strawberry", "rocks")
+    response.set_cookie("snek", "is_little")
+    assert response.headers["Set-Cookie"] == [
+        "strawberry=rocks; Path=/; Secure",
+        "snek=is_little; Path=/; Secure",
+    ]
+
+
+def test_set_three_cookies():
+    response = TemporalResponse()
+    response.set_cookie("strawberry", "rocks")
+    response.set_cookie("snek", "is_little")
+    response.set_cookie("cookie", "is_tasty")
+    assert response.headers["Set-Cookie"] == [
+        "strawberry=rocks; Path=/; Secure",
+        "snek=is_little; Path=/; Secure",
+        "cookie=is_tasty; Path=/; Secure",
+    ]
+
+
+def test_delete_cookie():
+    response = TemporalResponse()
+    response.delete_cookie("strawberry")
+    assert response.headers["Set-Cookie"] == 'strawberry=""; Max-Age=0; Path=/; Secure'

--- a/tests/http/test_temporal_response.py
+++ b/tests/http/test_temporal_response.py
@@ -1,5 +1,3 @@
-
-
 from strawberry.http.temporal_response import TemporalResponse
 
 

--- a/tests/views/schema.py
+++ b/tests/views/schema.py
@@ -114,6 +114,31 @@ class Query:
 
         return name
 
+    @strawberry.field
+    def set_cookie(self, info: Info[Any, Any]) -> str:
+        response = info.context["response"]
+        response.set_cookie(
+            "strawberry",
+            "rocks",
+        )
+
+        return "adb"
+
+    @strawberry.field
+    def set_two_cookies(self, info: Info[Any, Any]) -> str:
+        response = info.context["response"]
+        response.set_cookie(
+            "strawberry",
+            "rocks",
+        )
+
+        response.set_cookie(
+            "snek",
+            "is_little",
+        )
+
+        return "adb"
+
 
 @strawberry.type
 class Mutation:


### PR DESCRIPTION
WIP

This PR adds support for setting cookies in integrations that use a `TemporalResponse` in their context, e.g.:

* Sanic
* Chalice
* Channels

## Description

For Chalice and Sanic, not many changes were needed.

For Channels, I had to change the type of the headers field in `ChannelsResponse` to a list of tuples, so that it is possible to set multiple cookies in one response. Channels itself supports a list of tuples as headers in the `send_response` method automatically.

This also adds a breaking change to the `TemporalResponse` class. Header values can be a list now.


## Types of Changes

- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #2832

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
