### PR TITLE
Deprecate sentry extension

### DIFF
--- a/.github/workflows/ok-to-preview.yml
+++ b/.github/workflows/ok-to-preview.yml
@@ -31,7 +31,7 @@ jobs:
             event_data = json.load(f)
 
         links = [
-          "https://strawberry.rocks/docs/pr/{pr_number}/{path}".format(
+          "https://beta.strawberry.rocks/docs/pr/{pr_number}/{path}".format(
             pr_number=event_data["number"],
             path=file.replace(".md", "").replace("docs/", "")
           )

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,11 +18,11 @@ jobs:
       change_type: ${{ steps.release-check.outputs.change_type }}
 
     steps:
-    - uses: actions/checkout@v1
+      - uses: actions/checkout@v1
 
-    - name: Release file check
-      uses: ./.github/release-check-action
-      id: release-check
+      - name: Release file check
+        uses: ./.github/release-check-action
+        id: release-check
 
   release:
     name: Release
@@ -99,7 +99,7 @@ jobs:
     steps:
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: "3.9"
       - name: Install dependencies
         run: pip install httpx
       - name: Update release on GitHub
@@ -159,21 +159,15 @@ jobs:
       has-tweet-file: ${{ steps.extract.outputs.has-tweet-file }}
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Extract tweet message and changelog
-      id: extract
-      uses: strawberry-graphql/tweet-actions/read-tweet@v5
-      with:
-        changelog: ${{ needs.release-file-check.outputs.changelog }}
-        version: ${{ needs.release.outputs.version }}
-        contributor_name: ${{ needs.get-contributor-info.outputs.contributor-name }}
-        contributor_twitter_username: ${{ needs.get-contributor-info.outputs.contributor-twitter-username }}
-
-  generate-preview:
-    name: Generate Preview
-    runs-on: ubuntu-latest
-    needs: [release-file-check, read-tweet-md, release, get-contributor-info]
-    if: ${{ needs.release-file-check.outputs.status == 'OK' }}
+      - uses: actions/checkout@v1
+      - name: Extract tweet message and changelog
+        id: extract
+        uses: strawberry-graphql/tweet-actions/read-tweet@v5
+        with:
+          changelog: ${{ needs.release-file-check.outputs.changelog }}
+          version: ${{ needs.release.outputs.version }}
+          contributor_name: ${{ needs.get-contributor-info.outputs.contributor-name }}
+          contributor_twitter_username: ${{ needs.get-contributor-info.outputs.contributor-twitter-username }}
 
   send-tweet:
     name: Send tweet
@@ -184,7 +178,7 @@ jobs:
     steps:
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: "3.9"
       - name: Install dependencies
         run: pip install tweepy==4.0.0
       - name: Send tweet
@@ -244,17 +238,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-      with:
-        persist-credentials: false
-    - name: Remove TWEET.md and commit
-      env:
-        GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
-      run: |
-        git config --global user.name 'Strawberry GraphQL Bot'
-        git config --global user.email 'bot@strawberry.rocks'
-        git remote set-url origin https://${{ secrets.BOT_TOKEN }}@github.com/${{ github.repository }}
-        git pull
-        git rm TWEET.md
-        git commit -m "Remove TWEET.md"
-        git push
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+      - name: Remove TWEET.md and commit
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+        run: |
+          git config --global user.name 'Strawberry GraphQL Bot'
+          git config --global user.email 'bot@strawberry.rocks'
+          git remote set-url origin https://${{ secrets.BOT_TOKEN }}@github.com/${{ github.repository }}
+          git pull
+          git rm TWEET.md
+          git commit -m "Remove TWEET.md"
+          git push

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,12 +97,12 @@ jobs:
       - uses: actions/setup-python@v4
         id: setup-python
         with:
-          python-version: "3.12.0-beta.3"
+          python-version: "3.12"
           architecture: x64
           cache: "poetry"
 
-      - run: poetry env use 3.12.0-beta.3
-      - run: poetry install --with integrations
+      - run: poetry env use 3.12
+      - run: poetry install
         if: steps.setup-python.outputs.cache-hit != 'true'
 
       - name: Run benchmarks

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,7 +102,7 @@ jobs:
           cache: "poetry"
 
       - run: poetry env use 3.12.0-beta.3
-      - run: poetry install
+      - run: poetry install --with integrations
         if: steps.setup-python.outputs.cache-hit != 'true'
 
       - name: Run benchmarks

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,22 @@
+Release type: minor
+
+This release deprecates our `SentryTracingExtension`, as it is now incorporated directly into Sentry itself as of [version 1.32.0](https://github.com/getsentry/sentry-python/releases/tag/1.32.0). You can now directly instrument Strawberry with Sentry.
+
+Below is the revised usage example:
+
+```python
+import sentry_sdk
+from sentry_sdk.integrations.strawberry import StrawberryIntegration
+
+sentry_sdk.init(
+    dsn="___PUBLIC_DSN___",
+    integrations=[
+        # make sure to set async_execution to False if you're executing
+        # GraphQL queries synchronously
+        StrawberryIntegration(async_execution=True),
+    ],
+    traces_sample_rate=1.0,
+)
+```
+
+Many thanks to @sentrivana for their work on this integration!

--- a/docs/extensions/sentry-tracing.md
+++ b/docs/extensions/sentry-tracing.md
@@ -4,6 +4,13 @@ summary: Add Sentry tracing to your GraphQL server.
 tags: tracing
 ---
 
+<Warning>
+
+As of Sentry 1.32.0, Strawberry is now supported by default. This extension is no longer necessary.
+For more details, please refer to the [release notes](https://github.com/getsentry/sentry-python/releases/tag/1.32.0).
+
+</Warning>
+
 # `SentryTracingExtension`
 
 This extension adds support for tracing with Sentry.

--- a/docs/extensions/sentry-tracing.md
+++ b/docs/extensions/sentry-tracing.md
@@ -9,6 +9,23 @@ tags: tracing
 As of Sentry 1.32.0, Strawberry is now supported by default. This extension is no longer necessary.
 For more details, please refer to the [release notes](https://github.com/getsentry/sentry-python/releases/tag/1.32.0).
 
+Below is the revised usage example:
+
+```python
+import sentry_sdk
+from sentry_sdk.integrations.strawberry import StrawberryIntegration
+
+sentry_sdk.init(
+    dsn="___PUBLIC_DSN___",
+    integrations=[
+        # make sure to set async_execution to False if you're executing
+        # GraphQL queries synchronously
+        StrawberryIntegration(async_execution=True),
+    ],
+    traces_sample_rate=1.0,
+)
+```
+
 </Warning>
 
 # `SentryTracingExtension`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,6 +163,7 @@ asyncio_mode = "auto"
 filterwarnings = [
     "ignore::DeprecationWarning:strawberry.*.resolver",
     "ignore:LazyType is deprecated:DeprecationWarning",
+    "ignore::django.utils.deprecation.RemovedInDjango50Warning",
 ]
 
 [tool.autopub]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,7 +163,9 @@ asyncio_mode = "auto"
 filterwarnings = [
     "ignore::DeprecationWarning:strawberry.*.resolver",
     "ignore:LazyType is deprecated:DeprecationWarning",
-    "ignore::django.utils.deprecation.RemovedInDjango50Warning",
+    # ignoring the text instead of the whole warning because we'd
+    # get an error when django is not installed
+    "ignore:The default value of USE_TZ",
 ]
 
 [tool.autopub]

--- a/strawberry/extensions/tracing/sentry.py
+++ b/strawberry/extensions/tracing/sentry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import warnings
 from functools import cached_property
 from inspect import isawaitable
 from typing import TYPE_CHECKING, Any, Callable, Generator, Optional
@@ -22,6 +23,12 @@ class SentryTracingExtension(SchemaExtension):
         *,
         execution_context: Optional[ExecutionContext] = None,
     ):
+        warnings.warn(
+            "The Sentry tracing extension is deprecated, please update to sentry>=1.32.0",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         if execution_context:
             self.execution_context = execution_context
 

--- a/tests/schema/extensions/test_sentry.py
+++ b/tests/schema/extensions/test_sentry.py
@@ -91,7 +91,10 @@ async def test_sentry_tracer(
         }
     """
 
-    await schema.execute(query)
+    with pytest.warns(
+        DeprecationWarning, match="The Sentry tracing extension is deprecated"
+    ):
+        await schema.execute(query)
 
     assert mock.configure_scope.mock_calls == [
         mocker.call(),
@@ -174,7 +177,10 @@ async def test_uses_operation_name(
         }
     """
 
-    await schema.execute(query, operation_name="MyExampleQuery")
+    with pytest.warns(
+        DeprecationWarning, match="The Sentry tracing extension is deprecated"
+    ):
+        await schema.execute(query, operation_name="MyExampleQuery")
 
     mock.configure_scope().__enter__().span.start_child.assert_any_call(
         op="gql", description="MyExampleQuery"
@@ -195,7 +201,11 @@ async def test_uses_operation_type(
         }
     """
 
-    await schema.execute(query, operation_name="MyMutation")
+    with pytest.warns(
+        DeprecationWarning, match="The Sentry tracing extension is deprecated"
+    ):
+        await schema.execute(query, operation_name="MyMutation")
+
     mock.configure_scope().__enter__().span.start_child().set_tag.assert_any_call(
         "graphql.operation_type", "mutation"
     )
@@ -215,7 +225,11 @@ async def test_uses_operation_subscription(
         }
     """
 
-    await schema.execute(query, operation_name="MySubscription")
+    with pytest.warns(
+        DeprecationWarning, match="The Sentry tracing extension is deprecated"
+    ):
+        await schema.execute(query, operation_name="MySubscription")
+
     mock.configure_scope().__enter__().span.start_child().set_tag.assert_any_call(
         "graphql.operation_type", "subscription"
     )
@@ -236,7 +250,10 @@ def test_sentry_tracer_sync(
         }
     """
 
-    schema.execute_sync(query)
+    with pytest.warns(
+        DeprecationWarning, match="The Sentry tracing extension is deprecated"
+    ):
+        schema.execute_sync(query)
 
     assert mock.configure_scope.mock_calls == [
         mocker.call(),
@@ -318,7 +335,10 @@ def test_uses_operation_name_sync(
         }
     """
 
-    schema.execute_sync(query, operation_name="MyExampleQuery")
+    with pytest.warns(
+        DeprecationWarning, match="The Sentry tracing extension is deprecated"
+    ):
+        schema.execute_sync(query, operation_name="MyExampleQuery")
 
     mock.configure_scope().__enter__().span.start_child.assert_any_call(
         op="gql", description="MyExampleQuery"
@@ -338,7 +358,10 @@ def test_uses_operation_type_sync(
         }
     """
 
-    schema.execute_sync(query, operation_name="MyMutation")
+    with pytest.warns(
+        DeprecationWarning, match="The Sentry tracing extension is deprecated"
+    ):
+        schema.execute_sync(query, operation_name="MyMutation")
 
     mock.configure_scope().__enter__().span.start_child().set_tag.assert_any_call(
         "graphql.operation_type", "mutation"


### PR DESCRIPTION
See https://github.com/getsentry/sentry-python/releases/tag/1.32.0

# TODO:

- [x] Deprecate extension
- [x] Update docs with example using the Sentry SDK, could be done in another PR