### PR TITLE
[strawberry.ext.mypy_plugin] Fix import error for users who don't use pydantic

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: minor
+
+Fix import error in `strawberry.ext.mypy_plugin` for users who don't use pydantic.

--- a/strawberry/ext/mypy_plugin.py
+++ b/strawberry/ext/mypy_plugin.py
@@ -52,7 +52,6 @@ from mypy.types import (
 )
 from mypy.typevars import fill_typevars
 from mypy.util import get_unique_redefinition_name
-from strawberry.experimental.pydantic._compat import IS_PYDANTIC_V1
 
 # Backwards compatible with the removal of `TypeVarDef` in mypy 0.920.
 try:
@@ -64,8 +63,11 @@ except ImportError:
 try:
     from pydantic.mypy import METADATA_KEY as PYDANTIC_METADATA_KEY
     from pydantic.mypy import PydanticModelField
+
+    from strawberry.experimental.pydantic._compat import IS_PYDANTIC_V1
 except ImportError:
     PYDANTIC_METADATA_KEY = ""
+    IS_PYDANTIC_V1 = False
 
 
 if TYPE_CHECKING:


### PR DESCRIPTION
This should fix import error in strawberry.ext.mypy_plugin for users who don't use pydantic introduced in latest version. Hopefully the new location of the import is fine.

`Error importing plugin "strawberry.ext.mypy_plugin": No module named 'pydantic'`