### PR TITLE
Fix usage with default and default_factory arguments

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: minor
+
+Fix using strawberry with default or default_factory (dataclasses basics)

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -221,7 +221,15 @@ class StrawberryField(dataclasses.Field):
         if self.base_resolver:
             return self.base_resolver(*args, **kwargs)
 
-        return self.default_resolver(source, self.python_name)
+        try:
+            return self.default_resolver(source, self.python_name)
+        except AttributeError as exc:
+            # fallback if source is not available or is not an proper instance
+            if self.default:
+                return self.default
+            if self.default_factory:
+                return self.default_factory()
+            raise exc
 
     @property
     def is_basic_field(self) -> bool:

--- a/tests/schema/test_basic.py
+++ b/tests/schema/test_basic.py
@@ -580,3 +580,43 @@ def test_kw_only():
             FooBar(foo=1)
         FooBar(bar=2)
         FooBar(foo=1, bar=2)
+
+
+def test_use_default_factory_on_root():
+    @strawberry.type
+    class Sub:
+        foo: str = strawberry.field(default="bar")
+
+    @strawberry.type
+    class Query:
+        sub: Sub = strawberry.field(default_factory=Sub)
+
+    schema = strawberry.Schema(query=Query)
+
+    result = schema.execute_sync(
+        """
+        query TestQuery{
+            sub {
+                foo
+            }
+        }
+        """
+    )
+    assert result.data == {"sub": {"foo": "bar"}}
+
+
+def test_use_default_on_root():
+    @strawberry.type
+    class Query:
+        sub: bool = strawberry.field(default=True)
+
+    schema = strawberry.Schema(query=Query)
+
+    result = schema.execute_sync(
+        """
+        query TestQuery{
+            sub
+        }
+        """
+    )
+    assert result.data == {"sub": True}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Currently it is not always possible to use the default and default_factory argument on strawberry.field.
It fails randomly and especially on root Query
This PR fixes the issue.


## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
