### PR TITLE
Use asyncio.run instead of asgiref for benchmarks

### DIFF
--- a/tests/benchmarks/test_execute.py
+++ b/tests/benchmarks/test_execute.py
@@ -1,10 +1,10 @@
+import asyncio
 import datetime
 import random
 from datetime import date
 from typing import List, Type, cast
 
 import pytest
-from asgiref.sync import async_to_sync
 from pytest_codspeed.plugin import BenchmarkFixture
 
 import strawberry
@@ -72,7 +72,10 @@ def test_execute(benchmark: BenchmarkFixture):
         }
     """
 
-    benchmark(async_to_sync(schema.execute), query)
+    def run():
+        return asyncio.run(schema.execute(query))
+
+    benchmark(run)
 
 
 @pytest.mark.parametrize("ntypes", [2**k for k in range(0, 13, 4)])
@@ -92,10 +95,16 @@ def test_interface_performance(benchmark: BenchmarkFixture, ntypes: int):
     schema = strawberry.Schema(query=Query, types=CONCRETE_TYPES)
     query = "query { items { id } }"
 
-    benchmark(
-        async_to_sync(schema.execute),
-        query,
-        root_value=Query(
-            items=[CONCRETE_TYPES[i % ntypes](id=cast(ID, i)) for i in range(1000)]
-        ),
-    )
+    def run():
+        return asyncio.run(
+            schema.execute(
+                query,
+                root_value=Query(
+                    items=[
+                        CONCRETE_TYPES[i % ntypes](id=cast(ID, i)) for i in range(1000)
+                    ]
+                ),
+            )
+        )
+
+    benchmark(run)


### PR DESCRIPTION
This makes the traces easier to read