### PR TITLE
Add text/html content-type to chalice graphiql response

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Add text/html content-type to chalice graphiql response

--- a/strawberry/chalice/views.py
+++ b/strawberry/chalice/views.py
@@ -76,7 +76,10 @@ class GraphQLView(
         Returns:
             The GraphiQL html page as a string
         """
-        return get_graphiql_html(subscription_enabled=False)  # type: ignore
+        return Response(
+            get_graphiql_html(subscription_enabled=False),
+            headers={"Content-Type": "text/html"},
+        )
 
     def get_sub_response(self, request: Request) -> TemporalResponse:
         return TemporalResponse()

--- a/tests/http/test_graphiql.py
+++ b/tests/http/test_graphiql.py
@@ -9,9 +9,12 @@ from .clients.base import HttpClient
 async def test_renders_graphiql(header_value: str, http_client_class: Type[HttpClient]):
     http_client = http_client_class()
     response = await http_client.get("/graphql", headers={"Accept": header_value})
+    content_type = response.headers.get(
+        "content-type", response.headers.get("Content-Type", "")
+    )
 
     assert response.status_code == 200
-
+    assert "text/html" in content_type
     assert "<title>Strawberry GraphiQL</title>" in response.text
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

The Chalice GraphQLView returns a string for the graphiql response, but because the default Content-Type of Chalice is `application/json` the result is plain text in the browser. I've added the appropriate Content-Type to the result. I wanted to add tests but I couldn't get the local tests to run because of #3126, but would love to add a check for Content-Type

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
