### PR TITLE
fix: do not strip the type when using auto

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,11 @@
+Release type: patch
+
+This release fixes an issue when trying to use `Annotated[strawberry.auto, ...]`
+on python 3.10 or older, which got evident after the fix from 0.196.1.
+
+Previously we were throwing the type away, since it usually is `Any`, but python
+3.10 and older will validate that the first argument passed for `Annotated`
+is callable (3.11+ does not do that anymore), and `StrawberryAuto` is not.
+
+This changes it to keep that `Any`, which is also what someone would expect
+when resolving the annotation using our custom `eval_type` function.

--- a/strawberry/experimental/pydantic/error_type.py
+++ b/strawberry/experimental/pydantic/error_type.py
@@ -83,13 +83,12 @@ def error_type(
             )
 
         existing_fields = getattr(cls, "__annotations__", {})
-        fields_set = fields_set.union(
-            {
-                name
-                for name, type_ in existing_fields.items()
-                if isinstance(type_, StrawberryAuto)
-            }
-        )
+        auto_fields_set = {
+            name
+            for name, type_ in existing_fields.items()
+            if isinstance(type_, StrawberryAuto)
+        }
+        fields_set |= auto_fields_set
 
         if all_fields:
             if fields_set:
@@ -124,7 +123,10 @@ def error_type(
                 field,
             )
             for field in extra_fields + private_fields
-            if not isinstance(field.type, StrawberryAuto)
+            if (
+                field.name not in auto_fields_set
+                and not isinstance(field.type, StrawberryAuto)
+            )
         )
 
         cls = dataclasses.make_dataclass(

--- a/strawberry/utils/typing.py
+++ b/strawberry/utils/typing.py
@@ -361,7 +361,7 @@ def eval_type(
                     remaining_args = [
                         a for a in args[1:] if not isinstance(a, StrawberryAuto)
                     ]
-                    args = (arg, *remaining_args)
+                    args = (args[0], arg, *remaining_args)
                     break
 
             # If we have only a StrawberryLazyReference and no more annotations,

--- a/tests/utils/test_typing.py
+++ b/tests/utils/test_typing.py
@@ -56,6 +56,14 @@ def test_eval_type():
             strawberry.lazy("tests.utils.test_typing"),
         ]
     )
+    assert (
+        eval_type(
+            ForwardRef("Annotated[strawberry.auto, 'foobar']"),
+            {"strawberry": strawberry, "Annotated": Annotated},
+            None,
+        )
+        == Annotated[strawberry.auto, "foobar"]
+    )
 
 
 def test_is_classvar():


### PR DESCRIPTION
`Annotated[auto, ...]` produce issues on python 3.10 and older
due to the fact that it tries to check that the type is `callable`.

This was being masked by the issue that 5bd41027366a04f644feb2679c752cd51b120e08
fixed, due to the fact that extra `Annotated` args were being thrown
away.

This change the evaluation to avoid throwing the original type (usually
`Any`) away, fixing that issue.
