### PR TITLE
Add a way to filter fields

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,33 @@
+Release type: minor
+
+This release adds a new method `get_fields` on the `Schema` class.
+You can use `get_fields` to hide certain field based on some conditions,
+for example:
+
+```python
+@strawberry.type
+class User:
+    name: str
+    email: str = strawberry.field(metadata={"tags": ["internal"]})
+
+
+@strawberry.type
+class Query:
+    user: User
+
+
+def public_field_filter(field: StrawberryField) -> bool:
+    return "internal" not in field.metadata.get("tags", [])
+
+
+class PublicSchema(strawberry.Schema):
+    def get_fields(
+        self, type_definition: StrawberryObjectDefinition
+    ) -> List[StrawberryField]:
+        return list(filter(public_field_filter, type_definition.fields))
+
+
+schema = PublicSchema(query=Query)
+```
+
+The schema here would only have the `name` field on the `User` type.

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -100,7 +100,9 @@ class Schema(BaseSchema):
             # TODO: check that the overrides are valid
             scalar_registry.update(cast(SCALAR_OVERRIDES_DICT_TYPE, scalar_overrides))
 
-        self.schema_converter = GraphQLCoreConverter(self.config, scalar_registry)
+        self.schema_converter = GraphQLCoreConverter(
+            self.config, scalar_registry, self.get_fields
+        )
         self.directives = directives
         self.schema_directives = list(schema_directives)
 
@@ -230,6 +232,11 @@ class Schema(BaseSchema):
             ),
             None,
         )
+
+    def get_fields(
+        self, type_definition: StrawberryObjectDefinition
+    ) -> List[StrawberryField]:
+        return type_definition.fields
 
     async def execute(
         self,

--- a/tests/pyright/test_federation.py
+++ b/tests/pyright/test_federation.py
@@ -29,13 +29,13 @@ def test_federation_type():
     results = run_pyright(CODE)
 
     assert results == [
-        Result(type="error", message='No parameter named "n"', line=16, column=6),
         Result(
             type="error",
             message='Argument missing for parameter "name"',
             line=16,
             column=1,
         ),
+        Result(type="error", message='No parameter named "n"', line=16, column=6),
         Result(
             type="information",
             message='Type of "User" is "type[User]"',
@@ -75,15 +75,15 @@ def test_federation_interface():
     assert results == [
         Result(
             type="error",
-            message='No parameter named "n"',
-            line=12,
-            column=6,
-        ),
-        Result(
-            type="error",
             message='Argument missing for parameter "name"',
             line=12,
             column=1,
+        ),
+        Result(
+            type="error",
+            message='No parameter named "n"',
+            line=12,
+            column=6,
         ),
         Result(
             type="information",
@@ -122,15 +122,15 @@ def test_federation_input():
     assert results == [
         Result(
             type="error",
-            message='No parameter named "n"',
-            line=10,
-            column=6,
-        ),
-        Result(
-            type="error",
             message='Argument missing for parameter "name"',
             line=10,
             column=1,
+        ),
+        Result(
+            type="error",
+            message='No parameter named "n"',
+            line=10,
+            column=6,
         ),
         Result(
             type="information",

--- a/tests/pyright/test_federation_fields.py
+++ b/tests/pyright/test_federation_fields.py
@@ -44,6 +44,12 @@ def test_pyright():
     assert results == [
         Result(
             type="error",
+            message='Argument missing for parameter "name"',
+            line=24,
+            column=1,
+        ),
+        Result(
+            type="error",
             message='No parameter named "n"',
             line=24,
             column=6,
@@ -51,7 +57,7 @@ def test_pyright():
         Result(
             type="error",
             message='Argument missing for parameter "name"',
-            line=24,
+            line=27,
             column=1,
         ),
         Result(
@@ -59,12 +65,6 @@ def test_pyright():
             message='No parameter named "n"',
             line=27,
             column=11,
-        ),
-        Result(
-            type="error",
-            message='Argument missing for parameter "name"',
-            line=27,
-            column=1,
         ),
         Result(
             type="information",

--- a/tests/pyright/test_federation_params.py
+++ b/tests/pyright/test_federation_params.py
@@ -23,14 +23,14 @@ def test_pyright():
     assert results == [
         Result(
             type="error",
-            message='No parameter named "n"',
-            line=11,
-            column=11,
-        ),
-        Result(
-            type="error",
             message='Argument missing for parameter "name"',
             line=11,
             column=1,
+        ),
+        Result(
+            type="error",
+            message='No parameter named "n"',
+            line=11,
+            column=11,
         ),
     ]

--- a/tests/pyright/test_fields.py
+++ b/tests/pyright/test_fields.py
@@ -26,15 +26,15 @@ def test_pyright():
     assert results == [
         Result(
             type="error",
-            message='No parameter named "n"',
-            line=11,
-            column=6,
-        ),
-        Result(
-            type="error",
             message='Argument missing for parameter "name"',
             line=11,
             column=1,
+        ),
+        Result(
+            type="error",
+            message='No parameter named "n"',
+            line=11,
+            column=6,
         ),
         Result(
             type="information",

--- a/tests/pyright/test_fields_input.py
+++ b/tests/pyright/test_fields_input.py
@@ -25,15 +25,15 @@ def test_pyright():
     assert results == [
         Result(
             type="error",
-            message='No parameter named "n"',
-            line=11,
-            column=6,
-        ),
-        Result(
-            type="error",
             message='Argument missing for parameter "name"',
             line=11,
             column=1,
+        ),
+        Result(
+            type="error",
+            message='No parameter named "n"',
+            line=11,
+            column=6,
         ),
         Result(
             type="information",

--- a/tests/pyright/test_fields_resolver.py
+++ b/tests/pyright/test_fields_resolver.py
@@ -29,15 +29,15 @@ def test_pyright():
     assert results == [
         Result(
             type="error",
-            message='No parameter named "n"',
-            line=15,
-            column=6,
-        ),
-        Result(
-            type="error",
             message='Argument missing for parameter "name"',
             line=15,
             column=1,
+        ),
+        Result(
+            type="error",
+            message='No parameter named "n"',
+            line=15,
+            column=6,
         ),
         Result(
             type="information",

--- a/tests/pyright/test_fields_resolver_async.py
+++ b/tests/pyright/test_fields_resolver_async.py
@@ -29,15 +29,15 @@ def test_pyright():
     assert results == [
         Result(
             type="error",
-            message='No parameter named "n"',
-            line=15,
-            column=6,
-        ),
-        Result(
-            type="error",
             message='Argument missing for parameter "name"',
             line=15,
             column=1,
+        ),
+        Result(
+            type="error",
+            message='No parameter named "n"',
+            line=15,
+            column=6,
         ),
         Result(
             type="information",

--- a/tests/pyright/test_params.py
+++ b/tests/pyright/test_params.py
@@ -31,12 +31,6 @@ def test_pyright():
     assert results == [
         Result(
             type="error",
-            message='No parameter named "n"',
-            line=16,
-            column=11,
-        ),
-        Result(
-            type="error",
             message='Argument missing for parameter "name"',
             line=16,
             column=1,
@@ -44,7 +38,7 @@ def test_pyright():
         Result(
             type="error",
             message='No parameter named "n"',
-            line=19,
+            line=16,
             column=11,
         ),
         Result(
@@ -52,5 +46,11 @@ def test_pyright():
             message='Argument missing for parameter "name"',
             line=19,
             column=1,
+        ),
+        Result(
+            type="error",
+            message='No parameter named "n"',
+            line=19,
+            column=11,
         ),
     ]

--- a/tests/pyright/test_private.py
+++ b/tests/pyright/test_private.py
@@ -27,15 +27,15 @@ def test_pyright():
     assert results == [
         Result(
             type="error",
-            message='No parameter named "n"',
-            line=12,
-            column=6,
-        ),
-        Result(
-            type="error",
             message='Arguments missing for parameters "name", "age"',
             line=12,
             column=1,
+        ),
+        Result(
+            type="error",
+            message='No parameter named "n"',
+            line=12,
+            column=6,
         ),
         Result(
             type="information",

--- a/tests/pyright/utils.py
+++ b/tests/pyright/utils.py
@@ -70,7 +70,7 @@ def run_pyright(code: str, strict: bool = True) -> List[Result]:
 
     pyright_result: PyrightCLIResult = json.loads(process_result.stdout.decode("utf-8"))
 
-    return [
+    result = [
         Result(
             type=cast(ResultType, diagnostic["severity"].strip()),
             message=diagnostic["message"].strip(),
@@ -79,6 +79,11 @@ def run_pyright(code: str, strict: bool = True) -> List[Result]:
         )
         for diagnostic in pyright_result["generalDiagnostics"]
     ]
+
+    # make sure that results are sorted by line and column and then message
+    result.sort(key=lambda x: (x.line, x.column, x.message))
+
+    return result
 
 
 def pyright_exist() -> bool:

--- a/tests/schema/test_schema_hooks.py
+++ b/tests/schema/test_schema_hooks.py
@@ -23,7 +23,8 @@ def test_can_change_which_fields_are_exposed():
         def get_fields(
             self, type_definition: StrawberryObjectDefinition
         ) -> List[StrawberryField]:
-            return list(filter(public_field_filter, type_definition.fields))
+            fields = super().get_fields(type_definition)
+            return list(filter(public_field_filter, fields))
 
     schema = PublicSchema(query=Query)
 

--- a/tests/schema/test_schema_hooks.py
+++ b/tests/schema/test_schema_hooks.py
@@ -1,0 +1,42 @@
+import textwrap
+from typing import List
+
+import strawberry
+from strawberry.field import StrawberryField
+from strawberry.types.types import StrawberryObjectDefinition
+
+
+def test_can_change_which_fields_are_exposed():
+    @strawberry.type
+    class User:
+        name: str
+        email: str = strawberry.field(metadata={"tags": ["internal"]})
+
+    @strawberry.type
+    class Query:
+        user: User
+
+    def public_field_filter(field: StrawberryField) -> bool:
+        return "internal" not in field.metadata.get("tags", [])
+
+    class PublicSchema(strawberry.Schema):
+        def get_fields(
+            self, type_definition: StrawberryObjectDefinition
+        ) -> List[StrawberryField]:
+            return list(filter(public_field_filter, type_definition.fields))
+
+    schema = PublicSchema(query=Query)
+
+    expected_schema = textwrap.dedent(
+        """
+        type Query {
+          user: User!
+        }
+
+        type User {
+          name: String!
+        }
+        """
+    ).strip()
+
+    assert schema.as_str() == expected_schema


### PR DESCRIPTION
This is a POC for allowing to filter/extend fields from the GraphQL schema, it came from this discord conversation: https://discord.com/channels/689806334337482765/1180117357943853116/1180117357943853116


I think it would be cool to allow filtering, but not sure if this is the nicest way (I don't like having to pass that function around), maybe we could think about using the schema config?

/cc @erikwrede @bellini666 @jkimbo for opinions 😊