### PR TITLE
fix: use markcoroutinefunction on django async view to support python 3.12

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+Mark Django's asyncview as a coroutine using `asgiref.sync.markcoroutinefunction`
+to support using it with Python 3.12.

--- a/noxfile.py
+++ b/noxfile.py
@@ -52,7 +52,7 @@ def tests(session: Session) -> None:
     )
 
 
-@session(python=["3.11"], name="Django tests", tags=["tests"])
+@session(python=["3.11", "3.12"], name="Django tests", tags=["tests"])
 @nox.parametrize("django", ["4.2.0", "4.1.0", "4.0.0", "3.2.0"])
 def tests_django(session: Session, django: str) -> None:
     session.run_always("poetry", "install", external=True)

--- a/poetry.lock
+++ b/poetry.lock
@@ -3885,4 +3885,4 @@ starlite = ["starlite"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "593264d87f8eceb562d0551b1aa8beb4ce25825a596750e00a5235dc650a73b2"
+content-hash = "796ccc105615a0a2c70e56ca538e8170f12ac7d679efb7b2356a7b844e9cb349"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ chalice = {version = "^1.22"}
 channels = "^3.0.5"
 Django = ">=3.2"
 fastapi = {version = ">=0.65.0", optional = false}
-flask = ">=1.1"
+flask = ">=1.1,<3"
 pydantic = {version = ">1.6.1", optional = false}
 pytest-aiohttp = "^1.0.3"
 pytest-django = {version = "^4.5"}

--- a/strawberry/django/views.py
+++ b/strawberry/django/views.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import json
 from typing import (
     TYPE_CHECKING,
@@ -12,6 +11,7 @@ from typing import (
     cast,
 )
 
+from asgiref.sync import markcoroutinefunction
 from django.http import HttpRequest, HttpResponseNotAllowed, JsonResponse
 from django.http.response import HttpResponse
 from django.template import RequestContext, Template
@@ -231,7 +231,8 @@ class AsyncGraphQLView(
         # https://docs.djangoproject.com/en/3.1/topics/async/#async-views
 
         view = super().as_view(**initkwargs)
-        view._is_coroutine = asyncio.coroutines._is_coroutine  # type: ignore[attr-defined]
+        markcoroutinefunction(view)
+
         return view
 
     async def get_root_value(self, request: HttpRequest) -> Any:


### PR DESCRIPTION
Trying to mark strawberry-django as compatible with Python 3.12 and discovered the tests were failing because of this.

Python 3.12 removed `_is_coroutine` check. `asgiref.sync.markcoroutinefunction` will use the new `inspect.markcoroutinefunction` on python 3.12 and fallback to the older behaviour for older python versions

Related: https://github.com/strawberry-graphql/strawberry-graphql-django/pull/359