### PR TITLE
Improved error message when supplying incorrect globalid

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Improved error message when suppling GlobalID format that relates to another type then the query itself.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,3 @@
 Release type: patch
 
-Improved error message when suppling GlobalID format that relates to another type then the query itself.
+Improved error message when supplying GlobalID format that relates to another type than the query itself.

--- a/strawberry/relay/types.py
+++ b/strawberry/relay/types.py
@@ -198,7 +198,11 @@ class GlobalID:
                 ensure_type = tuple(get_args(ensure_type))
 
             if not isinstance(node, ensure_type):
-                raise TypeError(f"{ensure_type} expected, found {node!r}")
+                msg = (
+                    f"Cannot resolve. GlobalID requires {ensure_type}, received {node!r}. "
+                    "Verify that the supplied ID is entended for this Query/Mutation/Subscription."
+                )
+                raise TypeError(msg)
 
         return node
 
@@ -294,7 +298,11 @@ class GlobalID:
                 ensure_type = tuple(get_args(ensure_type))
 
             if not isinstance(node, ensure_type):
-                raise TypeError(f"{ensure_type} expected, found {node!r}")
+                msg = (
+                    f"Cannot resolve. GlobalID requires {ensure_type}, received {node!r}. "
+                    "Verify that the supplied ID is entended for this Query/Mutation/Subscription."
+                )
+                raise TypeError(msg)
 
         return node
 

--- a/strawberry/relay/types.py
+++ b/strawberry/relay/types.py
@@ -200,7 +200,7 @@ class GlobalID:
             if not isinstance(node, ensure_type):
                 msg = (
                     f"Cannot resolve. GlobalID requires {ensure_type}, received {node!r}. "
-                    "Verify that the supplied ID is entended for this Query/Mutation/Subscription."
+                    "Verify that the supplied ID is intended for this Query/Mutation/Subscription."
                 )
                 raise TypeError(msg)
 
@@ -300,7 +300,7 @@ class GlobalID:
             if not isinstance(node, ensure_type):
                 msg = (
                     f"Cannot resolve. GlobalID requires {ensure_type}, received {node!r}. "
-                    "Verify that the supplied ID is entended for this Query/Mutation/Subscription."
+                    "Verify that the supplied ID is intended for this Query/Mutation/Subscription."
                 )
                 raise TypeError(msg)
 


### PR DESCRIPTION
When querying with a GlobalID from another model-type the return message is not entirely clear.
This became very clean when using Proxy-models due to their nature.

You can see the struggle in this reproducible example:
https://github.com/sdobbelaere/strawberry_django_proxy_test


Instead, I've adjusted the error message with some suggestions:
```python
msg = (
    f"Cannot resolve. GlobalID requires {ensure_type}, received {node!r}. "
    "Verify that the supplied ID is entended for this Query/Mutation/Subscription."
)

```

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
