### PR TITLE
Unpack list type when looking up namespaces

### DIFF
--- a/strawberry/utils/typing.py
+++ b/strawberry/utils/typing.py
@@ -283,6 +283,14 @@ def _get_namespace_from_ast(
     elif (
         isinstance(expr, ast.Subscript)
         and isinstance(expr.value, ast.Name)
+        and expr.value.id in {"list", "List"}
+    ):
+        expr_slice = expr.slice
+        cast(ast.Tuple, expr_slice)
+        extra.update(_get_namespace_from_ast(expr_slice, globalns, localns))
+    elif (
+        isinstance(expr, ast.Subscript)
+        and isinstance(expr.value, ast.Name)
         and expr.value.id == "Annotated"
     ):
         assert ast_unparse


### PR DESCRIPTION
## Description

The namespace resolver does not check for lists, meaning a type definition of `List[Annotated[MyType, strawberry.lazy("my.module")]]` throws `strawberry.exceptions.unresolved_field_type.UnresolvedFieldTypeError`

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/strawberry-graphql/strawberry/issues/2896

## Checklist

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
  - Fixes `test_lazy_forward_reference_schema_with_a_list_only` introduced in https://github.com/strawberry-graphql/strawberry/pull/2895
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
