### PR TITLE
remove stack_info from logging

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Remove stack_info from error log messages to not clutter error logging with unnecessary information.

--- a/strawberry/utils/logging.py
+++ b/strawberry/utils/logging.py
@@ -22,12 +22,4 @@ class StrawberryLogger:
         # https://www.python.org/dev/peps/pep-0484/#arbitrary-argument-lists-and-default-argument-values
         **logger_kwargs: Any,
     ) -> None:
-        # "stack_info" is a boolean; check for None explicitly
-        if logger_kwargs.get("stack_info") is None:
-            logger_kwargs["stack_info"] = True
-
-        # stacklevel was added in version 3.8
-        # https://docs.python.org/3/library/logging.html#logging.Logger.debug
-        logger_kwargs["stacklevel"] = 3
-
         cls.logger.error(error, exc_info=error.original_error, **logger_kwargs)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
stack_info (as described here: https://docs.python.org/3/library/logging.html#logging.Logger.debug) adds the stacktrace to the location where the logger.error call was done. That is not helpful when using strawberry, since it's always the same location, so it just adds clutter.

Since exec_info is properly passed to the logger, the actual location of the problem is available and that is what is interesting during logging.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/strawberry-graphql/strawberry/issues/2384

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
