### PR TITLE
ensure that `Schema.process_errors()` is called properly

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+This release makes sure that `Schema.process_errors()` is called _once_ for every error
+which happens with `graphql-transport-ws` operations.

--- a/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
@@ -248,6 +248,7 @@ class BaseGraphQLTransportWSHandler(ABC):
 
         # Handle initial validation errors
         if isinstance(result_source, GraphQLExecutionResult):
+            assert operation_type == OperationType.SUBSCRIPTION
             assert result_source.errors
             payload = [err.formatted for err in result_source.errors]
             await self.send_message(ErrorMessage(id=message.id, payload=payload))
@@ -301,11 +302,13 @@ class BaseGraphQLTransportWSHandler(ABC):
                     error_payload = [err.formatted for err in result.errors]
                     error_message = ErrorMessage(id=operation.id, payload=error_payload)
                     await operation.send_message(error_message)
-                    self.schema.process_errors(result.errors)
+                    # don't need to call schema.process_errors() here because
+                    # it was already done by schema.execute()
                     return
                 else:
                     next_payload = {"data": result.data}
                     if result.errors:
+                        self.schema.process_errors(result.errors)
                         next_payload["errors"] = [
                             err.formatted for err in result.errors
                         ]

--- a/tests/views/schema.py
+++ b/tests/views/schema.py
@@ -10,7 +10,7 @@ from strawberry.extensions import SchemaExtension
 from strawberry.file_uploads import Upload
 from strawberry.permission import BasePermission
 from strawberry.subscriptions.protocols.graphql_transport_ws.types import PingMessage
-from strawberry.types import Info
+from strawberry.types import ExecutionContext, Info
 
 
 class AlwaysFailPermission(BasePermission):
@@ -262,7 +262,17 @@ class Subscription:
             await asyncio.sleep(delay)
 
 
-schema = strawberry.Schema(
+class Schema(strawberry.Schema):
+    def process_errors(
+        self, errors: List, execution_context: Optional[ExecutionContext] = None
+    ) -> None:
+        import traceback
+
+        traceback.print_stack()
+        return super().process_errors(errors, execution_context)
+
+
+schema = Schema(
     query=Query,
     mutation=Mutation,
     subscription=Subscription,

--- a/tests/websockets/test_graphql_transport_ws.py
+++ b/tests/websockets/test_graphql_transport_ws.py
@@ -4,7 +4,7 @@ import sys
 import time
 from datetime import timedelta
 from typing import AsyncGenerator, Type
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 try:
     from unittest.mock import AsyncMock
@@ -29,6 +29,7 @@ from strawberry.subscriptions.protocols.graphql_transport_ws.types import (
 )
 from tests.http.clients import AioHttpClient, ChannelsHttpClient
 from tests.http.clients.base import DebuggableGraphQLTransportWSMixin
+from tests.views.schema import Schema
 
 from ..http.clients import HttpClient, WebSocketClient
 
@@ -345,25 +346,28 @@ async def test_subscription_syntax_error(ws: WebSocketClient):
 
 
 async def test_subscription_field_errors(ws: WebSocketClient):
-    await ws.send_json(
-        SubscribeMessage(
-            id="sub1",
-            payload=SubscribeMessagePayload(
-                query="subscription { notASubscriptionField }",
-            ),
-        ).as_dict()
-    )
+    process_errors = Mock()
+    with patch.object(Schema, "process_errors", process_errors):
+        await ws.send_json(
+            SubscribeMessage(
+                id="sub1",
+                payload=SubscribeMessagePayload(
+                    query="subscription { notASubscriptionField }",
+                ),
+            ).as_dict()
+        )
 
-    response = await ws.receive_json()
-    assert response["type"] == ErrorMessage.type
-    assert response["id"] == "sub1"
-    assert len(response["payload"]) == 1
-    assert response["payload"][0].get("path") is None
-    assert response["payload"][0]["locations"] == [{"line": 1, "column": 16}]
-    assert (
-        response["payload"][0]["message"]
-        == "The subscription field 'notASubscriptionField' is not defined."
-    )
+        response = await ws.receive_json()
+        assert response["type"] == ErrorMessage.type
+        assert response["id"] == "sub1"
+        assert len(response["payload"]) == 1
+        assert response["payload"][0].get("path") is None
+        assert response["payload"][0]["locations"] == [{"line": 1, "column": 16}]
+        assert (
+            response["payload"][0]["message"]
+            == "The subscription field 'notASubscriptionField' is not defined."
+        )
+        process_errors.assert_called_once()
 
 
 async def test_subscription_cancellation(ws: WebSocketClient):
@@ -471,22 +475,25 @@ async def test_operation_error_no_complete(ws: WebSocketClient):
 
 
 async def test_subscription_exceptions(ws: WebSocketClient):
-    await ws.send_json(
-        SubscribeMessage(
-            id="sub1",
-            payload=SubscribeMessagePayload(
-                query='subscription { exception(message: "TEST EXC") }',
-            ),
-        ).as_dict()
-    )
+    process_errors = Mock()
+    with patch.object(Schema, "process_errors", process_errors):
+        await ws.send_json(
+            SubscribeMessage(
+                id="sub1",
+                payload=SubscribeMessagePayload(
+                    query='subscription { exception(message: "TEST EXC") }',
+                ),
+            ).as_dict()
+        )
 
-    response = await ws.receive_json()
-    assert response["type"] == ErrorMessage.type
-    assert response["id"] == "sub1"
-    assert len(response["payload"]) == 1
-    assert response["payload"][0].get("path") is None
-    assert response["payload"][0].get("locations") is None
-    assert response["payload"][0]["message"] == "TEST EXC"
+        response = await ws.receive_json()
+        assert response["type"] == ErrorMessage.type
+        assert response["id"] == "sub1"
+        assert len(response["payload"]) == 1
+        assert response["payload"][0].get("path") is None
+        assert response["payload"][0].get("locations") is None
+        assert response["payload"][0]["message"] == "TEST EXC"
+        process_errors.assert_called_once()
 
 
 async def test_single_result_query_operation(ws: WebSocketClient):
@@ -640,20 +647,23 @@ async def test_single_result_invalid_operation_selection(ws: WebSocketClient):
 
 
 async def test_single_result_operation_error(ws: WebSocketClient):
-    await ws.send_json(
-        SubscribeMessage(
-            id="sub1",
-            payload=SubscribeMessagePayload(
-                query="query { alwaysFail }",
-            ),
-        ).as_dict()
-    )
+    process_errors = Mock()
+    with patch.object(Schema, "process_errors", process_errors):
+        await ws.send_json(
+            SubscribeMessage(
+                id="sub1",
+                payload=SubscribeMessagePayload(
+                    query="query { alwaysFail }",
+                ),
+            ).as_dict()
+        )
 
-    response = await ws.receive_json()
-    assert response["type"] == ErrorMessage.type
-    assert response["id"] == "sub1"
-    assert len(response["payload"]) == 1
-    assert response["payload"][0]["message"] == "You are not authorized"
+        response = await ws.receive_json()
+        assert response["type"] == ErrorMessage.type
+        assert response["id"] == "sub1"
+        assert len(response["payload"]) == 1
+        assert response["payload"][0]["message"] == "You are not authorized"
+        process_errors.assert_called_once()
 
 
 async def test_single_result_operation_exception(ws: WebSocketClient):
@@ -661,21 +671,24 @@ async def test_single_result_operation_exception(ws: WebSocketClient):
     Test that single-result-operations which raise exceptions
     behave in the same way as streaming operations
     """
-    await ws.send_json(
-        SubscribeMessage(
-            id="sub1",
-            payload=SubscribeMessagePayload(
-                query='query { exception(message: "bummer") }',
-            ),
-        ).as_dict()
-    )
+    process_errors = Mock()
+    with patch.object(Schema, "process_errors", process_errors):
+        await ws.send_json(
+            SubscribeMessage(
+                id="sub1",
+                payload=SubscribeMessagePayload(
+                    query='query { exception(message: "bummer") }',
+                ),
+            ).as_dict()
+        )
 
-    response = await ws.receive_json()
-    assert response["type"] == ErrorMessage.type
-    assert response["id"] == "sub1"
-    assert len(response["payload"]) == 1
-    assert response["payload"][0].get("path") == ["exception"]
-    assert response["payload"][0]["message"] == "bummer"
+        response = await ws.receive_json()
+        assert response["type"] == ErrorMessage.type
+        assert response["id"] == "sub1"
+        assert len(response["payload"]) == 1
+        assert response["payload"][0].get("path") == ["exception"]
+        assert response["payload"][0]["message"] == "bummer"
+        process_errors.assert_called_once()
 
 
 async def test_single_result_duplicate_ids_sub(ws: WebSocketClient):
@@ -878,33 +891,35 @@ async def test_subscription_errors_continue(ws: WebSocketClient):
     Verify that an ExecutionResult with errors during subscription does not terminate
     the subscription
     """
+    process_errors = Mock()
+    with patch.object(Schema, "process_errors", process_errors):
+        await ws.send_json(
+            SubscribeMessage(
+                id="sub1",
+                payload=SubscribeMessagePayload(
+                    query="subscription { flavorsInvalid }",
+                ),
+            ).as_dict()
+        )
 
-    await ws.send_json(
-        SubscribeMessage(
-            id="sub1",
-            payload=SubscribeMessagePayload(
-                query="subscription { flavorsInvalid }",
-            ),
-        ).as_dict()
-    )
+        response = await ws.receive_json()
+        assert response["type"] == NextMessage.type
+        assert response["id"] == "sub1"
+        assert response["payload"]["data"] == {"flavorsInvalid": "VANILLA"}
 
-    response = await ws.receive_json()
-    assert response["type"] == NextMessage.type
-    assert response["id"] == "sub1"
-    assert response["payload"]["data"] == {"flavorsInvalid": "VANILLA"}
+        response = await ws.receive_json()
+        assert response["type"] == NextMessage.type
+        assert response["id"] == "sub1"
+        assert response["payload"]["data"] is None
+        errors = response["payload"]["errors"]
+        assert "cannot represent value" in str(errors)
+        process_errors.assert_called_once()
 
-    response = await ws.receive_json()
-    assert response["type"] == NextMessage.type
-    assert response["id"] == "sub1"
-    assert response["payload"]["data"] is None
-    errors = response["payload"]["errors"]
-    assert "cannot represent value" in str(errors)
+        response = await ws.receive_json()
+        assert response["type"] == NextMessage.type
+        assert response["id"] == "sub1"
+        assert response["payload"]["data"] == {"flavorsInvalid": "CHOCOLATE"}
 
-    response = await ws.receive_json()
-    assert response["type"] == NextMessage.type
-    assert response["id"] == "sub1"
-    assert response["payload"]["data"] == {"flavorsInvalid": "CHOCOLATE"}
-
-    response = await ws.receive_json()
-    assert response["type"] == CompleteMessage.type
-    assert response["id"] == "sub1"
+        response = await ws.receive_json()
+        assert response["type"] == CompleteMessage.type
+        assert response["id"] == "sub1"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

for `graphql-transport-ws` there were problems with calling `Schema.process_errors()`

- for single-result operations this method would be called twice.
- for errors during subscriptions (`NextMessage`) they would _not be called_

This PR fixes that and adds tests for this in the unit-tests.

When we add a proper `Extension` mechanism for subscriptions, this will have to be revisited, but the
unit-tests will make sure that it happens.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
