### PR TITLE
Support Federation Spec 2.7

### DIFF
--- a/.github/workflows/federation-compatibility.yml
+++ b/.github/workflows/federation-compatibility.yml
@@ -37,7 +37,7 @@ jobs:
         run: poetry run strawberry export-schema schema:schema > schema.graphql
         working-directory: federation-compatibility
 
-      - uses: apollographql/federation-subgraph-compatibility@v1
+      - uses: apollographql/federation-subgraph-compatibility@v2
         with:
           compose: 'federation-compatibility/docker-compose.yml'
           schema: 'federation-compatibility/schema.graphql'

--- a/.github/workflows/federation-compatibility.yml
+++ b/.github/workflows/federation-compatibility.yml
@@ -28,9 +28,9 @@ jobs:
       - uses: actions/setup-python@v4
         id: setup-python
         with:
-          python-version: "3.10"
+          python-version: "3.12"
           cache: "poetry"
-      - run: poetry env use python3.10
+      - run: poetry env use python3.12
       - run: poetry install
 
       - name: export schema
@@ -43,5 +43,5 @@ jobs:
           schema: 'federation-compatibility/schema.graphql'
           port: 4001
           token: ${{ secrets.BOT_TOKEN }}
-          failOnWarning: true
+          failOnWarning: false
           failOnRequired: true

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,4 @@
-Release type: patch
+Release type: minor
 
 Update federation support for v2.6 which includes the @authenticated, @requiresScopes, and @policy directives.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,13 +1,14 @@
 Release type: minor
 
-Update federation support for v2.6 which includes the @authenticated, @requiresScopes, and @policy directives.
+This release adds support for Apollo Federation v2.6 which includes the `@authenticated`, `@requiresScopes`, and `@policy` directives.
+As usual, we have first class support for them in the `strawberry.federation` namespace, here's an example:
 
-```
-    @strawberry.federation.type(
-        authenticated=True,
-        policy=[["client", "poweruser"], ["admin"]],
-        requires_scopes=[["client", "poweruser"], ["admin"]]
-    )
-    class Product(SomeInterface):
-        upc: str
+```python
+@strawberry.federation.type(
+    authenticated=True,
+    policy=[["client", "poweruser"], ["admin"]],
+    requires_scopes=[["client", "poweruser"], ["admin"]],
+)
+class Product(SomeInterface):
+    upc: str
 ```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,13 @@
+Release type: patch
+
+Update federation support for v2.6 which includes the @authenticated, @requiresScopes, and @policy directives.
+
+```
+    @strawberry.federation.type(
+        authenticated=True,
+        policy=[["client", "poweruser"], ["admin"]],
+        requires_scopes=[["client", "poweruser"], ["admin"]]
+    )
+    class Product(SomeInterface):
+        upc: str
+```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,14 +1,19 @@
 Release type: minor
 
-This release adds support for Apollo Federation v2.6 which includes the `@authenticated`, `@requiresScopes`, and `@policy` directives.
+This release adds support for Apollo Federation v2.7 which includes the `@authenticated`, `@requiresScopes`, `@policy` directives, as well as the `label` argument for `@override`.
 As usual, we have first class support for them in the `strawberry.federation` namespace, here's an example:
 
 ```python
+from strawberry.federation.schema_directives import Override
+
+
 @strawberry.federation.type(
     authenticated=True,
     policy=[["client", "poweruser"], ["admin"]],
     requires_scopes=[["client", "poweruser"], ["admin"]],
 )
-class Product(SomeInterface):
-    upc: str
+class Product:
+    upc: str = strawberry.federation.field(
+        override=Override(override_from="mySubGraph", label="percent(1)")
+    )
 ```

--- a/docs/guides/federation.md
+++ b/docs/guides/federation.md
@@ -327,7 +327,7 @@ Strawberry and Federation. The repo is available here:
 
 Strawberry provides implementations for
 [Apollo federation-specific GraphQL directives](https://www.apollographql.com/docs/federation/federated-types/federated-directives/)
-up to federation spec v2.6.
+up to federation spec v2.7.
 
 Some of these directives may not be necessary to directly include in your code,
 and are accessed through other means.
@@ -376,7 +376,7 @@ Will result in the following GraphQL schema:
 ```graphql
 schema
   @link(
-    url: "https://specs.apollo.dev/federation/v2.6"
+    url: "https://specs.apollo.dev/federation/v2.7"
     import: ["@key", "@inaccessible", "@shareable", "@tag"]
   ) {
   query: Query

--- a/docs/guides/federation.md
+++ b/docs/guides/federation.md
@@ -326,7 +326,8 @@ Strawberry and Federation. The repo is available here:
 ## Federated schema directives
 
 Strawberry provides implementations for
-[Apollo federation-specific GraphQL directives](https://www.apollographql.com/docs/federation/federated-types/federated-directives/).
+[Apollo federation-specific GraphQL directives](https://www.apollographql.com/docs/federation/federated-types/federated-directives/)
+up to federation spec v2.6.
 
 Some of these directives may not be necessary to directly include in your code,
 and are accessed through other means.

--- a/docs/guides/federation.md
+++ b/docs/guides/federation.md
@@ -372,7 +372,7 @@ Will result in the following GraphQL schema:
 ```graphql
 schema
   @link(
-    url: "https://specs.apollo.dev/federation/v2.3"
+    url: "https://specs.apollo.dev/federation/v2.6"
     import: ["@key", "@inaccessible", "@shareable", "@tag"]
   ) {
   query: Query

--- a/docs/guides/federation.md
+++ b/docs/guides/federation.md
@@ -348,6 +348,9 @@ Other directives you may need to specifically include when relevant.
 - `@requires`
 - `@shareable`
 - `@tag`
+- `@authenticated`
+- `@requiresScopes`
+- `@policy`
 
 For example, adding the following directives:
 

--- a/strawberry/federation/enum.py
+++ b/strawberry/federation/enum.py
@@ -49,7 +49,7 @@ def enum(
     directives: Iterable[object] = (),
     authenticated: bool = False,
     inaccessible: bool = False,
-    policies: Optional[List[List[Federation__Policy]]] = None,
+    policy: Optional[List[List[Federation__Policy]]] = None,
     requires_scopes: Optional[List[List[Federation__Scope]]] = None,
     tags: Optional[Iterable[str]] = (),
 ) -> EnumType:
@@ -65,7 +65,7 @@ def enum(
     directives: Iterable[object] = (),
     authenticated: bool = False,
     inaccessible: bool = False,
-    policies: Optional[List[List[Federation__Policy]]] = None,
+    policy: Optional[List[List[Federation__Policy]]] = None,
     requires_scopes: Optional[List[List[Federation__Scope]]] = None,
     tags: Optional[Iterable[str]] = (),
 ) -> Callable[[EnumType], EnumType]:
@@ -80,7 +80,7 @@ def enum(
     directives=(),
     authenticated: bool = False,
     inaccessible: bool = False,
-    policies: Optional[List[List[Federation__Policy]]] = None,
+    policy: Optional[List[List[Federation__Policy]]] = None,
     requires_scopes: Optional[List[List[Federation__Scope]]] = None,
     tags: Optional[Iterable[str]] = (),
 ) -> Union[EnumType, Callable[[EnumType], EnumType]]:
@@ -106,8 +106,8 @@ def enum(
     if inaccessible:
         directives.append(Inaccessible())
 
-    if policies:
-        directives.append(Policy(policies=policies))
+    if policy:
+        directives.append(Policy(policies=policy))
 
     if requires_scopes:
         directives.append(RequiresScopes(scopes=requires_scopes))

--- a/strawberry/federation/enum.py
+++ b/strawberry/federation/enum.py
@@ -1,12 +1,23 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Optional, Union, overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Iterable,
+    List,
+    Optional,
+    Union,
+    overload,
+)
 
 from strawberry.enum import _process_enum
 from strawberry.enum import enum_value as base_enum_value
 
 if TYPE_CHECKING:
     from strawberry.enum import EnumType, EnumValueDefinition
+
+    from .types import Federation__Policy, Federation__Scope
 
 
 def enum_value(
@@ -36,7 +47,10 @@ def enum(
     name: Optional[str] = None,
     description: Optional[str] = None,
     directives: Iterable[object] = (),
+    authenticated: bool = False,
     inaccessible: bool = False,
+    policies: Optional[List[List[Federation__Policy]]] = None,
+    requires_scopes: Optional[List[List[Federation__Scope]]] = None,
     tags: Optional[Iterable[str]] = (),
 ) -> EnumType:
     ...
@@ -49,7 +63,10 @@ def enum(
     name: Optional[str] = None,
     description: Optional[str] = None,
     directives: Iterable[object] = (),
+    authenticated: bool = False,
     inaccessible: bool = False,
+    policies: Optional[List[List[Federation__Policy]]] = None,
+    requires_scopes: Optional[List[List[Federation__Scope]]] = None,
     tags: Optional[Iterable[str]] = (),
 ) -> Callable[[EnumType], EnumType]:
     ...
@@ -61,8 +78,11 @@ def enum(
     name=None,
     description=None,
     directives=(),
-    inaccessible=False,
-    tags=(),
+    authenticated: bool = False,
+    inaccessible: bool = False,
+    policies: Optional[List[List[Federation__Policy]]] = None,
+    requires_scopes: Optional[List[List[Federation__Scope]]] = None,
+    tags: Optional[Iterable[str]] = (),
 ) -> Union[EnumType, Callable[[EnumType], EnumType]]:
     """Registers the enum in the GraphQL type system.
 
@@ -70,12 +90,27 @@ def enum(
     the value passed of name instead of the Enum class name.
     """
 
-    from strawberry.federation.schema_directives import Inaccessible, Tag
+    from strawberry.federation.schema_directives import (
+        Authenticated,
+        Inaccessible,
+        Policy,
+        RequiresScopes,
+        Tag,
+    )
 
     directives = list(directives)
 
+    if authenticated:
+        directives.append(Authenticated())
+
     if inaccessible:
         directives.append(Inaccessible())
+
+    if policies:
+        directives.append(Policy(policies=policies))
+
+    if requires_scopes:
+        directives.append(RequiresScopes(scopes=requires_scopes))
 
     if tags:
         directives.extend(Tag(name=tag) for tag in tags)

--- a/strawberry/federation/enum.py
+++ b/strawberry/federation/enum.py
@@ -17,8 +17,6 @@ from strawberry.enum import enum_value as base_enum_value
 if TYPE_CHECKING:
     from strawberry.enum import EnumType, EnumValueDefinition
 
-    from .types import Federation__Policy, Federation__Scope
-
 
 def enum_value(
     value: Any,
@@ -49,8 +47,8 @@ def enum(
     directives: Iterable[object] = (),
     authenticated: bool = False,
     inaccessible: bool = False,
-    policy: Optional[List[List[Federation__Policy]]] = None,
-    requires_scopes: Optional[List[List[Federation__Scope]]] = None,
+    policy: Optional[List[List[str]]] = None,
+    requires_scopes: Optional[List[List[str]]] = None,
     tags: Optional[Iterable[str]] = (),
 ) -> EnumType:
     ...
@@ -65,8 +63,8 @@ def enum(
     directives: Iterable[object] = (),
     authenticated: bool = False,
     inaccessible: bool = False,
-    policy: Optional[List[List[Federation__Policy]]] = None,
-    requires_scopes: Optional[List[List[Federation__Scope]]] = None,
+    policy: Optional[List[List[str]]] = None,
+    requires_scopes: Optional[List[List[str]]] = None,
     tags: Optional[Iterable[str]] = (),
 ) -> Callable[[EnumType], EnumType]:
     ...
@@ -80,8 +78,8 @@ def enum(
     directives=(),
     authenticated: bool = False,
     inaccessible: bool = False,
-    policy: Optional[List[List[Federation__Policy]]] = None,
-    requires_scopes: Optional[List[List[Federation__Scope]]] = None,
+    policy: Optional[List[List[str]]] = None,
+    requires_scopes: Optional[List[List[str]]] = None,
     tags: Optional[Iterable[str]] = (),
 ) -> Union[EnumType, Callable[[EnumType], EnumType]]:
     """Registers the enum in the GraphQL type system.

--- a/strawberry/federation/field.py
+++ b/strawberry/federation/field.py
@@ -25,6 +25,8 @@ if TYPE_CHECKING:
     from strawberry.field import _RESOLVER_TYPE, StrawberryField
     from strawberry.permission import BasePermission
 
+    from .schema_directives import Override
+
 T = TypeVar("T")
 
 
@@ -40,7 +42,7 @@ def field(
     inaccessible: bool = False,
     policy: Optional[List[List[str]]] = None,
     provides: Optional[List[str]] = None,
-    override: Optional[str] = None,
+    override: Optional[Union[Override, str]] = None,
     requires: Optional[List[str]] = None,
     requires_scopes: Optional[List[List[str]]] = None,
     tags: Optional[Iterable[str]] = (),
@@ -68,7 +70,7 @@ def field(
     inaccessible: bool = False,
     policy: Optional[List[List[str]]] = None,
     provides: Optional[List[str]] = None,
-    override: Optional[str] = None,
+    override: Optional[Union[Override, str]] = None,
     requires: Optional[List[str]] = None,
     requires_scopes: Optional[List[List[str]]] = None,
     tags: Optional[Iterable[str]] = (),
@@ -97,7 +99,7 @@ def field(
     inaccessible: bool = False,
     policy: Optional[List[List[str]]] = None,
     provides: Optional[List[str]] = None,
-    override: Optional[str] = None,
+    override: Optional[Union[Override, str]] = None,
     requires: Optional[List[str]] = None,
     requires_scopes: Optional[List[List[str]]] = None,
     tags: Optional[Iterable[str]] = (),
@@ -124,7 +126,7 @@ def field(
     inaccessible: bool = False,
     policy: Optional[List[List[str]]] = None,
     provides: Optional[List[str]] = None,
-    override: Optional[str] = None,
+    override: Optional[Union[Override, str]] = None,
     requires: Optional[List[str]] = None,
     requires_scopes: Optional[List[List[str]]] = None,
     tags: Optional[Iterable[str]] = (),
@@ -166,7 +168,11 @@ def field(
         directives.append(Inaccessible())
 
     if override:
-        directives.append(Override(override_from=override))
+        directives.append(
+            Override(override_from=override, label=UNSET)
+            if isinstance(override, str)
+            else override
+        )
 
     if policy:
         directives.append(Policy(policies=policy))

--- a/strawberry/federation/field.py
+++ b/strawberry/federation/field.py
@@ -25,8 +25,6 @@ if TYPE_CHECKING:
     from strawberry.field import _RESOLVER_TYPE, StrawberryField
     from strawberry.permission import BasePermission
 
-    from .types import Federation__Policy, Federation__Scope
-
 T = TypeVar("T")
 
 
@@ -40,11 +38,11 @@ def field(
     authenticated: bool = False,
     external: bool = False,
     inaccessible: bool = False,
-    policy: Optional[List[List[Federation__Policy]]] = None,
+    policy: Optional[List[List[str]]] = None,
     provides: Optional[List[str]] = None,
     override: Optional[str] = None,
     requires: Optional[List[str]] = None,
-    requires_scopes: Optional[List[List[Federation__Scope]]] = None,
+    requires_scopes: Optional[List[List[str]]] = None,
     tags: Optional[Iterable[str]] = (),
     shareable: bool = False,
     init: Literal[False] = False,
@@ -68,11 +66,11 @@ def field(
     authenticated: bool = False,
     external: bool = False,
     inaccessible: bool = False,
-    policy: Optional[List[List[Federation__Policy]]] = None,
+    policy: Optional[List[List[str]]] = None,
     provides: Optional[List[str]] = None,
     override: Optional[str] = None,
     requires: Optional[List[str]] = None,
-    requires_scopes: Optional[List[List[Federation__Scope]]] = None,
+    requires_scopes: Optional[List[List[str]]] = None,
     tags: Optional[Iterable[str]] = (),
     shareable: bool = False,
     init: Literal[True] = True,
@@ -97,11 +95,11 @@ def field(
     authenticated: bool = False,
     external: bool = False,
     inaccessible: bool = False,
-    policy: Optional[List[List[Federation__Policy]]] = None,
+    policy: Optional[List[List[str]]] = None,
     provides: Optional[List[str]] = None,
     override: Optional[str] = None,
     requires: Optional[List[str]] = None,
-    requires_scopes: Optional[List[List[Federation__Scope]]] = None,
+    requires_scopes: Optional[List[List[str]]] = None,
     tags: Optional[Iterable[str]] = (),
     shareable: bool = False,
     permission_classes: Optional[List[Type[BasePermission]]] = None,
@@ -124,11 +122,11 @@ def field(
     authenticated: bool = False,
     external: bool = False,
     inaccessible: bool = False,
-    policy: Optional[List[List[Federation__Policy]]] = None,
+    policy: Optional[List[List[str]]] = None,
     provides: Optional[List[str]] = None,
     override: Optional[str] = None,
     requires: Optional[List[str]] = None,
-    requires_scopes: Optional[List[List[Federation__Scope]]] = None,
+    requires_scopes: Optional[List[List[str]]] = None,
     tags: Optional[Iterable[str]] = (),
     shareable: bool = False,
     permission_classes: Optional[List[Type[BasePermission]]] = None,

--- a/strawberry/federation/field.py
+++ b/strawberry/federation/field.py
@@ -40,7 +40,7 @@ def field(
     authenticated: bool = False,
     external: bool = False,
     inaccessible: bool = False,
-    policies: Optional[List[List[Federation__Policy]]] = None,
+    policy: Optional[List[List[Federation__Policy]]] = None,
     provides: Optional[List[str]] = None,
     override: Optional[str] = None,
     requires: Optional[List[str]] = None,
@@ -68,7 +68,7 @@ def field(
     authenticated: bool = False,
     external: bool = False,
     inaccessible: bool = False,
-    policies: Optional[List[List[Federation__Policy]]] = None,
+    policy: Optional[List[List[Federation__Policy]]] = None,
     provides: Optional[List[str]] = None,
     override: Optional[str] = None,
     requires: Optional[List[str]] = None,
@@ -97,7 +97,7 @@ def field(
     authenticated: bool = False,
     external: bool = False,
     inaccessible: bool = False,
-    policies: Optional[List[List[Federation__Policy]]] = None,
+    policy: Optional[List[List[Federation__Policy]]] = None,
     provides: Optional[List[str]] = None,
     override: Optional[str] = None,
     requires: Optional[List[str]] = None,
@@ -124,7 +124,7 @@ def field(
     authenticated: bool = False,
     external: bool = False,
     inaccessible: bool = False,
-    policies: Optional[List[List[Federation__Policy]]] = None,
+    policy: Optional[List[List[Federation__Policy]]] = None,
     provides: Optional[List[str]] = None,
     override: Optional[str] = None,
     requires: Optional[List[str]] = None,
@@ -170,8 +170,8 @@ def field(
     if override:
         directives.append(Override(override_from=override))
 
-    if policies:
-        directives.append(Policy(policies=policies))
+    if policy:
+        directives.append(Policy(policies=policy))
 
     if provides:
         directives.append(Provides(fields=" ".join(provides)))

--- a/strawberry/federation/field.py
+++ b/strawberry/federation/field.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     from strawberry.field import _RESOLVER_TYPE, StrawberryField
     from strawberry.permission import BasePermission
 
+    from .types import Federation__Policy, Federation__Scope
 
 T = TypeVar("T")
 
@@ -36,13 +37,16 @@ def field(
     name: Optional[str] = None,
     is_subscription: bool = False,
     description: Optional[str] = None,
-    provides: Optional[List[str]] = None,
-    requires: Optional[List[str]] = None,
+    authenticated: bool = False,
     external: bool = False,
-    shareable: bool = False,
-    tags: Optional[Iterable[str]] = (),
-    override: Optional[str] = None,
     inaccessible: bool = False,
+    policies: Optional[List[List[Federation__Policy]]] = None,
+    provides: Optional[List[str]] = None,
+    override: Optional[str] = None,
+    requires: Optional[List[str]] = None,
+    requires_scopes: Optional[List[List[Federation__Scope]]] = None,
+    tags: Optional[Iterable[str]] = (),
+    shareable: bool = False,
     init: Literal[False] = False,
     permission_classes: Optional[List[Type[BasePermission]]] = None,
     deprecation_reason: Optional[str] = None,
@@ -61,13 +65,16 @@ def field(
     name: Optional[str] = None,
     is_subscription: bool = False,
     description: Optional[str] = None,
-    provides: Optional[List[str]] = None,
-    requires: Optional[List[str]] = None,
+    authenticated: bool = False,
     external: bool = False,
-    shareable: bool = False,
-    tags: Optional[Iterable[str]] = (),
-    override: Optional[str] = None,
     inaccessible: bool = False,
+    policies: Optional[List[List[Federation__Policy]]] = None,
+    provides: Optional[List[str]] = None,
+    override: Optional[str] = None,
+    requires: Optional[List[str]] = None,
+    requires_scopes: Optional[List[List[Federation__Scope]]] = None,
+    tags: Optional[Iterable[str]] = (),
+    shareable: bool = False,
     init: Literal[True] = True,
     permission_classes: Optional[List[Type[BasePermission]]] = None,
     deprecation_reason: Optional[str] = None,
@@ -87,13 +94,16 @@ def field(
     name: Optional[str] = None,
     is_subscription: bool = False,
     description: Optional[str] = None,
-    provides: Optional[List[str]] = None,
-    requires: Optional[List[str]] = None,
+    authenticated: bool = False,
     external: bool = False,
-    shareable: bool = False,
-    tags: Optional[Iterable[str]] = (),
-    override: Optional[str] = None,
     inaccessible: bool = False,
+    policies: Optional[List[List[Federation__Policy]]] = None,
+    provides: Optional[List[str]] = None,
+    override: Optional[str] = None,
+    requires: Optional[List[str]] = None,
+    requires_scopes: Optional[List[List[Federation__Scope]]] = None,
+    tags: Optional[Iterable[str]] = (),
+    shareable: bool = False,
     permission_classes: Optional[List[Type[BasePermission]]] = None,
     deprecation_reason: Optional[str] = None,
     default: Any = UNSET,
@@ -111,13 +121,16 @@ def field(
     name: Optional[str] = None,
     is_subscription: bool = False,
     description: Optional[str] = None,
-    provides: Optional[List[str]] = None,
-    requires: Optional[List[str]] = None,
+    authenticated: bool = False,
     external: bool = False,
-    shareable: bool = False,
-    tags: Optional[Iterable[str]] = (),
-    override: Optional[str] = None,
     inaccessible: bool = False,
+    policies: Optional[List[List[Federation__Policy]]] = None,
+    provides: Optional[List[str]] = None,
+    override: Optional[str] = None,
+    requires: Optional[List[str]] = None,
+    requires_scopes: Optional[List[List[Federation__Scope]]] = None,
+    tags: Optional[Iterable[str]] = (),
+    shareable: bool = False,
     permission_classes: Optional[List[Type[BasePermission]]] = None,
     deprecation_reason: Optional[str] = None,
     default: Any = dataclasses.MISSING,
@@ -131,16 +144,34 @@ def field(
     init: Literal[True, False, None] = None,
 ) -> Any:
     from .schema_directives import (
+        Authenticated,
         External,
         Inaccessible,
         Override,
+        Policy,
         Provides,
         Requires,
+        RequiresScopes,
         Shareable,
         Tag,
     )
 
     directives = list(directives)
+
+    if authenticated:
+        directives.append(Authenticated())
+
+    if external:
+        directives.append(External())
+
+    if inaccessible:
+        directives.append(Inaccessible())
+
+    if override:
+        directives.append(Override(override_from=override))
+
+    if policies:
+        directives.append(Policy(policies=policies))
 
     if provides:
         directives.append(Provides(fields=" ".join(provides)))
@@ -148,20 +179,14 @@ def field(
     if requires:
         directives.append(Requires(fields=" ".join(requires)))
 
-    if external:
-        directives.append(External())
+    if requires_scopes:
+        directives.append(RequiresScopes(scopes=requires_scopes))
 
     if shareable:
         directives.append(Shareable())
 
     if tags:
         directives.extend(Tag(name=tag) for tag in tags)
-
-    if override:
-        directives.append(Override(override_from=override))
-
-    if inaccessible:
-        directives.append(Inaccessible())
 
     return base_field(  # type: ignore
         resolver=resolver,  # type: ignore

--- a/strawberry/federation/object_type.py
+++ b/strawberry/federation/object_type.py
@@ -33,7 +33,7 @@ def _impl_type(
     name: Optional[str] = None,
     description: Optional[str] = None,
     directives: Iterable[object] = (),
-    authenticated: bool = UNSET,
+    authenticated: bool = False,
     keys: Iterable[Union["Key", str]] = (),
     extend: bool = False,
     shareable: bool = False,
@@ -63,7 +63,7 @@ def _impl_type(
         for key in keys
     )
 
-    if authenticated is not UNSET:
+    if authenticated:
         directives.append(Authenticated())
 
     if inaccessible is not UNSET:
@@ -107,7 +107,7 @@ def type(
     name: Optional[str] = None,
     description: Optional[str] = None,
     directives: Iterable[object] = (),
-    authenticated: bool = UNSET,
+    authenticated: bool = False,
     extend: bool = False,
     inaccessible: bool = UNSET,
     keys: Iterable[Union["Key", str]] = (),
@@ -130,7 +130,7 @@ def type(
     name: Optional[str] = None,
     description: Optional[str] = None,
     directives: Iterable[object] = (),
-    authenticated: bool = UNSET,
+    authenticated: bool = False,
     extend: bool = False,
     inaccessible: bool = UNSET,
     keys: Iterable[Union["Key", str]] = (),
@@ -148,7 +148,7 @@ def type(
     name: Optional[str] = None,
     description: Optional[str] = None,
     directives: Iterable[object] = (),
-    authenticated: bool = UNSET,
+    authenticated: bool = False,
     extend: bool = False,
     inaccessible: bool = UNSET,
     keys: Iterable[Union["Key", str]] = (),
@@ -240,7 +240,7 @@ def interface(
     name: Optional[str] = None,
     description: Optional[str] = None,
     directives: Iterable[object] = (),
-    authenticated: bool = UNSET,
+    authenticated: bool = False,
     inaccessible: bool = UNSET,
     keys: Iterable[Union["Key", str]] = (),
     policy: Optional[List[List[Federation__Policy]]] = None,
@@ -261,7 +261,7 @@ def interface(
     name: Optional[str] = None,
     description: Optional[str] = None,
     directives: Iterable[object] = (),
-    authenticated: bool = UNSET,
+    authenticated: bool = False,
     inaccessible: bool = UNSET,
     keys: Iterable[Union["Key", str]] = (),
     policy: Optional[List[List[Federation__Policy]]] = None,
@@ -277,7 +277,7 @@ def interface(
     name: Optional[str] = None,
     description: Optional[str] = None,
     directives: Iterable[object] = (),
-    authenticated: bool = UNSET,
+    authenticated: bool = False,
     inaccessible: bool = UNSET,
     keys: Iterable[Union["Key", str]] = (),
     policy: Optional[List[List[Federation__Policy]]] = None,
@@ -311,7 +311,7 @@ def interface_object(
     name: Optional[str] = None,
     description: Optional[str] = None,
     directives: Iterable[object] = (),
-    authenticated: bool = UNSET,
+    authenticated: bool = False,
     inaccessible: bool = UNSET,
     keys: Iterable[Union["Key", str]] = (),
     policy: Optional[List[List[Federation__Policy]]] = None,
@@ -332,7 +332,7 @@ def interface_object(
     name: Optional[str] = None,
     description: Optional[str] = None,
     directives: Iterable[object] = (),
-    authenticated: bool = UNSET,
+    authenticated: bool = False,
     inaccessible: bool = UNSET,
     keys: Iterable[Union["Key", str]] = (),
     policy: Optional[List[List[Federation__Policy]]] = None,
@@ -348,7 +348,7 @@ def interface_object(
     name: Optional[str] = None,
     description: Optional[str] = None,
     directives: Iterable[object] = (),
-    authenticated: bool = UNSET,
+    authenticated: bool = False,
     inaccessible: bool = UNSET,
     keys: Iterable[Union["Key", str]] = (),
     policy: Optional[List[List[Federation__Policy]]] = None,

--- a/strawberry/federation/object_type.py
+++ b/strawberry/federation/object_type.py
@@ -18,7 +18,6 @@ from strawberry.object_type import type as base_type
 from strawberry.unset import UNSET
 
 from .field import field
-from .types import Federation__Policy, Federation__Scope
 
 if TYPE_CHECKING:
     from .schema_directives import Key
@@ -38,8 +37,8 @@ def _impl_type(
     extend: bool = False,
     shareable: bool = False,
     inaccessible: bool = UNSET,
-    policy: Optional[List[List[Federation__Policy]]] = None,
-    requires_scopes: Optional[List[List[Federation__Scope]]] = None,
+    policy: Optional[List[List[str]]] = None,
+    requires_scopes: Optional[List[List[str]]] = None,
     tags: Iterable[str] = (),
     is_input: bool = False,
     is_interface: bool = False,
@@ -111,8 +110,8 @@ def type(
     extend: bool = False,
     inaccessible: bool = UNSET,
     keys: Iterable[Union["Key", str]] = (),
-    policy: Optional[List[List[Federation__Policy]]] = None,
-    requires_scopes: Optional[List[List[Federation__Scope]]] = None,
+    policy: Optional[List[List[str]]] = None,
+    requires_scopes: Optional[List[List[str]]] = None,
     shareable: bool = False,
     tags: Iterable[str] = (),
 ) -> T:
@@ -134,8 +133,8 @@ def type(
     extend: bool = False,
     inaccessible: bool = UNSET,
     keys: Iterable[Union["Key", str]] = (),
-    policy: Optional[List[List[Federation__Policy]]] = None,
-    requires_scopes: Optional[List[List[Federation__Scope]]] = None,
+    policy: Optional[List[List[str]]] = None,
+    requires_scopes: Optional[List[List[str]]] = None,
     shareable: bool = False,
     tags: Iterable[str] = (),
 ) -> Callable[[T], T]:
@@ -152,8 +151,8 @@ def type(
     extend: bool = False,
     inaccessible: bool = UNSET,
     keys: Iterable[Union["Key", str]] = (),
-    policy: Optional[List[List[Federation__Policy]]] = None,
-    requires_scopes: Optional[List[List[Federation__Scope]]] = None,
+    policy: Optional[List[List[str]]] = None,
+    requires_scopes: Optional[List[List[str]]] = None,
     shareable: bool = False,
     tags: Iterable[str] = (),
 ):
@@ -243,8 +242,8 @@ def interface(
     authenticated: bool = False,
     inaccessible: bool = UNSET,
     keys: Iterable[Union["Key", str]] = (),
-    policy: Optional[List[List[Federation__Policy]]] = None,
-    requires_scopes: Optional[List[List[Federation__Scope]]] = None,
+    policy: Optional[List[List[str]]] = None,
+    requires_scopes: Optional[List[List[str]]] = None,
     tags: Iterable[str] = (),
 ) -> T:
     ...
@@ -264,8 +263,8 @@ def interface(
     authenticated: bool = False,
     inaccessible: bool = UNSET,
     keys: Iterable[Union["Key", str]] = (),
-    policy: Optional[List[List[Federation__Policy]]] = None,
-    requires_scopes: Optional[List[List[Federation__Scope]]] = None,
+    policy: Optional[List[List[str]]] = None,
+    requires_scopes: Optional[List[List[str]]] = None,
     tags: Iterable[str] = (),
 ) -> Callable[[T], T]:
     ...
@@ -280,8 +279,8 @@ def interface(
     authenticated: bool = False,
     inaccessible: bool = UNSET,
     keys: Iterable[Union["Key", str]] = (),
-    policy: Optional[List[List[Federation__Policy]]] = None,
-    requires_scopes: Optional[List[List[Federation__Scope]]] = None,
+    policy: Optional[List[List[str]]] = None,
+    requires_scopes: Optional[List[List[str]]] = None,
     tags: Iterable[str] = (),
 ):
     return _impl_type(
@@ -314,8 +313,8 @@ def interface_object(
     authenticated: bool = False,
     inaccessible: bool = UNSET,
     keys: Iterable[Union["Key", str]] = (),
-    policy: Optional[List[List[Federation__Policy]]] = None,
-    requires_scopes: Optional[List[List[Federation__Scope]]] = None,
+    policy: Optional[List[List[str]]] = None,
+    requires_scopes: Optional[List[List[str]]] = None,
     tags: Iterable[str] = (),
 ) -> T:
     ...
@@ -335,8 +334,8 @@ def interface_object(
     authenticated: bool = False,
     inaccessible: bool = UNSET,
     keys: Iterable[Union["Key", str]] = (),
-    policy: Optional[List[List[Federation__Policy]]] = None,
-    requires_scopes: Optional[List[List[Federation__Scope]]] = None,
+    policy: Optional[List[List[str]]] = None,
+    requires_scopes: Optional[List[List[str]]] = None,
     tags: Iterable[str] = (),
 ) -> Callable[[T], T]:
     ...
@@ -351,8 +350,8 @@ def interface_object(
     authenticated: bool = False,
     inaccessible: bool = UNSET,
     keys: Iterable[Union["Key", str]] = (),
-    policy: Optional[List[List[Federation__Policy]]] = None,
-    requires_scopes: Optional[List[List[Federation__Scope]]] = None,
+    policy: Optional[List[List[str]]] = None,
+    requires_scopes: Optional[List[List[str]]] = None,
     tags: Iterable[str] = (),
 ):
     return _impl_type(

--- a/strawberry/federation/object_type.py
+++ b/strawberry/federation/object_type.py
@@ -38,7 +38,7 @@ def _impl_type(
     extend: bool = False,
     shareable: bool = False,
     inaccessible: bool = UNSET,
-    policies: Optional[List[List[Federation__Policy]]] = None,
+    policy: Optional[List[List[Federation__Policy]]] = None,
     requires_scopes: Optional[List[List[Federation__Scope]]] = None,
     tags: Iterable[str] = (),
     is_input: bool = False,
@@ -69,8 +69,8 @@ def _impl_type(
     if inaccessible is not UNSET:
         directives.append(Inaccessible())
 
-    if policies:
-        directives.append(Policy(policies=policies))
+    if policy:
+        directives.append(Policy(policies=policy))
 
     if requires_scopes:
         directives.append(RequiresScopes(scopes=requires_scopes))
@@ -111,7 +111,7 @@ def type(
     extend: bool = False,
     inaccessible: bool = UNSET,
     keys: Iterable[Union["Key", str]] = (),
-    policies: Optional[List[List[Federation__Policy]]] = None,
+    policy: Optional[List[List[Federation__Policy]]] = None,
     requires_scopes: Optional[List[List[Federation__Scope]]] = None,
     shareable: bool = False,
     tags: Iterable[str] = (),
@@ -134,7 +134,7 @@ def type(
     extend: bool = False,
     inaccessible: bool = UNSET,
     keys: Iterable[Union["Key", str]] = (),
-    policies: Optional[List[List[Federation__Policy]]] = None,
+    policy: Optional[List[List[Federation__Policy]]] = None,
     requires_scopes: Optional[List[List[Federation__Scope]]] = None,
     shareable: bool = False,
     tags: Iterable[str] = (),
@@ -152,7 +152,7 @@ def type(
     extend: bool = False,
     inaccessible: bool = UNSET,
     keys: Iterable[Union["Key", str]] = (),
-    policies: Optional[List[List[Federation__Policy]]] = None,
+    policy: Optional[List[List[Federation__Policy]]] = None,
     requires_scopes: Optional[List[List[Federation__Scope]]] = None,
     shareable: bool = False,
     tags: Iterable[str] = (),
@@ -166,7 +166,7 @@ def type(
         keys=keys,
         extend=extend,
         inaccessible=inaccessible,
-        policies=policies,
+        policy=policy,
         requires_scopes=requires_scopes,
         shareable=shareable,
         tags=tags,
@@ -243,7 +243,7 @@ def interface(
     authenticated: bool = UNSET,
     inaccessible: bool = UNSET,
     keys: Iterable[Union["Key", str]] = (),
-    policies: Optional[List[List[Federation__Policy]]] = None,
+    policy: Optional[List[List[Federation__Policy]]] = None,
     requires_scopes: Optional[List[List[Federation__Scope]]] = None,
     tags: Iterable[str] = (),
 ) -> T:
@@ -264,7 +264,7 @@ def interface(
     authenticated: bool = UNSET,
     inaccessible: bool = UNSET,
     keys: Iterable[Union["Key", str]] = (),
-    policies: Optional[List[List[Federation__Policy]]] = None,
+    policy: Optional[List[List[Federation__Policy]]] = None,
     requires_scopes: Optional[List[List[Federation__Scope]]] = None,
     tags: Iterable[str] = (),
 ) -> Callable[[T], T]:
@@ -280,7 +280,7 @@ def interface(
     authenticated: bool = UNSET,
     inaccessible: bool = UNSET,
     keys: Iterable[Union["Key", str]] = (),
-    policies: Optional[List[List[Federation__Policy]]] = None,
+    policy: Optional[List[List[Federation__Policy]]] = None,
     requires_scopes: Optional[List[List[Federation__Scope]]] = None,
     tags: Iterable[str] = (),
 ):
@@ -292,7 +292,7 @@ def interface(
         authenticated=authenticated,
         keys=keys,
         inaccessible=inaccessible,
-        policies=policies,
+        policy=policy,
         requires_scopes=requires_scopes,
         tags=tags,
         is_interface=True,
@@ -314,7 +314,7 @@ def interface_object(
     authenticated: bool = UNSET,
     inaccessible: bool = UNSET,
     keys: Iterable[Union["Key", str]] = (),
-    policies: Optional[List[List[Federation__Policy]]] = None,
+    policy: Optional[List[List[Federation__Policy]]] = None,
     requires_scopes: Optional[List[List[Federation__Scope]]] = None,
     tags: Iterable[str] = (),
 ) -> T:
@@ -335,7 +335,7 @@ def interface_object(
     authenticated: bool = UNSET,
     inaccessible: bool = UNSET,
     keys: Iterable[Union["Key", str]] = (),
-    policies: Optional[List[List[Federation__Policy]]] = None,
+    policy: Optional[List[List[Federation__Policy]]] = None,
     requires_scopes: Optional[List[List[Federation__Scope]]] = None,
     tags: Iterable[str] = (),
 ) -> Callable[[T], T]:
@@ -351,7 +351,7 @@ def interface_object(
     authenticated: bool = UNSET,
     inaccessible: bool = UNSET,
     keys: Iterable[Union["Key", str]] = (),
-    policies: Optional[List[List[Federation__Policy]]] = None,
+    policy: Optional[List[List[Federation__Policy]]] = None,
     requires_scopes: Optional[List[List[Federation__Scope]]] = None,
     tags: Iterable[str] = (),
 ):
@@ -363,7 +363,7 @@ def interface_object(
         authenticated=authenticated,
         keys=keys,
         inaccessible=inaccessible,
-        policies=policies,
+        policy=policy,
         requires_scopes=requires_scopes,
         tags=tags,
         is_interface=False,

--- a/strawberry/federation/object_type.py
+++ b/strawberry/federation/object_type.py
@@ -2,6 +2,7 @@ from typing import (
     TYPE_CHECKING,
     Callable,
     Iterable,
+    List,
     Optional,
     Sequence,
     Type,
@@ -17,6 +18,7 @@ from strawberry.object_type import type as base_type
 from strawberry.unset import UNSET
 
 from .field import field
+from .types import Federation__Policy, Federation__Scope
 
 if TYPE_CHECKING:
     from .schema_directives import Key
@@ -31,19 +33,25 @@ def _impl_type(
     name: Optional[str] = None,
     description: Optional[str] = None,
     directives: Iterable[object] = (),
+    authenticated: bool = UNSET,
     keys: Iterable[Union["Key", str]] = (),
     extend: bool = False,
     shareable: bool = False,
     inaccessible: bool = UNSET,
+    policies: Optional[List[List[Federation__Policy]]] = None,
+    requires_scopes: Optional[List[List[Federation__Scope]]] = None,
     tags: Iterable[str] = (),
     is_input: bool = False,
     is_interface: bool = False,
     is_interface_object: bool = False,
 ) -> T:
     from strawberry.federation.schema_directives import (
+        Authenticated,
         Inaccessible,
         InterfaceObject,
         Key,
+        Policy,
+        RequiresScopes,
         Shareable,
         Tag,
     )
@@ -55,11 +63,20 @@ def _impl_type(
         for key in keys
     )
 
-    if shareable:
-        directives.append(Shareable())
+    if authenticated is not UNSET:
+        directives.append(Authenticated())
 
     if inaccessible is not UNSET:
         directives.append(Inaccessible())
+
+    if policies:
+        directives.append(Policy(policies=policies))
+
+    if requires_scopes:
+        directives.append(RequiresScopes(scopes=requires_scopes))
+
+    if shareable:
+        directives.append(Shareable())
 
     if tags:
         directives.extend(Tag(name=tag) for tag in tags)
@@ -89,10 +106,15 @@ def type(
     *,
     name: Optional[str] = None,
     description: Optional[str] = None,
-    keys: Iterable[Union["Key", str]] = (),
-    inaccessible: bool = UNSET,
-    tags: Iterable[str] = (),
+    directives: Iterable[object] = (),
+    authenticated: bool = UNSET,
     extend: bool = False,
+    inaccessible: bool = UNSET,
+    keys: Iterable[Union["Key", str]] = (),
+    policies: Optional[List[List[Federation__Policy]]] = None,
+    requires_scopes: Optional[List[List[Federation__Scope]]] = None,
+    shareable: bool = False,
+    tags: Iterable[str] = (),
 ) -> T:
     ...
 
@@ -107,12 +129,15 @@ def type(
     *,
     name: Optional[str] = None,
     description: Optional[str] = None,
-    keys: Iterable[Union["Key", str]] = (),
-    inaccessible: bool = UNSET,
-    tags: Iterable[str] = (),
-    extend: bool = False,
-    shareable: bool = False,
     directives: Iterable[object] = (),
+    authenticated: bool = UNSET,
+    extend: bool = False,
+    inaccessible: bool = UNSET,
+    keys: Iterable[Union["Key", str]] = (),
+    policies: Optional[List[List[Federation__Policy]]] = None,
+    requires_scopes: Optional[List[List[Federation__Scope]]] = None,
+    shareable: bool = False,
+    tags: Iterable[str] = (),
 ) -> Callable[[T], T]:
     ...
 
@@ -122,22 +147,28 @@ def type(
     *,
     name: Optional[str] = None,
     description: Optional[str] = None,
-    keys: Iterable[Union["Key", str]] = (),
-    inaccessible: bool = UNSET,
-    tags: Iterable[str] = (),
-    extend: bool = False,
-    shareable: bool = False,
     directives: Iterable[object] = (),
+    authenticated: bool = UNSET,
+    extend: bool = False,
+    inaccessible: bool = UNSET,
+    keys: Iterable[Union["Key", str]] = (),
+    policies: Optional[List[List[Federation__Policy]]] = None,
+    requires_scopes: Optional[List[List[Federation__Scope]]] = None,
+    shareable: bool = False,
+    tags: Iterable[str] = (),
 ):
     return _impl_type(
         cls,
         name=name,
         description=description,
         directives=directives,
+        authenticated=authenticated,
         keys=keys,
         extend=extend,
-        shareable=shareable,
         inaccessible=inaccessible,
+        policies=policies,
+        requires_scopes=requires_scopes,
+        shareable=shareable,
         tags=tags,
     )
 
@@ -208,10 +239,13 @@ def interface(
     *,
     name: Optional[str] = None,
     description: Optional[str] = None,
-    keys: Iterable[Union["Key", str]] = (),
-    inaccessible: bool = UNSET,
-    tags: Iterable[str] = (),
     directives: Iterable[object] = (),
+    authenticated: bool = UNSET,
+    inaccessible: bool = UNSET,
+    keys: Iterable[Union["Key", str]] = (),
+    policies: Optional[List[List[Federation__Policy]]] = None,
+    requires_scopes: Optional[List[List[Federation__Scope]]] = None,
+    tags: Iterable[str] = (),
 ) -> T:
     ...
 
@@ -226,10 +260,13 @@ def interface(
     *,
     name: Optional[str] = None,
     description: Optional[str] = None,
-    keys: Iterable[Union["Key", str]] = (),
-    inaccessible: bool = UNSET,
-    tags: Iterable[str] = (),
     directives: Iterable[object] = (),
+    authenticated: bool = UNSET,
+    inaccessible: bool = UNSET,
+    keys: Iterable[Union["Key", str]] = (),
+    policies: Optional[List[List[Federation__Policy]]] = None,
+    requires_scopes: Optional[List[List[Federation__Scope]]] = None,
+    tags: Iterable[str] = (),
 ) -> Callable[[T], T]:
     ...
 
@@ -239,20 +276,26 @@ def interface(
     *,
     name: Optional[str] = None,
     description: Optional[str] = None,
-    keys: Iterable[Union["Key", str]] = (),
-    inaccessible: bool = UNSET,
-    tags: Iterable[str] = (),
     directives: Iterable[object] = (),
+    authenticated: bool = UNSET,
+    inaccessible: bool = UNSET,
+    keys: Iterable[Union["Key", str]] = (),
+    policies: Optional[List[List[Federation__Policy]]] = None,
+    requires_scopes: Optional[List[List[Federation__Scope]]] = None,
+    tags: Iterable[str] = (),
 ):
     return _impl_type(
         cls,
         name=name,
         description=description,
         directives=directives,
+        authenticated=authenticated,
         keys=keys,
         inaccessible=inaccessible,
-        is_interface=True,
+        policies=policies,
+        requires_scopes=requires_scopes,
         tags=tags,
+        is_interface=True,
     )
 
 
@@ -265,12 +308,15 @@ def interface(
 def interface_object(
     cls: T,
     *,
-    keys: Iterable[Union["Key", str]],
     name: Optional[str] = None,
     description: Optional[str] = None,
-    inaccessible: bool = UNSET,
-    tags: Iterable[str] = (),
     directives: Iterable[object] = (),
+    authenticated: bool = UNSET,
+    inaccessible: bool = UNSET,
+    keys: Iterable[Union["Key", str]] = (),
+    policies: Optional[List[List[Federation__Policy]]] = None,
+    requires_scopes: Optional[List[List[Federation__Scope]]] = None,
+    tags: Iterable[str] = (),
 ) -> T:
     ...
 
@@ -283,12 +329,15 @@ def interface_object(
 )
 def interface_object(
     *,
-    keys: Iterable[Union["Key", str]],
     name: Optional[str] = None,
     description: Optional[str] = None,
-    inaccessible: bool = UNSET,
-    tags: Iterable[str] = (),
     directives: Iterable[object] = (),
+    authenticated: bool = UNSET,
+    inaccessible: bool = UNSET,
+    keys: Iterable[Union["Key", str]] = (),
+    policies: Optional[List[List[Federation__Policy]]] = None,
+    requires_scopes: Optional[List[List[Federation__Scope]]] = None,
+    tags: Iterable[str] = (),
 ) -> Callable[[T], T]:
     ...
 
@@ -296,21 +345,27 @@ def interface_object(
 def interface_object(
     cls: Optional[T] = None,
     *,
-    keys: Iterable[Union["Key", str]],
     name: Optional[str] = None,
     description: Optional[str] = None,
-    inaccessible: bool = UNSET,
-    tags: Iterable[str] = (),
     directives: Iterable[object] = (),
+    authenticated: bool = UNSET,
+    inaccessible: bool = UNSET,
+    keys: Iterable[Union["Key", str]] = (),
+    policies: Optional[List[List[Federation__Policy]]] = None,
+    requires_scopes: Optional[List[List[Federation__Scope]]] = None,
+    tags: Iterable[str] = (),
 ):
     return _impl_type(
         cls,
         name=name,
         description=description,
         directives=directives,
+        authenticated=authenticated,
         keys=keys,
         inaccessible=inaccessible,
+        policies=policies,
+        requires_scopes=requires_scopes,
+        tags=tags,
         is_interface=False,
         is_interface_object=True,
-        tags=tags,
     )

--- a/strawberry/federation/scalar.py
+++ b/strawberry/federation/scalar.py
@@ -14,8 +14,6 @@ from typing import (
 
 from strawberry.custom_scalar import _process_scalar
 
-from .types import Federation__Policy, Federation__Scope
-
 # in python 3.10+ NewType is a class
 if sys.version_info >= (3, 10):
     _T = TypeVar("_T", bound=Union[type, NewType])
@@ -39,8 +37,8 @@ def scalar(
     directives: Iterable[object] = (),
     authenticated: bool = False,
     inaccessible: bool = False,
-    policy: Optional[List[List[Federation__Policy]]] = None,
-    requires_scopes: Optional[List[List[Federation__Scope]]] = None,
+    policy: Optional[List[List[str]]] = None,
+    requires_scopes: Optional[List[List[str]]] = None,
     tags: Optional[Iterable[str]] = (),
 ) -> Callable[[_T], _T]:
     ...
@@ -59,8 +57,8 @@ def scalar(
     directives: Iterable[object] = (),
     authenticated: bool = False,
     inaccessible: bool = False,
-    policy: Optional[List[List[Federation__Policy]]] = None,
-    requires_scopes: Optional[List[List[Federation__Scope]]] = None,
+    policy: Optional[List[List[str]]] = None,
+    requires_scopes: Optional[List[List[str]]] = None,
     tags: Optional[Iterable[str]] = (),
 ) -> _T:
     ...
@@ -78,8 +76,8 @@ def scalar(
     directives: Iterable[object] = (),
     authenticated: bool = False,
     inaccessible: bool = False,
-    policy: Optional[List[List[Federation__Policy]]] = None,
-    requires_scopes: Optional[List[List[Federation__Scope]]] = None,
+    policy: Optional[List[List[str]]] = None,
+    requires_scopes: Optional[List[List[str]]] = None,
     tags: Optional[Iterable[str]] = (),
 ) -> Any:
     """Annotates a class or type as a GraphQL custom scalar.

--- a/strawberry/federation/scalar.py
+++ b/strawberry/federation/scalar.py
@@ -3,6 +3,7 @@ from typing import (
     Any,
     Callable,
     Iterable,
+    List,
     NewType,
     Optional,
     Type,
@@ -12,6 +13,8 @@ from typing import (
 )
 
 from strawberry.custom_scalar import _process_scalar
+
+from .types import Federation__Policy, Federation__Scope
 
 # in python 3.10+ NewType is a class
 if sys.version_info >= (3, 10):
@@ -34,7 +37,10 @@ def scalar(
     parse_value: Optional[Callable] = None,
     parse_literal: Optional[Callable] = None,
     directives: Iterable[object] = (),
+    authenticated: bool = False,
     inaccessible: bool = False,
+    policies: Optional[List[List[Federation__Policy]]] = None,
+    requires_scopes: Optional[List[List[Federation__Scope]]] = None,
     tags: Optional[Iterable[str]] = (),
 ) -> Callable[[_T], _T]:
     ...
@@ -51,7 +57,10 @@ def scalar(
     parse_value: Optional[Callable] = None,
     parse_literal: Optional[Callable] = None,
     directives: Iterable[object] = (),
+    authenticated: bool = False,
     inaccessible: bool = False,
+    policies: Optional[List[List[Federation__Policy]]] = None,
+    requires_scopes: Optional[List[List[Federation__Scope]]] = None,
     tags: Optional[Iterable[str]] = (),
 ) -> _T:
     ...
@@ -67,7 +76,10 @@ def scalar(
     parse_value: Optional[Callable] = None,
     parse_literal: Optional[Callable] = None,
     directives: Iterable[object] = (),
+    authenticated: bool = False,
     inaccessible: bool = False,
+    policies: Optional[List[List[Federation__Policy]]] = None,
+    requires_scopes: Optional[List[List[Federation__Scope]]] = None,
     tags: Optional[Iterable[str]] = (),
 ) -> Any:
     """Annotates a class or type as a GraphQL custom scalar.
@@ -95,15 +107,30 @@ def scalar(
     >>>         self.items = items
 
     """
-    from strawberry.federation.schema_directives import Inaccessible, Tag
+    from strawberry.federation.schema_directives import (
+        Authenticated,
+        Inaccessible,
+        Policy,
+        RequiresScopes,
+        Tag,
+    )
 
     if parse_value is None:
         parse_value = cls
 
     directives = list(directives)
 
+    if authenticated:
+        directives.append(Authenticated())
+
     if inaccessible:
         directives.append(Inaccessible())
+
+    if policies:
+        directives.append(Policy(policies=policies))
+
+    if requires_scopes:
+        directives.append(RequiresScopes(scopes=requires_scopes))
 
     if tags:
         directives.extend(Tag(name=tag) for tag in tags)

--- a/strawberry/federation/scalar.py
+++ b/strawberry/federation/scalar.py
@@ -39,7 +39,7 @@ def scalar(
     directives: Iterable[object] = (),
     authenticated: bool = False,
     inaccessible: bool = False,
-    policies: Optional[List[List[Federation__Policy]]] = None,
+    policy: Optional[List[List[Federation__Policy]]] = None,
     requires_scopes: Optional[List[List[Federation__Scope]]] = None,
     tags: Optional[Iterable[str]] = (),
 ) -> Callable[[_T], _T]:
@@ -59,7 +59,7 @@ def scalar(
     directives: Iterable[object] = (),
     authenticated: bool = False,
     inaccessible: bool = False,
-    policies: Optional[List[List[Federation__Policy]]] = None,
+    policy: Optional[List[List[Federation__Policy]]] = None,
     requires_scopes: Optional[List[List[Federation__Scope]]] = None,
     tags: Optional[Iterable[str]] = (),
 ) -> _T:
@@ -78,7 +78,7 @@ def scalar(
     directives: Iterable[object] = (),
     authenticated: bool = False,
     inaccessible: bool = False,
-    policies: Optional[List[List[Federation__Policy]]] = None,
+    policy: Optional[List[List[Federation__Policy]]] = None,
     requires_scopes: Optional[List[List[Federation__Scope]]] = None,
     tags: Optional[Iterable[str]] = (),
 ) -> Any:
@@ -126,8 +126,8 @@ def scalar(
     if inaccessible:
         directives.append(Inaccessible())
 
-    if policies:
-        directives.append(Policy(policies=policies))
+    if policy:
+        directives.append(Policy(policies=policy))
 
     if requires_scopes:
         directives.append(RequiresScopes(scopes=requires_scopes))

--- a/strawberry/federation/schema_directives.py
+++ b/strawberry/federation/schema_directives.py
@@ -5,13 +5,13 @@ from strawberry import directive_field
 from strawberry.schema_directive import Location, schema_directive
 from strawberry.unset import UNSET
 
-from .types import FieldSet, LinkImport, LinkPurpose
+from .types import Federation__Policy, Federation__Scope, FieldSet, LinkImport, LinkPurpose
 
 
 @dataclass
 class ImportedFrom:
     name: str
-    url: str = "https://specs.apollo.dev/federation/v2.3"
+    url: str = "https://specs.apollo.dev/federation/v2.6"
 
 
 class FederationDirective:
@@ -23,7 +23,7 @@ class FederationDirective:
 )
 class External(FederationDirective):
     imported_from: ClassVar[ImportedFrom] = ImportedFrom(
-        name="external", url="https://specs.apollo.dev/federation/v2.3"
+        name="external", url="https://specs.apollo.dev/federation/v2.6"
     )
 
 
@@ -33,7 +33,7 @@ class External(FederationDirective):
 class Requires(FederationDirective):
     fields: FieldSet
     imported_from: ClassVar[ImportedFrom] = ImportedFrom(
-        name="requires", url="https://specs.apollo.dev/federation/v2.3"
+        name="requires", url="https://specs.apollo.dev/federation/v2.6"
     )
 
 
@@ -43,7 +43,7 @@ class Requires(FederationDirective):
 class Provides(FederationDirective):
     fields: FieldSet
     imported_from: ClassVar[ImportedFrom] = ImportedFrom(
-        name="provides", url="https://specs.apollo.dev/federation/v2.3"
+        name="provides", url="https://specs.apollo.dev/federation/v2.6"
     )
 
 
@@ -57,7 +57,7 @@ class Key(FederationDirective):
     fields: FieldSet
     resolvable: Optional[bool] = True
     imported_from: ClassVar[ImportedFrom] = ImportedFrom(
-        name="key", url="https://specs.apollo.dev/federation/v2.3"
+        name="key", url="https://specs.apollo.dev/federation/v2.6"
     )
 
 
@@ -69,7 +69,7 @@ class Key(FederationDirective):
 )
 class Shareable(FederationDirective):
     imported_from: ClassVar[ImportedFrom] = ImportedFrom(
-        name="shareable", url="https://specs.apollo.dev/federation/v2.3"
+        name="shareable", url="https://specs.apollo.dev/federation/v2.6"
     )
 
 
@@ -115,7 +115,7 @@ class Link:
 class Tag(FederationDirective):
     name: str
     imported_from: ClassVar[ImportedFrom] = ImportedFrom(
-        name="tag", url="https://specs.apollo.dev/federation/v2.3"
+        name="tag", url="https://specs.apollo.dev/federation/v2.6"
     )
 
 
@@ -125,7 +125,7 @@ class Tag(FederationDirective):
 class Override(FederationDirective):
     override_from: str = directive_field(name="from")
     imported_from: ClassVar[ImportedFrom] = ImportedFrom(
-        name="override", url="https://specs.apollo.dev/federation/v2.3"
+        name="override", url="https://specs.apollo.dev/federation/v2.6"
     )
 
 
@@ -147,7 +147,7 @@ class Override(FederationDirective):
 )
 class Inaccessible(FederationDirective):
     imported_from: ClassVar[ImportedFrom] = ImportedFrom(
-        name="inaccessible", url="https://specs.apollo.dev/federation/v2.3"
+        name="inaccessible", url="https://specs.apollo.dev/federation/v2.6"
     )
 
 
@@ -157,7 +157,7 @@ class Inaccessible(FederationDirective):
 class ComposeDirective(FederationDirective):
     name: str
     imported_from: ClassVar[ImportedFrom] = ImportedFrom(
-        name="composeDirective", url="https://specs.apollo.dev/federation/v2.3"
+        name="composeDirective", url="https://specs.apollo.dev/federation/v2.6"
     )
 
 
@@ -166,5 +166,34 @@ class ComposeDirective(FederationDirective):
 )
 class InterfaceObject(FederationDirective):
     imported_from: ClassVar[ImportedFrom] = ImportedFrom(
-        name="interfaceObject", url="https://specs.apollo.dev/federation/v2.3"
+        name="interfaceObject", url="https://specs.apollo.dev/federation/v2.6"
+    )
+
+@schema_directive(
+    locations=[Location.FIELD_DEFINITION, Location.OBJECT, Location.INTERFACE, Location.SCALAR, Location.ENUM],
+    name="authenticated"
+)
+class Authenticated(FederationDirective):
+    imported_from: ClassVar[ImportedFrom] = ImportedFrom(
+        name="authenticated", url="https://specs.apollo.dev/federation/v2.7"
+    )
+
+@schema_directive(
+    locations=[Location.FIELD_DEFINITION, Location.OBJECT, Location.INTERFACE, Location.SCALAR, Location.ENUM],
+    name="requiresScopes"
+)
+class RequiresScopes(FederationDirective):
+    scopes: "list[list[Federation__Scope]]"
+    imported_from: ClassVar[ImportedFrom] = ImportedFrom(
+        name="requiresScopes", url="https://specs.apollo.dev/federation/v2.7"
+    )
+
+@schema_directive(
+    locations=[Location.FIELD_DEFINITION, Location.OBJECT, Location.INTERFACE, Location.SCALAR, Location.ENUM],
+    name="requiresScopes"
+)
+class Policy(FederationDirective):
+    scopes: "list[list[Federation__Policy]]"
+    imported_from: ClassVar[ImportedFrom] = ImportedFrom(
+        name="policy", url="https://specs.apollo.dev/federation/v2.7"
     )

--- a/strawberry/federation/schema_directives.py
+++ b/strawberry/federation/schema_directives.py
@@ -15,7 +15,7 @@ from .types import (
 @dataclass
 class ImportedFrom:
     name: str
-    url: str = "https://specs.apollo.dev/federation/v2.6"
+    url: str = "https://specs.apollo.dev/federation/v2.7"
 
 
 class FederationDirective:
@@ -27,7 +27,7 @@ class FederationDirective:
 )
 class External(FederationDirective):
     imported_from: ClassVar[ImportedFrom] = ImportedFrom(
-        name="external", url="https://specs.apollo.dev/federation/v2.6"
+        name="external", url="https://specs.apollo.dev/federation/v2.7"
     )
 
 
@@ -37,7 +37,7 @@ class External(FederationDirective):
 class Requires(FederationDirective):
     fields: FieldSet
     imported_from: ClassVar[ImportedFrom] = ImportedFrom(
-        name="requires", url="https://specs.apollo.dev/federation/v2.6"
+        name="requires", url="https://specs.apollo.dev/federation/v2.7"
     )
 
 
@@ -47,7 +47,7 @@ class Requires(FederationDirective):
 class Provides(FederationDirective):
     fields: FieldSet
     imported_from: ClassVar[ImportedFrom] = ImportedFrom(
-        name="provides", url="https://specs.apollo.dev/federation/v2.6"
+        name="provides", url="https://specs.apollo.dev/federation/v2.7"
     )
 
 
@@ -61,7 +61,7 @@ class Key(FederationDirective):
     fields: FieldSet
     resolvable: Optional[bool] = True
     imported_from: ClassVar[ImportedFrom] = ImportedFrom(
-        name="key", url="https://specs.apollo.dev/federation/v2.6"
+        name="key", url="https://specs.apollo.dev/federation/v2.7"
     )
 
 
@@ -73,7 +73,7 @@ class Key(FederationDirective):
 )
 class Shareable(FederationDirective):
     imported_from: ClassVar[ImportedFrom] = ImportedFrom(
-        name="shareable", url="https://specs.apollo.dev/federation/v2.6"
+        name="shareable", url="https://specs.apollo.dev/federation/v2.7"
     )
 
 
@@ -119,7 +119,7 @@ class Link:
 class Tag(FederationDirective):
     name: str
     imported_from: ClassVar[ImportedFrom] = ImportedFrom(
-        name="tag", url="https://specs.apollo.dev/federation/v2.6"
+        name="tag", url="https://specs.apollo.dev/federation/v2.7"
     )
 
 
@@ -128,8 +128,9 @@ class Tag(FederationDirective):
 )
 class Override(FederationDirective):
     override_from: str = directive_field(name="from")
+    label: Optional[str] = UNSET
     imported_from: ClassVar[ImportedFrom] = ImportedFrom(
-        name="override", url="https://specs.apollo.dev/federation/v2.6"
+        name="override", url="https://specs.apollo.dev/federation/v2.7"
     )
 
 
@@ -151,7 +152,7 @@ class Override(FederationDirective):
 )
 class Inaccessible(FederationDirective):
     imported_from: ClassVar[ImportedFrom] = ImportedFrom(
-        name="inaccessible", url="https://specs.apollo.dev/federation/v2.6"
+        name="inaccessible", url="https://specs.apollo.dev/federation/v2.7"
     )
 
 
@@ -161,7 +162,7 @@ class Inaccessible(FederationDirective):
 class ComposeDirective(FederationDirective):
     name: str
     imported_from: ClassVar[ImportedFrom] = ImportedFrom(
-        name="composeDirective", url="https://specs.apollo.dev/federation/v2.6"
+        name="composeDirective", url="https://specs.apollo.dev/federation/v2.7"
     )
 
 
@@ -170,7 +171,7 @@ class ComposeDirective(FederationDirective):
 )
 class InterfaceObject(FederationDirective):
     imported_from: ClassVar[ImportedFrom] = ImportedFrom(
-        name="interfaceObject", url="https://specs.apollo.dev/federation/v2.6"
+        name="interfaceObject", url="https://specs.apollo.dev/federation/v2.7"
     )
 
 
@@ -187,7 +188,7 @@ class InterfaceObject(FederationDirective):
 )
 class Authenticated(FederationDirective):
     imported_from: ClassVar[ImportedFrom] = ImportedFrom(
-        name="authenticated", url="https://specs.apollo.dev/federation/v2.6"
+        name="authenticated", url="https://specs.apollo.dev/federation/v2.7"
     )
 
 
@@ -205,7 +206,7 @@ class Authenticated(FederationDirective):
 class RequiresScopes(FederationDirective):
     scopes: "List[List[str]]"
     imported_from: ClassVar[ImportedFrom] = ImportedFrom(
-        name="requiresScopes", url="https://specs.apollo.dev/federation/v2.6"
+        name="requiresScopes", url="https://specs.apollo.dev/federation/v2.7"
     )
 
 
@@ -223,5 +224,5 @@ class RequiresScopes(FederationDirective):
 class Policy(FederationDirective):
     policies: "List[List[str]]"
     imported_from: ClassVar[ImportedFrom] = ImportedFrom(
-        name="policy", url="https://specs.apollo.dev/federation/v2.6"
+        name="policy", url="https://specs.apollo.dev/federation/v2.7"
     )

--- a/strawberry/federation/schema_directives.py
+++ b/strawberry/federation/schema_directives.py
@@ -185,10 +185,11 @@ class InterfaceObject(FederationDirective):
         Location.ENUM,
     ],
     name="authenticated",
+    print_definition=False,
 )
 class Authenticated(FederationDirective):
     imported_from: ClassVar[ImportedFrom] = ImportedFrom(
-        name="authenticated", url="https://specs.apollo.dev/federation/v2.7"
+        name="authenticated", url="https://specs.apollo.dev/federation/v2.6"
     )
 
 
@@ -201,11 +202,12 @@ class Authenticated(FederationDirective):
         Location.ENUM,
     ],
     name="requiresScopes",
+    print_definition=False,
 )
 class RequiresScopes(FederationDirective):
-    scopes: "list[list[Federation__Scope]]"
+    scopes: "List[List[Federation__Scope]]"
     imported_from: ClassVar[ImportedFrom] = ImportedFrom(
-        name="requiresScopes", url="https://specs.apollo.dev/federation/v2.7"
+        name="requiresScopes", url="https://specs.apollo.dev/federation/v2.6"
     )
 
 
@@ -217,10 +219,11 @@ class RequiresScopes(FederationDirective):
         Location.SCALAR,
         Location.ENUM,
     ],
-    name="requiresScopes",
+    name="policy",
+    print_definition=False,
 )
 class Policy(FederationDirective):
-    scopes: "list[list[Federation__Policy]]"
+    policies: "List[List[Federation__Policy]]"
     imported_from: ClassVar[ImportedFrom] = ImportedFrom(
-        name="policy", url="https://specs.apollo.dev/federation/v2.7"
+        name="policy", url="https://specs.apollo.dev/federation/v2.6"
     )

--- a/strawberry/federation/schema_directives.py
+++ b/strawberry/federation/schema_directives.py
@@ -5,7 +5,13 @@ from strawberry import directive_field
 from strawberry.schema_directive import Location, schema_directive
 from strawberry.unset import UNSET
 
-from .types import Federation__Policy, Federation__Scope, FieldSet, LinkImport, LinkPurpose
+from .types import (
+    Federation__Policy,
+    Federation__Scope,
+    FieldSet,
+    LinkImport,
+    LinkPurpose,
+)
 
 
 @dataclass
@@ -169,18 +175,32 @@ class InterfaceObject(FederationDirective):
         name="interfaceObject", url="https://specs.apollo.dev/federation/v2.6"
     )
 
+
 @schema_directive(
-    locations=[Location.FIELD_DEFINITION, Location.OBJECT, Location.INTERFACE, Location.SCALAR, Location.ENUM],
-    name="authenticated"
+    locations=[
+        Location.FIELD_DEFINITION,
+        Location.OBJECT,
+        Location.INTERFACE,
+        Location.SCALAR,
+        Location.ENUM,
+    ],
+    name="authenticated",
 )
 class Authenticated(FederationDirective):
     imported_from: ClassVar[ImportedFrom] = ImportedFrom(
         name="authenticated", url="https://specs.apollo.dev/federation/v2.7"
     )
 
+
 @schema_directive(
-    locations=[Location.FIELD_DEFINITION, Location.OBJECT, Location.INTERFACE, Location.SCALAR, Location.ENUM],
-    name="requiresScopes"
+    locations=[
+        Location.FIELD_DEFINITION,
+        Location.OBJECT,
+        Location.INTERFACE,
+        Location.SCALAR,
+        Location.ENUM,
+    ],
+    name="requiresScopes",
 )
 class RequiresScopes(FederationDirective):
     scopes: "list[list[Federation__Scope]]"
@@ -188,9 +208,16 @@ class RequiresScopes(FederationDirective):
         name="requiresScopes", url="https://specs.apollo.dev/federation/v2.7"
     )
 
+
 @schema_directive(
-    locations=[Location.FIELD_DEFINITION, Location.OBJECT, Location.INTERFACE, Location.SCALAR, Location.ENUM],
-    name="requiresScopes"
+    locations=[
+        Location.FIELD_DEFINITION,
+        Location.OBJECT,
+        Location.INTERFACE,
+        Location.SCALAR,
+        Location.ENUM,
+    ],
+    name="requiresScopes",
 )
 class Policy(FederationDirective):
     scopes: "list[list[Federation__Policy]]"

--- a/strawberry/federation/schema_directives.py
+++ b/strawberry/federation/schema_directives.py
@@ -6,8 +6,6 @@ from strawberry.schema_directive import Location, schema_directive
 from strawberry.unset import UNSET
 
 from .types import (
-    Federation__Policy,
-    Federation__Scope,
     FieldSet,
     LinkImport,
     LinkPurpose,
@@ -205,7 +203,7 @@ class Authenticated(FederationDirective):
     print_definition=False,
 )
 class RequiresScopes(FederationDirective):
-    scopes: "List[List[Federation__Scope]]"
+    scopes: "List[List[str]]"
     imported_from: ClassVar[ImportedFrom] = ImportedFrom(
         name="requiresScopes", url="https://specs.apollo.dev/federation/v2.6"
     )
@@ -223,7 +221,7 @@ class RequiresScopes(FederationDirective):
     print_definition=False,
 )
 class Policy(FederationDirective):
-    policies: "List[List[Federation__Policy]]"
+    policies: "List[List[str]]"
     imported_from: ClassVar[ImportedFrom] = ImportedFrom(
         name="policy", url="https://specs.apollo.dev/federation/v2.6"
     )

--- a/strawberry/federation/types.py
+++ b/strawberry/federation/types.py
@@ -3,6 +3,10 @@ from enum import Enum
 from strawberry.custom_scalar import scalar
 from strawberry.enum import enum
 
+Federation__Policy = scalar(str, name="federation__Policy")
+
+Federation__Scope = scalar(str, name="federation__Scope")
+
 FieldSet = scalar(str, name="_FieldSet")
 
 LinkImport = scalar(object, name="link__Import")

--- a/strawberry/federation/types.py
+++ b/strawberry/federation/types.py
@@ -3,13 +3,13 @@ from enum import Enum
 from strawberry.custom_scalar import scalar
 from strawberry.enum import enum
 
-Federation__Policy = scalar(str, name="federation__Policy")
-
-Federation__Scope = scalar(str, name="federation__Scope")
-
 FieldSet = scalar(str, name="_FieldSet")
 
 LinkImport = scalar(object, name="link__Import")
+
+Federation__Policy = scalar(str, name="federation__Policy")
+
+Federation__Scope = scalar(str, name="federation__Scope")
 
 
 @enum(name="link__Purpose")

--- a/strawberry/federation/types.py
+++ b/strawberry/federation/types.py
@@ -7,10 +7,6 @@ FieldSet = scalar(str, name="_FieldSet")
 
 LinkImport = scalar(object, name="link__Import")
 
-Federation__Policy = scalar(str, name="federation__Policy")
-
-Federation__Scope = scalar(str, name="federation__Scope")
-
 
 @enum(name="link__Purpose")
 class LinkPurpose(Enum):

--- a/tests/federation/printer/test_authenticated.py
+++ b/tests/federation/printer/test_authenticated.py
@@ -1,0 +1,122 @@
+import textwrap
+from enum import Enum
+from typing import List
+from typing_extensions import Annotated
+
+import strawberry
+
+
+def test_field_authenticated_printed_correctly():
+    @strawberry.federation.interface(authenticated=True)
+    class SomeInterface:
+        id: strawberry.ID
+
+    @strawberry.federation.type(authenticated=True)
+    class Product(SomeInterface):
+        upc: str = strawberry.federation.field(authenticated=True)
+
+    @strawberry.federation.type
+    class Query:
+        @strawberry.federation.field(authenticated=True)
+        def top_products(
+            self, first: Annotated[int, strawberry.federation.argument()]
+        ) -> List[Product]:
+            return []
+
+    schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
+
+    expected = """
+        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@authenticated"]) {
+          query: Query
+        }
+
+        type Product implements SomeInterface @authenticated {
+          id: ID!
+          upc: String! @authenticated
+        }
+
+        type Query {
+          _service: _Service!
+          topProducts(first: Int!): [Product!]! @authenticated
+        }
+
+        interface SomeInterface @authenticated {
+          id: ID!
+        }
+
+        scalar _Any
+
+        type _Service {
+          sdl: String!
+        }
+    """
+
+    assert schema.as_str() == textwrap.dedent(expected).strip()
+
+
+def test_field_authenticated_printed_correctly_on_scalar():
+    @strawberry.federation.scalar(authenticated=True)
+    class SomeScalar(str):
+        __slots__ = ()
+
+    @strawberry.federation.type
+    class Query:
+        hello: SomeScalar
+
+    schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
+
+    expected = """
+        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@authenticated"]) {
+          query: Query
+        }
+
+        type Query {
+          _service: _Service!
+          hello: SomeScalar!
+        }
+
+        scalar SomeScalar @authenticated
+
+        scalar _Any
+
+        type _Service {
+          sdl: String!
+        }
+    """
+
+    assert schema.as_str() == textwrap.dedent(expected).strip()
+
+
+def test_field_authenticated_printed_correctly_on_enum():
+    @strawberry.federation.enum(authenticated=True)
+    class SomeEnum(Enum):
+        A = "A"
+
+    @strawberry.federation.type
+    class Query:
+        hello: SomeEnum
+
+    schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
+
+    expected = """
+        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@authenticated"]) {
+          query: Query
+        }
+
+        type Query {
+          _service: _Service!
+          hello: SomeEnum!
+        }
+
+        enum SomeEnum @authenticated {
+          A
+        }
+
+        scalar _Any
+
+        type _Service {
+          sdl: String!
+        }
+    """
+
+    assert schema.as_str() == textwrap.dedent(expected).strip()

--- a/tests/federation/printer/test_authenticated.py
+++ b/tests/federation/printer/test_authenticated.py
@@ -26,7 +26,7 @@ def test_field_authenticated_printed_correctly():
     schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@authenticated"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@authenticated"]) {
           query: Query
         }
 
@@ -66,7 +66,7 @@ def test_field_authenticated_printed_correctly_on_scalar():
     schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@authenticated"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@authenticated"]) {
           query: Query
         }
 
@@ -99,7 +99,7 @@ def test_field_authenticated_printed_correctly_on_enum():
     schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@authenticated"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@authenticated"]) {
           query: Query
         }
 

--- a/tests/federation/printer/test_compose_directive.py
+++ b/tests/federation/printer/test_compose_directive.py
@@ -37,7 +37,7 @@ def test_schema_directives_and_compose_schema():
 
     directive @sensitive(reason: String!) on OBJECT
 
-    schema @composeDirective(name: "@cacheControl") @link(url: "https://directives.strawberry.rocks/cacheControl/v0.1", import: ["@cacheControl"]) @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@key", "@shareable"]) {
+    schema @composeDirective(name: "@cacheControl") @link(url: "https://directives.strawberry.rocks/cacheControl/v0.1", import: ["@cacheControl"]) @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@composeDirective", "@key", "@shareable"]) {
       query: Query
     }
 
@@ -102,7 +102,7 @@ def test_schema_directives_and_compose_schema_custom_import_url():
 
     directive @sensitive(reason: String!) on OBJECT
 
-    schema @composeDirective(name: "@cacheControl") @link(url: "https://f.strawberry.rocks/cacheControl/v1.0", import: ["@cacheControl"]) @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@key", "@shareable"]) {
+    schema @composeDirective(name: "@cacheControl") @link(url: "https://f.strawberry.rocks/cacheControl/v1.0", import: ["@cacheControl"]) @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@composeDirective", "@key", "@shareable"]) {
       query: Query
     }
 

--- a/tests/federation/printer/test_compose_directive.py
+++ b/tests/federation/printer/test_compose_directive.py
@@ -37,7 +37,7 @@ def test_schema_directives_and_compose_schema():
 
     directive @sensitive(reason: String!) on OBJECT
 
-    schema @composeDirective(name: "@cacheControl") @link(url: "https://directives.strawberry.rocks/cacheControl/v0.1", import: ["@cacheControl"]) @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@composeDirective", "@key", "@shareable"]) {
+    schema @composeDirective(name: "@cacheControl") @link(url: "https://directives.strawberry.rocks/cacheControl/v0.1", import: ["@cacheControl"]) @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@key", "@shareable"]) {
       query: Query
     }
 
@@ -102,7 +102,7 @@ def test_schema_directives_and_compose_schema_custom_import_url():
 
     directive @sensitive(reason: String!) on OBJECT
 
-    schema @composeDirective(name: "@cacheControl") @link(url: "https://f.strawberry.rocks/cacheControl/v1.0", import: ["@cacheControl"]) @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@composeDirective", "@key", "@shareable"]) {
+    schema @composeDirective(name: "@cacheControl") @link(url: "https://f.strawberry.rocks/cacheControl/v1.0", import: ["@cacheControl"]) @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@key", "@shareable"]) {
       query: Query
     }
 

--- a/tests/federation/printer/test_entities.py
+++ b/tests/federation/printer/test_entities.py
@@ -33,7 +33,7 @@ def test_entities_type_when_no_type_has_keys():
     schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@external"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@external"]) {
           query: Query
         }
 
@@ -96,7 +96,7 @@ def test_entities_type_when_one_type_has_keys():
     schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@external", "@key"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@external", "@key"]) {
           query: Query
         }
 

--- a/tests/federation/printer/test_entities.py
+++ b/tests/federation/printer/test_entities.py
@@ -33,7 +33,7 @@ def test_entities_type_when_no_type_has_keys():
     schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@external"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@external"]) {
           query: Query
         }
 
@@ -96,7 +96,7 @@ def test_entities_type_when_one_type_has_keys():
     schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@external", "@key"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@external", "@key"]) {
           query: Query
         }
 

--- a/tests/federation/printer/test_inaccessible.py
+++ b/tests/federation/printer/test_inaccessible.py
@@ -44,7 +44,7 @@ def test_field_inaccessible_printed_correctly():
     )
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@external", "@inaccessible", "@key"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@external", "@inaccessible", "@key"]) {
           query: Query
         }
 
@@ -107,7 +107,7 @@ def test_inaccessible_on_mutation():
     )
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@inaccessible"]) {
           query: Query
           mutation: Mutation
         }
@@ -144,7 +144,7 @@ def test_inaccessible_on_scalar():
     )
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@inaccessible"]) {
           query: Query
         }
 
@@ -180,7 +180,7 @@ def test_inaccessible_on_enum():
     )
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@inaccessible"]) {
           query: Query
         }
 
@@ -218,7 +218,7 @@ def test_inaccessible_on_enum_value():
     )
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@inaccessible"]) {
           query: Query
         }
 
@@ -259,7 +259,7 @@ def test_field_tag_printed_correctly_on_union():
     schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@inaccessible"]) {
           query: Query
         }
 

--- a/tests/federation/printer/test_inaccessible.py
+++ b/tests/federation/printer/test_inaccessible.py
@@ -44,7 +44,7 @@ def test_field_inaccessible_printed_correctly():
     )
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@external", "@inaccessible", "@key"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@external", "@inaccessible", "@key"]) {
           query: Query
         }
 
@@ -107,7 +107,7 @@ def test_inaccessible_on_mutation():
     )
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible"]) {
           query: Query
           mutation: Mutation
         }
@@ -144,7 +144,7 @@ def test_inaccessible_on_scalar():
     )
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible"]) {
           query: Query
         }
 
@@ -180,7 +180,7 @@ def test_inaccessible_on_enum():
     )
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible"]) {
           query: Query
         }
 
@@ -218,7 +218,7 @@ def test_inaccessible_on_enum_value():
     )
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible"]) {
           query: Query
         }
 
@@ -259,7 +259,7 @@ def test_field_tag_printed_correctly_on_union():
     schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible"]) {
           query: Query
         }
 

--- a/tests/federation/printer/test_interface.py
+++ b/tests/federation/printer/test_interface.py
@@ -22,7 +22,7 @@ def test_entities_extending_interface():
     schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@external", "@key"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@external", "@key"]) {
           query: Query
         }
 

--- a/tests/federation/printer/test_interface.py
+++ b/tests/federation/printer/test_interface.py
@@ -22,7 +22,7 @@ def test_entities_extending_interface():
     schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@external", "@key"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@external", "@key"]) {
           query: Query
         }
 

--- a/tests/federation/printer/test_interface_object.py
+++ b/tests/federation/printer/test_interface_object.py
@@ -13,7 +13,7 @@ def test_interface_object():
     )
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@interfaceObject", "@key"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@interfaceObject", "@key"]) {
           query: Query
         }
 

--- a/tests/federation/printer/test_interface_object.py
+++ b/tests/federation/printer/test_interface_object.py
@@ -13,7 +13,7 @@ def test_interface_object():
     )
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@interfaceObject", "@key"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@interfaceObject", "@key"]) {
           query: Query
         }
 

--- a/tests/federation/printer/test_keys.py
+++ b/tests/federation/printer/test_keys.py
@@ -96,7 +96,7 @@ def test_keys_federation_2():
     schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@external", "@key"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@external", "@key"]) {
           query: Query
         }
 

--- a/tests/federation/printer/test_keys.py
+++ b/tests/federation/printer/test_keys.py
@@ -96,7 +96,7 @@ def test_keys_federation_2():
     schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@external", "@key"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@external", "@key"]) {
           query: Query
         }
 

--- a/tests/federation/printer/test_link.py
+++ b/tests/federation/printer/test_link.py
@@ -47,7 +47,7 @@ def test_link_directive_imports():
         query=Query,
         schema_directives=[
             Link(
-                url="https://specs.apollo.dev/federation/v2.3",
+                url="https://specs.apollo.dev/federation/v2.6",
                 import_=[
                     "@key",
                     "@requires",
@@ -64,7 +64,7 @@ def test_link_directive_imports():
     )
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@key", "@requires", "@provides", "@external", {name: "@tag", as: "@mytag"}, "@extends", "@shareable", "@inaccessible", "@override"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@key", "@requires", "@provides", "@external", {name: "@tag", as: "@mytag"}, "@extends", "@shareable", "@inaccessible", "@override"]) {
           query: Query
         }
 
@@ -95,7 +95,7 @@ def test_adds_link_directive_automatically():
     schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@key"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@key"]) {
           query: Query
         }
 
@@ -139,7 +139,7 @@ def test_adds_link_directive_from_interface():
     )
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@key"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@key"]) {
           query: Query
         }
 
@@ -184,7 +184,7 @@ def test_adds_link_directive_from_input_types():
     )
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible"]) {
           query: Query
         }
 
@@ -224,7 +224,7 @@ def test_adds_link_directive_automatically_from_field():
     schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@key", "@tag"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@key", "@tag"]) {
           query: Query
         }
 
@@ -303,7 +303,7 @@ def test_adds_link_directive_automatically_from_scalar():
     schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@key"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@key"]) {
           query: Query
         }
 

--- a/tests/federation/printer/test_link.py
+++ b/tests/federation/printer/test_link.py
@@ -47,7 +47,7 @@ def test_link_directive_imports():
         query=Query,
         schema_directives=[
             Link(
-                url="https://specs.apollo.dev/federation/v2.6",
+                url="https://specs.apollo.dev/federation/v2.7",
                 import_=[
                     "@key",
                     "@requires",
@@ -64,7 +64,7 @@ def test_link_directive_imports():
     )
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@key", "@requires", "@provides", "@external", {name: "@tag", as: "@mytag"}, "@extends", "@shareable", "@inaccessible", "@override"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@key", "@requires", "@provides", "@external", {name: "@tag", as: "@mytag"}, "@extends", "@shareable", "@inaccessible", "@override"]) {
           query: Query
         }
 
@@ -95,7 +95,7 @@ def test_adds_link_directive_automatically():
     schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@key"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@key"]) {
           query: Query
         }
 
@@ -139,7 +139,7 @@ def test_adds_link_directive_from_interface():
     )
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@key"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@key"]) {
           query: Query
         }
 
@@ -184,7 +184,7 @@ def test_adds_link_directive_from_input_types():
     )
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@inaccessible"]) {
           query: Query
         }
 
@@ -224,7 +224,7 @@ def test_adds_link_directive_automatically_from_field():
     schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@key", "@tag"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@key", "@tag"]) {
           query: Query
         }
 
@@ -303,7 +303,7 @@ def test_adds_link_directive_automatically_from_scalar():
     schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@key"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@key"]) {
           query: Query
         }
 

--- a/tests/federation/printer/test_override.py
+++ b/tests/federation/printer/test_override.py
@@ -24,7 +24,7 @@ def test_field_override_printed_correctly():
     schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@external", "@key", "@override"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@external", "@key", "@override"]) {
           query: Query
         }
 

--- a/tests/federation/printer/test_override.py
+++ b/tests/federation/printer/test_override.py
@@ -4,6 +4,7 @@ import textwrap
 from typing import List
 
 import strawberry
+from strawberry.federation.schema_directives import Override
 
 
 def test_field_override_printed_correctly():
@@ -24,13 +25,65 @@ def test_field_override_printed_correctly():
     schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@external", "@key", "@override"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@external", "@key", "@override"]) {
           query: Query
         }
 
         extend type Product implements SomeInterface @key(fields: "upc") {
           id: ID!
           upc: String! @external @override(from: "mySubGraph")
+        }
+
+        type Query {
+          _entities(representations: [_Any!]!): [_Entity]!
+          _service: _Service!
+          topProducts(first: Int!): [Product!]!
+        }
+
+        interface SomeInterface {
+          id: ID!
+        }
+
+        scalar _Any
+
+        union _Entity = Product
+
+        type _Service {
+          sdl: String!
+        }
+    """
+
+    assert schema.as_str() == textwrap.dedent(expected).strip()
+
+
+def test_field_override_label_printed_correctly():
+    @strawberry.interface
+    class SomeInterface:
+        id: strawberry.ID
+
+    @strawberry.federation.type(keys=["upc"], extend=True)
+    class Product(SomeInterface):
+        upc: str = strawberry.federation.field(
+            external=True,
+            override=Override(override_from="mySubGraph", label="percent(1)"),
+        )
+
+    @strawberry.federation.type
+    class Query:
+        @strawberry.field
+        def top_products(self, first: int) -> List[Product]:
+            return []
+
+    schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
+
+    expected = """
+        schema @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@external", "@key", "@override"]) {
+          query: Query
+        }
+
+        extend type Product implements SomeInterface @key(fields: "upc") {
+          id: ID!
+          upc: String! @external @override(from: "mySubGraph", label: "percent(1)")
         }
 
         type Query {

--- a/tests/federation/printer/test_policy.py
+++ b/tests/federation/printer/test_policy.py
@@ -8,21 +8,21 @@ import strawberry
 
 def test_field_policy_printed_correctly():
     @strawberry.federation.interface(
-        policies=[["client", "poweruser"], ["admin"], ["productowner"]]
+        policy=[["client", "poweruser"], ["admin"], ["productowner"]]
     )
     class SomeInterface:
         id: strawberry.ID
 
     @strawberry.federation.type(
-        policies=[["client", "poweruser"], ["admin"], ["productowner"]]
+        policy=[["client", "poweruser"], ["admin"], ["productowner"]]
     )
     class Product(SomeInterface):
-        upc: str = strawberry.federation.field(policies=[["productowner"]])
+        upc: str = strawberry.federation.field(policy=[["productowner"]])
 
     @strawberry.federation.type
     class Query:
         @strawberry.federation.field(
-            policies=[["client", "poweruser"], ["admin"], ["productowner"]]
+            policy=[["client", "poweruser"], ["admin"], ["productowner"]]
         )
         def top_products(
             self, first: Annotated[int, strawberry.federation.argument()]
@@ -62,7 +62,7 @@ def test_field_policy_printed_correctly():
 
 def test_field_policy_printed_correctly_on_scalar():
     @strawberry.federation.scalar(
-        policies=[["client", "poweruser"], ["admin"], ["productowner"]]
+        policy=[["client", "poweruser"], ["admin"], ["productowner"]]
     )
     class SomeScalar(str):
         __slots__ = ()
@@ -97,7 +97,7 @@ def test_field_policy_printed_correctly_on_scalar():
 
 def test_field_policy_printed_correctly_on_enum():
     @strawberry.federation.enum(
-        policies=[["client", "poweruser"], ["admin"], ["productowner"]]
+        policy=[["client", "poweruser"], ["admin"], ["productowner"]]
     )
     class SomeEnum(Enum):
         A = "A"

--- a/tests/federation/printer/test_policy.py
+++ b/tests/federation/printer/test_policy.py
@@ -32,7 +32,7 @@ def test_field_policy_printed_correctly():
     schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@policy"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@policy"]) {
           query: Query
         }
 
@@ -74,7 +74,7 @@ def test_field_policy_printed_correctly_on_scalar():
     schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@policy"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@policy"]) {
           query: Query
         }
 
@@ -109,7 +109,7 @@ def test_field_policy_printed_correctly_on_enum():
     schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@policy"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@policy"]) {
           query: Query
         }
 

--- a/tests/federation/printer/test_policy.py
+++ b/tests/federation/printer/test_policy.py
@@ -1,0 +1,132 @@
+import textwrap
+from enum import Enum
+from typing import List
+from typing_extensions import Annotated
+
+import strawberry
+
+
+def test_field_policy_printed_correctly():
+    @strawberry.federation.interface(
+        policies=[["client", "poweruser"], ["admin"], ["productowner"]]
+    )
+    class SomeInterface:
+        id: strawberry.ID
+
+    @strawberry.federation.type(
+        policies=[["client", "poweruser"], ["admin"], ["productowner"]]
+    )
+    class Product(SomeInterface):
+        upc: str = strawberry.federation.field(policies=[["productowner"]])
+
+    @strawberry.federation.type
+    class Query:
+        @strawberry.federation.field(
+            policies=[["client", "poweruser"], ["admin"], ["productowner"]]
+        )
+        def top_products(
+            self, first: Annotated[int, strawberry.federation.argument()]
+        ) -> List[Product]:
+            return []
+
+    schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
+
+    expected = """
+        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@policy"]) {
+          query: Query
+        }
+
+        type Product implements SomeInterface @policy(policies: [["client", "poweruser"], ["admin"], ["productowner"]]) {
+          id: ID!
+          upc: String! @policy(policies: [["productowner"]])
+        }
+
+        type Query {
+          _service: _Service!
+          topProducts(first: Int!): [Product!]! @policy(policies: [["client", "poweruser"], ["admin"], ["productowner"]])
+        }
+
+        interface SomeInterface @policy(policies: [["client", "poweruser"], ["admin"], ["productowner"]]) {
+          id: ID!
+        }
+
+        scalar _Any
+
+        type _Service {
+          sdl: String!
+        }
+    """
+
+    assert schema.as_str() == textwrap.dedent(expected).strip()
+
+
+def test_field_policy_printed_correctly_on_scalar():
+    @strawberry.federation.scalar(
+        policies=[["client", "poweruser"], ["admin"], ["productowner"]]
+    )
+    class SomeScalar(str):
+        __slots__ = ()
+
+    @strawberry.federation.type
+    class Query:
+        hello: SomeScalar
+
+    schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
+
+    expected = """
+        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@policy"]) {
+          query: Query
+        }
+
+        type Query {
+          _service: _Service!
+          hello: SomeScalar!
+        }
+
+        scalar SomeScalar @policy(policies: [["client", "poweruser"], ["admin"], ["productowner"]])
+
+        scalar _Any
+
+        type _Service {
+          sdl: String!
+        }
+    """
+
+    assert schema.as_str() == textwrap.dedent(expected).strip()
+
+
+def test_field_policy_printed_correctly_on_enum():
+    @strawberry.federation.enum(
+        policies=[["client", "poweruser"], ["admin"], ["productowner"]]
+    )
+    class SomeEnum(Enum):
+        A = "A"
+
+    @strawberry.federation.type
+    class Query:
+        hello: SomeEnum
+
+    schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
+
+    expected = """
+        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@policy"]) {
+          query: Query
+        }
+
+        type Query {
+          _service: _Service!
+          hello: SomeEnum!
+        }
+
+        enum SomeEnum @policy(policies: [["client", "poweruser"], ["admin"], ["productowner"]]) {
+          A
+        }
+
+        scalar _Any
+
+        type _Service {
+          sdl: String!
+        }
+    """
+
+    assert schema.as_str() == textwrap.dedent(expected).strip()

--- a/tests/federation/printer/test_provides.py
+++ b/tests/federation/printer/test_provides.py
@@ -39,7 +39,7 @@ def test_field_provides_are_printed_correctly_camel_case_on():
     )
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@external", "@key", "@provides"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@external", "@key", "@provides"]) {
           query: Query
         }
 
@@ -111,7 +111,7 @@ def test_field_provides_are_printed_correctly_camel_case_off():
     )
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@external", "@key", "@provides"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@external", "@key", "@provides"]) {
           query: Query
         }
 

--- a/tests/federation/printer/test_provides.py
+++ b/tests/federation/printer/test_provides.py
@@ -39,7 +39,7 @@ def test_field_provides_are_printed_correctly_camel_case_on():
     )
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@external", "@key", "@provides"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@external", "@key", "@provides"]) {
           query: Query
         }
 
@@ -111,7 +111,7 @@ def test_field_provides_are_printed_correctly_camel_case_off():
     )
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@external", "@key", "@provides"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@external", "@key", "@provides"]) {
           query: Query
         }
 

--- a/tests/federation/printer/test_requires.py
+++ b/tests/federation/printer/test_requires.py
@@ -39,7 +39,7 @@ def test_fields_requires_are_printed_correctly():
     schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@external", "@key", "@requires"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@external", "@key", "@requires"]) {
           query: Query
         }
 

--- a/tests/federation/printer/test_requires.py
+++ b/tests/federation/printer/test_requires.py
@@ -39,7 +39,7 @@ def test_fields_requires_are_printed_correctly():
     schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@external", "@key", "@requires"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@external", "@key", "@requires"]) {
           query: Query
         }
 

--- a/tests/federation/printer/test_requires_scopes.py
+++ b/tests/federation/printer/test_requires_scopes.py
@@ -1,0 +1,132 @@
+import textwrap
+from enum import Enum
+from typing import List
+from typing_extensions import Annotated
+
+import strawberry
+
+
+def test_field_requires_scopes_printed_correctly():
+    @strawberry.federation.interface(
+        requires_scopes=[["client", "poweruser"], ["admin"], ["productowner"]]
+    )
+    class SomeInterface:
+        id: strawberry.ID
+
+    @strawberry.federation.type(
+        requires_scopes=[["client", "poweruser"], ["admin"], ["productowner"]]
+    )
+    class Product(SomeInterface):
+        upc: str = strawberry.federation.field(requires_scopes=[["productowner"]])
+
+    @strawberry.federation.type
+    class Query:
+        @strawberry.federation.field(
+            requires_scopes=[["client", "poweruser"], ["admin"], ["productowner"]]
+        )
+        def top_products(
+            self, first: Annotated[int, strawberry.federation.argument()]
+        ) -> List[Product]:
+            return []
+
+    schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
+
+    expected = """
+        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@requiresScopes"]) {
+          query: Query
+        }
+
+        type Product implements SomeInterface @requiresScopes(scopes: [["client", "poweruser"], ["admin"], ["productowner"]]) {
+          id: ID!
+          upc: String! @requiresScopes(scopes: [["productowner"]])
+        }
+
+        type Query {
+          _service: _Service!
+          topProducts(first: Int!): [Product!]! @requiresScopes(scopes: [["client", "poweruser"], ["admin"], ["productowner"]])
+        }
+
+        interface SomeInterface @requiresScopes(scopes: [["client", "poweruser"], ["admin"], ["productowner"]]) {
+          id: ID!
+        }
+
+        scalar _Any
+
+        type _Service {
+          sdl: String!
+        }
+    """
+
+    assert schema.as_str() == textwrap.dedent(expected).strip()
+
+
+def test_field_requires_scopes_printed_correctly_on_scalar():
+    @strawberry.federation.scalar(
+        requires_scopes=[["client", "poweruser"], ["admin"], ["productowner"]]
+    )
+    class SomeScalar(str):
+        __slots__ = ()
+
+    @strawberry.federation.type
+    class Query:
+        hello: SomeScalar
+
+    schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
+
+    expected = """
+        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@requiresScopes"]) {
+          query: Query
+        }
+
+        type Query {
+          _service: _Service!
+          hello: SomeScalar!
+        }
+
+        scalar SomeScalar @requiresScopes(scopes: [["client", "poweruser"], ["admin"], ["productowner"]])
+
+        scalar _Any
+
+        type _Service {
+          sdl: String!
+        }
+    """
+
+    assert schema.as_str() == textwrap.dedent(expected).strip()
+
+
+def test_field_requires_scopes_printed_correctly_on_enum():
+    @strawberry.federation.enum(
+        requires_scopes=[["client", "poweruser"], ["admin"], ["productowner"]]
+    )
+    class SomeEnum(Enum):
+        A = "A"
+
+    @strawberry.federation.type
+    class Query:
+        hello: SomeEnum
+
+    schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
+
+    expected = """
+        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@requiresScopes"]) {
+          query: Query
+        }
+
+        type Query {
+          _service: _Service!
+          hello: SomeEnum!
+        }
+
+        enum SomeEnum @requiresScopes(scopes: [["client", "poweruser"], ["admin"], ["productowner"]]) {
+          A
+        }
+
+        scalar _Any
+
+        type _Service {
+          sdl: String!
+        }
+    """
+
+    assert schema.as_str() == textwrap.dedent(expected).strip()

--- a/tests/federation/printer/test_requires_scopes.py
+++ b/tests/federation/printer/test_requires_scopes.py
@@ -32,7 +32,7 @@ def test_field_requires_scopes_printed_correctly():
     schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@requiresScopes"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@requiresScopes"]) {
           query: Query
         }
 
@@ -74,7 +74,7 @@ def test_field_requires_scopes_printed_correctly_on_scalar():
     schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@requiresScopes"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@requiresScopes"]) {
           query: Query
         }
 
@@ -109,7 +109,7 @@ def test_field_requires_scopes_printed_correctly_on_enum():
     schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@requiresScopes"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@requiresScopes"]) {
           query: Query
         }
 

--- a/tests/federation/printer/test_shareable.py
+++ b/tests/federation/printer/test_shareable.py
@@ -24,7 +24,7 @@ def test_field_shareable_printed_correctly():
     schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@external", "@key", "@shareable"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@external", "@key", "@shareable"]) {
           query: Query
         }
 

--- a/tests/federation/printer/test_shareable.py
+++ b/tests/federation/printer/test_shareable.py
@@ -24,7 +24,7 @@ def test_field_shareable_printed_correctly():
     schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@external", "@key", "@shareable"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@external", "@key", "@shareable"]) {
           query: Query
         }
 

--- a/tests/federation/printer/test_tag.py
+++ b/tests/federation/printer/test_tag.py
@@ -28,7 +28,7 @@ def test_field_tag_printed_correctly():
     schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@external", "@tag"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@external", "@tag"]) {
           query: Query
         }
 
@@ -68,7 +68,7 @@ def test_field_tag_printed_correctly_on_scalar():
     schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@tag"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@tag"]) {
           query: Query
         }
 
@@ -101,7 +101,7 @@ def test_field_tag_printed_correctly_on_enum():
     schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@tag"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@tag"]) {
           query: Query
         }
 
@@ -136,7 +136,7 @@ def test_field_tag_printed_correctly_on_enum_value():
     schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@tag"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@tag"]) {
           query: Query
         }
 
@@ -177,7 +177,7 @@ def test_field_tag_printed_correctly_on_union():
     schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@tag"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@tag"]) {
           query: Query
         }
 
@@ -220,7 +220,7 @@ def test_tag_printed_correctly_on_inputs():
     )
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@tag"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@tag"]) {
           query: Query
         }
 

--- a/tests/federation/printer/test_tag.py
+++ b/tests/federation/printer/test_tag.py
@@ -28,7 +28,7 @@ def test_field_tag_printed_correctly():
     schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@external", "@tag"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@external", "@tag"]) {
           query: Query
         }
 
@@ -68,7 +68,7 @@ def test_field_tag_printed_correctly_on_scalar():
     schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@tag"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@tag"]) {
           query: Query
         }
 
@@ -101,7 +101,7 @@ def test_field_tag_printed_correctly_on_enum():
     schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@tag"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@tag"]) {
           query: Query
         }
 
@@ -136,7 +136,7 @@ def test_field_tag_printed_correctly_on_enum_value():
     schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@tag"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@tag"]) {
           query: Query
         }
 
@@ -177,7 +177,7 @@ def test_field_tag_printed_correctly_on_union():
     schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@tag"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@tag"]) {
           query: Query
         }
 
@@ -220,7 +220,7 @@ def test_tag_printed_correctly_on_inputs():
     )
 
     expected = """
-        schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@tag"]) {
+        schema @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@tag"]) {
           query: Query
         }
 


### PR DESCRIPTION
Update federation support for v2.7 which includes the `@authenticated`, `@requiresScopes`, `@policy` directives, as well as the `label` argument for `@override`. 

## Description

<!--- Describe your changes in detail here. -->
Update federation support to be in alignment with the apollo specification [here](https://www.apollographql.com/docs/federation/subgraph-spec#subgraph-schema-additions)

Specifically:
```
directive @authenticated on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
directive @requiresScopes(scopes: [[federation__Scope!]!]!) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
directive @policy(policies: [[federation__Policy!]!]!) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM

directive @override(from: String! lable: string) on FIELD_DEFINITION
```


## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
