### PR TITLE
refactor: support node_id values containing colons

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,9 @@
+Release type: minor
+
+Add support for extra colons in the `GlobalID` string.
+
+Before, the string `SomeType:some:value` would produce raise an error saying that
+it was expected the string to be splited in 2 parts when doing `.split(":")`.
+
+Now we are using `.split(":", 1)`, meaning that the example above will consider
+`SomeType` to be the type name, and `some:value` to be the node_id.

--- a/strawberry/relay/utils.py
+++ b/strawberry/relay/utils.py
@@ -21,7 +21,7 @@ def from_base64(value: str) -> Tuple[str, str]:
 
     """
     try:
-        res = base64.b64decode(value.encode()).decode().split(":")
+        res = base64.b64decode(value.encode()).decode().split(":", 1)
     except Exception as e:
         raise ValueError(str(e)) from e
 

--- a/tests/relay/test_utils.py
+++ b/tests/relay/test_utils.py
@@ -9,9 +9,15 @@ from .schema import Fruit
 
 
 def test_from_base64():
-    type_name, node_id = from_base64("Zm9vYmFyOjE=")
+    type_name, node_id = from_base64("Zm9vYmFyOjE=")  # foobar:1
     assert type_name == "foobar"
     assert node_id == "1"
+
+
+def test_from_base64_with_extra_colon():
+    type_name, node_id = from_base64("Zm9vYmFyOjE6Mjoz")  # foobar:1:2:3
+    assert type_name == "foobar"
+    assert node_id == "1:2:3"
 
 
 @pytest.mark.parametrize("value", [None, 1, 1.1, "dsadfas"])
@@ -23,8 +29,9 @@ def test_from_base64_non_base64(value: Any):
 @pytest.mark.parametrize(
     "value",
     [
-        "Zm9vYmFy",  # "foobar"
-        "Zm9vYmFyOjE6Mg==",  # "foobar:1:2"
+        "Zm9vYmFy",  # foobar
+        "Zm9vYmFyLDE=",  # foobar,1
+        "Zm9vYmFyOzE=",  # foobar;1
     ],
 )
 def test_from_base64_wrong_number_of_args(value: Any):


### PR DESCRIPTION
The node_id can be anything depending on how the user is handling it, so colons can appear in it, specially when it is some kind of encrypted value.

This changes how we split the `GlobalID` string to only split the first colon in it, meaning that the remaining of the string will be considered as a whole for the node_id.
