### PR TITLE
Add extensions support to federation.field

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,9 @@
+Release type: minor
+
+Adds an optional `extensions` parameter to `strawberry.federation.field`, with default value `None`. The key is passed through to `strawberry.field`, so the functionality is exactly as described [here](https://strawberry.rocks/docs/guides/field-extensions).
+
+Example:
+
+```python
+strawberry.federation.field(extensions=[InputMutationExtension()])
+```

--- a/strawberry/federation/field.py
+++ b/strawberry/federation/field.py
@@ -21,8 +21,8 @@ from strawberry.unset import UNSET
 if TYPE_CHECKING:
     from typing_extensions import Literal
 
-    from strawberry.field import _RESOLVER_TYPE, StrawberryField
     from strawberry.extensions.field_extension import FieldExtension
+    from strawberry.field import _RESOLVER_TYPE, StrawberryField
     from strawberry.permission import BasePermission
 
 

--- a/strawberry/federation/field.py
+++ b/strawberry/federation/field.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from typing_extensions import Literal
 
     from strawberry.field import _RESOLVER_TYPE, StrawberryField
+    from strawberry.extensions.field_extension import FieldExtension
     from strawberry.permission import BasePermission
 
 
@@ -48,6 +49,7 @@ def field(
     default: Any = UNSET,
     default_factory: Union[Callable[..., object], object] = UNSET,
     directives: Sequence[object] = (),
+    extensions: Optional[List[FieldExtension]] = None,
     graphql_type: Optional[Any] = None,
 ) -> T:
     ...
@@ -72,6 +74,7 @@ def field(
     default: Any = UNSET,
     default_factory: Union[Callable[..., object], object] = UNSET,
     directives: Sequence[object] = (),
+    extensions: Optional[List[FieldExtension]] = None,
     graphql_type: Optional[Any] = None,
 ) -> Any:
     ...
@@ -96,6 +99,7 @@ def field(
     default: Any = UNSET,
     default_factory: Union[Callable[..., object], object] = UNSET,
     directives: Sequence[object] = (),
+    extensions: Optional[List[FieldExtension]] = None,
     graphql_type: Optional[Any] = None,
 ) -> StrawberryField:
     ...
@@ -119,6 +123,7 @@ def field(
     default: Any = dataclasses.MISSING,
     default_factory: Union[Callable[..., object], object] = dataclasses.MISSING,
     directives: Sequence[object] = (),
+    extensions: Optional[List[FieldExtension]] = None,
     graphql_type: Optional[Any] = None,
     # This init parameter is used by PyRight to determine whether this field
     # is added in the constructor or not. It is not used to change
@@ -169,5 +174,6 @@ def field(
         default_factory=default_factory,
         init=init,  # type: ignore
         directives=directives,
+        extensions=extensions,
         graphql_type=graphql_type,
     )

--- a/tests/schema/extensions/test_input_mutation_federation.py
+++ b/tests/schema/extensions/test_input_mutation_federation.py
@@ -1,0 +1,103 @@
+import textwrap
+from typing_extensions import Annotated
+
+import strawberry
+from strawberry.field_extensions import InputMutationExtension
+
+
+@strawberry.federation.type
+class Fruit:
+    name: str
+    color: str
+
+
+@strawberry.federation.type
+class Query:
+    @strawberry.field
+    def hello(self) -> str:
+        return "hi"
+
+
+@strawberry.federation.type
+class Mutation:
+    @strawberry.federation.mutation(extensions=[InputMutationExtension()])
+    def create_fruit(
+        self,
+        name: str,
+        color: Annotated[
+            str,
+            strawberry.federation.argument(
+                description="The color of the fruit",
+            ),
+        ],
+    ) -> Fruit:
+        return Fruit(
+            name=name,
+            color=color,
+        )
+
+
+schema = strawberry.federation.Schema(query=Query, mutation=Mutation)
+
+
+def test_schema():
+    expected = '''
+    input CreateFruitInput {
+      name: String!
+
+      """The color of the fruit"""
+      color: String!
+    }
+
+    type Fruit {
+      name: String!
+      color: String!
+    }
+
+    type Mutation {
+      createFruit(
+        """Input data for `createFruit` mutation"""
+        input: CreateFruitInput!
+      ): Fruit!
+    }
+
+    type Query {
+      _service: _Service!
+      hello: String!
+    }
+
+    scalar _Any
+
+    type _Service {
+      sdl: String!
+    }
+    '''
+    assert str(schema).strip() == textwrap.dedent(expected).strip()
+
+
+def test_input_mutation():
+    result = schema.execute_sync(
+        """
+        mutation TestQuery ($input: CreateFruitInput!) {
+            createFruit (input: $input) {
+                ... on Fruit {
+                    name
+                    color
+                }
+            }
+        }
+        """,
+        variable_values={
+            "input": {
+                "name": "Dragonfruit",
+                "color": "red",
+            }
+        },
+    )
+    assert result.errors is None
+    assert result.data == {
+        "createFruit": {
+            "name": "Dragonfruit",
+            "color": "red",
+        },
+    }

--- a/tests/schema/extensions/test_input_mutation_federation.py
+++ b/tests/schema/extensions/test_input_mutation_federation.py
@@ -14,7 +14,7 @@ class Fruit:
 @strawberry.federation.type
 class Query:
     @strawberry.field
-    def hello(self) -> str: # pragma: no cover
+    def hello(self) -> str:  # pragma: no cover
         return "hi"
 
 

--- a/tests/schema/extensions/test_input_mutation_federation.py
+++ b/tests/schema/extensions/test_input_mutation_federation.py
@@ -14,7 +14,7 @@ class Fruit:
 @strawberry.federation.type
 class Query:
     @strawberry.field
-    def hello(self) -> str:
+    def hello(self) -> str: # pragma: no cover
         return "hi"
 
 


### PR DESCRIPTION
## Description
Adds an optional `extensions` parameter to `strawberry.federation.field`, with default value `None`. The key is passed through to `strawberry.field`, so the functionality is exactly as described [here](https://strawberry.rocks/docs/guides/field-extensions).

Example:

```python
strawberry.federation.field(extensions=[InputMutationExtension()])
```

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

n/a

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
