### PR TITLE
Allow null payload in ws

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+Release type: patch
+
+This release fixes an issue in the `graphql-ws` implementation
+where sending a `null` payload would cause the connection
+to be closed.

--- a/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
@@ -21,6 +21,7 @@ from strawberry.subscriptions.protocols.graphql_transport_ws.types import (
     SubscribeMessagePayload,
 )
 from strawberry.types.graphql import OperationType
+from strawberry.unset import UNSET
 from strawberry.utils.debug import pretty_print_graphql_operation
 from strawberry.utils.operation import get_operation_type
 
@@ -162,7 +163,11 @@ class BaseGraphQLTransportWSHandler(ABC):
         if self.connection_init_timeout_task:
             self.connection_init_timeout_task.cancel()
 
-        payload = message.payload or {}
+        payload = (
+            message.payload
+            if message.payload is not None and message.payload is not UNSET
+            else {}
+        )
 
         if not isinstance(payload, dict):
             await self.close(code=4400, reason="Invalid connection init payload")

--- a/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
@@ -21,7 +21,6 @@ from strawberry.subscriptions.protocols.graphql_transport_ws.types import (
     SubscribeMessagePayload,
 )
 from strawberry.types.graphql import OperationType
-from strawberry.unset import UNSET
 from strawberry.utils.debug import pretty_print_graphql_operation
 from strawberry.utils.operation import get_operation_type
 

--- a/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
@@ -163,11 +163,13 @@ class BaseGraphQLTransportWSHandler(ABC):
         if self.connection_init_timeout_task:
             self.connection_init_timeout_task.cancel()
 
-        if message.payload is not UNSET and not isinstance(message.payload, dict):
+        payload = message.payload or {}
+
+        if not isinstance(payload, dict):
             await self.close(code=4400, reason="Invalid connection init payload")
             return
 
-        self.connection_params = message.payload
+        self.connection_params = payload
 
         if self.connection_init_received:
             reason = "Too many initialisation requests"

--- a/tests/websockets/test_graphql_transport_ws.py
+++ b/tests/websockets/test_graphql_transport_ws.py
@@ -183,8 +183,11 @@ async def test_close_twice(
     ) as ws:
         transport_close = mocker.patch.object(ws, "close")
 
-        # TODO: payload is set to 1 to force close, but is this right?
-        await ws.send_json(ConnectionInitMessage(payload=1).as_dict())
+        # We set payload is set to "invalid value" to force a invalid payload error
+        # which will close the connection
+        await ws.send_json(
+            ConnectionInitMessage(payload="invalid value").as_dict(),  # type: ignore
+        )
         # Yield control so that ._close can be called
         await asyncio.sleep(0)
 

--- a/tests/websockets/test_graphql_transport_ws.py
+++ b/tests/websockets/test_graphql_transport_ws.py
@@ -803,9 +803,15 @@ async def test_rejects_connection_params_not_dict(ws_raw: WebSocketClient):
     ws.assert_reason("Invalid connection init payload")
 
 
-async def test_rejects_connection_params_with_wrong_type(ws_raw: WebSocketClient):
+@pytest.mark.parametrize(
+    "payload",
+    [[], "invalid value", 1],
+)
+async def test_rejects_connection_params_with_wrong_type(
+    payload: Any, ws_raw: WebSocketClient
+):
     ws = ws_raw
-    await ws.send_json(ConnectionInitMessage(payload="abc").as_dict())
+    await ws.send_json(ConnectionInitMessage(payload=payload).as_dict())
 
     data = await ws.receive(timeout=2)
     assert ws.closed

--- a/tests/websockets/test_graphql_transport_ws.py
+++ b/tests/websockets/test_graphql_transport_ws.py
@@ -183,7 +183,8 @@ async def test_close_twice(
     ) as ws:
         transport_close = mocker.patch.object(ws, "close")
 
-        await ws.send_json(ConnectionInitMessage(payload=None).as_dict())
+        # TODO: payload is set to 1 to force close, but is this right?
+        await ws.send_json(ConnectionInitMessage(payload=1).as_dict())
         # Yield control so that ._close can be called
         await asyncio.sleep(0)
 
@@ -799,9 +800,9 @@ async def test_rejects_connection_params_not_dict(ws_raw: WebSocketClient):
     ws.assert_reason("Invalid connection init payload")
 
 
-async def test_rejects_connection_params_not_unset(ws_raw: WebSocketClient):
+async def test_rejects_connection_params_with_wrong_type(ws_raw: WebSocketClient):
     ws = ws_raw
-    await ws.send_json(ConnectionInitMessage(payload=None).as_dict())
+    await ws.send_json(ConnectionInitMessage(payload="abc").as_dict())
 
     data = await ws.receive(timeout=2)
     assert ws.closed


### PR DESCRIPTION
We were rejecting payloads that had an explicit null value, while they are supported in the Protocol:

https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md#connectionack