### PR TITLE
fix: properly handle async iterables that after sliced are not async iterable anymore

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,7 @@
+Release type: patch
+
+This release fixes an issue on `relay.ListConnection` where async iterables that returns
+non async iterable objects after being sliced where producing errors.
+
+This should fix an issue with async strawberry-graphql-django when returning already
+prefetched QuerySets.


### PR DESCRIPTION
This should fix this issue from strawberry-graphql-django: https://github.com/strawberry-graphql/strawberry-graphql-django/issues/324
