### PR TITLE
Add support for returning interfaces directly in resolvers

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,29 @@
+Release type: minor
+
+This release adds support for returning interfaces directly in resolvers:
+
+```python
+@strawberry.interface
+class Node:
+    id: strawberry.ID
+
+    @classmethod
+    def resolve_type(cls, obj: Any, *args: Any, **kwargs: Any) -> str:
+        return "Video" if obj.id == "1" else "Image"
+
+@strawberry.type
+class Video(Node):
+    ...
+
+@strawberry.type
+class Image(Node):
+    ...
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def node(self, id: strawberry.ID) -> Node:
+        return Node(id=id)
+
+schema = strawberry.Schema(query=Query, types=[Video, Image])
+```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,19 +11,23 @@ class Node:
     def resolve_type(cls, obj: Any, *args: Any, **kwargs: Any) -> str:
         return "Video" if obj.id == "1" else "Image"
 
+
 @strawberry.type
 class Video(Node):
     ...
 
+
 @strawberry.type
 class Image(Node):
     ...
+
 
 @strawberry.type
 class Query:
     @strawberry.field
     def node(self, id: strawberry.ID) -> Node:
         return Node(id=id)
+
 
 schema = strawberry.Schema(query=Query, types=[Video, Image])
 ```

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -492,6 +492,13 @@ class GraphQLCoreConverter:
             if not object_type.interfaces:
                 return None
 
+            # this allows returning interfaces types as well as the actual object type
+            # this is useful in combination with `resolve_type` in interfaces
+            possible_types = (
+                *tuple(interface.origin for interface in object_type.interfaces),
+                object_type.origin,
+            )
+
             def is_type_of(obj: Any, _info: GraphQLResolveInfo) -> bool:
                 if object_type.concrete_of and (
                     has_object_definition(obj)
@@ -499,10 +506,6 @@ class GraphQLCoreConverter:
                     is object_type.concrete_of.origin
                 ):
                     return True
-
-                # this allows returning interfaces as well as the object type
-
-                possible_types = (*tuple(interface.origin for interface in object_type.interfaces), object_type.origin)
 
                 return isinstance(obj, possible_types)
 

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -500,7 +500,13 @@ class GraphQLCoreConverter:
                 ):
                     return True
 
-                return isinstance(obj, object_type.origin)
+                # this allows returning interfaces as well as the object type
+
+                possible_types = tuple(
+                    interface.origin for interface in object_type.interfaces
+                ) + (object_type.origin,)
+
+                return isinstance(obj, possible_types)
 
             return is_type_of
 

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -502,9 +502,7 @@ class GraphQLCoreConverter:
 
                 # this allows returning interfaces as well as the object type
 
-                possible_types = tuple(
-                    interface.origin for interface in object_type.interfaces
-                ) + (object_type.origin,)
+                possible_types = (*tuple(interface.origin for interface in object_type.interfaces), object_type.origin)
 
                 return isinstance(obj, possible_types)
 


### PR DESCRIPTION
This PR add support for returning interfaces directly inside resolvers, for example:

```python
@strawberry.interface
class Node:
    id: strawberry.ID

    @classmethod
    def resolve_type(cls, obj: Any, *args: Any, **kwargs: Any) -> str:
        return "Video" if obj.id == "1" else "Image"


@strawberry.type
class Video(Node):
    ...


@strawberry.type
class Image(Node):
    ...


@strawberry.type
class Query:
    @strawberry.field
    def node(self, id: strawberry.ID) -> Node:
        return Node(id=id)


schema = strawberry.Schema(query=Query, types=[Video, Image])
```

our node field returns a Node instance here. The `resolve_type` function is what defines the actual type being returned.

This could simplify cases where you might want to use a common interface and not having to worry about instantiating the right type (since that will be taken care by resolve_type)