### PR TITLE
Add `_handle_errors` hook on http views

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+Release type: patch
+
+This release adds a new private hook in our HTTP views, it is called
+`_handle_errors` and it is meant to be used by Sentry (or other integrations)
+to handle errors without having to patch methods that could be overridden
+by the users

--- a/tests/http/test_query.py
+++ b/tests/http/test_query.py
@@ -1,6 +1,7 @@
 from typing_extensions import Literal
 
 import pytest
+from pytest_mock import MockFixture
 
 from .clients.base import HttpClient
 
@@ -15,6 +16,36 @@ async def test_graphql_query(method: Literal["get", "post"], http_client: HttpCl
 
     assert response.status_code == 200
     assert data["hello"] == "Hello world"
+
+
+@pytest.mark.parametrize("method", ["get", "post"])
+async def test_calls_handle_errors(
+    method: Literal["get", "post"], http_client: HttpClient, mocker: MockFixture
+):
+    sync_mock = mocker.patch(
+        "strawberry.http.sync_base_view.SyncBaseHTTPView._handle_errors"
+    )
+    async_mock = mocker.patch(
+        "strawberry.http.async_base_view.AsyncBaseHTTPView._handle_errors"
+    )
+
+    response = await http_client.query(
+        method=method,
+        query="{ hey }",
+    )
+    data = response.json["data"]
+
+    assert response.status_code == 200
+    assert data is None
+
+    assert response.json["errors"] == [
+        {
+            "message": "Cannot query field 'hey' on type 'Query'.",
+            "locations": [{"line": 1, "column": 3}],
+        }
+    ]
+
+    assert sync_mock.called or async_mock.called
 
 
 @pytest.mark.parametrize("method", ["get", "post"])


### PR DESCRIPTION
This should make this PR for sentry a bit better: https://github.com/getsentry/sentry-python/pull/2393
