### PR TITLE
Add pydantic conversion compatibility with specialized list class

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,28 @@
+Release type: patch
+
+Enhancements:
+- Improved pydantic conversion compatibility with specialized list classes.
+  - Modified `StrawberryAnnotation._is_list` to check if the `annotation` extends from the `list` type, enabling it to be considered a list.
+  - in `StrawberryAnnotation` Moved the `_is_list` check before the `_is_generic` check in `resolve` to avoid `unsupported` error in `_is_generic` before it checked `_is_list`.
+
+This enhancement enables the usage of constrained lists as class types and allows the creation of specialized lists. The following example demonstrates this feature:
+
+```python
+import strawberry
+from pydantic import BaseModel, ConstrainedList
+
+
+class FriendList(ConstrainedList):
+    min_items = 1
+
+
+class UserModel(BaseModel):
+    age: int
+    friend_names: FriendList[str]
+
+
+@strawberry.experimental.pydantic.type(UserModel)
+class User:
+    age: strawberry.auto
+    friend_names: strawberry.auto
+```

--- a/strawberry/annotation.py
+++ b/strawberry/annotation.py
@@ -141,6 +141,8 @@ class StrawberryAnnotation:
 
         if self._is_lazy_type(evaled_type):
             return evaled_type
+        if self._is_list(evaled_type):
+            return self.create_list(evaled_type)
 
         if self._is_generic(evaled_type):
             if any(is_type_var(type_) for type_ in get_args(evaled_type)):
@@ -151,8 +153,6 @@ class StrawberryAnnotation:
         # a StrawberryType
         if self._is_enum(evaled_type):
             return self.create_enum(evaled_type)
-        if self._is_list(evaled_type):
-            return self.create_list(evaled_type)
         elif self._is_optional(evaled_type, args):
             return self.create_optional(evaled_type)
         elif self._is_union(evaled_type, args):
@@ -298,8 +298,14 @@ class StrawberryAnnotation:
         """Returns True if annotation is a List"""
 
         annotation_origin = get_origin(annotation)
+        annotation_mro = getattr(annotation, "__mro__", [])
+        is_list = any(x is list for x in annotation_mro)
 
-        return (annotation_origin in (list, tuple)) or annotation_origin is abc.Sequence
+        return (
+            (annotation_origin in (list, tuple))
+            or annotation_origin is abc.Sequence
+            or is_list
+        )
 
     @classmethod
     def _is_strawberry_type(cls, evaled_type: Any) -> bool:

--- a/tests/experimental/pydantic/schema/test_basic.py
+++ b/tests/experimental/pydantic/schema/test_basic.py
@@ -526,3 +526,32 @@ def test_basic_type_with_optional_and_default():
     assert not result.errors
     assert result.data["user"]["age"] == 1
     assert result.data["user"]["password"] is None
+
+
+def test_basic_type_with_constrained_list():
+    class FriendList(pydantic.ConstrainedList):
+        min_items = 1
+
+    class UserModel(pydantic.BaseModel):
+        age: int
+        friend_names: FriendList[str]
+
+    @strawberry.experimental.pydantic.type(UserModel)
+    class User:
+        age: strawberry.auto
+        friend_names: strawberry.auto
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def user(self) -> User:
+            return User(age=1, friend_names=["A", "B"])
+
+    schema = strawberry.Schema(query=Query)
+
+    query = "{ user { friendNames } }"
+
+    result = schema.execute_sync(query)
+
+    assert not result.errors
+    assert result.data["user"]["friendNames"] == ["A", "B"]


### PR DESCRIPTION
## Description

- move `_is_list` check before the `_is_generic` check in `StrawberryAnnotation.resolve`, so it does not get stuck on `ValueError: Not supported type` and first checks if it is a list.
- change `StrawberryAnnotation._is_list` to check if the `annotation` extends from list and can be considered a list.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/strawberry-graphql/strawberry/issues/2904

## Checklist

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
