### PR TITLE
fix: remove hardcoded version in pydantic>=2 tests

### DIFF
--- a/tests/experimental/pydantic/schema/test_mutation.py
+++ b/tests/experimental/pydantic/schema/test_mutation.py
@@ -87,7 +87,7 @@ def test_mutation_with_validation():
             "  String should have at least 2 characters [type=string_too_short, "
             "input_value='P', input_type=str]\n"
             "    For further information visit "
-            "https://errors.pydantic.dev/2.0.3/v/string_too_short"
+            f"https://errors.pydantic.dev/{pydantic.version.version_short()}/v/string_too_short"
         )
     else:
         assert result.errors[0].message == (
@@ -149,7 +149,7 @@ def test_mutation_with_validation_of_nested_model():
             "  String should have at least 2 characters [type=string_too_short, "
             "input_value='P', input_type=str]\n"
             "    For further information visit "
-            "https://errors.pydantic.dev/2.0.3/v/string_too_short"
+            f"https://errors.pydantic.dev/{pydantic.version.version_short()}/v/string_too_short"
         )
 
     else:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

When I run the test with pydantic>=2 (pydantic!=2.0.3), two tests fail due to the hardcoded version.
This problem has not been found because no tests are currently run against pydantic2.

<details><summary>Error Log</summary>

```
strawberry-graphql> ________________________ test_mutation_with_validation _________________________
strawberry-graphql> 
strawberry-graphql>     def test_mutation_with_validation():
strawberry-graphql>         class User(pydantic.BaseModel):
strawberry-graphql>             name: pydantic.constr(min_length=2)
strawberry-graphql>     
strawberry-graphql>         @strawberry.experimental.pydantic.input(User)
strawberry-graphql>         class CreateUserInput:
strawberry-graphql>             name: strawberry.auto
strawberry-graphql>     
strawberry-graphql>         @strawberry.experimental.pydantic.type(User)
strawberry-graphql>         class UserType:
strawberry-graphql>             name: strawberry.auto
strawberry-graphql>     
strawberry-graphql>         @strawberry.type
strawberry-graphql>         class Query:
strawberry-graphql>             h: str
strawberry-graphql>     
strawberry-graphql>         @strawberry.type
strawberry-graphql>         class Mutation:
strawberry-graphql>             @strawberry.mutation
strawberry-graphql>             def create_user(self, input: CreateUserInput) -> UserType:
strawberry-graphql>                 data = input.to_pydantic()
strawberry-graphql>     
strawberry-graphql>                 return UserType(name=data.name)
strawberry-graphql>     
strawberry-graphql>         schema = strawberry.Schema(query=Query, mutation=Mutation)
strawberry-graphql>     
strawberry-graphql>         query = """
strawberry-graphql>             mutation {
strawberry-graphql>                 createUser(input: { name: "P" }) {
strawberry-graphql>                     name
strawberry-graphql>                 }
strawberry-graphql>             }
strawberry-graphql>         """
strawberry-graphql>     
strawberry-graphql>         result = schema.execute_sync(query)
strawberry-graphql>     
strawberry-graphql>         if IS_PYDANTIC_V2:
strawberry-graphql> >           assert result.errors[0].message == (
strawberry-graphql>                 "1 validation error for User\n"
strawberry-graphql>                 "name\n"
strawberry-graphql>                 "  String should have at least 2 characters [type=string_too_short, "
strawberry-graphql>                 "input_value='P', input_type=str]\n"
strawberry-graphql>                 "    For further information visit "
strawberry-graphql>                 "https://errors.pydantic.dev/2.0.3/v/string_too_short"
strawberry-graphql>             )
strawberry-graphql> E           assert "1 validation error for User\nname\n  String should have at least 2 characters [type=string_too_short, input_value='P', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.3/v/string_too_short" == "1 validation error for User\nname\n  String should have at least 2 characters [type=string_too_short, input_value='P', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.0.3/v/string_too_short"
strawberry-graphql> E               1 validation error for User
strawberry-graphql> E               name
strawberry-graphql> E                 String should have at least 2 characters [type=string_too_short, input_value='P', input_type=str]
strawberry-graphql> E             -     For further information visit https://errors.pydantic.dev/2.0.3/v/string_too_short
strawberry-graphql> E             ?                                                                 --
strawberry-graphql> E             +     For further information visit https://errors.pydantic.dev/2.3/v/string_too_short
strawberry-graphql> 
strawberry-graphql> tests/experimental/pydantic/schema/test_mutation.py:84: AssertionError
```
</details>

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

I don't think RELEASE.md is necessary since this is a fix for internal test.
