### PR TITLE
feat: support union operator on BasePermission

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,22 @@
+Release type: minor
+
+Permissions can now be combined with the `|` operator to require the user pass _either_ of the `has_permission` checks:
+
+```python
+import strawberry
+from strawberry.permission import PermissionExtension
+
+
+@strawberry.type
+class User:
+    @strawberry.field(
+        extensions=[
+            PermissionExtension(
+                # require auth AND (node is current user OR current user is staff)
+                permissions=[IsAuthenticated(), IsExactUser() | IsStaff()]
+            )
+        ]
+    )
+    def ssn(self) -> str:
+        return "555-55-5555"
+```

--- a/docs/guides/permissions.md
+++ b/docs/guides/permissions.md
@@ -204,6 +204,29 @@ To customize the error handling, the `on_unauthorized` method on
 the `BasePermission` class can be used. Further changes can be implemented by
 subclassing the `PermissionExtension` class.
 
+## `|` operator support
+
+Permissions can be combined with the `|` operator to require the user pass _either_ of the `has_permission` checks:
+
+```python
+import strawberry
+from strawberry.permission import PermissionExtension
+
+
+@strawberry.type
+class User:
+    @strawberry.field(
+        extensions=[
+            PermissionExtension(
+                # require auth AND (node is current user OR current user is staff)
+                permissions=[IsAuthenticated(), IsExactUser() | IsStaff()]
+            )
+        ]
+    )
+    def ssn(self) -> str:
+        return "555-55-5555"
+```
+
 ## Schema Directives
 
 Permissions will automatically be added as schema directives to the schema. This

--- a/strawberry/permission.py
+++ b/strawberry/permission.py
@@ -100,6 +100,9 @@ class OrPermission(BasePermission):
     failed_permission: Optional[BasePermission] = None
 
     def __init__(self, permissions: Tuple[BasePermission, ...]):
+        if not permissions:
+            raise ValueError("At least one permission is required")
+
         self.permissions = permissions
 
         messages = [p.message for p in permissions if p.message]

--- a/tests/schema/test_permission.py
+++ b/tests/schema/test_permission.py
@@ -510,7 +510,7 @@ def test_silent_permissions_incompatible_types():
     strawberry.Schema(query=Query)
 
 
-def test_permission_directives_added():
+def test_base_permission_directives_added():
     class IsAuthorized(BasePermission):
         message = "User is not authorized"
 
@@ -532,6 +532,39 @@ def test_permission_directives_added():
 
     type Query {
       name: String! @isAuthorized
+    }
+    """
+    assert print_schema(schema) == textwrap.dedent(expected_output).strip()
+
+
+def test_or_permission_directives_added():
+    class AllowedPermission(BasePermission):
+        message = "Allowed"
+
+        def has_permission(self, source, info, **kwargs: typing.Any):
+            return True
+
+    class DeniedPermission(BasePermission):
+        message = "Denied"
+
+        def has_permission(self, source, info, **kwargs: typing.Any):
+            return False
+
+    @strawberry.type
+    class Query:
+        @strawberry.field(
+            extensions=[PermissionExtension([AllowedPermission() | DeniedPermission()])]
+        )
+        def name(self) -> str:  # pragma: no cover
+            return "ABC"
+
+    schema = strawberry.Schema(query=Query)
+
+    expected_output = """
+    directive @allowedPermissionOrDeniedPermission on FIELD_DEFINITION
+
+    type Query {
+      name: String! @allowedPermissionOrDeniedPermission
     }
     """
     assert print_schema(schema) == textwrap.dedent(expected_output).strip()

--- a/tests/test_permission.py
+++ b/tests/test_permission.py
@@ -1,0 +1,74 @@
+from typing import Any
+
+from strawberry.permission import BasePermission
+from strawberry.types import Info
+
+
+def test_or_permission_condition():
+    class AllowedPermission(BasePermission):
+        message = "Allowed"
+
+        def has_permission(self, source: Any, info: Info, **kwargs: Any):
+            return True
+
+    class DeniedPermission(BasePermission):
+        message = "Denied"
+
+        def has_permission(self, source: Any, info: Info, **kwargs: Any):
+            return False
+
+    class IsAuthenticated(BasePermission):
+        message = "User is not authenticated"
+
+        def has_permission(self, source: Any, info: Info, **kwargs: Any):
+            return False
+
+    # cases with all `has_permission(...) == False` should deny on the last
+    denied_permission = DeniedPermission()
+    not_a_or_not_b = IsAuthenticated() | denied_permission
+    assert not_a_or_not_b.has_permission(None, None) is False
+    assert not_a_or_not_b.message == denied_permission.message
+    assert not_a_or_not_b.on_unauthorized == denied_permission.on_unauthorized
+
+    # cases with any true should allow
+    not_a_or_b = DeniedPermission() | AllowedPermission()
+    a_or_not_b = AllowedPermission() | DeniedPermission()
+    a_or_b = AllowedPermission() | AllowedPermission()
+    assert not_a_or_b.has_permission(None, None) is True
+    assert a_or_not_b.has_permission(None, None) is True
+    assert a_or_b.has_permission(None, None) is True
+
+
+def test_or_permission_async_to_sync():
+    class AllowedPermission(BasePermission):
+        message = "Allowed"
+
+        def has_permission(self, source: Any, info: Info, **kwargs: Any):
+            return True
+
+    class DeniedPermission(BasePermission):
+        message = "Denied"
+
+        async def has_permission(self, source: Any, info: Info, **kwargs: Any):
+            return False
+
+    class IsAuthenticated(BasePermission):
+        message = "User is not authenticated"
+
+        def has_permission(self, source: Any, info: Info, **kwargs: Any):
+            return False
+
+    # cases with all `has_permission(...) == False` should deny on the last
+    denied_permission = DeniedPermission()
+    not_a_or_not_b = IsAuthenticated() | denied_permission
+    assert not_a_or_not_b.has_permission(None, None) is False
+    assert not_a_or_not_b.message == denied_permission.message
+    assert not_a_or_not_b.on_unauthorized == denied_permission.on_unauthorized
+
+    # cases with any true should allow
+    not_a_or_b = DeniedPermission() | AllowedPermission()
+    a_or_not_b = AllowedPermission() | DeniedPermission()
+    a_or_b = AllowedPermission() | AllowedPermission()
+    assert not_a_or_b.has_permission(None, None) is True
+    assert a_or_not_b.has_permission(None, None) is True
+    assert a_or_b.has_permission(None, None) is True


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

 _**👉 tl;dr:**_ Lets you use `|` between permission instances, e.g. `is_cool_color = IsBlue() | IsGreen()`

- Added: `BasePermission.__or__` instance method, which returns an `OrPermission` instance
- Added: `OrPermission`, inheriting from `BasePermission`
  - `__init__` takes a tuple of `BasePermission` instances to be evaluated
  - `has_permission` returns `True` as long as `has_permission` returns `True` from any of its input permissions
  - `message` and `on_unauthorized` refer to the last failed permission
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

- closes #2350
  - Per the discussion I am also into [DRF's OperandHolder pattern](https://github.com/encode/django-rest-framework/blob/0f39e0124d358b0098261f070175fa8e0359b739/rest_framework/permissions.py#L11). If folks are strongly opinionated I can take a stab at that instead

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
  - Also fully tested on the job 👍 
