### PR TITLE
Fix pydantic type decorator - add missing internal methods

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Fix pydantic type decorator - add internal methods not copied by `dataclasses.make_dataclass()`

--- a/strawberry/experimental/pydantic/object_type.py
+++ b/strawberry/experimental/pydantic/object_type.py
@@ -237,13 +237,20 @@ def type(
         else:
             kwargs["init"] = False
 
-        cls = dataclasses.make_dataclass(
+        new_cls = dataclasses.make_dataclass(
             cls.__name__,
             [field.to_tuple() for field in all_model_fields],
             bases=cls.__bases__,
             namespace=namespace,
             **kwargs,  # type: ignore
         )
+
+        # Add back attributes that were not copied (like internal methods)
+        for key, value in vars(cls).items():
+            if not hasattr(new_cls, key):
+                setattr(new_cls, key, value)
+
+        cls = new_cls
 
         if sys.version_info < (3, 10, 1):
             add_custom_init_fn(cls)

--- a/tests/experimental/pydantic/test_basic.py
+++ b/tests/experimental/pydantic/test_basic.py
@@ -141,6 +141,30 @@ def test_auto_fields_other_sentinel():
     assert field3.type is other_sentinel
 
 
+def test_basic_type_with_internal_method():
+    class User(pydantic.BaseModel):
+        age: int
+        password: Optional[str]
+
+    @strawberry.experimental.pydantic.type(User)
+    class UserType:
+        age: strawberry.auto
+        password: strawberry.auto
+
+        @strawberry.field
+        def password_hash(self) -> int:
+            return self.perform_hash(self.password)
+
+        def perform_hash(self, data: str) -> int:
+            return hash(data)
+
+    definition: StrawberryObjectDefinition = UserType.__strawberry_definition__
+    assert definition.name == "UserType"
+
+    assert len(definition.fields) == 3
+    assert hasattr(UserType, "perform_hash")
+
+
 def test_referencing_other_models_fails_when_not_registered():
     class Group(pydantic.BaseModel):
         name: str


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

I noticed that when wrapping a class with `@strawberry.experimental.pydantic.type`, internal methods "disappear" (I hope I got the terminology right, by internal methods I mean methods not marked as `@strawberry.field`).

See this example from the test I added:

```python
class User(pydantic.BaseModel):
    age: int
    password: Optional[str]

@strawberry.experimental.pydantic.type(User)
class UserType:
    age: strawberry.auto
    password: strawberry.auto

    @strawberry.field
    def password_hash(self) -> int:
        return self.perform_hash(self.password)

    def perform_hash(self, data: str) -> int:
        return hash(data)
```

Before the change, querying for `password_hash` would have raised an error: `AttributeError: type object 'UserType' has no attribute 'perform_hash'`.

The change I propose is simple - after calling `make_dataclass`, add back attributes that were not copied from the original class.


<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
