### PR TITLE
fix: preserve extra annotations when resolving auto/lazy fields

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+Release type: patch
+
+This release fixes an issue where annotations resolution for auto and lazy fields
+using `Annotated` where not preserving the remaining arguments because of a
+typo in the arguments filtering.

--- a/strawberry/lazy_type.py
+++ b/strawberry/lazy_type.py
@@ -81,6 +81,15 @@ class StrawberryLazyReference:
     def resolve_forward_ref(self, forward_ref: ForwardRef) -> LazyType:
         return LazyType(forward_ref.__forward_arg__, self.module, self.package)
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, StrawberryLazyReference):
+            return NotImplemented
+
+        return self.module == other.module and self.package == other.package
+
+    def __hash__(self) -> int:
+        return hash((self.__class__, self.module, self.package))
+
 
 def lazy(module_path: str) -> StrawberryLazyReference:
     return StrawberryLazyReference(module_path)

--- a/strawberry/utils/typing.py
+++ b/strawberry/utils/typing.py
@@ -350,11 +350,14 @@ def eval_type(
                         for a in args[1:]
                         if not isinstance(a, StrawberryLazyReference)
                     ]
-                    type_arg = (
-                        arg.resolve_forward_ref(args[0])
-                        if isinstance(args[0], ForwardRef)
-                        else args[0]
-                    )
+                    # The type itself will come as str for python 3.7/3.8 and as a
+                    # ForwardRef for python 3.9+
+                    if isinstance(args[0], str):
+                        type_arg = arg.resolve_forward_ref(ForwardRef(args[0]))
+                    elif isinstance(args[0], ForwardRef):
+                        type_arg = arg.resolve_forward_ref(args[0])
+                    else:
+                        type_arg = args[0]
                     args = (type_arg, *remaining_args)
                     break
                 if isinstance(arg, StrawberryAuto):

--- a/strawberry/utils/typing.py
+++ b/strawberry/utils/typing.py
@@ -295,7 +295,7 @@ def _get_namespace_from_ast(
         # here to resolve lazy types by execing the annotated args, resolving the
         # type directly and then adding it to extra namespace, so that _eval_type
         # can properly resolve it later
-        type_name = args[0]
+        type_name = args[0].strip()
         for arg in args[1:]:
             evaled_arg = eval(arg, globalns, localns)  # noqa: PGH001
             if isinstance(evaled_arg, StrawberryLazyReference):

--- a/strawberry/utils/typing.py
+++ b/strawberry/utils/typing.py
@@ -348,7 +348,7 @@ def eval_type(
                     remaining_args = [
                         a
                         for a in args[1:]
-                        if not isinstance(arg, StrawberryLazyReference)
+                        if not isinstance(a, StrawberryLazyReference)
                     ]
                     type_arg = (
                         arg.resolve_forward_ref(args[0])
@@ -359,7 +359,7 @@ def eval_type(
                     break
                 if isinstance(arg, StrawberryAuto):
                     remaining_args = [
-                        a for a in args[1:] if not isinstance(arg, StrawberryAuto)
+                        a for a in args[1:] if not isinstance(a, StrawberryAuto)
                     ]
                     args = (arg, *remaining_args)
                     break

--- a/strawberry/utils/typing.py
+++ b/strawberry/utils/typing.py
@@ -350,14 +350,11 @@ def eval_type(
                         for a in args[1:]
                         if not isinstance(a, StrawberryLazyReference)
                     ]
-                    # The type itself will come as str for python 3.7/3.8 and as a
-                    # ForwardRef for python 3.9+
-                    if isinstance(args[0], str):
-                        type_arg = arg.resolve_forward_ref(ForwardRef(args[0]))
-                    elif isinstance(args[0], ForwardRef):
-                        type_arg = arg.resolve_forward_ref(args[0])
-                    else:
-                        type_arg = args[0]
+                    type_arg = (
+                        arg.resolve_forward_ref(args[0])
+                        if isinstance(args[0], ForwardRef)
+                        else args[0]
+                    )
                     args = (type_arg, *remaining_args)
                     break
                 if isinstance(arg, StrawberryAuto):

--- a/tests/utils/test_typing.py
+++ b/tests/utils/test_typing.py
@@ -1,7 +1,14 @@
 import typing
 from typing import ClassVar, ForwardRef, Optional, Union
+from typing_extensions import Annotated
 
+import strawberry
 from strawberry.utils.typing import eval_type, get_optional_annotation, is_classvar
+
+
+@strawberry.type
+class Fruit:
+    ...
 
 
 def test_get_optional_annotation():
@@ -32,6 +39,20 @@ def test_eval_type():
     assert (
         eval_type(ForwardRef("Optional[Union[Foo, str]]"), globals(), locals())
         == Union[Foo, str, None]
+    )
+    assert (
+        eval_type(ForwardRef("Annotated[str, 'foobar']"), globals(), locals())
+        is Annotated[str, "foobar"]
+    )
+    assert (
+        eval_type(
+            ForwardRef(
+                "Annotated['Fruit', strawberry.lazy('tests.utils.test_typing')]"
+            ),
+            globals(),
+            locals(),
+        )
+        == Annotated[Fruit, strawberry.lazy("tests.utils.test_typing")]
     )
 
 

--- a/tests/utils/test_typing.py
+++ b/tests/utils/test_typing.py
@@ -3,6 +3,7 @@ from typing import ClassVar, ForwardRef, Optional, Union
 from typing_extensions import Annotated
 
 import strawberry
+from strawberry.lazy_type import LazyType
 from strawberry.utils.typing import eval_type, get_optional_annotation, is_classvar
 
 
@@ -46,13 +47,14 @@ def test_eval_type():
     )
     assert (
         eval_type(
-            ForwardRef(
-                "Annotated['Fruit', strawberry.lazy('tests.utils.test_typing')]"
-            ),
-            globals(),
-            locals(),
+            ForwardRef("Annotated[Fruit, strawberry.lazy('tests.utils.test_typing')]"),
+            {"strawberry": strawberry, "Annotated": Annotated},
+            None,
         )
-        == Annotated[Fruit, strawberry.lazy("tests.utils.test_typing")]
+        == Annotated[
+            LazyType("Fruit", "tests.utils.test_typing"),
+            strawberry.lazy("tests.utils.test_typing"),
+        ]
     )
 
 


### PR DESCRIPTION
Fix a typo which made extra `Annotated` arguments to be discarded by mistake when resolving auto/lazy fields.
