### PR TITLE
Fix misplaced parenthesis in custom scalar docs

### DIFF
--- a/docs/types/scalars.md
+++ b/docs/types/scalars.md
@@ -113,7 +113,7 @@ import strawberry
 Base64 = strawberry.scalar(
     NewType("Base64", bytes),
     serialize=lambda v: base64.b64encode(v).decode("utf-8"),
-    parse_value=lambda v: base64.b64decode(v).encode("utf-8"),
+    parse_value=lambda v: base64.b64decode(v.encode("utf-8")),
 )
 
 


### PR DESCRIPTION
The implementation of the Base64 custom scalar given in the docs differs from the implementation actually used. The implementation currently shown in the docs raises an AttributeError when used. It appears that the docs were originally created with an extra stray close paren, and the wrong one was deleted when that was fixed.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

It's the user's input that needs to be encoded as `bytes`, not the output of `base64.b64decode`, which is already `bytes`.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [n/a] My code follows the code style of this project.
- [n/a] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [n/a] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
