### PR TITLE
Fix pydantic v2 test error ConstrainedList removed in v2

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Mark pydantic constrained list test with need_pydantic_v1 since it is removed in pydantic V2

--- a/tests/experimental/pydantic/test_conversion.py
+++ b/tests/experimental/pydantic/test_conversion.py
@@ -6,7 +6,7 @@ from enum import Enum
 from typing import Any, Dict, List, NewType, Optional, TypeVar, Union
 
 import pytest
-from pydantic import BaseModel, ConstrainedList, Field, ValidationError
+from pydantic import BaseModel, Field, ValidationError
 
 import strawberry
 from strawberry.experimental.pydantic._compat import (
@@ -21,6 +21,7 @@ from strawberry.experimental.pydantic.exceptions import (
 from strawberry.experimental.pydantic.utils import get_default_factory_for_field
 from strawberry.type import StrawberryList, StrawberryOptional
 from strawberry.types.types import StrawberryObjectDefinition
+from tests.experimental.pydantic.utils import needs_pydantic_v1
 
 if IS_PYDANTIC_V2:
     pass
@@ -1227,7 +1228,10 @@ def test_can_convert_optional_union_type_expression_fields_to_strawberry():
     assert test.optional_str is None
 
 
+@needs_pydantic_v1
 def test_can_convert_pydantic_type_to_strawberry_with_constrained_list():
+    from pydantic import ConstrainedList
+
     class WorkModel(BaseModel):
         name: str
 


### PR DESCRIPTION
- Mark pydantic constrained list test with need_pydantic_v1 since it is removed in pydantic V2

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
