### PR TITLE
docs: include subscription constants in FastAPI section

### DIFF
--- a/docs/general/subscriptions.md
+++ b/docs/general/subscriptions.md
@@ -331,6 +331,7 @@ regarding it.
 
 ```python
 from strawberry.fastapi import GraphQLRouter
+from strawberry.subscriptions import GRAPHQL_TRANSPORT_WS_PROTOCOL, GRAPHQL_WS_PROTOCOL
 from fastapi import FastAPI
 from api.schema import schema
 


### PR DESCRIPTION
I noticed the FastAPI section of the subscription doc was missing an import that the other sections had.

## Description

Added `from strawberry.subscriptions import GRAPHQL_TRANSPORT_WS_PROTOCOL, GRAPHQL_WS_PROTOCOL` to the FastAPI section of the subscriptions document.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

* N/A

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added 0 tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
