### PR TITLE
Fix incorrect TypingUnionType import check

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Fix incorrect TypingUnionType import check of python version `< 3.9` to `< 3.10` in `experimental.pydantic.fields.py`

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,5 @@
 Release type: patch
 
-Fix incorrect TypingUnionType import check of python version `< 3.9` to `< 3.10` in `experimental.pydantic.fields.py`
+TypingUnionType import error check is reraised because TypingGenericAlias is checked at the same time which is checked under 3.9 instead of under 3.10
+
+Fix by separating TypingUnionType and TypingGenericAlias imports in their own try-catch

--- a/noxfile.py
+++ b/noxfile.py
@@ -104,7 +104,7 @@ def tests_integrations(session: Session, integration: str) -> None:
     session.run("pytest", *COMMON_PYTEST_OPTIONS, "-m", integration)
 
 
-@session(python=["3.11"], name="Pydantic tests", tags=["tests"])
+@session(python=PYTHON_VERSIONS, name="Pydantic tests", tags=["tests"])
 @nox.parametrize("pydantic", ["1.10", "2.0.3"])
 def test_pydantic(session: Session, pydantic: str) -> None:
     session.run_always("poetry", "install", external=True)

--- a/strawberry/experimental/pydantic/fields.py
+++ b/strawberry/experimental/pydantic/fields.py
@@ -26,13 +26,10 @@ try:
 except ImportError:
     import sys
 
-    # python < 3.9 does not have GenericAlias (list[int], tuple[str, ...] and so on)
+    # python < 3.10 does not have GenericAlias (list[int], tuple[str, ...] and so on)
     # we do this under a conditional to avoid a mypy :)
-    if sys.version_info < (3, 9):
-        TypingGenericAlias = ()
-    else:
-        raise
     if sys.version_info < (3, 10):
+        TypingGenericAlias = ()
         TypingUnionType = ()
     else:
         raise

--- a/strawberry/experimental/pydantic/fields.py
+++ b/strawberry/experimental/pydantic/fields.py
@@ -22,15 +22,23 @@ from strawberry.types.types import StrawberryObjectDefinition
 
 try:
     from types import UnionType as TypingUnionType
+except ImportError:
+    import sys
+
+    if sys.version_info < (3, 10):
+        TypingUnionType = ()
+    else:
+        raise
+
+try:
     from typing import GenericAlias as TypingGenericAlias  # type: ignore
 except ImportError:
     import sys
 
-    # python < 3.10 does not have GenericAlias (list[int], tuple[str, ...] and so on)
+    # python < 3.9 does not have GenericAlias (list[int], tuple[str, ...] and so on)
     # we do this under a conditional to avoid a mypy :)
-    if sys.version_info < (3, 10):
+    if sys.version_info < (3, 9):
         TypingGenericAlias = ()
-        TypingUnionType = ()
     else:
         raise
 

--- a/tests/experimental/pydantic/test_fields.py
+++ b/tests/experimental/pydantic/test_fields.py
@@ -220,3 +220,15 @@ def test_literal_types():
 
     assert field.python_name == "field"
     assert field.type == Literal["field"]
+
+
+def test_typing_union_type_import():
+    from strawberry.experimental.pydantic.fields import TypingUnionType
+
+    assert TypingUnionType
+
+
+def test_typing_generic_alias_import():
+    from strawberry.experimental.pydantic.fields import TypingGenericAlias
+
+    assert TypingGenericAlias

--- a/tests/experimental/pydantic/test_fields.py
+++ b/tests/experimental/pydantic/test_fields.py
@@ -220,15 +220,3 @@ def test_literal_types():
 
     assert field.python_name == "field"
     assert field.type == Literal["field"]
-
-
-def test_typing_union_type_import():
-    from strawberry.experimental.pydantic.fields import TypingUnionType
-
-    assert TypingUnionType
-
-
-def test_typing_generic_alias_import():
-    from strawberry.experimental.pydantic.fields import TypingGenericAlias
-
-    assert TypingGenericAlias


### PR DESCRIPTION
- TypingUnionType import error check is set to `< 3.9` but 3.9 fails the import and it should be `< 3.10`

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
