### PR TITLE
Fix strawberry mypy plugin for pydantic v1

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Fix strawberry mypy plugin for pydantic v1

--- a/strawberry/ext/mypy_plugin.py
+++ b/strawberry/ext/mypy_plugin.py
@@ -410,12 +410,11 @@ def strawberry_pydantic_class_callback(ctx: ClassDefContext) -> None:
 
         pydantic_fields: Set[PydanticModelField] = set()
         try:
-            for data in model_type.type.metadata[PYDANTIC_METADATA_KEY][
-                "fields"
-            ].items():
+            fields = model_type.type.metadata[PYDANTIC_METADATA_KEY]["fields"]
+            for data in fields.items():
                 if IS_PYDANTIC_V1:
                     field = PydanticModelField.deserialize(
-                        ctx.cls.info, data
+                        ctx.cls.info, data[1]
                     )  # type:ignore[call-arg]
                 else:
                     field = PydanticModelField.deserialize(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

With the update for initial pydantic 2 support, the old pydantic v1 mypy `strawberry_pydantic_class_callback` does not work correctly anymore.

traceback from mypy:
```
version: 1.2.0
Traceback (most recent call last):
  File "mypy/semanal.py", line 6272, in accept
  File "mypy/nodes.py", line 1127, in accept
  File "mypy/semanal.py", line 1567, in visit_class_def
  File "mypy/semanal.py", line 1647, in analyze_class
  File "mypy/semanal.py", line 1674, in analyze_class_body_common
  File "mypy/semanal.py", line 1743, in apply_class_plugin_hooks
  File "orchestrator-core/.venv/lib/python3.11/site-packages/strawberry/ext/mypy_plugin.py", line 417, in strawberry_pydantic_class_callback
    field = PydanticModelField.deserialize(
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "pydantic/mypy.py", line 746, in pydantic.mypy.PydanticModelField.deserialize
ValueError: dictionary update sequence element #0 has length 13; 2 is required
```

I looked through the changes and have seen that the looping through `fields` dict changed from `.values()` to a `.items()`, which gives a key and value tuple instead of just value. I changed it to only use value from the tuple in `PydanticModelField.deserialize`.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
