### PR TITLE
Add setter on `StrawberryAnnotation.annotation`

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+This release adds a setter on `StrawberryAnnotation.annotation`, this fixes
+an issue on Strawberry Django.

--- a/strawberry/annotation.py
+++ b/strawberry/annotation.py
@@ -95,6 +95,10 @@ class StrawberryAnnotation:
             # block or if the type is declared later on in a module.
             return self.raw_annotation
 
+    @annotation.setter
+    def annotation(self, value: Union[object, str]) -> None:
+        self.raw_annotation = value
+
     def evaluate(self) -> type:
         """Return evaluated annotation using `strawberry.util.typing.eval_type`."""
         evaled_type = self.__eval_cache__

--- a/tests/types/test_annotation.py
+++ b/tests/types/test_annotation.py
@@ -66,3 +66,10 @@ def test_eq_on_other_type():
 def test_eq_on_non_annotation():
     assert StrawberryAnnotation(int) != int
     assert StrawberryAnnotation(int) != 123
+
+
+def test_set_anntation():
+    annotation = StrawberryAnnotation(int)
+    annotation.annotation = str
+
+    assert annotation.annotation == str


### PR DESCRIPTION
Fixes this issue on Strawberry Django:

```
AttributeError: property 'annotation' of 'StrawberryAnnotation' object has no setter
```
