### PR TITLE
Fix a codegen fragment spread bug

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,25 @@
+Release type: patch
+
+This fixes a bug where codegen would choke on FragmentSpread nodes in the GraphQL during type collection.
+
+e.g.:
+
+```
+fragment PartialBlogPost on BlogPost {
+  title
+}
+
+query OperationName {
+  interface {
+    id
+    ... on BlogPost {
+      ...PartialBlogPost
+    }
+    ... on Image {
+      url
+    }
+  }
+}
+```
+
+The current version of the code generator is not able to handle the `...PartialBogPost` in this position because it assumes it can only find `Field` type nodes even though the spread should be legit.

--- a/strawberry/codegen/query_codegen.py
+++ b/strawberry/codegen/query_codegen.py
@@ -857,7 +857,7 @@ class QueryCodegen:
             if any(isinstance(f, GraphQLFragmentSpread) for f in fields):
                 if len(fields) > 1:
                     raise ValueError(
-                        "Queries with Fragments cannot currently include separate fields."
+                        "Queries with Fragments cannot include separate fields."
                     )
                 spread_field = fields[0]
                 assert isinstance(spread_field, GraphQLFragmentSpread)

--- a/strawberry/codegen/query_codegen.py
+++ b/strawberry/codegen/query_codegen.py
@@ -819,9 +819,12 @@ class QueryCodegen:
             if isinstance(sub_selection, InlineFragmentNode):
                 fragments.append(sub_selection)
 
+        all_common_fields_typename = all(f.name == "__typename" for f in common_fields)
+
         for fragment in fragments:
             type_condition_name = fragment.type_condition.name.value
             fragment_class_name = class_name + type_condition_name
+
             current_type = GraphQLObjectType(
                 fragment_class_name,
                 list(common_fields),
@@ -864,6 +867,9 @@ class QueryCodegen:
                     if isinstance(t, GraphQLObjectType) and t.name == spread_field.name
                 )
                 fields = [*sub_type.fields]
+                if all_common_fields_typename:  # No need to create a new type.
+                    sub_types.append(sub_type)
+                    continue
 
             # This cast is safe because all the fields are either
             # `GraphQLField` or `GraphQLFragmentSpread`

--- a/tests/codegen/queries/interface_fragments_with_spread.graphql
+++ b/tests/codegen/queries/interface_fragments_with_spread.graphql
@@ -1,0 +1,15 @@
+fragment PartialBlogPost on BlogPost {
+  title
+}
+
+query OperationName {
+  interface {
+    id
+    ... on BlogPost {
+      ...PartialBlogPost
+    }
+    ... on Image {
+      url
+    }
+  }
+}

--- a/tests/codegen/queries/union_with_typename_and_fragment.graphql
+++ b/tests/codegen/queries/union_with_typename_and_fragment.graphql
@@ -1,0 +1,23 @@
+fragment AnimalProjection on Animal {
+  age
+}
+
+query OperationName {
+  __typename
+  union {
+    ... on Animal {
+      ...AnimalProjection
+    }
+    ... on Person {
+      name
+    }
+  }
+  optionalUnion {
+    ... on Animal {
+      ...AnimalProjection
+    }
+    ... on Person {
+      name
+    }
+  }
+}

--- a/tests/codegen/snapshots/python/interface_fragments_with_spread.py
+++ b/tests/codegen/snapshots/python/interface_fragments_with_spread.py
@@ -1,0 +1,20 @@
+from typing import Union
+
+class PartialBlogPost:
+    # typename: BlogPost
+    title: str
+
+class OperationNameResultInterfaceBlogPost:
+    # typename: BlogPost
+    id: str
+    title: str
+
+class OperationNameResultInterfaceImage:
+    # typename: Image
+    id: str
+    url: str
+
+OperationNameResultInterface = Union[OperationNameResultInterfaceBlogPost, OperationNameResultInterfaceImage]
+
+class OperationNameResult:
+    interface: OperationNameResultInterface

--- a/tests/codegen/snapshots/python/union_with_typename_and_fragment.py
+++ b/tests/codegen/snapshots/python/union_with_typename_and_fragment.py
@@ -1,0 +1,21 @@
+from typing import Optional, Union
+
+class AnimalProjection:
+    # typename: Animal
+    age: int
+
+class OperationNameResultUnionPerson:
+    # typename: Person
+    name: str
+
+OperationNameResultUnion = Union[AnimalProjection, OperationNameResultUnionPerson]
+
+class OperationNameResultOptionalUnionPerson:
+    # typename: Person
+    name: str
+
+OperationNameResultOptionalUnion = Union[AnimalProjection, OperationNameResultOptionalUnionPerson]
+
+class OperationNameResult:
+    union: OperationNameResultUnion
+    optional_union: Optional[OperationNameResultOptionalUnion]

--- a/tests/codegen/snapshots/typescript/interface_fragments_with_spread.ts
+++ b/tests/codegen/snapshots/typescript/interface_fragments_with_spread.ts
@@ -1,0 +1,19 @@
+type PartialBlogPost = {
+    title: string
+}
+
+type OperationNameResultInterfaceBlogPost = {
+    id: string
+    title: string
+}
+
+type OperationNameResultInterfaceImage = {
+    id: string
+    url: string
+}
+
+type OperationNameResultInterface = OperationNameResultInterfaceBlogPost | OperationNameResultInterfaceImage
+
+type OperationNameResult = {
+    interface: OperationNameResultInterface
+}

--- a/tests/codegen/snapshots/typescript/union_with_typename_and_fragment.ts
+++ b/tests/codegen/snapshots/typescript/union_with_typename_and_fragment.ts
@@ -1,0 +1,21 @@
+type AnimalProjection = {
+    age: number
+}
+
+type OperationNameResultUnionPerson = {
+    name: string
+}
+
+type OperationNameResultUnion = AnimalProjection | OperationNameResultUnionPerson
+
+type OperationNameResultOptionalUnionPerson = {
+    name: string
+}
+
+type OperationNameResultOptionalUnion = AnimalProjection | OperationNameResultOptionalUnionPerson
+
+type OperationNameResult = {
+    __typename: string
+    union: OperationNameResultUnion
+    optional_union: OperationNameResultOptionalUnion | undefined
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

The `RELEASE.md` should summarize the bug fix pretty well with an example.  Ultimately, we were assuming that a `GraphQLFragmentSpread` node was not able to appear in a particular position and that assumption was false.

(The previous code had a `# TODO` to figure out how to deal with this -- so seemingly we were aware that this was a potential problem, we just hadn't had time/need to fix it.)

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The main change here is that we effectively handle the `GraphQLFragmentSpread` nodes like we handle them elsewhere.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #3085

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
