### PR TITLE
Fix missed pydantic v2 tests with error ConstrainedList removed in v2

### DIFF
--- a/tests/experimental/pydantic/schema/test_basic.py
+++ b/tests/experimental/pydantic/schema/test_basic.py
@@ -1,10 +1,13 @@
+import sys
 import textwrap
 from enum import Enum
 from typing import List, Optional, Union
 
 import pydantic
+import pytest
 
 import strawberry
+from tests.experimental.pydantic.utils import needs_pydantic_v1
 
 
 def test_basic_type_field_list():
@@ -528,6 +531,11 @@ def test_basic_type_with_optional_and_default():
     assert result.data["user"]["password"] is None
 
 
+@needs_pydantic_v1
+@pytest.mark.skipif(
+    sys.version_info < (3, 9),
+    reason="ConstrainedList with another model does not work with 3.8",
+)
 def test_basic_type_with_constrained_list():
     class FriendList(pydantic.ConstrainedList):
         min_items = 1

--- a/tests/experimental/pydantic/test_conversion.py
+++ b/tests/experimental/pydantic/test_conversion.py
@@ -1229,6 +1229,10 @@ def test_can_convert_optional_union_type_expression_fields_to_strawberry():
 
 
 @needs_pydantic_v1
+@pytest.mark.skipif(
+    sys.version_info < (3, 9),
+    reason="ConstrainedList with another model does not work with 3.8",
+)
 def test_can_convert_pydantic_type_to_strawberry_with_constrained_list():
     from pydantic import ConstrainedList
 
@@ -1265,6 +1269,10 @@ class SpecialList(List[SI]):
     pass
 
 
+@needs_pydantic_v1
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="SpecialList does not work with 3.8"
+)
 def test_can_convert_pydantic_type_to_strawberry_with_specialized_list():
     class WorkModel(BaseModel):
         name: str


### PR DESCRIPTION
- Mark missed pydantic constrained list tests with need_pydantic_v1 since it is removed in pydantic V2

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
