### PR TITLE
Exclude unit tests themselves from code coverage results.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,7 @@
 # .coveragerc to control coverage.py
 [run]
 branch = True
+omit = tests/*
 
 [report]
 # Regexes for lines to exclude from consideration

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Exclude tests themselves from code coverage results.


### PR DESCRIPTION
I noticed in https://github.com/strawberry-graphql/strawberry/pull/3017 that we're analyzing coverage of the test files themselves. This both takes unnecessary execution time/cost, and reduces signal quality.