### PR TITLE
Fix ParserCache Syntax Errors

### DIFF
--- a/strawberry/extensions/parser_cache.py
+++ b/strawberry/extensions/parser_cache.py
@@ -1,5 +1,6 @@
 from functools import lru_cache
 from typing import Iterator, Optional
+from graphql import GraphQLError
 
 from strawberry.extensions.base_extension import SchemaExtension
 from strawberry.schema.execute import parse_document
@@ -36,7 +37,10 @@ class ParserCache(SchemaExtension):
     def on_parse(self) -> Iterator[None]:
         execution_context = self.execution_context
 
-        execution_context.graphql_document = self.cached_parse_document(
-            execution_context.query, **execution_context.parse_options
-        )
+        try:
+            execution_context.graphql_document = self.cached_parse_document(
+                execution_context.query, **execution_context.parse_options
+            )
+        except GraphQLError as error:
+            execution_context.errors = [error]
         yield

--- a/strawberry/extensions/parser_cache.py
+++ b/strawberry/extensions/parser_cache.py
@@ -1,5 +1,6 @@
 from functools import lru_cache
 from typing import Iterator, Optional
+
 from graphql import GraphQLError
 
 from strawberry.extensions.base_extension import SchemaExtension

--- a/tests/schema/extensions/test_parser_cache.py
+++ b/tests/schema/extensions/test_parser_cache.py
@@ -76,6 +76,24 @@ def test_parser_cache_extension_arguments(mock_parse):
 
 
 @patch("strawberry.schema.execute.parse", wraps=parse)
+def test_parser_cache_extension_syntax_error(mock_parse):
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def hello(self) -> str:
+            return "world"
+
+    schema = strawberry.Schema(query=Query, extensions=[ParserCache()])
+
+    query = "query { hello"
+
+    result = schema.execute_sync(query)
+
+    assert result.errors
+    assert mock_parse.call_count == 1
+
+
+@patch("strawberry.schema.execute.parse", wraps=parse)
 def test_parser_cache_extension_max_size(mock_parse):
     @strawberry.type
     class Query:


### PR DESCRIPTION
## Description

ParserCache does not catch SyntaxErrors in the GraphQL input.

Expected behaviour can be seen in [strawberry.schema.execute](https://github.com/strawberry-graphql/strawberry/blob/a90dea2a3053e857aa2adf685d5c4f5d39c527c4/strawberry/schema/execute.py#L98). 

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

N/A

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
