### PR TITLE
Move Strawberry config to a typed dict

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: major
+
+Make schema config parameter a TypedDict

--- a/docs/types/schema-configurations.md
+++ b/docs/types/schema-configurations.md
@@ -13,15 +13,13 @@ example below:
 ```python
 import strawberry
 
-from strawberry.schema.config import StrawberryConfig
-
 
 @strawberry.type
 class Query:
     example_field: str
 
 
-schema = strawberry.Schema(query=Query, config=StrawberryConfig(auto_camel_case=False))
+schema = strawberry.Schema(query=Query, config={"auto_camel_case": False})
 ```
 
 In this case we are disabling the auto camel casing feature, so your output schema

--- a/strawberry/codemods/schema_config.py
+++ b/strawberry/codemods/schema_config.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import libcst as cst
+import libcst.matchers as m
+from libcst._nodes.expression import BaseExpression  # noqa: TCH002
+from libcst.codemod import VisitorBasedCodemodCommand
+from libcst.codemod.visitors import RemoveImportsVisitor
+
+
+class ConvertStrawberryConfigToDict(VisitorBasedCodemodCommand):
+    DESCRIPTION: str = "Converts StrawberryConfig(...) to dict"
+
+    @m.leave(m.Call(func=m.Name("StrawberryConfig")))
+    def leave_strawberry_config_call(
+        self, original_node: cst.Call, _: cst.Call
+    ) -> BaseExpression:
+        RemoveImportsVisitor.remove_unused_import(
+            self.context, "strawberry.schema.config", "StrawberryConfig"
+        )
+        return cst.Call(func=cst.Name(value="dict"), args=original_node.args)

--- a/strawberry/federation/schema.py
+++ b/strawberry/federation/schema.py
@@ -43,7 +43,7 @@ if TYPE_CHECKING:
     from strawberry.enum import EnumDefinition
     from strawberry.extensions import SchemaExtension
     from strawberry.federation.schema_directives import ComposeDirective
-    from strawberry.schema.config import StrawberryConfig
+    from strawberry.schema.config import StrawberryConfigDict
     from strawberry.schema.types.concrete_type import TypeMap
     from strawberry.schema_directive import StrawberrySchemaDirective
     from strawberry.union import StrawberryUnion
@@ -60,7 +60,7 @@ class Schema(BaseSchema):
         types: Iterable[Type] = (),
         extensions: Iterable[Union[Type["SchemaExtension"], "SchemaExtension"]] = (),
         execution_context_class: Optional[Type["GraphQLExecutionContext"]] = None,
-        config: Optional["StrawberryConfig"] = None,
+        config: Optional["StrawberryConfigDict"] = None,
         scalar_overrides: Optional[
             Dict[object, Union[Type, "ScalarWrapper", "ScalarDefinition"]]
         ] = None,

--- a/strawberry/schema/config.py
+++ b/strawberry/schema/config.py
@@ -1,9 +1,16 @@
 from __future__ import annotations
 
 from dataclasses import InitVar, dataclass, field
-from typing import Any, Callable
+from typing import Any, Callable, TypedDict
 
 from .name_converter import NameConverter
+
+
+class StrawberryConfigDict(TypedDict, total=False):
+    auto_camel_case: bool
+    name_converter: NameConverter
+    default_resolver: Callable[[Any, str], object]
+    relay_max_results: int
 
 
 @dataclass
@@ -19,3 +26,9 @@ class StrawberryConfig:
     ):
         if auto_camel_case is not None:
             self.name_converter.auto_camel_case = auto_camel_case
+
+    @classmethod
+    def from_dict(cls, data: StrawberryConfigDict | None) -> StrawberryConfig:
+        if not data:
+            return cls()
+        return cls(**data)

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -54,6 +54,7 @@ if TYPE_CHECKING:
     from strawberry.enum import EnumDefinition
     from strawberry.extensions import SchemaExtension
     from strawberry.field import StrawberryField
+    from strawberry.schema.config import StrawberryConfigDict
     from strawberry.type import StrawberryType
     from strawberry.types import ExecutionResult
     from strawberry.union import StrawberryUnion
@@ -77,7 +78,7 @@ class Schema(BaseSchema):
         types: Iterable[Union[Type, StrawberryType]] = (),
         extensions: Iterable[Union[Type[SchemaExtension], SchemaExtension]] = (),
         execution_context_class: Optional[Type[GraphQLExecutionContext]] = None,
-        config: Optional[StrawberryConfig] = None,
+        config: Optional[StrawberryConfigDict] = None,
         scalar_overrides: Optional[
             Dict[object, Union[Type, ScalarWrapper, ScalarDefinition]]
         ] = None,
@@ -89,7 +90,7 @@ class Schema(BaseSchema):
 
         self.extensions = extensions
         self.execution_context_class = execution_context_class
-        self.config = config or StrawberryConfig()
+        self.config = StrawberryConfig.from_dict(config)
 
         SCALAR_OVERRIDES_DICT_TYPE = Dict[
             object, Union["ScalarWrapper", "ScalarDefinition"]

--- a/tests/codemods/test_schema_config.py
+++ b/tests/codemods/test_schema_config.py
@@ -1,0 +1,123 @@
+from libcst.codemod import CodemodTest
+
+from strawberry.codemods.schema_config import ConvertStrawberryConfigToDict
+
+
+class TestConvertConstantCommand(CodemodTest):
+    TRANSFORM = ConvertStrawberryConfigToDict
+
+    def test_update_config(self) -> None:
+        before = """
+            import strawberry
+            from strawberry.schema.config import StrawberryConfig
+
+            schema = strawberry.Schema(
+                query=Query, config=StrawberryConfig(auto_camel_case=False)
+            )
+        """
+
+        after = """
+            import strawberry
+
+            schema = strawberry.Schema(
+                query=Query, config=dict(auto_camel_case=False)
+            )
+        """
+
+        self.assertCodemod(
+            before,
+            after,
+        )
+
+    def test_update_config_default(self) -> None:
+        before = """
+            import strawberry
+            from strawberry.schema.config import StrawberryConfig
+
+            schema = strawberry.Schema(
+                query=Query, config=StrawberryConfig()
+            )
+        """
+
+        after = """
+            import strawberry
+
+            schema = strawberry.Schema(
+                query=Query, config=dict()
+            )
+        """
+
+        self.assertCodemod(
+            before,
+            after,
+        )
+
+    def test_update_config_with_two_args(self) -> None:
+        before = """
+            import strawberry
+            from strawberry.schema.config import StrawberryConfig
+
+            schema = strawberry.Schema(
+                query=Query,
+                config=StrawberryConfig(auto_camel_case=True, default_resolver=getitem)
+            )
+        """
+
+        after = """
+            import strawberry
+
+            schema = strawberry.Schema(
+                query=Query,
+                config=dict(auto_camel_case=True, default_resolver=getitem)
+            )
+        """
+
+        self.assertCodemod(
+            before,
+            after,
+        )
+
+    def test_update_config_declared_outside(self) -> None:
+        before = """
+            import strawberry
+            from strawberry.schema.config import StrawberryConfig
+
+            config = StrawberryConfig(auto_camel_case=True, default_resolver=getitem)
+
+            schema = strawberry.Schema(
+                query=Query,
+                config=config
+            )
+        """
+
+        after = """
+            import strawberry
+
+            config = dict(auto_camel_case=True, default_resolver=getitem)
+
+            schema = strawberry.Schema(
+                query=Query,
+                config=config
+            )
+        """
+
+        self.assertCodemod(
+            before,
+            after,
+        )
+
+    def test_update_config_declared_outside_not_used_in_module(self) -> None:
+        before = """
+            from strawberry.schema.config import StrawberryConfig
+
+            config = StrawberryConfig(auto_camel_case=True, default_resolver=getitem)
+        """
+
+        after = """
+            config = dict(auto_camel_case=True, default_resolver=getitem)
+        """
+
+        self.assertCodemod(
+            before,
+            after,
+        )

--- a/tests/schema/test_camel_casing.py
+++ b/tests/schema/test_camel_casing.py
@@ -1,5 +1,4 @@
 import strawberry
-from strawberry.schema.config import StrawberryConfig
 
 
 def test_camel_case_is_on_by_default():
@@ -30,9 +29,7 @@ def test_can_set_camel_casing():
     class Query:
         example_field: str = "Example"
 
-    schema = strawberry.Schema(
-        query=Query, config=StrawberryConfig(auto_camel_case=True)
-    )
+    schema = strawberry.Schema(query=Query, config={"auto_camel_case": True})
 
     query = """
         {
@@ -55,9 +52,7 @@ def test_can_set_camel_casing_to_false():
     class Query:
         example_field: str = "Example"
 
-    schema = strawberry.Schema(
-        query=Query, config=StrawberryConfig(auto_camel_case=False)
-    )
+    schema = strawberry.Schema(query=Query, config={"auto_camel_case": False})
 
     query = """
         {
@@ -80,9 +75,7 @@ def test_can_set_camel_casing_to_false_uses_name():
     class Query:
         example_field: str = strawberry.field(name="exampleField")
 
-    schema = strawberry.Schema(
-        query=Query, config=StrawberryConfig(auto_camel_case=False)
-    )
+    schema = strawberry.Schema(query=Query, config={"auto_camel_case": False})
 
     query = """
         {
@@ -107,9 +100,7 @@ def test_can_set_camel_casing_to_false_uses_name_field_decorator():
         def example_field(self) -> str:
             return "ABC"
 
-    schema = strawberry.Schema(
-        query=Query, config=StrawberryConfig(auto_camel_case=False)
-    )
+    schema = strawberry.Schema(query=Query, config={"auto_camel_case": False})
 
     query = """
         {
@@ -162,9 +153,7 @@ def test_can_turn_camel_case_off_arguments():
         def example_field(self, example_input: str) -> str:
             return example_input
 
-    schema = strawberry.Schema(
-        query=Query, config=StrawberryConfig(auto_camel_case=False)
-    )
+    schema = strawberry.Schema(query=Query, config={"auto_camel_case": False})
 
     query = """
         {
@@ -192,9 +181,7 @@ def test_can_turn_camel_case_off_arguments_conversion_works():
         def example_field(self, example_input: str) -> str:
             return example_input
 
-    schema = strawberry.Schema(
-        query=Query, config=StrawberryConfig(auto_camel_case=False)
-    )
+    schema = strawberry.Schema(query=Query, config={"auto_camel_case": False})
 
     query = """
         {

--- a/tests/schema/test_directives.py
+++ b/tests/schema/test_directives.py
@@ -7,7 +7,6 @@ import pytest
 import strawberry
 from strawberry.directive import DirectiveLocation, DirectiveValue
 from strawberry.extensions import SchemaExtension
-from strawberry.schema.config import StrawberryConfig
 from strawberry.type import get_object_definition
 from strawberry.types.info import Info
 from strawberry.utils.await_maybe import await_maybe
@@ -224,7 +223,7 @@ def test_runs_directives_camel_case_off():
     schema = strawberry.Schema(
         query=Query,
         directives=[turn_uppercase, replace],
-        config=StrawberryConfig(auto_camel_case=False),
+        config={"auto_camel_case": False},
     )
 
     query = """query People($identified: Boolean!){

--- a/tests/schema/test_fields.py
+++ b/tests/schema/test_fields.py
@@ -5,7 +5,6 @@ from operator import getitem
 import strawberry
 from strawberry.field import StrawberryField
 from strawberry.printer import print_schema
-from strawberry.schema.config import StrawberryConfig
 
 
 def test_custom_field():
@@ -62,7 +61,7 @@ def test_can_change_default_resolver():
 
     schema = strawberry.Schema(
         query=Query,
-        config=StrawberryConfig(default_resolver=getitem),
+        config={"default_resolver": getitem},
     )
 
     query = "{ user { name } }"

--- a/tests/schema/test_name_converter.py
+++ b/tests/schema/test_name_converter.py
@@ -8,7 +8,6 @@ from strawberry.custom_scalar import ScalarDefinition
 from strawberry.directive import StrawberryDirective
 from strawberry.enum import EnumDefinition, EnumValue
 from strawberry.field import StrawberryField
-from strawberry.schema.config import StrawberryConfig
 from strawberry.schema.name_converter import NameConverter
 from strawberry.schema_directive import Location, StrawberrySchemaDirective
 from strawberry.type import StrawberryType
@@ -125,7 +124,7 @@ class Query:
 schema = strawberry.Schema(
     query=Query,
     types=[MyScalar, Node],
-    config=StrawberryConfig(name_converter=AppendsNameConverter("X")),
+    config={"name_converter": AppendsNameConverter("X")},
 )
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

This MR aims to change Strawberry's schema config to be a typed dictionary. Then only one import would be required to instantiate the schema.
```python
import strawberry
...
schema = strawberry.Schema(..., config={"auto_camel_case": False})
```
In the `Schema` class initialization the former `dataclass` is used to handle default values and validations. Then, my approach for this fix was not to remove the old dataclass. 

UTs were updated accordingly.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #2942 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
