### PR TITLE
change: parse query params to use parse_json

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Fixed the base view so it uses `parse_json` when loading parameters from the query string instead of `json.loads`.

--- a/strawberry/http/async_base_view.py
+++ b/strawberry/http/async_base_view.py
@@ -217,7 +217,7 @@ class AsyncBaseHTTPView(
 
         return GraphQLRequestData(
             query=data.get("query"),
-            variables=data.get("variables"),  # type: ignore
+            variables=data.get("variables"),
             operation_name=data.get("operationName"),
         )
 

--- a/strawberry/http/base.py
+++ b/strawberry/http/base.py
@@ -44,7 +44,7 @@ class BaseView(Generic[Request]):
     def is_request_allowed(self, request: BaseRequestProtocol) -> bool:
         return request.method in ("GET", "POST")
 
-    def parse_json(self, data: Union[str, bytes]) -> Dict[str, str]:
+    def parse_json(self, data: Union[str, bytes]) -> Any:
         try:
             return json.loads(data)
         except json.JSONDecodeError as e:
@@ -65,7 +65,7 @@ class BaseView(Generic[Request]):
                 variables = variables[0]
 
             if variables:
-                params["variables"] = json.loads(variables)
+                params["variables"] = self.parse_json(variables)
 
         return params
 

--- a/strawberry/http/sync_base_view.py
+++ b/strawberry/http/sync_base_view.py
@@ -157,7 +157,7 @@ class SyncBaseHTTPView(
 
         return GraphQLRequestData(
             query=data.get("query"),
-            variables=data.get("variables"),  # type: ignore
+            variables=data.get("variables"),
             operation_name=data.get("operationName"),
         )
 


### PR DESCRIPTION
## Description

Updated the base view generic to also use `parse_json` when loading parameters from the query string. It makes overriding easier / centralized to the `parse_json` and `encode_json` functions.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
