### PR TITLE
Initial work for first class pydantic usage

### DIFF
--- a/strawberry/experimental/pydantic/first_class.py
+++ b/strawberry/experimental/pydantic/first_class.py
@@ -1,0 +1,181 @@
+from strawberry.annotation import StrawberryAnnotation
+from strawberry.experimental.pydantic._compat import CompatModelField, get_model_fields
+from strawberry.experimental.pydantic.fields import replace_types_recursively
+from strawberry.experimental.pydantic.utils import get_default_factory_for_field
+from strawberry.field import StrawberryField
+
+
+from pydantic import BaseModel
+
+
+import dataclasses
+from typing import Callable, Dict, List, Optional, Sequence, Type
+
+from strawberry.object_type import _get_interfaces
+from strawberry.types.types import StrawberryObjectDefinition
+from strawberry.utils.deprecations import DEPRECATION_MESSAGES, DeprecatedDescriptor
+from strawberry.utils.str_converters import to_camel_case
+
+from strawberry.experimental.pydantic.conversion_types import PydanticModel
+
+
+def _get_strawberry_fields_from_basemodel(
+    model: Type[BaseModel], is_input: bool, use_pydantic_alias: bool
+) -> List[StrawberryField]:
+    """Get all the strawberry fields off a pydantic BaseModel cls
+    This function returns a list of StrawberryFields (one for each field item), while
+    also paying attention the name and typing of the field.
+    model:
+        A pure pydantic field. Will not have a StrawberryField; one will need to
+        be created in this function. Type annotation is required.
+    """
+    fields: list[StrawberryField] = []
+
+    # BaseModel already has fields, so we need to get them from there
+    model_fields: Dict[str, CompatModelField] = get_model_fields(model)
+    for name, field in model_fields.items():
+        converted_type = replace_types_recursively(field.outer_type_, is_input=is_input)
+        if field.allow_none:
+            converted_type = Optional[converted_type]
+        fields.append(
+            StrawberryField(
+                python_name=name,
+                graphql_name=field.alias if use_pydantic_alias else None,
+                # always unset because we use default_factory instead
+                default=dataclasses.MISSING,
+                default_factory=get_default_factory_for_field(field),
+                type_annotation=StrawberryAnnotation.from_annotation(converted_type),
+                description=field.description,
+                deprecation_reason=None,
+                permission_classes=[],
+                directives=[],
+                metadata={},
+            )
+        )
+
+    return fields
+
+
+def first_class_process_basemodel(
+    model: Type[BaseModel],
+    *,
+    name: Optional[str] = None,
+    is_input: bool = False,
+    is_interface: bool = False,
+    description: Optional[str] = None,
+    directives: Optional[Sequence[object]] = (),
+    extend: bool = False,
+    use_pydantic_alias: bool = True,
+):
+    name = name or to_camel_case(model.__name__)
+
+    interfaces = _get_interfaces(model)
+    fields = _get_strawberry_fields_from_basemodel(
+        model, is_input=is_input, use_pydantic_alias=use_pydantic_alias
+    )
+    is_type_of = getattr(model, "is_type_of", None)
+    resolve_type = getattr(model, "resolve_type", None)
+
+    model.__strawberry_definition__ = StrawberryObjectDefinition(
+        name=name,
+        is_input=is_input,
+        is_interface=is_interface,
+        interfaces=interfaces,
+        description=description,
+        directives=directives,
+        origin=model,
+        extend=extend,
+        fields=fields,
+        is_type_of=is_type_of,
+        resolve_type=resolve_type,
+    )
+    # TODO: remove when deprecating _type_definition
+    DeprecatedDescriptor(
+        DEPRECATION_MESSAGES._TYPE_DEFINITION,
+        model.__strawberry_definition__,
+        "_type_definition",
+    ).inject(model)
+
+    return model
+
+
+def register_first_class(
+    model: Type[PydanticModel],
+    *,
+    name: Optional[str] = None,
+    is_input: bool = False,
+    is_interface: bool = False,
+    description: Optional[str] = None,
+    use_pydantic_alias: bool = True,
+) -> Type[PydanticModel]:
+    """A function for registering a pydantic model as a first class strawberry type.
+    This is useful when your pydantic model is some code that you can't edit
+    (e.g. from a third party library).
+
+    Example:
+        class User(BaseModel):
+            id: int
+            name: str
+
+        register_first_class(User)
+
+        @strawberry.type
+        class Query:
+            @strawberry.field
+            def user(self) -> User:
+                return User(id=1, name="Patrick")
+    """
+
+    first_class_process_basemodel(
+        model,
+        name=name,
+        is_input=is_input,
+        is_interface=is_interface,
+        description=description,
+        use_pydantic_alias=use_pydantic_alias,
+    )
+
+    if is_input:
+        # TODO: Probably should check if the name clashes with an existing type?
+        model._strawberry_input_type = model  # type: ignore
+    else:
+        model._strawberry_type = model  # type: ignore
+
+    return model
+
+
+def first_class(
+    name: Optional[str] = None,
+    is_input: bool = False,
+    is_interface: bool = False,
+    description: Optional[str] = None,
+    use_pydantic_alias: bool = True,
+) -> Callable[[Type[PydanticModel]], Type[PydanticModel]]:
+    """A decorator to make a pydantic class work on strawberry without creating
+    a separate strawberry type.
+    
+    Example:
+        @strawberry.experimental.pydantic.first_class()
+        class User(BaseModel):
+            id: int
+            name: str
+
+        @strawberry.type
+        class Query:
+            @strawberry.field
+            def user(self) -> User:
+                return User(id=1, name="Patrick")
+    
+    """
+
+    def wrap(model: Type[PydanticModel]) -> Type[PydanticModel]:
+        return register_first_class(
+            model,
+            name=name,
+            is_input=is_input,
+            is_interface=is_interface,
+            description=description,
+            use_pydantic_alias=use_pydantic_alias,
+        )
+
+    return wrap

--- a/strawberry/experimental/pydantic/object_type.py
+++ b/strawberry/experimental/pydantic/object_type.py
@@ -242,6 +242,7 @@ def register_first_class(
     )
 
     if is_input:
+        # TODO: Probably should check if the name clashes with an existing type?
         model._strawberry_input_type = model  # type: ignore
     else:
         model._strawberry_type = model  # type: ignore

--- a/tests/experimental/pydantic_first_class/test_basic.py
+++ b/tests/experimental/pydantic_first_class/test_basic.py
@@ -1,0 +1,48 @@
+import sys
+import textwrap
+from enum import Enum
+from typing import List, Optional, Union
+
+import pydantic
+import pytest
+
+import strawberry
+from tests.experimental.pydantic.utils import needs_pydantic_v1
+
+from strawberry.experimental.pydantic.object_type import register_first_class
+
+
+def test_basic_type_field_list():
+    class User(pydantic.BaseModel):
+        age: int
+        password: Optional[str]
+
+    register_first_class(User)
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def user(self) -> User:
+            return User(age=1, password="ABC")
+
+    schema = strawberry.Schema(query=Query)
+
+    expected_schema = """
+    type Query {
+      user: User!
+    }
+
+    type User {
+      age: Int!
+      password: String
+    }
+    """
+
+    assert str(schema) == textwrap.dedent(expected_schema).strip()
+
+    query = "{ user { age } }"
+
+    result = schema.execute_sync(query)
+
+    assert not result.errors
+    assert result.data["user"]["age"] == 1

--- a/tests/experimental/pydantic_first_class/test_basic.py
+++ b/tests/experimental/pydantic_first_class/test_basic.py
@@ -3,6 +3,7 @@ import sys
 import textwrap
 from enum import Enum
 from typing import Annotated, Any, List, Optional, Union
+from graphql import is_input_type
 
 import pydantic
 import pytest
@@ -303,52 +304,33 @@ def test_interface():
 
 
 def test_both_output_and_input_type():
+    @first_class_type(name="WorkInput",is_input=True)
+    @first_class_type(name="WorkOutput")
     class Work(pydantic.BaseModel):
         time: float
+
+    @first_class_type(name="UserInput",is_input=True)
+    @first_class_type(name="UserOutput")
 
     class User(pydantic.BaseModel):
         name: str
         # Note that pydantic v2 requires an explicit default of None for Optionals
         work: Optional[Work] = None
 
+    @first_class_type(name="GroupInput",is_input=True)
+    @first_class_type(name="GroupOutput")
     class Group(pydantic.BaseModel):
         users: List[User]
 
-    # Test both definition orders
-    @strawberry.experimental.pydantic.input(Work)
-    class WorkInput:
-        time: strawberry.auto
-
-    @strawberry.experimental.pydantic.type(Work)
-    class WorkOutput:
-        time: strawberry.auto
-
-    @strawberry.experimental.pydantic.type(User)
-    class UserOutput:
-        name: strawberry.auto
-        work: strawberry.auto
-
-    @strawberry.experimental.pydantic.input(User)
-    class UserInput:
-        name: strawberry.auto
-        work: strawberry.auto
-
-    @strawberry.experimental.pydantic.input(Group)
-    class GroupInput:
-        users: strawberry.auto
-
-    @strawberry.experimental.pydantic.type(Group)
-    class GroupOutput:
-        users: strawberry.auto
 
     @strawberry.type
     class Query:
-        groups: List[GroupOutput]
+        groups: List[Group]
 
     @strawberry.type
     class Mutation:
         @strawberry.mutation
-        def updateGroup(group: GroupInput) -> GroupOutput:
+        def updateGroup(group: Group) -> Group:
             pass
 
     # This triggers the exception from #1504

--- a/tests/experimental/pydantic_first_class/test_basic.py
+++ b/tests/experimental/pydantic_first_class/test_basic.py
@@ -1,7 +1,8 @@
+import dataclasses
 import sys
 import textwrap
 from enum import Enum
-from typing import List, Optional, Union
+from typing import Annotated, Any, List, Optional, Union
 
 import pydantic
 import pytest
@@ -9,15 +10,29 @@ import pytest
 import strawberry
 from tests.experimental.pydantic.utils import needs_pydantic_v1
 
-from strawberry.experimental.pydantic.object_type import register_first_class
+from strawberry.experimental.pydantic.object_type import (
+    first_class_type,
+    register_first_class,
+)
+
+from strawberry.types.types import StrawberryObjectDefinition
+
+from strawberry.type import StrawberryList, StrawberryOptional
+
+from strawberry.experimental.pydantic.exceptions import MissingFieldsListError
+
+from strawberry.union import StrawberryUnion
+
+from strawberry.enum import EnumDefinition
+
+from strawberry.schema_directive import Location
 
 
 def test_basic_type_field_list():
+    @first_class_type()
     class User(pydantic.BaseModel):
         age: int
         password: Optional[str]
-
-    register_first_class(User)
 
     @strawberry.type
     class Query:
@@ -46,3 +61,750 @@ def test_basic_type_field_list():
 
     assert not result.errors
     assert result.data["user"]["age"] == 1
+
+
+def test_referencing_other_models_fails_when_not_registered():
+    class Group(pydantic.BaseModel):
+        name: str
+
+    with pytest.raises(
+        strawberry.experimental.pydantic.UnregisteredTypeException,
+        match=("Cannot find a Strawberry Type for (.*) did you forget to register it?"),
+    ):
+
+        @first_class_type()
+        class User(pydantic.BaseModel):
+            age: int
+            password: Optional[str]
+            group: Group
+
+
+def test_referencing_other_input_models_fails_when_not_registered():
+    @first_class_type()  # Not an input type so it should fail
+    class Group(pydantic.BaseModel):
+        name: str
+
+    with pytest.raises(
+        strawberry.experimental.pydantic.UnregisteredTypeException,
+        match=("Cannot find a Strawberry Type for (.*) did you forget to register it?"),
+    ):
+
+        @first_class_type(is_input=True)
+        class User(pydantic.BaseModel):
+            age: int
+            password: Optional[str]
+            group: Group
+
+
+def test_referencing_other_registered_models():
+    @first_class_type()
+    class Group(pydantic.BaseModel):
+        name: str
+
+    @first_class_type()
+    class User(pydantic.BaseModel):
+        age: int
+        group: Group
+
+    definition: StrawberryObjectDefinition = User.__strawberry_definition__
+    assert definition.name == "User"
+
+    [field1, field2] = definition.fields
+
+    assert field1.python_name == "age"
+    assert field1.type is int
+
+    assert field2.python_name == "group"
+    assert field2.type is Group
+
+
+def test_list():
+    @first_class_type()
+    class User(pydantic.BaseModel):
+        friend_names: List[str]
+
+    definition: StrawberryObjectDefinition = User.__strawberry_definition__
+    assert definition.name == "User"
+
+    [field] = definition.fields
+
+    assert field.python_name == "friend_names"
+    assert isinstance(field.type, StrawberryList)
+    assert field.type.of_type is str
+
+
+def test_list_of_types():
+    @first_class_type()
+    class Friend(pydantic.BaseModel):
+        name: str
+
+    @first_class_type()
+    class User(pydantic.BaseModel):
+        friends: Optional[List[Optional[Friend]]]
+
+    definition: StrawberryObjectDefinition = User.__strawberry_definition__
+    assert definition.name == "User"
+
+    [field] = definition.fields
+
+    assert field.python_name == "friends"
+    assert isinstance(field.type, StrawberryOptional)
+    assert isinstance(field.type.of_type, StrawberryList)
+    assert isinstance(field.type.of_type.of_type, StrawberryOptional)
+    assert field.type.of_type.of_type.of_type is Friend
+
+
+def test_default_and_default_factory():
+    class User1(pydantic.BaseModel):
+        friend: Optional[str] = "friend_value"
+
+    @strawberry.experimental.pydantic.type(User1)
+    class UserType1:
+        friend: strawberry.auto
+
+    assert UserType1().friend == "friend_value"
+    assert UserType1().to_pydantic().friend == "friend_value"
+
+    class User2(pydantic.BaseModel):
+        friend: Optional[str] = None
+
+    @strawberry.experimental.pydantic.type(User2)
+    class UserType2:
+        friend: strawberry.auto
+
+    assert UserType2().friend is None
+    assert UserType2().to_pydantic().friend is None
+
+    # Test instantiation using default_factory
+
+    class User3(pydantic.BaseModel):
+        friend: Optional[str] = pydantic.Field(default_factory=lambda: "friend_value")
+
+    @strawberry.experimental.pydantic.type(User3)
+    class UserType3:
+        friend: strawberry.auto
+
+    assert UserType3().friend == "friend_value"
+    assert UserType3().to_pydantic().friend == "friend_value"
+
+    class User4(pydantic.BaseModel):
+        friend: Optional[str] = pydantic.Field(default_factory=lambda: None)
+
+    @strawberry.experimental.pydantic.type(User4)
+    class UserType4:
+        friend: strawberry.auto
+
+    assert UserType4().friend is None
+    assert UserType4().to_pydantic().friend is None
+
+
+def test_optional_and_default():
+    class UserModel(pydantic.BaseModel):
+        age: int
+        name: str = pydantic.Field("Michael", description="The user name")
+        password: Optional[str] = pydantic.Field(default="ABC")
+        passwordtwo: Optional[str] = None
+        some_list: Optional[List[str]] = pydantic.Field(default_factory=list)
+        check: Optional[bool] = False
+
+    @strawberry.experimental.pydantic.type(UserModel, all_fields=True)
+    class User:
+        pass
+
+    definition: StrawberryObjectDefinition = User.__strawberry_definition__
+    assert definition.name == "User"
+
+    [
+        age_field,
+        name_field,
+        password_field,
+        passwordtwo_field,
+        some_list_field,
+        check_field,
+    ] = definition.fields
+
+    assert age_field.python_name == "age"
+    assert age_field.type is int
+
+    assert name_field.python_name == "name"
+    assert name_field.type is str
+
+    assert password_field.python_name == "password"
+    assert isinstance(password_field.type, StrawberryOptional)
+    assert password_field.type.of_type is str
+
+    assert passwordtwo_field.python_name == "passwordtwo"
+    assert isinstance(passwordtwo_field.type, StrawberryOptional)
+    assert passwordtwo_field.type.of_type is str
+
+    assert some_list_field.python_name == "some_list"
+    assert isinstance(some_list_field.type, StrawberryOptional)
+    assert isinstance(some_list_field.type.of_type, StrawberryList)
+    assert some_list_field.type.of_type.of_type is str
+
+    assert check_field.python_name == "check"
+    assert isinstance(check_field.type, StrawberryOptional)
+    assert check_field.type.of_type is bool
+
+
+def test_type_with_fields_mutable_default():
+    empty_list = []
+
+    class User(pydantic.BaseModel):
+        groups: List[str]
+        friends: List[str] = empty_list
+
+    @strawberry.experimental.pydantic.type(User)
+    class UserType:
+        groups: strawberry.auto
+        friends: strawberry.auto
+
+    definition: StrawberryObjectDefinition = UserType.__strawberry_definition__
+    assert definition.name == "UserType"
+
+    [groups_field, friends_field] = definition.fields
+
+    assert groups_field.default is dataclasses.MISSING
+    assert groups_field.default_factory is dataclasses.MISSING
+    assert friends_field.default is dataclasses.MISSING
+
+    # check that we really made a copy
+    assert friends_field.default_factory() is not empty_list
+    assert UserType(groups=["groups"]).friends is not empty_list
+    UserType(groups=["groups"]).friends.append("joe")
+    assert empty_list == []
+
+
+@pytest.mark.xfail(
+    reason=(
+        "passing default values when extending types from pydantic is not"
+        "supported. https://github.com/strawberry-graphql/strawberry/issues/829"
+    )
+)
+def test_type_with_fields_coming_from_strawberry_and_pydantic_with_default():
+    class User(pydantic.BaseModel):
+        age: int
+        password: Optional[str]
+
+    @strawberry.experimental.pydantic.type(User)
+    class UserType:
+        name: str = "Michael"
+        age: strawberry.auto
+        password: strawberry.auto
+
+    definition: StrawberryObjectDefinition = UserType.__strawberry_definition__
+    assert definition.name == "UserType"
+
+    [field1, field2, field3] = definition.fields
+
+    assert field1.python_name == "age"
+    assert field1.type is int
+
+    assert field2.python_name == "password"
+    assert isinstance(field2.type, StrawberryOptional)
+    assert field2.type.of_type is str
+
+    assert field3.python_name == "name"
+    assert field3.type is str
+    assert field3.default == "Michael"
+
+
+def test_type_with_nested_fields_coming_from_strawberry_and_pydantic():
+    @strawberry.type
+    class Name:
+        first_name: str
+        last_name: str
+
+    class User(pydantic.BaseModel):
+        age: int
+        password: Optional[str]
+
+    @strawberry.experimental.pydantic.type(User)
+    class UserType:
+        name: Name
+        age: strawberry.auto
+        password: strawberry.auto
+
+    definition: StrawberryObjectDefinition = UserType.__strawberry_definition__
+    assert definition.name == "UserType"
+
+    [field1, field2, field3] = definition.fields
+
+    assert field1.python_name == "name"
+    assert field1.type is Name
+
+    assert field2.python_name == "age"
+    assert field2.type is int
+
+    assert field3.python_name == "password"
+    assert isinstance(field3.type, StrawberryOptional)
+    assert field3.type.of_type is str
+
+
+def test_type_with_aliased_pydantic_field():
+    class UserModel(pydantic.BaseModel):
+        age_: int = pydantic.Field(..., alias="age")
+        password: Optional[str]
+
+    @strawberry.experimental.pydantic.type(UserModel)
+    class User:
+        age_: strawberry.auto
+        password: strawberry.auto
+
+    definition: StrawberryObjectDefinition = User.__strawberry_definition__
+    assert definition.name == "User"
+
+    [field1, field2] = definition.fields
+
+    assert field1.python_name == "age_"
+    assert field1.type is int
+    assert field1.graphql_name == "age"
+
+    assert field2.python_name == "password"
+    assert isinstance(field2.type, StrawberryOptional)
+    assert field2.type.of_type is str
+
+
+def test_union():
+    class BranchA(pydantic.BaseModel):
+        field_a: str
+
+    class BranchB(pydantic.BaseModel):
+        field_b: int
+
+    class User(pydantic.BaseModel):
+        age: int
+        union_field: Union[BranchA, BranchB]
+
+    @strawberry.experimental.pydantic.type(BranchA)
+    class BranchAType:
+        field_a: strawberry.auto
+
+    @strawberry.experimental.pydantic.type(BranchB)
+    class BranchBType:
+        field_b: strawberry.auto
+
+    @strawberry.experimental.pydantic.type(User)
+    class UserType:
+        age: strawberry.auto
+        union_field: strawberry.auto
+
+    definition: StrawberryObjectDefinition = UserType.__strawberry_definition__
+    assert definition.name == "UserType"
+
+    [field1, field2] = definition.fields
+
+    assert field1.python_name == "age"
+    assert field1.type is int
+
+    assert field2.python_name == "union_field"
+    assert isinstance(field2.type, StrawberryUnion)
+    assert field2.type.types[0] is BranchAType
+    assert field2.type.types[1] is BranchBType
+
+
+def test_enum():
+    @strawberry.enum
+    class UserKind(Enum):
+        user = 0
+        admin = 1
+
+    class User(pydantic.BaseModel):
+        age: int
+        kind: UserKind
+
+    @strawberry.experimental.pydantic.type(User)
+    class UserType:
+        age: strawberry.auto
+        kind: strawberry.auto
+
+    definition: StrawberryObjectDefinition = UserType.__strawberry_definition__
+    assert definition.name == "UserType"
+
+    [field1, field2] = definition.fields
+
+    assert field1.python_name == "age"
+    assert field1.type is int
+
+    assert field2.python_name == "kind"
+    assert isinstance(field2.type, EnumDefinition)
+    assert field2.type.wrapped_cls is UserKind
+
+
+def test_interface():
+    class Base(pydantic.BaseModel):
+        base_field: str
+
+    class BranchA(Base):
+        field_a: str
+
+    class BranchB(Base):
+        field_b: int
+
+    class User(pydantic.BaseModel):
+        age: int
+        interface_field: Base
+
+    @strawberry.experimental.pydantic.interface(Base)
+    class BaseType:
+        base_field: strawberry.auto
+
+    @strawberry.experimental.pydantic.type(BranchA)
+    class BranchAType(BaseType):
+        field_a: strawberry.auto
+
+    @strawberry.experimental.pydantic.type(BranchB)
+    class BranchBType(BaseType):
+        field_b: strawberry.auto
+
+    @strawberry.experimental.pydantic.type(User)
+    class UserType:
+        age: strawberry.auto
+        interface_field: strawberry.auto
+
+    definition: StrawberryObjectDefinition = UserType.__strawberry_definition__
+    assert definition.name == "UserType"
+
+    [field1, field2] = definition.fields
+
+    assert field1.python_name == "age"
+    assert field1.type is int
+
+    assert field2.python_name == "interface_field"
+    assert field2.type is BaseType
+
+
+def test_both_output_and_input_type():
+    class Work(pydantic.BaseModel):
+        time: float
+
+    class User(pydantic.BaseModel):
+        name: str
+        # Note that pydantic v2 requires an explicit default of None for Optionals
+        work: Optional[Work] = None
+
+    class Group(pydantic.BaseModel):
+        users: List[User]
+
+    # Test both definition orders
+    @strawberry.experimental.pydantic.input(Work)
+    class WorkInput:
+        time: strawberry.auto
+
+    @strawberry.experimental.pydantic.type(Work)
+    class WorkOutput:
+        time: strawberry.auto
+
+    @strawberry.experimental.pydantic.type(User)
+    class UserOutput:
+        name: strawberry.auto
+        work: strawberry.auto
+
+    @strawberry.experimental.pydantic.input(User)
+    class UserInput:
+        name: strawberry.auto
+        work: strawberry.auto
+
+    @strawberry.experimental.pydantic.input(Group)
+    class GroupInput:
+        users: strawberry.auto
+
+    @strawberry.experimental.pydantic.type(Group)
+    class GroupOutput:
+        users: strawberry.auto
+
+    @strawberry.type
+    class Query:
+        groups: List[GroupOutput]
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        def updateGroup(group: GroupInput) -> GroupOutput:
+            pass
+
+    # This triggers the exception from #1504
+    schema = strawberry.Schema(query=Query, mutation=Mutation)
+    expected_schema = """
+input GroupInput {
+  users: [UserInput!]!
+}
+
+type GroupOutput {
+  users: [UserOutput!]!
+}
+
+type Mutation {
+  updateGroup(group: GroupInput!): GroupOutput!
+}
+
+type Query {
+  groups: [GroupOutput!]!
+}
+
+input UserInput {
+  name: String!
+  work: WorkInput = null
+}
+
+type UserOutput {
+  name: String!
+  work: WorkOutput
+}
+
+input WorkInput {
+  time: Float!
+}
+
+type WorkOutput {
+  time: Float!
+}"""
+    assert schema.as_str().strip() == expected_schema.strip()
+
+    assert Group._strawberry_type == GroupOutput
+    assert Group._strawberry_input_type == GroupInput
+    assert User._strawberry_type == UserOutput
+    assert User._strawberry_input_type == UserInput
+    assert Work._strawberry_type == WorkOutput
+    assert Work._strawberry_input_type == WorkInput
+
+
+def test_single_field_changed_type():
+    class User(pydantic.BaseModel):
+        age: int
+
+    @strawberry.experimental.pydantic.type(User)
+    class UserType:
+        age: str
+
+    definition: StrawberryObjectDefinition = UserType.__strawberry_definition__
+    assert definition.name == "UserType"
+
+    [field1] = definition.fields
+
+    assert field1.python_name == "age"
+    assert field1.graphql_name is None
+    assert field1.type is str
+
+
+def test_type_with_aliased_pydantic_field_changed_type():
+    class UserModel(pydantic.BaseModel):
+        age_: int = pydantic.Field(..., alias="age")
+        password: Optional[str]
+
+    @strawberry.experimental.pydantic.type(UserModel)
+    class User:
+        age_: str
+        password: strawberry.auto
+
+    definition: StrawberryObjectDefinition = User.__strawberry_definition__
+    assert definition.name == "User"
+
+    [field1, field2] = definition.fields
+
+    assert field1.python_name == "age_"
+    assert field1.type is str
+    assert field1.graphql_name == "age"
+
+    assert field2.python_name == "password"
+    assert isinstance(field2.type, StrawberryOptional)
+    assert field2.type.of_type is str
+
+
+def test_deprecated_fields():
+    class User(pydantic.BaseModel):
+        age: int
+        password: Optional[str]
+        other: float
+
+    @strawberry.experimental.pydantic.type(User)
+    class UserType:
+        age: strawberry.auto = strawberry.field(deprecation_reason="Because")
+        password: strawberry.auto
+
+    definition: StrawberryObjectDefinition = UserType.__strawberry_definition__
+    assert definition.name == "UserType"
+
+    [field1, field2] = definition.fields
+
+    assert field1.python_name == "age"
+    assert field1.graphql_name is None
+    assert field1.type is int
+    assert field1.deprecation_reason == "Because"
+
+    assert field2.python_name == "password"
+    assert field2.graphql_name is None
+    assert isinstance(field2.type, StrawberryOptional)
+    assert field2.type.of_type is str
+
+
+def test_permission_classes():
+    class IsAuthenticated(strawberry.BasePermission):
+        message = "User is not authenticated"
+
+        def has_permission(
+            self, source: Any, info: strawberry.types.Info, **kwargs: Any
+        ) -> bool:
+            return False
+
+    class User(pydantic.BaseModel):
+        age: int
+        password: Optional[str]
+        other: float
+
+    @strawberry.experimental.pydantic.type(User)
+    class UserType:
+        age: strawberry.auto = strawberry.field(permission_classes=[IsAuthenticated])
+        password: strawberry.auto
+
+    definition: StrawberryObjectDefinition = UserType.__strawberry_definition__
+    assert definition.name == "UserType"
+
+    [field1, field2] = definition.fields
+
+    assert field1.python_name == "age"
+    assert field1.graphql_name is None
+    assert field1.type is int
+    assert field1.permission_classes == [IsAuthenticated]
+
+    assert field2.python_name == "password"
+    assert field2.graphql_name is None
+    assert isinstance(field2.type, StrawberryOptional)
+    assert field2.type.of_type is str
+
+
+def test_field_directives():
+    @strawberry.schema_directive(locations=[Location.FIELD_DEFINITION])
+    class Sensitive:
+        reason: str
+
+    class User(pydantic.BaseModel):
+        age: int
+        password: Optional[str]
+        other: float
+
+    @strawberry.experimental.pydantic.type(User)
+    class UserType:
+        age: strawberry.auto = strawberry.field(directives=[Sensitive(reason="GDPR")])
+        password: strawberry.auto
+
+    definition: StrawberryObjectDefinition = UserType.__strawberry_definition__
+    assert definition.name == "UserType"
+
+    [field1, field2] = definition.fields
+
+    assert field1.python_name == "age"
+    assert field1.graphql_name is None
+    assert field1.type is int
+    assert field1.directives == [Sensitive(reason="GDPR")]
+
+    assert field2.python_name == "password"
+    assert field2.graphql_name is None
+    assert isinstance(field2.type, StrawberryOptional)
+    assert field2.type.of_type is str
+
+
+def test_alias_fields():
+    class User(pydantic.BaseModel):
+        age: int
+
+    @strawberry.experimental.pydantic.type(User)
+    class UserType:
+        age: strawberry.auto = strawberry.field(name="ageAlias")
+
+    definition: StrawberryObjectDefinition = UserType.__strawberry_definition__
+    assert definition.name == "UserType"
+
+    field1 = definition.fields[0]
+
+    assert field1.python_name == "age"
+    assert field1.graphql_name == "ageAlias"
+    assert field1.type is int
+
+
+def test_alias_fields_with_use_pydantic_alias():
+    class User(pydantic.BaseModel):
+        age: int
+        state: str = pydantic.Field(alias="statePydantic")
+        country: str = pydantic.Field(alias="countryPydantic")
+
+    @strawberry.experimental.pydantic.type(User, use_pydantic_alias=True)
+    class UserType:
+        age: strawberry.auto = strawberry.field(name="ageAlias")
+        state: strawberry.auto = strawberry.field(name="state")
+        country: strawberry.auto
+
+    definition: StrawberryObjectDefinition = UserType.__strawberry_definition__
+    assert definition.name == "UserType"
+
+    [field1, field2, field3] = definition.fields
+
+    assert field1.python_name == "age"
+    assert field1.graphql_name == "ageAlias"
+
+    assert field2.python_name == "state"
+    assert field2.graphql_name == "state"
+
+    assert field3.python_name == "country"
+    assert field3.graphql_name == "countryPydantic"
+
+
+def test_field_metadata():
+    class User(pydantic.BaseModel):
+        private: bool
+        public: bool
+
+    @strawberry.experimental.pydantic.type(User)
+    class UserType:
+        private: strawberry.auto = strawberry.field(metadata={"admin_only": True})
+        public: strawberry.auto
+
+    definition: StrawberryObjectDefinition = UserType.__strawberry_definition__
+    assert definition.name == "UserType"
+
+    [field1, field2] = definition.fields
+
+    assert field1.python_name == "private"
+    assert field1.metadata["admin_only"]
+
+    assert field2.python_name == "public"
+    assert not field2.metadata
+
+
+def test_annotated():
+    class User(pydantic.BaseModel):
+        a: Annotated[int, "metadata"]
+
+    @strawberry.experimental.pydantic.input(User, all_fields=True)
+    class UserType:
+        pass
+
+    definition: StrawberryObjectDefinition = UserType.__strawberry_definition__
+    assert definition.name == "UserType"
+
+    [field] = definition.fields
+    assert field.python_name == "a"
+    assert field.type is int
+
+
+def test_nested_annotated():
+    class User(pydantic.BaseModel):
+        a: Optional[Annotated[int, "metadata"]]
+        b: Optional[List[Annotated[int, "metadata"]]]
+
+    @strawberry.experimental.pydantic.input(User, all_fields=True)
+    class UserType:
+        pass
+
+    definition: StrawberryObjectDefinition = UserType.__strawberry_definition__
+    assert definition.name == "UserType"
+
+    [field_a, field_b] = definition.fields
+    assert field_a.python_name == "a"
+    assert isinstance(field_a.type, StrawberryOptional)
+    assert field_a.type.of_type is int
+
+    assert field_b.python_name == "b"
+    assert isinstance(field_b.type, StrawberryOptional)
+    assert isinstance(field_b.type.of_type, StrawberryList)
+    assert field_b.type.of_type.of_type is int


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

Initial work that allows you to use pydantic classes out of the box, without converting it into a strawberry dataclass type.

What works
- Basic usage of just using the pydantic type as an input / output

What doesn't work (Alot of things, don't use this yet)
- Directives
- Strawberry fields
- Resolvers

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
