### PR TITLE
Add default argument to typer Argument.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: bugfix
+
+Added default argument to the typer Argument function.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,3 @@
-Release type: bugfix
+Release type: patch
 
 Added default argument to the typer Argument function.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,4 @@
 Release type: patch
 
-Added default argument to the typer Argument function.
+Added default argument to the typer Argument function, this adds
+support for older versions of typer.

--- a/strawberry/cli/commands/upgrade/__init__.py
+++ b/strawberry/cli/commands/upgrade/__init__.py
@@ -27,7 +27,7 @@ def upgrade(
         autocompletion=lambda: list(codemods.keys()),
         help="Name of the upgrade to run",
     ),
-    paths: List[pathlib.Path] = typer.Argument(file_okay=True, dir_okay=True),
+    paths: List[pathlib.Path] = typer.Argument(..., file_okay=True, dir_okay=True),
     python_target: str = typer.Option(
         ".".join(str(x) for x in sys.version_info[:2]),
         "--python-target",


### PR DESCRIPTION
## Description

typer Arguments without default value are only valid from version 0.9.0, this PR adds the default argument to make it consistent with the `pyproject.toml` typer version >=0.7.0.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

None

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
