### PR TITLE
improve performance of `strawberry.lazy()` with relative imports

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+This release includes a performance improvement to `strawberry.lazy()` to allow relative module imports to be resolved faster.

--- a/strawberry/lazy_type.py
+++ b/strawberry/lazy_type.py
@@ -68,11 +68,11 @@ class LazyType(Generic[TypeName, Module]):
 
 
 class StrawberryLazyReference:
-    def __init__(self, module: str) -> None:
+    def __init__(self, module: str, package: Optional[str] = None) -> None:
         self.module = module
-        self.package = None
+        self.package = package
 
-        if module.startswith("."):
+        if module.startswith(".") and not package:
             frame = inspect.stack()[2][0]
             # TODO: raise a nice error if frame is None
             assert frame is not None
@@ -82,5 +82,5 @@ class StrawberryLazyReference:
         return LazyType(forward_ref.__forward_arg__, self.module, self.package)
 
 
-def lazy(module_path: str) -> StrawberryLazyReference:
-    return StrawberryLazyReference(module_path)
+def lazy(module_path: str, package: Optional[str] = None) -> StrawberryLazyReference:
+    return StrawberryLazyReference(module_path, package)

--- a/strawberry/lazy_type.py
+++ b/strawberry/lazy_type.py
@@ -68,12 +68,12 @@ class LazyType(Generic[TypeName, Module]):
 
 
 class StrawberryLazyReference:
-    def __init__(self, module: str, package: Optional[str] = None) -> None:
+    def __init__(self, module: str) -> None:
         self.module = module
-        self.package = package
+        self.package = None
 
         if module.startswith(".") and not package:
-            frame = inspect.stack()[2][0]
+            frame = inspect.currentframe().f_back.f_back
             # TODO: raise a nice error if frame is None
             assert frame is not None
             self.package = cast(str, frame.f_globals["__package__"])
@@ -82,5 +82,5 @@ class StrawberryLazyReference:
         return LazyType(forward_ref.__forward_arg__, self.module, self.package)
 
 
-def lazy(module_path: str, package: Optional[str] = None) -> StrawberryLazyReference:
-    return StrawberryLazyReference(module_path, package)
+def lazy(module_path: str) -> StrawberryLazyReference:
+    return StrawberryLazyReference(module_path)

--- a/strawberry/lazy_type.py
+++ b/strawberry/lazy_type.py
@@ -72,7 +72,7 @@ class StrawberryLazyReference:
         self.module = module
         self.package = None
 
-        if module.startswith(".") and not package:
+        if module.startswith("."):
             frame = inspect.currentframe().f_back.f_back
             # TODO: raise a nice error if frame is None
             assert frame is not None

--- a/strawberry/lazy_type.py
+++ b/strawberry/lazy_type.py
@@ -73,7 +73,7 @@ class StrawberryLazyReference:
         self.package = None
 
         if module.startswith("."):
-            frame = inspect.currentframe().f_back.f_back
+            frame = sys._getframe(2)
             # TODO: raise a nice error if frame is None
             assert frame is not None
             self.package = cast(str, frame.f_globals["__package__"])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

I've been profiling a few tests in my company's codebase and realized that some tests that actually only perform about 1s of business logic take ~12s to run. A large part of that time (~8-9s) is spent resolving forward refs in `strawberry.lazy()`. The largest culprit there was the use of `inspect.stack()` which seems to be incredibly slow.

This PR updates the method of retrieving the target stack frame. It seems that the stack frames are stored as a linkedlist anyways, so retrieving the active frame and then working backwards is significantly faster (likely because `.stack()` collects more information for every frame that is unused by strawberry). This one line change took my test down from 12s to 2.5s.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

N/a

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
