### PR TITLE
Improve how we strip async types and annotated

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,4 @@
-Release type: path
+Release type: patch
 
 This releases improves how we handle Annotated and async types
 (used in subscriptions). Previously we weren't able to use

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,30 @@
+Release type: path
+
+This releases improves how we handle Annotated and async types
+(used in subscriptions). Previously we weren't able to use
+unions with names inside subscriptions, now that's fixed 😊
+
+Example:
+
+```python
+@strawberry.type
+class A:
+    a: str
+
+
+@strawberry.type
+class B:
+    b: str
+
+
+@strawberry.type
+class Query:
+    x: str = "Hello"
+
+
+@strawberry.type
+class Subscription:
+    @strawberry.subscription
+    async def example_with_union(self) -> AsyncGenerator[Union[A, B], None]:
+        yield A(a="Hi")
+```

--- a/strawberry/annotation.py
+++ b/strawberry/annotation.py
@@ -118,8 +118,6 @@ class StrawberryAnnotation:
     def _get_type_with_args(
         self, evaled_type: Type[Any]
     ) -> Tuple[Type[Any], List[Any]]:
-        args: List[Any] = []
-
         if self._is_async_type(evaled_type):
             return self._get_type_with_args(self._strip_async_type(evaled_type))
 
@@ -128,7 +126,7 @@ class StrawberryAnnotation:
             stripped_type, stripped_args = self._get_type_with_args(evaled_type)
             return stripped_type, args + stripped_args
 
-        return evaled_type, args
+        return evaled_type, []
 
     def resolve(self) -> Union[StrawberryType, type]:
         """Return resolved (transformed) annotation."""
@@ -139,7 +137,7 @@ class StrawberryAnnotation:
 
         args: List[Any] = []
 
-        evaled_type, *args = self._get_type_with_args(evaled_type)
+        evaled_type, args = self._get_type_with_args(evaled_type)
 
         if self._is_lazy_type(evaled_type):
             return evaled_type

--- a/strawberry/annotation.py
+++ b/strawberry/annotation.py
@@ -358,7 +358,7 @@ class StrawberryAnnotation:
         return annotation.__args__[0]
 
     @classmethod
-    def _strip_lazy_type(cls, annotation: LazyType[None, None]) -> type:
+    def _strip_lazy_type(cls, annotation: LazyType[Any, Any]) -> type:
         return annotation.resolve_type()
 
 

--- a/strawberry/annotation.py
+++ b/strawberry/annotation.py
@@ -358,7 +358,7 @@ class StrawberryAnnotation:
         return annotation.__args__[0]
 
     @classmethod
-    def _strip_lazy_type(cls, annotation: LazyType) -> type:
+    def _strip_lazy_type(cls, annotation: LazyType[None, None]) -> type:
         return annotation.resolve_type()
 
 

--- a/strawberry/lazy_type.py
+++ b/strawberry/lazy_type.py
@@ -4,7 +4,7 @@ import sys
 import warnings
 from dataclasses import dataclass
 from pathlib import Path
-from typing import ForwardRef, Generic, Optional, Tuple, Type, TypeVar, cast
+from typing import Any, ForwardRef, Generic, Optional, Tuple, Type, TypeVar, cast
 
 TypeName = TypeVar("TypeName")
 Module = TypeVar("Module")
@@ -38,7 +38,7 @@ class LazyType(Generic[TypeName, Module]):
 
         return cls(type_name, module, package)
 
-    def resolve_type(self) -> Type:
+    def resolve_type(self) -> Type[Any]:
         module = importlib.import_module(self.module, self.package)
         main_module = sys.modules.get("__main__", None)
         if main_module:

--- a/tests/schema/test_subscription.py
+++ b/tests/schema/test_subscription.py
@@ -1,8 +1,10 @@
+# ruff: noqa: F821
 from __future__ import annotations
 
 import sys
-import typing
 from collections import abc  # noqa: F401
+from typing import AsyncGenerator, AsyncIterable, AsyncIterator, Union  # noqa: F401
+from typing_extensions import Annotated
 
 import pytest
 
@@ -18,7 +20,7 @@ async def test_subscription():
     @strawberry.type
     class Subscription:
         @strawberry.subscription
-        async def example(self) -> typing.AsyncGenerator[str, None]:
+        async def example(self) -> AsyncGenerator[str, None]:
             yield "Hi"
 
     schema = strawberry.Schema(query=Query, subscription=Subscription)
@@ -41,7 +43,7 @@ async def test_subscription_with_arguments():
     @strawberry.type
     class Subscription:
         @strawberry.subscription
-        async def example(self, name: str) -> typing.AsyncGenerator[str, None]:
+        async def example(self, name: str) -> AsyncGenerator[str, None]:
             yield f"Hi {name}"
 
     schema = strawberry.Schema(query=Query, subscription=Subscription)
@@ -64,9 +66,9 @@ requires_builtin_generics = pytest.mark.skipif(
 @pytest.mark.parametrize(
     "return_annotation",
     (
-        "typing.AsyncGenerator[str, None]",
-        "typing.AsyncIterable[str]",
-        "typing.AsyncIterator[str]",
+        "AsyncGenerator[str, None]",
+        "AsyncIterable[str]",
+        "AsyncIterator[str]",
         pytest.param("abc.AsyncIterator[str]", marks=requires_builtin_generics),
         pytest.param("abc.AsyncGenerator[str, None]", marks=requires_builtin_generics),
         pytest.param("abc.AsyncIterable[str]", marks=requires_builtin_generics),
@@ -86,6 +88,105 @@ async def test_subscription_return_annotations(return_annotation: str):
     @strawberry.type
     class Subscription:
         example = strawberry.subscription(resolver=async_resolver)
+
+    schema = strawberry.Schema(query=Query, subscription=Subscription)
+
+    query = "subscription { example }"
+
+    sub = await schema.subscribe(query)
+    result = await sub.__anext__()
+
+    assert not result.errors
+    assert result.data["example"] == "Hi"
+
+
+@pytest.mark.asyncio
+async def test_subscription_with_unions():
+    global A, B
+
+    @strawberry.type
+    class A:
+        a: str
+
+    @strawberry.type
+    class B:
+        b: str
+
+    @strawberry.type
+    class Query:
+        x: str = "Hello"
+
+    @strawberry.type
+    class Subscription:
+        @strawberry.subscription
+        async def example_with_union(self) -> AsyncGenerator[Union[A, B], None]:
+            yield A(a="Hi")
+
+    schema = strawberry.Schema(query=Query, subscription=Subscription)
+
+    query = "subscription { exampleWithUnion { ... on A { a } } }"
+
+    sub = await schema.subscribe(query)
+    result = await sub.__anext__()
+
+    assert not result.errors
+    assert result.data["exampleWithUnion"]["a"] == "Hi"
+
+    del A, B
+
+
+@pytest.mark.asyncio
+async def test_subscription_with_unions_and_annotated():
+    global C, D
+
+    @strawberry.type
+    class C:
+        c: str
+
+    @strawberry.type
+    class D:
+        d: str
+
+    @strawberry.type
+    class Query:
+        x: str = "Hello"
+
+    @strawberry.type
+    class Subscription:
+        @strawberry.subscription
+        async def example_with_annotated_union(
+            self,
+        ) -> AsyncGenerator[
+            Annotated[Union[C, D], strawberry.union("UnionName")], None
+        ]:
+            yield C(c="Hi")
+
+    schema = strawberry.Schema(query=Query, subscription=Subscription)
+
+    query = "subscription { exampleWithAnnotatedUnion { ... on C { c } } }"
+
+    sub = await schema.subscribe(query)
+    result = await sub.__anext__()
+
+    assert not result.errors
+    assert result.data["exampleWithAnnotatedUnion"]["c"] == "Hi"
+
+    del C, D
+
+
+@pytest.mark.asyncio
+async def test_subscription_with_annotated():
+    @strawberry.type
+    class Query:
+        x: str = "Hello"
+
+    @strawberry.type
+    class Subscription:
+        @strawberry.subscription
+        async def example(
+            self,
+        ) -> Annotated[AsyncGenerator[str, None], "this doesn't matter"]:
+            yield "Hi"
 
     schema = strawberry.Schema(query=Query, subscription=Subscription)
 


### PR DESCRIPTION
This pretty much adds support for returning union with names in subscriptions (when using `AsyncGenerator`) 😊

The PR changes how we get arguments and how we strip async types to be recursive so we handle all cases (see tests :) )