### PR TITLE
fix: exclude "self" from ConflictingArgumentsError check

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,7 @@
+Release type: patch
+
+This release changes how we check for conflicting resolver arguments to
+exclude `self` from those checks, which were introduced on version 0.208.0.
+
+It is a common pattern among integrations, such as the Django one, to
+use `root: Model` in the resolvers for better typing inference.

--- a/strawberry/types/fields/resolver.py
+++ b/strawberry/types/fields/resolver.py
@@ -240,7 +240,11 @@ class StrawberryResolver(Generic[T]):
         if (
             conflicting_arguments := (
                 populated_reserved_parameters
-                & {SELF_PARAMSPEC, ROOT_PARAMSPEC, PARENT_PARAMSPEC}
+                # TODO: Maybe use SELF_PARAMSPEC in the future? Right now
+                # it would prevent some common pattern for integrations
+                # (e.g. django) of typing the `root` parameters as the
+                # type of the real object being used
+                & {ROOT_PARAMSPEC, PARENT_PARAMSPEC}
             )
         ) and len(conflicting_arguments) > 1:
             raise ConflictingArgumentsError(

--- a/tests/schema/test_resolvers.py
+++ b/tests/schema/test_resolvers.py
@@ -606,11 +606,23 @@ def multiple_infos(root, info1: Info, info2: Info) -> str:
 @pytest.mark.parametrize(
     "resolver",
     (
-        pytest.param(parent_and_self),
         pytest.param(parent_self_and_root),
-        pytest.param(self_and_root),
         pytest.param(multiple_parents),
         pytest.param(multiple_infos),
+        pytest.param(
+            parent_and_self,
+            marks=pytest.mark.xfail(
+                strict=True,
+                reason="`self` should not raise ConflictingArgumentsError",
+            ),
+        ),
+        pytest.param(
+            self_and_root,
+            marks=pytest.mark.xfail(
+                strict=True,
+                reason="`self` should not raise ConflictingArgumentsError",
+            ),
+        ),
     ),
 )
 @pytest.mark.raises_strawberry_exception(


### PR DESCRIPTION
Change how we check for conflicting resolver arguments to exclude `self` from those checks, which were introduced on version 0.208.0.

It is a common pattern among integrations, such as the Django one, to use `root: Model` in the resolvers for better typing inference.
