### PR TITLE
Handle UNSET values in the strawberry schema.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,14 @@
+Release type: minor
+
+`strawberry codegen` previously choked for inputs that used the
+`strawberry.UNSET` sentinal singleton value as a default.  The intent
+here is to say that if a variable is not part of the request payload,
+then the `UNSET` default value will not be modified and the service
+code can then treat an unset value differently from a default value,
+etc.
+
+For codegen, we treat the `UNSET` default value as a `GraphQLNullValue`.
+The `.value` property is the `UNSET` object in this case (instead of
+the usual `None`).  In the built-in python code generator, this causes
+the client to generate an object with a `None` default.  Custom client
+generators can sniff at this value and update their behavior.

--- a/strawberry/codegen/plugins/python.py
+++ b/strawberry/codegen/plugins/python.py
@@ -10,6 +10,7 @@ from strawberry.codegen.types import (
     GraphQLEnum,
     GraphQLEnumValue,
     GraphQLList,
+    GraphQLNullValue,
     GraphQLObjectType,
     GraphQLOptional,
     GraphQLScalar,
@@ -141,6 +142,8 @@ class PythonPlugin(QueryCodegenPlugin):
                     "GraphQLEnumValue must have a type for python code gen. {argval}"
                 )
             return f"{argval.enum_type}.{argval.name}"
+        if isinstance(argval, GraphQLNullValue):
+            return "None"
         if not hasattr(argval, "value"):
             raise TypeError(f"Unrecognized values type: {argval}")
         return repr(argval.value)

--- a/strawberry/codegen/query_codegen.py
+++ b/strawberry/codegen/query_codegen.py
@@ -52,6 +52,7 @@ from strawberry.type import (
 )
 from strawberry.types.types import StrawberryObjectDefinition
 from strawberry.union import StrawberryUnion
+from strawberry.unset import UNSET
 from strawberry.utils.str_converters import capitalize_first, to_camel_case
 
 from .exceptions import (
@@ -178,8 +179,9 @@ _TYPE_TO_GRAPHQL_TYPE = {
 
 def _py_to_graphql_value(obj: Any) -> GraphQLArgumentValue:
     """Convert a python object to a GraphQLArgumentValue."""
-    if obj is None:
-        return GraphQLNullValue()
+    if obj is None or obj is UNSET:
+        return GraphQLNullValue(value=obj)
+
     obj_type = type(obj)
     if obj_type in _TYPE_TO_GRAPHQL_TYPE:
         return _TYPE_TO_GRAPHQL_TYPE[obj_type](obj)

--- a/strawberry/codegen/types.py
+++ b/strawberry/codegen/types.py
@@ -7,6 +7,8 @@ if TYPE_CHECKING:
     from enum import EnumMeta
     from typing_extensions import Literal
 
+    from strawberry.unset import UnsetType
+
 
 @dataclass
 class GraphQLOptional:
@@ -134,7 +136,7 @@ class GraphQLBoolValue:
 class GraphQLNullValue:
     """A class that represents a GraphQLNull value."""
 
-    value: None = None
+    value: None | UnsetType = None
 
 
 @dataclass

--- a/tests/codegen/conftest.py
+++ b/tests/codegen/conftest.py
@@ -60,6 +60,7 @@ class Image(Node):
 @strawberry.input
 class PersonInput:
     name: str
+    age: Optional[int] = strawberry.UNSET
 
 
 @strawberry.input

--- a/tests/codegen/snapshots/python/variables.py
+++ b/tests/codegen/snapshots/python/variables.py
@@ -5,6 +5,7 @@ class OperationNameResult:
 
 class PersonInput:
     name: str
+    age: Optional[int] = None
 
 class ExampleInput:
     id: str

--- a/tests/codegen/snapshots/typescript/variables.ts
+++ b/tests/codegen/snapshots/typescript/variables.ts
@@ -4,6 +4,7 @@ type OperationNameResult = {
 
 type PersonInput = {
     name: string
+    age: number | undefined
 }
 
 type ExampleInput = {


### PR DESCRIPTION
The codegen currently chokes on `strawberry.UNSET` default values.  This PR updates the codegen to stop raising an exception and instead pass a `GraphQLNullValue(value=UNSET)` to the plugins.  The default python plugin writes a `None` as the default value because there really isn't a well understood concept of `UNSET` in the python ecosystem.  User defined plugins have all the information that they need to handle this differently if they choose to do so.


## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
