### PR TITLE
docs: add poetry configuration example for `mypy`

### DIFF
--- a/docs/editors/mypy.md
+++ b/docs/editors/mypy.md
@@ -25,5 +25,12 @@ root of our project and add the following settings:
 plugins = strawberry.ext.mypy_plugin
 ```
 
+The configuration for Poetry's `pyproject.toml`:
+
+```toml
+[tool.mypy]
+plugins = ["strawberry.ext.mypy_plugin"]
+```
+
 Once you have configured the settings, you can run `mypy` and you should be
 getting type checking errors.

--- a/docs/editors/mypy.md
+++ b/docs/editors/mypy.md
@@ -25,7 +25,7 @@ root of our project and add the following settings:
 plugins = strawberry.ext.mypy_plugin
 ```
 
-The configuration for Poetry's `pyproject.toml`:
+You can also configure Mypy inside the `pyproject.toml` file, like so:
 
 ```toml
 [tool.mypy]


### PR DESCRIPTION
Added `mypy` documentation example for `pyproject.toml`

## Description

Adding a mypy configuration example for pyproject.toml in documentation is important because it helps developers understand how to integrate mypy with their poetry projects. The example provides a clear and straightforward template that developers can use as a starting point. Documentation examples help reduce the learning curve and potential confusion for developers who might be new to configuring tools like mypy.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
