### PR TITLE
Allow codegen to process multiple query files in a single command

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,22 @@
+Release type: minor
+
+`strawberry codegen` can now operate on multiple input query files.
+The previous behavior of naming the file `types.js` and `types.py`
+for the builtin `typescript` and `python` plugins respectively is
+preserved, but only if a single query file is passed.  When more
+than one query file is passed, the code generator will now use
+the stem of the query file's name to construct the name of the
+output files.  e.g. `my_query.graphql` -> `my_query.js` or
+`my_query.py`.  Creators of custom plugins are responsible
+for controlling the name of the output file themselves.  To
+accomodate this, if the `__init__` method of a `QueryCodegenPlugin`
+has a parameter named `query` or `query_file`, the `pathlib.Path`
+to the query file will be passed to the plugin's `__init__`
+method.
+
+Finally, the `ConsolePlugin` has also recieved two new lifecycle
+methods.  Unlike other `QueryCodegenPlugin`, the same instance of
+the `ConsolePlugin` is used for each query file processed.  This
+allows it to keep state around how many total files were processed.
+The `ConsolePlugin` recieved two new lifecycle hooks: `before_any_start`
+and `after_all_finished` that get called at the appropriate times.

--- a/docs/codegen/query-codegen.md
+++ b/docs/codegen/query-codegen.md
@@ -119,6 +119,13 @@ from strawberry.codegen.types import GraphQLType, GraphQLOperation
 
 
 class QueryCodegenPlugin:
+    def __init__(self, query: Path) -> None:
+        """Initialize the plugin.
+
+        The singular argument is the path to the file that is being processed by this plugin.
+        """
+        self.query = query
+
     def on_start(self) -> None:
         ...
 
@@ -137,3 +144,36 @@ class QueryCodegenPlugin:
 - `generated_code` is called when the codegen starts and it receives the types
   and the operation. You cans use this to generate code for each type and
   operation.
+
+### Console plugin
+
+There is also a plugin that helps to orchestrate the codegen process and notify the
+user about what the current codegen process is doing.
+
+The interface for the ConsolePlugin looks like:
+
+```python
+class ConsolePlugin:
+    def __init__(self, output_dir: Path):
+        """Initialize the plugin and tell it where the output should be written."""
+        ...
+
+    def before_any_start(self) -> None:
+        """This method is called before any plugins have been invoked or any queries have been processed."""
+        ...
+
+    def after_all_finished(self) -> None:
+        """This method is called after the full code generation is complete.
+
+        It can be used to report on all the things that have happened during the codegen.
+        """
+        ...
+
+    def on_start(self, plugins: Iterable[QueryCodegenPlugin], query: Path) -> None:
+        """This method is called before any of the individual plugins have been started."""
+        ...
+
+    def on_end(self, result: CodegenResult) -> None:
+        """This method typically persists the results from a single query to the output directory."""
+        ...
+```

--- a/docs/codegen/query-codegen.md
+++ b/docs/codegen/query-codegen.md
@@ -73,7 +73,7 @@ With the following command:
 strawberry codegen --schema schema --output-dir ./output -p python query.graphql
 ```
 
-We'll get the following output inside `output/types.py`:
+We'll get the following output inside `output/query.py`:
 
 ```python
 class MyQueryResultUserPost:

--- a/strawberry/cli/commands/codegen.py
+++ b/strawberry/cli/commands/codegen.py
@@ -19,7 +19,7 @@ from strawberry.codegen.plugins.typescript import TypeScriptPlugin
 def _is_codegen_plugin(obj: object) -> bool:
     return (
         inspect.isclass(obj)
-        and issubclass(obj, QueryCodegenPlugin)
+        and issubclass(obj, (QueryCodegenPlugin, ConsolePlugin))
         and obj is not QueryCodegenPlugin
     )
 

--- a/strawberry/cli/commands/codegen.py
+++ b/strawberry/cli/commands/codegen.py
@@ -12,8 +12,6 @@ import typer
 from strawberry.cli.app import app
 from strawberry.cli.utils import load_schema
 from strawberry.codegen import ConsolePlugin, QueryCodegen, QueryCodegenPlugin
-from strawberry.codegen.plugins.python import PythonPlugin
-from strawberry.codegen.plugins.typescript import TypeScriptPlugin
 
 
 def _is_codegen_plugin(obj: object) -> bool:
@@ -134,15 +132,6 @@ def codegen(
     for q in query:
         plugins = _load_plugins(selected_plugins, q)
         console_plugin.query = q  # update the query in the console plugin.
-
-        for p in plugins:
-            # Adjust the names of the output files for the buildin plugins if there
-            # are multiple files being generated.
-            if len(query) > 1:
-                if isinstance(p, PythonPlugin):
-                    p.outfile_name = q.stem + ".py"
-                elif isinstance(p, TypeScriptPlugin):
-                    p.outfile_name = q.stem + ".ts"
 
         code_generator = QueryCodegen(
             schema_symbol, plugins=plugins, console_plugin=console_plugin

--- a/strawberry/cli/commands/codegen.py
+++ b/strawberry/cli/commands/codegen.py
@@ -1,19 +1,19 @@
 from __future__ import annotations
 
+import functools
 import importlib
 import inspect
 from pathlib import Path  # noqa: TCH003
-from typing import TYPE_CHECKING, List, Optional, Type
+from typing import List, Optional, Type
 
 import rich
 import typer
 
 from strawberry.cli.app import app
 from strawberry.cli.utils import load_schema
-from strawberry.codegen import QueryCodegen, QueryCodegenPlugin
-
-if TYPE_CHECKING:
-    from strawberry.codegen import CodegenResult
+from strawberry.codegen import ConsolePlugin, QueryCodegen, QueryCodegenPlugin
+from strawberry.codegen.plugins.python import PythonPlugin
+from strawberry.codegen.plugins.typescript import TypeScriptPlugin
 
 
 def _is_codegen_plugin(obj: object) -> bool:
@@ -62,6 +62,7 @@ def _import_plugin(plugin: str) -> Optional[Type[QueryCodegenPlugin]]:
     return None
 
 
+@functools.lru_cache
 def _load_plugin(plugin_path: str) -> Type[QueryCodegenPlugin]:
     # try to import plugin_name from current folder
     # then try to import from strawberry.codegen.plugins
@@ -78,43 +79,21 @@ def _load_plugin(plugin_path: str) -> Type[QueryCodegenPlugin]:
     return plugin
 
 
-def _load_plugins(plugins: List[str]) -> List[QueryCodegenPlugin]:
-    return [_load_plugin(plugin)() for plugin in plugins]
+def _load_plugins(plugin_ids: List[str], query: Path) -> List[QueryCodegenPlugin]:
+    plugins = []
+    for ptype_id in plugin_ids:
+        ptype = _load_plugin(ptype_id)
+        plugin = ptype(query)
+        plugins.append(plugin)
 
-
-class ConsolePlugin(QueryCodegenPlugin):
-    def __init__(
-        self, query: Path, output_dir: Path, plugins: List[QueryCodegenPlugin]
-    ):
-        self.query = query
-        self.output_dir = output_dir
-        self.plugins = plugins
-
-    def on_start(self) -> None:
-        rich.print(
-            "[bold yellow]The codegen is experimental. Please submit any bug at "
-            "https://github.com/strawberry-graphql/strawberry\n",
-        )
-
-        plugin_names = [plugin.__class__.__name__ for plugin in self.plugins]
-
-        rich.print(
-            f"[green]Generating code for {self.query} using "
-            f"{', '.join(plugin_names)} plugin(s)",
-        )
-
-    def on_end(self, result: CodegenResult) -> None:
-        self.output_dir.mkdir(parents=True, exist_ok=True)
-        result.write(self.output_dir)
-
-        rich.print(
-            f"[green] Generated {len(result.files)} files in {self.output_dir}",
-        )
+    return plugins
 
 
 @app.command(help="Generate code from a query")
 def codegen(
-    query: Path = typer.Argument(..., exists=True, dir_okay=False),
+    query: Optional[List[Path]] = typer.Argument(
+        default=None, exists=True, dir_okay=False
+    ),
     schema: str = typer.Option(..., help="Python path to the schema file"),
     app_dir: str = typer.Option(
         ".",
@@ -143,12 +122,31 @@ def codegen(
     ),
     cli_plugin: Optional[str] = None,
 ) -> None:
+    if not query:
+        return
+
     schema_symbol = load_schema(schema, app_dir)
 
-    console_plugin = _load_plugin(cli_plugin) if cli_plugin else ConsolePlugin
+    console_plugin_type = _load_plugin(cli_plugin) if cli_plugin else ConsolePlugin
+    console_plugin = console_plugin_type(output_dir)
+    console_plugin.before_any_start()
 
-    plugins = _load_plugins(selected_plugins)
-    plugins.append(console_plugin(query, output_dir, plugins))
+    for q in query:
+        plugins = _load_plugins(selected_plugins, q)
+        console_plugin.query = q  # update the query in the console plugin.
 
-    code_generator = QueryCodegen(schema_symbol, plugins=plugins)
-    code_generator.run(query.read_text())
+        for p in plugins:
+            # Adjust the names of the output files for the buildin plugins if there
+            # are multiple files being generated.
+            if len(query) > 1:
+                if isinstance(p, PythonPlugin):
+                    p.outfile_name = q.stem + ".py"
+                elif isinstance(p, TypeScriptPlugin):
+                    p.outfile_name = q.stem + ".ts"
+
+        code_generator = QueryCodegen(
+            schema_symbol, plugins=plugins, console_plugin=console_plugin
+        )
+        code_generator.run(q.read_text())
+
+    console_plugin.after_all_finished()

--- a/strawberry/codegen/__init__.py
+++ b/strawberry/codegen/__init__.py
@@ -1,3 +1,15 @@
-from .query_codegen import CodegenFile, CodegenResult, QueryCodegen, QueryCodegenPlugin
+from .query_codegen import (
+    CodegenFile,
+    CodegenResult,
+    ConsolePlugin,
+    QueryCodegen,
+    QueryCodegenPlugin,
+)
 
-__all__ = ["QueryCodegen", "QueryCodegenPlugin", "CodegenFile", "CodegenResult"]
+__all__ = [
+    "CodegenFile",
+    "CodegenResult",
+    "ConsolePlugin",
+    "QueryCodegen",
+    "QueryCodegenPlugin",
+]

--- a/strawberry/codegen/plugins/python.py
+++ b/strawberry/codegen/plugins/python.py
@@ -18,12 +18,17 @@ from strawberry.codegen.types import (
 )
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from strawberry.codegen.types import (
         GraphQLArgumentValue,
         GraphQLField,
         GraphQLOperation,
         GraphQLType,
     )
+
+
+DEFAULT_OUTFILE_NAME = "types.py"
 
 
 @dataclass
@@ -46,8 +51,10 @@ class PythonPlugin(QueryCodegenPlugin):
         "Decimal": PythonType("Decimal", "decimal"),
     }
 
-    def __init__(self) -> None:
+    def __init__(self, query: Path) -> None:
         self.imports: Dict[str, Set[str]] = defaultdict(set)
+        self.outfile_name: str = DEFAULT_OUTFILE_NAME
+        self.query = query
 
     def generate_code(
         self, types: List[GraphQLType], operation: GraphQLOperation
@@ -57,7 +64,7 @@ class PythonPlugin(QueryCodegenPlugin):
 
         code = imports + "\n\n" + "\n\n".join(printed_types)
 
-        return [CodegenFile("types.py", code.strip())]
+        return [CodegenFile(self.outfile_name, code.strip())]
 
     def _print_imports(self) -> str:
         imports = [

--- a/strawberry/codegen/plugins/python.py
+++ b/strawberry/codegen/plugins/python.py
@@ -28,9 +28,6 @@ if TYPE_CHECKING:
     )
 
 
-DEFAULT_OUTFILE_NAME = "types.py"
-
-
 @dataclass
 class PythonType:
     type: str
@@ -53,7 +50,7 @@ class PythonPlugin(QueryCodegenPlugin):
 
     def __init__(self, query: Path) -> None:
         self.imports: Dict[str, Set[str]] = defaultdict(set)
-        self.outfile_name: str = DEFAULT_OUTFILE_NAME
+        self.outfile_name: str = query.with_suffix(".py").name
         self.query = query
 
     def generate_code(

--- a/strawberry/codegen/plugins/typescript.py
+++ b/strawberry/codegen/plugins/typescript.py
@@ -19,9 +19,6 @@ if TYPE_CHECKING:
     from strawberry.codegen.types import GraphQLField, GraphQLOperation, GraphQLType
 
 
-DEFAULT_OUTFILE_NAME = "types.ts"
-
-
 class TypeScriptPlugin(QueryCodegenPlugin):
     SCALARS_TO_TS_TYPE = {
         "ID": "string",
@@ -39,7 +36,7 @@ class TypeScriptPlugin(QueryCodegenPlugin):
     }
 
     def __init__(self, query: Path) -> None:
-        self.outfile_name: str = DEFAULT_OUTFILE_NAME
+        self.outfile_name: str = query.with_suffix(".ts").name
         self.query = query
 
     def generate_code(

--- a/strawberry/codegen/plugins/typescript.py
+++ b/strawberry/codegen/plugins/typescript.py
@@ -14,7 +14,12 @@ from strawberry.codegen.types import (
 )
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from strawberry.codegen.types import GraphQLField, GraphQLOperation, GraphQLType
+
+
+DEFAULT_OUTFILE_NAME = "types.ts"
 
 
 class TypeScriptPlugin(QueryCodegenPlugin):
@@ -33,12 +38,16 @@ class TypeScriptPlugin(QueryCodegenPlugin):
         float: "number",
     }
 
+    def __init__(self, query: Path) -> None:
+        self.outfile_name: str = DEFAULT_OUTFILE_NAME
+        self.query = query
+
     def generate_code(
         self, types: List[GraphQLType], operation: GraphQLOperation
     ) -> List[CodegenFile]:
         printed_types = list(filter(None, (self._print_type(type) for type in types)))
 
-        return [CodegenFile("types.ts", "\n\n".join(printed_types))]
+        return [CodegenFile(self.outfile_name, "\n\n".join(printed_types))]
 
     def _get_type_name(self, type_: GraphQLType) -> str:
         if isinstance(type_, GraphQLOptional):

--- a/tests/cli/test_codegen.py
+++ b/tests/cli/test_codegen.py
@@ -29,21 +29,6 @@ class QueryCodegenTestPlugin(QueryCodegenPlugin):
         ]
 
 
-class QueryCodegenTestPluginWithInjectableQuery(QueryCodegenPlugin):
-    def __init__(self, query: Path, query_file: Path) -> None:
-        assert query == query_file
-
-    def generate_code(
-        self, types: List[GraphQLType], operation: GraphQLOperation
-    ) -> List[CodegenFile]:
-        return [
-            CodegenFile(
-                path="test.py",
-                content=f"# This is a test file for {operation.name}",
-            )
-        ]
-
-
 class EmptyPlugin(QueryCodegenPlugin):
     def generate_code(
         self, types: List[GraphQLType], operation: GraphQLOperation
@@ -96,32 +81,6 @@ def test_codegen(
             "codegen",
             "-p",
             "tests.cli.test_codegen:QueryCodegenTestPlugin",
-            "-o",
-            str(tmp_path),
-            "--schema",
-            selector,
-            str(query_file_path),
-        ],
-    )
-
-    assert result.exit_code == 0
-
-    code_path = tmp_path / "test.py"
-
-    assert code_path.exists()
-    assert code_path.read_text() == "# This is a test file for GetUser"
-
-
-def test_codegen_injection_parameters(
-    cli_app: Typer, cli_runner: CliRunner, query_file_path: Path, tmp_path: Path
-):
-    selector = "tests.fixtures.sample_package.sample_module:schema"
-    result = cli_runner.invoke(
-        cli_app,
-        [
-            "codegen",
-            "-p",
-            "tests.cli.test_codegen:QueryCodegenTestPluginWithInjectableQuery",
             "-o",
             str(tmp_path),
             "--schema",

--- a/tests/cli/test_codegen.py
+++ b/tests/cli/test_codegen.py
@@ -271,7 +271,7 @@ def test_codegen_finds_our_plugins(
 
     assert result.exit_code == 0
 
-    code_path = tmp_path / "types.py"
+    code_path = tmp_path / query_file_path.with_suffix(".py").name
 
     assert code_path.exists()
     assert "class GetUserResult" in code_path.read_text()

--- a/tests/codegen/test_print_operation.py
+++ b/tests/codegen/test_print_operation.py
@@ -14,7 +14,7 @@ def test_codegen(
     query: Path,
     schema,
 ):
-    generator = QueryCodegen(schema, plugins=[PrintOperationPlugin()])
+    generator = QueryCodegen(schema, plugins=[PrintOperationPlugin(query)])
     query_content = query.read_text()
 
     result = generator.run(query_content)

--- a/tests/codegen/test_query_codegen.py
+++ b/tests/codegen/test_query_codegen.py
@@ -40,7 +40,7 @@ def test_codegen(
     snapshot: Snapshot,
     schema,
 ):
-    generator = QueryCodegen(schema, plugins=[plugin_class()])
+    generator = QueryCodegen(schema, plugins=[plugin_class(query)])
 
     result = generator.run(query.read_text())
 
@@ -50,22 +50,37 @@ def test_codegen(
     snapshot.assert_match(code, f"{query.with_suffix('').stem}.{extension}")
 
 
-def test_codegen_fails_if_no_operation_name(schema):
-    generator = QueryCodegen(schema, plugins=[PythonPlugin()])
+def test_codegen_fails_if_no_operation_name(schema, tmp_path):
+    query = tmp_path / "query.graphql"
+    data = "query { hello }"
+    with query.open("w") as f:
+        f.write(data)
+
+    generator = QueryCodegen(schema, plugins=[PythonPlugin(query)])
 
     with pytest.raises(NoOperationNameProvidedError):
-        generator.run("query { hello }")
+        generator.run(data)
 
 
-def test_codegen_fails_if_no_operation(schema):
-    generator = QueryCodegen(schema, plugins=[PythonPlugin()])
+def test_codegen_fails_if_no_operation(schema, tmp_path):
+    query = tmp_path / "query.graphql"
+    data = "type X { hello: String }"
+    with query.open("w") as f:
+        f.write(data)
+
+    generator = QueryCodegen(schema, plugins=[PythonPlugin(query)])
 
     with pytest.raises(NoOperationProvidedError):
-        generator.run("type X { hello: String }")
+        generator.run(data)
 
 
-def test_fails_with_multiple_operations(schema):
-    generator = QueryCodegen(schema, plugins=[PythonPlugin()])
+def test_fails_with_multiple_operations(schema, tmp_path):
+    query = tmp_path / "query.graphql"
+    data = "query { hello } query { world }"
+    with query.open("w") as f:
+        f.write(data)
+
+    generator = QueryCodegen(schema, plugins=[PythonPlugin(query)])
 
     with pytest.raises(MultipleOperationsProvidedError):
-        generator.run("query { hello } query { world }")
+        generator.run(data)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

#2828 hopefully does a good job communicating the use-case for this feature.  Currently `codegen` can be very slow if the schema import is an expensive operation.  This allows a user to codegen multiple files with a single command (and a single schema import).  There are a few minor (backward compatible) extensions to the exposed `QueryCodegenPlugin` and `ConsolePlugin` interfaces.  The `RELEASE.md` should describe these changes and the class behaviors in their entirety.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #2828

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
