### PR TITLE
Add scalar_override example to File Upload

### DIFF
--- a/docs/guides/file-upload.md
+++ b/docs/guides/file-upload.md
@@ -23,6 +23,20 @@ runtime depends on the integration:
 | [Sanic](/docs/integrations/sanic)         | [`sanic.request.File`](https://sanic.readthedocs.io/en/stable/sanic/api/core.html#sanic.request.File)                                                 |
 | [Starlette](/docs/integrations/starlette) | [`starlette.datastructures.UploadFile`](https://www.starlette.io/requests/#request-files)                                                             |
 
+In order to have the correct runtime type in resolver type annotations you can
+set a scalar override based on the integrations above. For example with 
+Starlette: 
+```python
+import strawberry
+from starlette.datastructures import UploadFile
+from strawberry.file_uploads import Upload
+
+schema = strawberry.Schema(
+  ...
+  scalar_overrides={UploadFile: Upload}
+)
+```
+
 ## ASGI / FastAPI / Starlette
 
 Since these integrations use asyncio for communication, the resolver _must_ be

--- a/docs/guides/file-upload.md
+++ b/docs/guides/file-upload.md
@@ -24,8 +24,9 @@ runtime depends on the integration:
 | [Starlette](/docs/integrations/starlette) | [`starlette.datastructures.UploadFile`](https://www.starlette.io/requests/#request-files)                                                             |
 
 In order to have the correct runtime type in resolver type annotations you can
-set a scalar override based on the integrations above. For example with 
-Starlette: 
+set a scalar override based on the integrations above. For example with
+Starlette:
+
 ```python
 import strawberry
 from starlette.datastructures import UploadFile


### PR DESCRIPTION
Add an example of setting a scalar override in order to get the correct type annotation of the runtime type of the Upload scalar to the documentation, something which took me a while to work out myself. I don't know if it's worth the update, but would have saved me half an hour. 

I don't _think_ your adding RELEASE.md's for doc changes, but happy to add one if this is accepted.

## Description

Short documentation about how to get file upload type annotations working based on the particular integration your using. 

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [X] Documentation


## Checklist

- [ ] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
