### PR TITLE
Fix unresolved arguments using typing.Annotated

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,51 @@
+Release type: patch
+
+This release fixes an issue related to using `typing.Annotated` in resolver
+arguments following the declaration of a reserved argument such as
+`strawberry.types.Info`.
+
+Before this fix, the following would be converted incorrectly:
+
+```python
+from __future__ import annotations
+import strawberry
+import uuid
+from typing_extensions import Annotated
+from strawberry.types import Info
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def get_testing(
+        self,
+        info: Info[None, None],
+        id_: Annotated[uuid.UUID, strawberry.argument(name="id")],
+    ) -> str | None:
+        return None
+
+
+schema = strawberry.Schema(query=Query)
+
+print(schema)
+```
+
+Resulting in the schema:
+
+```graphql
+type Query {
+  getTesting(id_: UUID!): String # ⬅️ see `id_`
+}
+
+scalar UUID
+```
+
+After this fix, the schema is converted correctly:
+
+```graphql
+type Query {
+  getTesting(id: UUID!): String
+}
+
+scalar UUID
+```

--- a/strawberry/arguments.py
+++ b/strawberry/arguments.py
@@ -18,16 +18,12 @@ from typing_extensions import Annotated, get_args, get_origin
 from strawberry.annotation import StrawberryAnnotation
 from strawberry.enum import EnumDefinition
 from strawberry.lazy_type import LazyType, StrawberryLazyReference
-from strawberry.type import (
-    StrawberryList,
-    StrawberryOptional,
-    has_object_definition,
-)
+from strawberry.type import StrawberryList, StrawberryOptional, has_object_definition
 
 from .exceptions import MultipleStrawberryArgumentsError, UnsupportedTypeError
 from .scalars import is_scalar
 from .unset import UNSET as _deprecated_UNSET
-from .unset import _deprecated_is_unset  # noqa
+from .unset import _deprecated_is_unset  # noqa # type: ignore
 
 if TYPE_CHECKING:
     from strawberry.custom_scalar import ScalarDefinition, ScalarWrapper
@@ -83,7 +79,6 @@ class StrawberryArgument:
         self.graphql_name = graphql_name
         self.is_subscription = is_subscription
         self.description = description
-        self._type: Optional[StrawberryType] = None
         self.type_annotation = type_annotation
         self.deprecation_reason = deprecation_reason
         self.directives = directives
@@ -94,47 +89,45 @@ class StrawberryArgument:
             _deprecated_UNSET if default is inspect.Parameter.empty else default
         )
 
-        if self._annotation_is_annotated(type_annotation):
-            self._parse_annotated()
+        try:
+            evaled_type = type_annotation.evaluate()
+        except NameError:
+            pass
+        else:
+            if get_origin(evaled_type) is Annotated:
+                first, *rest = get_args(evaled_type)
+
+                # The first argument to Annotated is always the underlying type
+                self.type_annotation = StrawberryAnnotation(first)
+
+                # Find any instances of StrawberryArgumentAnnotation
+                # in the other Annotated args, raising an exception if there
+                # are multiple StrawberryArgumentAnnotations
+                argument_annotation_seen = False
+
+                for arg in rest:
+                    if isinstance(arg, StrawberryArgumentAnnotation):
+                        if argument_annotation_seen:
+                            raise MultipleStrawberryArgumentsError(
+                                argument_name=python_name
+                            )
+
+                        argument_annotation_seen = True
+
+                        self.description = arg.description
+                        self.graphql_name = arg.name
+                        self.deprecation_reason = arg.deprecation_reason
+                        self.directives = arg.directives
+                        self.metadata = arg.metadata
+
+                    if isinstance(arg, StrawberryLazyReference):
+                        self.type_annotation = StrawberryAnnotation(
+                            arg.resolve_forward_ref(first)
+                        )
 
     @property
     def type(self) -> Union[StrawberryType, type]:
         return self.type_annotation.resolve()
-
-    @classmethod
-    def _annotation_is_annotated(cls, annotation: StrawberryAnnotation) -> bool:
-        return get_origin(annotation.annotation) is Annotated
-
-    def _parse_annotated(self):
-        annotated_args = get_args(self.type_annotation.annotation)
-
-        # The first argument to Annotated is always the underlying type
-        self.type_annotation = StrawberryAnnotation(annotated_args[0])
-
-        # Find any instances of StrawberryArgumentAnnotation
-        # in the other Annotated args, raising an exception if there
-        # are multiple StrawberryArgumentAnnotations
-        argument_annotation_seen = False
-
-        for arg in annotated_args[1:]:
-            if isinstance(arg, StrawberryArgumentAnnotation):
-                if argument_annotation_seen:
-                    raise MultipleStrawberryArgumentsError(
-                        argument_name=self.python_name
-                    )
-
-                argument_annotation_seen = True
-
-                self.description = arg.description
-                self.graphql_name = arg.name
-                self.deprecation_reason = arg.deprecation_reason
-                self.directives = arg.directives
-                self.metadata = arg.metadata
-
-            if isinstance(arg, StrawberryLazyReference):
-                self.type_annotation = StrawberryAnnotation(
-                    arg.resolve_forward_ref(annotated_args[0])
-                )
 
 
 def convert_argument(
@@ -257,7 +250,7 @@ def __getattr__(name: str) -> Any:
 __all__ = [  # noqa: F822
     "StrawberryArgument",
     "StrawberryArgumentAnnotation",
-    "UNSET",  # for backwards compatibility
+    "UNSET",  # for backwards compatibility  # type: ignore
     "argument",
-    "is_unset",  # for backwards compatibility
+    "is_unset",  # for backwards compatibility  # type: ignore
 ]

--- a/strawberry/arguments.py
+++ b/strawberry/arguments.py
@@ -92,6 +92,8 @@ class StrawberryArgument:
         try:
             evaled_type = type_annotation.evaluate()
         except NameError:
+            # Evaluation failures can happen when importing types within a TYPE_CHECKING
+            # block or if the type is declared later on in the current module.
             pass
         else:
             if get_origin(evaled_type) is Annotated:

--- a/strawberry/types/fields/resolver.py
+++ b/strawberry/types/fields/resolver.py
@@ -9,7 +9,6 @@ from typing import (
     Any,
     Callable,
     Dict,
-    ForwardRef,
     Generic,
     List,
     Mapping,
@@ -29,7 +28,6 @@ from strawberry.exceptions import MissingArgumentsAnnotationsError
 from strawberry.type import StrawberryType, has_object_definition
 from strawberry.types.info import Info
 from strawberry.utils.cached_property import cached_property
-from strawberry.utils.typing import eval_type
 
 if TYPE_CHECKING:
     import builtins
@@ -59,7 +57,9 @@ class Signature(inspect.Signature):
 
 class ReservedParameterSpecification(Protocol):
     def find(
-        self, parameters: Tuple[inspect.Parameter, ...], resolver: StrawberryResolver
+        self,
+        parameters: Tuple[inspect.Parameter, ...],
+        resolver: StrawberryResolver[Any],
     ) -> Optional[inspect.Parameter]:
         """Finds the reserved parameter from ``parameters``."""
 
@@ -68,8 +68,11 @@ class ReservedName(NamedTuple):
     name: str
 
     def find(
-        self, parameters: Tuple[inspect.Parameter, ...], _: StrawberryResolver
+        self,
+        parameters: Tuple[inspect.Parameter, ...],
+        resolver: StrawberryResolver[Any],
     ) -> Optional[inspect.Parameter]:
+        del resolver
         return next((p for p in parameters if p.name == self.name), None)
 
 
@@ -77,8 +80,11 @@ class ReservedNameBoundParameter(NamedTuple):
     name: str
 
     def find(
-        self, parameters: Tuple[inspect.Parameter, ...], _: StrawberryResolver
+        self,
+        parameters: Tuple[inspect.Parameter, ...],
+        resolver: StrawberryResolver[Any],
     ) -> Optional[inspect.Parameter]:
+        del resolver
         if parameters:  # Add compatibility for resolvers with no arguments
             first_parameter = parameters[0]
             return first_parameter if first_parameter.name == self.name else None
@@ -94,27 +100,23 @@ class ReservedType(NamedTuple):
     """
 
     name: str
-    type: Type
+    type: Type[Any]
 
     def find(
-        self, parameters: Tuple[inspect.Parameter, ...], resolver: StrawberryResolver
+        self,
+        parameters: Tuple[inspect.Parameter, ...],
+        resolver: StrawberryResolver[Any],
     ) -> Optional[inspect.Parameter]:
         for parameter in parameters:
-            annotation = parameter.annotation
-            try:
-                resolved_annotation = eval_type(
-                    ForwardRef(annotation)
-                    if isinstance(annotation, str)
-                    else annotation,
-                    resolver._namespace,
-                    None,
-                )
-                resolver._resolved_annotations[parameter] = resolved_annotation
-            except NameError:
-                # Type-annotation could not be resolved
-                resolved_annotation = annotation
-            if self.is_reserved_type(resolved_annotation):
-                return parameter
+            annotation = resolver.strawberry_annotations[parameter]
+            if isinstance(annotation, StrawberryAnnotation):
+                try:
+                    evaled_annotation = annotation.evaluate()
+                except NameError:
+                    continue
+                else:
+                    if self.is_reserved_type(evaled_annotation):
+                        return parameter
 
         # Fallback to matching by name
         reserved_name = ReservedName(name=self.name).find(parameters, resolver)
@@ -130,7 +132,7 @@ class ReservedType(NamedTuple):
         else:
             return None
 
-    def is_reserved_type(self, other: Type) -> bool:
+    def is_reserved_type(self, other: Type[Any]) -> bool:
         origin = cast(type, get_origin(other)) or other
         if origin is Annotated:
             # Handle annotated arguments such as Private[str] and DirectiveValue[str]
@@ -174,11 +176,6 @@ class StrawberryResolver(Generic[T]):
 
         This is used when creating copies of types w/ generics
         """
-        self._resolved_annotations: Dict[inspect.Parameter, Any] = {}
-        """Populated during reserved parameter determination.
-
-        Caching resolved annotations this way prevents evaling them repeatedly.
-        """
 
     # TODO: Use this when doing the actual resolving? How to deal with async resolvers?
     def __call__(self, *args: str, **kwargs: Any) -> T:
@@ -189,6 +186,18 @@ class StrawberryResolver(Generic[T]):
     @cached_property
     def signature(self) -> inspect.Signature:
         return Signature.from_callable(self._unbound_wrapped_func, follow_wrapped=True)
+
+    # TODO: find better name
+    @cached_property
+    def strawberry_annotations(
+        self,
+    ) -> Dict[inspect.Parameter, Union[StrawberryAnnotation, None]]:
+        return {
+            p: StrawberryAnnotation(p.annotation, namespace=self._namespace)
+            if p.annotation is not inspect.Signature.empty
+            else None
+            for p in self.signature.parameters.values()
+        }
 
     @cached_property
     def reserved_parameters(
@@ -204,21 +213,19 @@ class StrawberryResolver(Generic[T]):
         parameters = self.signature.parameters.values()
         reserved_parameters = set(self.reserved_parameters.values())
 
-        missing_annotations = []
-        arguments = []
+        missing_annotations: List[str] = []
+        arguments: List[StrawberryArgument] = []
         user_parameters = (p for p in parameters if p not in reserved_parameters)
 
         for param in user_parameters:
-            annotation = self._resolved_annotations.get(param, param.annotation)
-            if annotation is inspect.Signature.empty:
+            annotation = self.strawberry_annotations[param]
+            if annotation is None:
                 missing_annotations.append(param.name)
             else:
                 argument = StrawberryArgument(
                     python_name=param.name,
                     graphql_name=None,
-                    type_annotation=StrawberryAnnotation(
-                        annotation=annotation, namespace=self._namespace
-                    ),
+                    type_annotation=annotation,
                     default=param.default,
                 )
                 arguments.append(argument)
@@ -243,6 +250,7 @@ class StrawberryResolver(Generic[T]):
         # TODO: What to do if resolver is a lambda?
         return self._unbound_wrapped_func.__name__
 
+    # TODO: consider deprecating
     @cached_property
     def annotations(self) -> Dict[str, object]:
         """Annotations for the resolver.

--- a/strawberry/types/fields/resolver.py
+++ b/strawberry/types/fields/resolver.py
@@ -192,9 +192,11 @@ class StrawberryResolver(Generic[T]):
         self,
     ) -> Dict[inspect.Parameter, Union[StrawberryAnnotation, None]]:
         return {
-            p: StrawberryAnnotation(p.annotation, namespace=self._namespace)
-            if p.annotation is not inspect.Signature.empty
-            else None
+            p: (
+                StrawberryAnnotation(p.annotation, namespace=self._namespace)
+                if p.annotation is not inspect.Signature.empty
+                else None
+            )
             for p in self.signature.parameters.values()
         }
 

--- a/strawberry/types/fields/resolver.py
+++ b/strawberry/types/fields/resolver.py
@@ -131,7 +131,7 @@ class ReservedType(NamedTuple):
         else:
             return None
 
-    def is_reserved_type(self, other: type) -> bool:
+    def is_reserved_type(self, other: builtins.type) -> bool:
         origin = cast(type, get_origin(other)) or other
         if origin is Annotated:
             # Handle annotated arguments such as Private[str] and DirectiveValue[str]

--- a/strawberry/types/fields/resolver.py
+++ b/strawberry/types/fields/resolver.py
@@ -15,7 +15,6 @@ from typing import (
     NamedTuple,
     Optional,
     Tuple,
-    Type,
     TypeVar,
     Union,
     cast,
@@ -100,7 +99,7 @@ class ReservedType(NamedTuple):
     """
 
     name: str
-    type: Type[Any]
+    type: type
 
     def find(
         self,
@@ -132,7 +131,7 @@ class ReservedType(NamedTuple):
         else:
             return None
 
-    def is_reserved_type(self, other: Type[Any]) -> bool:
+    def is_reserved_type(self, other: type) -> bool:
         origin = cast(type, get_origin(other)) or other
         if origin is Annotated:
             # Handle annotated arguments such as Private[str] and DirectiveValue[str]

--- a/tests/schema/test_annotated/type_a.py
+++ b/tests/schema/test_annotated/type_a.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import Optional
+from typing_extensions import Annotated
+from uuid import UUID
+
+import strawberry
+from strawberry.types import Info
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def get_testing(
+        self,
+        info: Info[None, None],
+        id_: Annotated[UUID, strawberry.argument(name="id")],
+    ) -> Optional[str]:
+        ...

--- a/tests/schema/test_annotated/type_b.py
+++ b/tests/schema/test_annotated/type_b.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import Optional
+from typing_extensions import Annotated
+from uuid import UUID
+
+import strawberry
+from strawberry.types import Info
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def get_testing(
+        self,
+        id_: Annotated[UUID, strawberry.argument(name="id")],
+        info: Info[None, None],
+    ) -> Optional[str]:
+        ...

--- a/tests/schema/test_arguments.py
+++ b/tests/schema/test_arguments.py
@@ -1,3 +1,4 @@
+import textwrap
 from textwrap import dedent
 from typing import Optional
 from typing_extensions import Annotated
@@ -199,3 +200,40 @@ def test_setting_metadata_on_argument():
     assert field_definition.arguments[0].metadata == {
         "test": "foo",
     }
+
+
+def test_argument_parse_order():
+    """Check early early exit from argument parsing due to finding ``info``.
+
+    Reserved argument parsing, which interally also resolves annotations, exits early
+    after detecting the ``info`` argumnent. As a result, the annotation of the ``id_``
+    argument in `tests.schema.test_annotated.type_a.Query` is never resolved. This
+    results in `StrawberryArgument` not being able to detect that ``id_`` makes use of
+    `typing.Annotated` and `strawberry.argument`.
+
+    This behavior is fixed by by ensuring that `StrawberryArgument` makes use of the new
+    `StrawberryAnnotation.evaluate` method instead of consuming the raw annotation.
+
+    An added benefit of this fix is that by removing annotation resolving code from
+    `StrawberryResolver` and making it a part of `StrawberryAnnotation`, it makes it
+    possible for `StrawberryArgument` and `StrawberryResolver` to share the same type
+    evaluation cache.
+
+    Refer to: https://github.com/strawberry-graphql/strawberry/issues/2855
+    """
+
+    from tests.schema.test_annotated import type_a, type_b
+
+    expected = """
+    type Query {
+      getTesting(id: UUID!): String
+    }
+
+    scalar UUID
+    """
+
+    schema_a = strawberry.Schema(type_a.Query)
+    schema_b = strawberry.Schema(type_b.Query)
+
+    assert str(schema_a) == str(schema_b)
+    assert f"\n{schema_a}\n" == textwrap.dedent(expected)

--- a/tests/schema/test_arguments.py
+++ b/tests/schema/test_arguments.py
@@ -236,4 +236,4 @@ def test_argument_parse_order():
     schema_b = strawberry.Schema(type_b.Query)
 
     assert str(schema_a) == str(schema_b)
-    assert f"\n{schema_a}\n" == textwrap.dedent(expected)
+    assert str(schema_a) == textwrap.dedent(expected).strip()


### PR DESCRIPTION
Reserved argument parsing, which interally also resolves annotations, exits early after detecting a reserved argument like an ``info`` argumnent. As a result, any subsequent annotations are not reserved arguments are unresolved. This results in `StrawberryArgument` not being able to determine that an argument annotation makes use of `typing.Annotated`.

This behavior is fixed by by ensuring that `StrawberryArgument` makes use of the new `StrawberryAnnotation.evaluate` method instead of consuming the raw annotation from it.

An added benefit of this fix is that by moving annotation resolving code from `StrawberryResolver` to `StrawberryAnnotation`, it makes it possible for `StrawberryArgument` and `StrawberryResolver` to share the same type evaluation cache.

Summary of Changes:
- Move type evaluation and caching logic to `StrawberryAnnotation`
- Separate type evalution from resolution with the new `StrawberryAnnotation.evaluate` method. This allows `StrawberryArgument` to access the evaluated annotation before it gets converted to `StraberryType` specializations
- Remove type evaluation cache from `StrawberryResolver` and move it to `StrawberryAnnotation`.
- Fix typing issues in `resolver.py`

Closes #2855

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #2855

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
