### PR TITLE
Restore evaled type access in `StrawberryAnnotation`

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,15 @@
+Release type: minor
+
+Restore evaled type access in `StrawberryAnnotation`
+
+Prior to Strawberry 192.2 the `annotation` attribute of `StrawberryAnnotation`
+would return an evaluated type when possible due reserved argument parsing.
+192.2 moved the responsibility of evaluating and caching results to the
+`evaluate` method of `StrawberryAnnotation`. This introduced a regression when
+using future annotations for any code implicitely relying on the `annotation`
+attribute being an evaluated type.
+
+To fix this regression and mimick pre-192.2 behavior, this release adds an
+`annotation` property to `StrawberryAnnotation` that internally calls the
+`evaluate` method. On success the evaluated type is returned. If a `NameError`
+is raised due to an unresolvable annotation, the raw annotation is returned.

--- a/strawberry/arguments.py
+++ b/strawberry/arguments.py
@@ -89,15 +89,11 @@ class StrawberryArgument:
             _deprecated_UNSET if default is inspect.Parameter.empty else default
         )
 
-        try:
-            evaled_type = type_annotation.evaluate()
-        except NameError:
-            # Evaluation failures can happen when importing types within a TYPE_CHECKING
-            # block or if the type is declared later on in the current module.
-            pass
-        else:
-            if get_origin(evaled_type) is Annotated:
-                first, *rest = get_args(evaled_type)
+        annotation = type_annotation.annotation
+        if not isinstance(annotation, str):
+            resolved_annotation = annotation
+            if get_origin(resolved_annotation) is Annotated:
+                first, *rest = get_args(resolved_annotation)
 
                 # The first argument to Annotated is always the underlying type
                 self.type_annotation = StrawberryAnnotation(first)

--- a/strawberry/auto.py
+++ b/strawberry/auto.py
@@ -39,7 +39,7 @@ class StrawberryAutoMeta(type):
         instance: Union[StrawberryAuto, StrawberryAnnotation, StrawberryType, type],
     ):
         if isinstance(instance, StrawberryAnnotation):
-            resolved = instance.annotation
+            resolved = instance.raw_annotation
             if isinstance(resolved, str):
                 namespace = instance.namespace
                 resolved = namespace and namespace.get(resolved)

--- a/tests/experimental/pydantic/test_fields.py
+++ b/tests/experimental/pydantic/test_fields.py
@@ -169,7 +169,7 @@ def test_constrained_list_nested():
     if sys.version_info >= (3, 9):
         expected_annotation = list[list[int]]
     else:
-        expected_annotation = List[List[str]]
+        expected_annotation = List[List[int]]
 
     assert (
         UserType.__strawberry_definition__.fields[0].type_annotation.annotation

--- a/tests/experimental/pydantic/test_fields.py
+++ b/tests/experimental/pydantic/test_fields.py
@@ -1,4 +1,5 @@
 import re
+import sys
 from typing import List
 from typing_extensions import Literal
 
@@ -131,9 +132,15 @@ def test_constrained_list():
         ...
 
     assert UserType.__strawberry_definition__.fields[0].name == "friends"
+
+    if sys.version_info >= (3, 9):
+        expected_annotation = list[str]
+    else:
+        expected_annotation = List[str]
+
     assert (
         UserType.__strawberry_definition__.fields[0].type_annotation.annotation
-        == List[str]
+        == expected_annotation
     )
 
     data = UserType(friends=[])
@@ -158,9 +165,15 @@ def test_constrained_list_nested():
         ...
 
     assert UserType.__strawberry_definition__.fields[0].name == "friends"
+
+    if sys.version_info >= (3, 9):
+        expected_annotation = list[list[int]]
+    else:
+        expected_annotation = List[List[str]]
+
     assert (
         UserType.__strawberry_definition__.fields[0].type_annotation.annotation
-        == List[List[int]]
+        == expected_annotation
     )
 
 

--- a/tests/experimental/pydantic/test_fields.py
+++ b/tests/experimental/pydantic/test_fields.py
@@ -1,5 +1,4 @@
 import re
-import sys
 from typing import List
 from typing_extensions import Literal
 
@@ -132,15 +131,9 @@ def test_constrained_list():
         ...
 
     assert UserType.__strawberry_definition__.fields[0].name == "friends"
-
-    if sys.version_info >= (3, 9):
-        expected_annotation = list[str]
-    else:
-        expected_annotation = List[str]
-
     assert (
-        UserType.__strawberry_definition__.fields[0].type_annotation.annotation
-        == expected_annotation
+        UserType.__strawberry_definition__.fields[0].type_annotation.raw_annotation
+        == List[str]
     )
 
     data = UserType(friends=[])
@@ -165,15 +158,9 @@ def test_constrained_list_nested():
         ...
 
     assert UserType.__strawberry_definition__.fields[0].name == "friends"
-
-    if sys.version_info >= (3, 9):
-        expected_annotation = list[list[int]]
-    else:
-        expected_annotation = List[List[int]]
-
     assert (
-        UserType.__strawberry_definition__.fields[0].type_annotation.annotation
-        == expected_annotation
+        UserType.__strawberry_definition__.fields[0].type_annotation.raw_annotation
+        == List[List[int]]
     )
 
 

--- a/tests/schema/extensions/test_input_mutation_future.py
+++ b/tests/schema/extensions/test_input_mutation_future.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import textwrap
+from uuid import UUID
+
+import strawberry
+from strawberry.field_extensions import InputMutationExtension
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    async def hello(self) -> str:
+        return "hi"
+
+
+@strawberry.type
+class Mutation:
+    @strawberry.mutation(extensions=[InputMutationExtension()])
+    async def buggy(self, some_id: UUID) -> None:
+        del some_id
+
+
+def test_schema():
+    schema = strawberry.Schema(query=Query, mutation=Mutation)
+
+    expected_schema = '''
+    input BuggyInput {
+      someId: UUID!
+    }
+
+    type Mutation {
+      buggy(
+        """Input data for `buggy` mutation"""
+        input: BuggyInput!
+      ): Void
+    }
+
+    type Query {
+      hello: String!
+    }
+
+    scalar UUID
+
+    """Represents NULL values"""
+    scalar Void
+    '''
+
+    assert textwrap.dedent(expected_schema).strip() == str(schema).strip()


### PR DESCRIPTION
Previously reserved argument parsing would evaluate stringified annotations when possible and cache these results. Therefore, when `StrawberryAnnotation` instances were created within `StrawberryResolver`, their `annotation` attribute could become an evaluated type. To restore this behavior, an `annotation` property is added to `StrawberryAnnotation` that calls
`StrawberryAnnotation.evaluate()`. On success the evaluated type is returned. If a `NameError` is raised due to an unresolvable annotation, the stringified annotation is returned instead.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
