### PR TITLE
Set an unicode encoding when redirecting output to `null`

### DIFF
--- a/tests/plugins/strawberry_exceptions.py
+++ b/tests/plugins/strawberry_exceptions.py
@@ -32,7 +32,7 @@ def suppress_output(verbosity_level: int = 0) -> Generator[None, None, None]:
 
         return
 
-    with Path(os.devnull).open("w") as devnull:
+    with Path(os.devnull).open("w", encoding="utf-8") as devnull:
         with contextlib.redirect_stdout(devnull):
             yield
 

--- a/tests/plugins/strawberry_exceptions.py
+++ b/tests/plugins/strawberry_exceptions.py
@@ -1,5 +1,4 @@
 import contextlib
-import io
 import os
 import re
 from collections import defaultdict
@@ -44,18 +43,6 @@ class StrawberryExceptionsPlugin:
             list
         )
         self.verbosity_level = verbosity_level
-        # check for encoding failure which can happen in VS Code on windows.
-        # For some reason, the underlying codec stays in a windows codepage,
-        # such as cp1252
-        console = rich.console.Console(record=True, width=120)
-
-        with suppress_output(self.verbosity_level):
-            try:
-                console.print("\u2771")
-            except UnicodeEncodeError:
-                self.use_rich = False
-            else:
-                self.use_rich = True
 
     @pytest.hookimpl(hookwrapper=True)
     def pytest_runtest_call(self, item: Item) -> Generator[None, _Result, None]:
@@ -115,14 +102,10 @@ class StrawberryExceptionsPlugin:
         self, test_name: str, raised_exception: StrawberryException
     ) -> None:
         console = rich.console.Console(record=True, width=120)
-        buf = io.StringIO()
 
         with suppress_output(self.verbosity_level):
             try:
-                if self.use_rich:
-                    console.print(raised_exception)
-                else:
-                    print(raised_exception, file=buf)
+                console.print(raised_exception)
             except UnableToFindExceptionSource:
                 traceback = Traceback(
                     Traceback.extract(
@@ -132,12 +115,9 @@ class StrawberryExceptionsPlugin:
                     ),
                     max_frames=10,
                 )
-                if self.use_rich:
-                    console.print(traceback)
-                else:
-                    print(traceback, file=buf)
+                console.print(traceback)
 
-        exception_text = console.export_text() + buf.getvalue()
+        exception_text = console.export_text()
 
         text = f"## {test_name}\n"
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

In VSCode on windows, when running `pytest` from the terminal, `rich.console` can fail when output is supressed.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

In some cases, the default encoding selected for the null device is not unicode compatible.
When redirecting output, explicitly select an unicode compatible encoding for the null device.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
