### PR TITLE
fix: only resolve a field's type after field extensions has been applied to it

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+Release type: patch
+
+This fixes a regression from 0.190.0 where changes to the
+return type of a field done by Field Extensions would not
+be taken in consideration by the schema.

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -56,7 +56,6 @@ from strawberry.type import (
     StrawberryList,
     StrawberryOptional,
     StrawberryType,
-    WithStrawberryObjectDefinition,
     has_object_definition,
 )
 from strawberry.types.info import Info
@@ -99,9 +98,7 @@ class FieldConverterProtocol(Generic[FieldType], Protocol):
         self,
         field: StrawberryField,
         *,
-        override_type: Optional[
-            Union[StrawberryType, Type[WithStrawberryObjectDefinition]]
-        ] = None,
+        type_definition: Optional[StrawberryObjectDefinition] = None,
     ) -> FieldType:
         ...
 
@@ -125,7 +122,7 @@ def _get_thunk_mapping(
     thunk_mapping: Dict[str, FieldType] = {}
 
     for field in type_definition.fields:
-        field_type = field.resolve_type(type_definition=type_definition)
+        field_type = field.type
 
         if field_type is UNRESOLVED:
             raise UnresolvedFieldTypeError(type_definition, field)
@@ -133,7 +130,7 @@ def _get_thunk_mapping(
         if not is_private(field_type):
             thunk_mapping[name_converter(field)] = field_converter(
                 field,
-                override_type=field_type,
+                type_definition=type_definition,
             )
 
     return thunk_mapping
@@ -305,15 +302,16 @@ class GraphQLCoreConverter:
         self,
         field: StrawberryField,
         *,
-        override_type: Optional[
-            Union[StrawberryType, Type[WithStrawberryObjectDefinition]]
-        ] = None,
+        type_definition: Optional[StrawberryObjectDefinition] = None,
     ) -> GraphQLField:
         # self.from_resolver needs to be called before accessing field.type because
         # in there a field extension might want to change the type during its apply
         resolver = self.from_resolver(field)
         field_type = cast(
-            "GraphQLOutputType", self.from_maybe_optional(override_type or field.type)
+            "GraphQLOutputType",
+            self.from_maybe_optional(
+                field.resolve_type(type_definition=type_definition)
+            ),
         )
         subscribe = None
 
@@ -342,12 +340,13 @@ class GraphQLCoreConverter:
         self,
         field: StrawberryField,
         *,
-        override_type: Optional[
-            Union[StrawberryType, Type[WithStrawberryObjectDefinition]]
-        ] = None,
+        type_definition: Optional[StrawberryObjectDefinition] = None,
     ) -> GraphQLInputField:
         field_type = cast(
-            "GraphQLInputType", self.from_maybe_optional(override_type or field.type)
+            "GraphQLInputType",
+            self.from_maybe_optional(
+                field.resolve_type(type_definition=type_definition)
+            ),
         )
         default_value: object
 

--- a/tests/fields/test_field_exceptions.py
+++ b/tests/fields/test_field_exceptions.py
@@ -1,10 +1,16 @@
+import textwrap
+from typing import Any
+
 import pytest
 
 import strawberry
+from strawberry.annotation import StrawberryAnnotation
 from strawberry.exceptions import (
     FieldWithResolverAndDefaultFactoryError,
     FieldWithResolverAndDefaultValueError,
 )
+from strawberry.extensions.field_extension import FieldExtension
+from strawberry.field import StrawberryField
 
 
 def test_field_with_resolver_default():
@@ -36,3 +42,28 @@ def test_field_with_resolver_default_factory():
             @strawberry.field(default_factory=lambda: "steel")
             def metal(self) -> str:
                 return "iron"
+
+
+def test_extension_changing_field_return_value():
+    """Ensure that field extensions can change the field's return type."""
+
+    class ChangeReturnTypeExtension(FieldExtension):
+        def apply(self, field: StrawberryField) -> None:
+            field.type_annotation = StrawberryAnnotation.from_annotation(int)
+
+        def resolve(self, next_, source, info, **kwargs: Any):
+            return next_(source, info, **kwargs)
+
+    @strawberry.type
+    class Query:
+        @strawberry.field(extensions=[ChangeReturnTypeExtension()])
+        def test_changing_return_type(self) -> bool:
+            ...
+
+    schema = strawberry.Schema(query=Query)
+    expected = """\
+      type Query {
+        testChangingReturnType: Int!
+      }
+    """
+    assert str(schema) == textwrap.dedent(expected).strip()


### PR DESCRIPTION
0.190.0 changed `from_field` to receive an optional `override_type` as the already resolved
type for that field.

The issue is that field extensions will only be applied when calling `from_resolver`, which happens
inside `from_field` itself.

This still works as expected for specialized generics, but ensures that any changes to
the type annotation made by field extensions is not ignored.

Fix #2921
