### PR TITLE
Ignore additional payload data in ws

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,7 @@
+Release type: patch
+
+This release fixes a small issue in the GraphQL Transport websocket
+where the connection would fail when receiving extra parameters
+in the payload sent from the client.
+
+This would happen when using Apollo Sandbox.

--- a/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
@@ -138,7 +138,15 @@ class BaseGraphQLTransportWSHandler(ABC):
 
             elif message_type == SubscribeMessage.type:
                 handler = self.handle_subscribe
-                payload = SubscribeMessagePayload(**message.pop("payload"))
+
+                payload_args = message.pop("payload")
+
+                payload = SubscribeMessagePayload(
+                    query=payload_args["query"],
+                    operationName=payload_args.get("operationName"),
+                    variables=payload_args.get("variables"),
+                    extensions=payload_args.get("extensions"),
+                )
                 handler_arg = SubscribeMessage(payload=payload, **message)
 
             elif message_type == CompleteMessage.type:


### PR DESCRIPTION
I found this issue while using subscriptions in Apollo sandbox,
basically sandbox was sending additional payload data 😊

![CleanShot 2024-01-23 at 22 55 24@2x](https://github.com/strawberry-graphql/strawberry/assets/667029/79fb8de1-8bbb-4cd7-b154-521f630d9116)

