### PR TITLE
fix parser_cache extension

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+Fix `parser_cache` extension in combination with another configurable extension e.g. `MaxTokensLimiter`
+(pass `parse_options` to `cached_parse_document` function)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,12 @@
 Release type: patch
 
-Fix `parser_cache` extension in combination with another configurable extension e.g. `MaxTokensLimiter`
-(pass `parse_options` to `cached_parse_document` function)
+This release fixes an issue that prevented the `parser_cache` extension to be used in combination with
+other extensions such as `MaxTokensLimiter`.
+
+The following should work as expected now:
+
+```python
+schema = strawberry.Schema(
+    query=Query, extensions=[MaxTokensLimiter(max_token_count=20), ParserCache()]
+)
+```

--- a/strawberry/extensions/parser_cache.py
+++ b/strawberry/extensions/parser_cache.py
@@ -37,6 +37,6 @@ class ParserCache(SchemaExtension):
         execution_context = self.execution_context
 
         execution_context.graphql_document = self.cached_parse_document(
-            execution_context.query,
+            execution_context.query, **execution_context.parse_options
         )
         yield

--- a/tests/schema/extensions/test_parser_cache.py
+++ b/tests/schema/extensions/test_parser_cache.py
@@ -4,7 +4,7 @@ import pytest
 from graphql import parse
 
 import strawberry
-from strawberry.extensions import ParserCache
+from strawberry.extensions import MaxTokensLimiter, ParserCache
 
 
 @patch("strawberry.schema.execute.parse", wraps=parse)
@@ -47,6 +47,32 @@ def test_parser_cache_extension(mock_parse):
     assert result.data == {"ping": "pong"}
 
     assert mock_parse.call_count == 2
+
+
+@patch("strawberry.schema.execute.parse", wraps=parse)
+def test_parser_cache_extension_arguments(mock_parse):
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def hello(self) -> str:
+            return "world"
+
+        @strawberry.field
+        def ping(self) -> str:
+            return "pong"
+
+    schema = strawberry.Schema(
+        query=Query, extensions=[MaxTokensLimiter(max_token_count=20), ParserCache()]
+    )
+
+    query = "query { hello }"
+
+    result = schema.execute_sync(query)
+
+    assert not result.errors
+    assert result.data == {"hello": "world"}
+
+    mock_parse.assert_called_with("query { hello }", max_tokens=20)
 
 
 @patch("strawberry.schema.execute.parse", wraps=parse)


### PR DESCRIPTION
Fix `parser_cache` extension in combination with another configurable extension e.g. `MaxTokensLimiter`

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* `parse_document` function was called without `parse_options` which caused problems when this extension was used in combination with another configurable extension e.g. `MaxTokensLimiter(max_token_count=20)` -> argument `max_token_count` was ignored.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
