### PR TITLE
Add missing type information to functions and methods

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2017,6 +2017,16 @@ files = [
     {file = "MarkupSafe-2.1.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:5bbe06f8eeafd38e5d0a4894ffec89378b6c6a625ff57e3028921f8ff59318ac"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win32.whl", hash = "sha256:dd15ff04ffd7e05ffcb7fe79f1b98041b8ea30ae9234aed2a9168b5797c3effb"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win_amd64.whl", hash = "sha256:134da1eca9ec0ae528110ccc9e48041e0828d79f24121a1a146161103c76e686"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:f698de3fd0c4e6972b92290a45bd9b1536bffe8c6759c62471efaa8acb4c37bc"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:aa57bd9cf8ae831a362185ee444e15a93ecb2e344c8e52e4d721ea3ab6ef1823"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffcc3f7c66b5f5b7931a5aa68fc9cecc51e685ef90282f4a82f0f5e9b704ad11"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47d4f1c5f80fc62fdd7777d0d40a2e9dda0a05883ab11374334f6c4de38adffd"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1f67c7038d560d92149c060157d623c542173016c4babc0c1913cca0564b9939"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:9aad3c1755095ce347e26488214ef77e0485a3c34a50c5a5e2471dff60b9dd9c"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:14ff806850827afd6b07a5f32bd917fb7f45b046ba40c57abdb636674a8b559c"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8f9293864fe09b8149f0cc42ce56e3f0e54de883a9de90cd427f191c346eb2e1"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-win32.whl", hash = "sha256:715d3562f79d540f251b99ebd6d8baa547118974341db04f5ad06d5ea3eb8007"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-win_amd64.whl", hash = "sha256:1b8dd8c3fd14349433c79fa8abeb573a55fc0fdd769133baac1f5e07abf54aeb"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8e254ae696c88d98da6555f5ace2279cf7cd5b3f52be2b5cf97feafe883b58d2"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cb0932dc158471523c9637e807d9bfb93e06a95cbf010f1a38b98623b929ef2b"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9402b03f1a1b4dc4c19845e5c749e3ab82d5078d16a2a4c2cd2df62d57bb0707"},
@@ -3226,6 +3236,7 @@ files = [
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
+    {file = "PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290"},
     {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
     {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
     {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
@@ -3233,8 +3244,16 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
+    {file = "PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b"},
     {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
+    {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df"},
     {file = "PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"},
@@ -3251,6 +3270,7 @@ files = [
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
+    {file = "PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6"},
     {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
     {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
     {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
@@ -3258,6 +3278,7 @@ files = [
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
+    {file = "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5"},
     {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
     {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
     {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
@@ -3581,6 +3602,32 @@ typing-extensions = "*"
 
 [package.extras]
 dev = ["flake8", "flake8-docstrings", "mypy", "packaging", "pre-commit", "pytest", "pytest-cov", "types-setuptools"]
+
+[[package]]
+name = "ruff"
+version = "0.3.7"
+description = "An extremely fast Python linter and code formatter, written in Rust."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "ruff-0.3.7-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:0e8377cccb2f07abd25e84fc5b2cbe48eeb0fea9f1719cad7caedb061d70e5ce"},
+    {file = "ruff-0.3.7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:15a4d1cc1e64e556fa0d67bfd388fed416b7f3b26d5d1c3e7d192c897e39ba4b"},
+    {file = "ruff-0.3.7-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d28bdf3d7dc71dd46929fafeec98ba89b7c3550c3f0978e36389b5631b793663"},
+    {file = "ruff-0.3.7-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:379b67d4f49774ba679593b232dcd90d9e10f04d96e3c8ce4a28037ae473f7bb"},
+    {file = "ruff-0.3.7-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c060aea8ad5ef21cdfbbe05475ab5104ce7827b639a78dd55383a6e9895b7c51"},
+    {file = "ruff-0.3.7-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:ebf8f615dde968272d70502c083ebf963b6781aacd3079081e03b32adfe4d58a"},
+    {file = "ruff-0.3.7-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d48098bd8f5c38897b03604f5428901b65e3c97d40b3952e38637b5404b739a2"},
+    {file = "ruff-0.3.7-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:da8a4fda219bf9024692b1bc68c9cff4b80507879ada8769dc7e985755d662ea"},
+    {file = "ruff-0.3.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c44e0149f1d8b48c4d5c33d88c677a4aa22fd09b1683d6a7ff55b816b5d074f"},
+    {file = "ruff-0.3.7-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:3050ec0af72b709a62ecc2aca941b9cd479a7bf2b36cc4562f0033d688e44fa1"},
+    {file = "ruff-0.3.7-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a29cc38e4c1ab00da18a3f6777f8b50099d73326981bb7d182e54a9a21bb4ff7"},
+    {file = "ruff-0.3.7-py3-none-musllinux_1_2_i686.whl", hash = "sha256:5b15cc59c19edca917f51b1956637db47e200b0fc5e6e1878233d3a938384b0b"},
+    {file = "ruff-0.3.7-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e491045781b1e38b72c91247cf4634f040f8d0cb3e6d3d64d38dcf43616650b4"},
+    {file = "ruff-0.3.7-py3-none-win32.whl", hash = "sha256:bc931de87593d64fad3a22e201e55ad76271f1d5bfc44e1a1887edd0903c7d9f"},
+    {file = "ruff-0.3.7-py3-none-win_amd64.whl", hash = "sha256:5ef0e501e1e39f35e03c2acb1d1238c595b8bb36cf7a170e7c1df1b73da00e74"},
+    {file = "ruff-0.3.7-py3-none-win_arm64.whl", hash = "sha256:789e144f6dc7019d1f92a812891c645274ed08af6037d11fc65fcbc183b7d59f"},
+    {file = "ruff-0.3.7.tar.gz", hash = "sha256:d5c1aebee5162c2226784800ae031f660c350e7a3402c4d1f8ea4e97e232e3ba"},
+]
 
 [[package]]
 name = "sanic"
@@ -4825,4 +4872,4 @@ starlite = ["starlite"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "06c76c2ddf2e93d48bf35f3bb1a7b157e22ff0dbd3ecea2e13a252e020b98e45"
+content-hash = "c42680c48cbcc646f6797ebf70612335ccaa8e1231c9ec99ef119d7ba6bcfb29"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ pytest-mypy-plugins = ">=1.10,<4.0"
 poetry-plugin-export = "^1.6.0"
 # another bug in poetry
 urllib3 = "<2"
+ruff = "^0.3.7"
 
 [tool.poetry.group.integrations]
 optional = true
@@ -239,8 +240,6 @@ ignore = [
     # definitely enable these, maybe not in tests
     "ANN102",
     "ANN202",
-    "ANN204",
-    "ANN205",
     "ANN401",
     "PGH003",
     "PGH004",
@@ -355,7 +354,22 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "strawberry/schema/types/concrete_type.py" = ["TCH002"]
-"tests/*" = ["RSE102", "SLF001", "TCH001", "TCH002", "TCH003", "ANN001", "ANN201", "PLW0603", "PLC1901", "S603", "S607", "B018"]
+"tests/*" = [
+    "RSE102",
+    "SLF001",
+    "TCH001",
+    "TCH002",
+    "TCH003",
+    "ANN001",
+    "ANN201",
+    "ANN202",
+    "ANN204",
+    "PLW0603",
+    "PLC1901",
+    "S603",
+    "S607",
+    "B018",
+]
 "strawberry/extensions/tracing/__init__.py" = ["TCH004"]
 "tests/http/clients/__init__.py" = ["F401"]
 

--- a/strawberry/aiohttp/handlers/graphql_transport_ws_handler.py
+++ b/strawberry/aiohttp/handlers/graphql_transport_ws_handler.py
@@ -23,7 +23,7 @@ class GraphQLTransportWSHandler(BaseGraphQLTransportWSHandler):
         get_context: Callable[..., Dict[str, Any]],
         get_root_value: Any,
         request: web.Request,
-    ):
+    ) -> None:
         super().__init__(schema, debug, connection_init_wait_timeout)
         self._get_context = get_context
         self._get_root_value = get_root_value

--- a/strawberry/aiohttp/handlers/graphql_ws_handler.py
+++ b/strawberry/aiohttp/handlers/graphql_ws_handler.py
@@ -22,7 +22,7 @@ class GraphQLWSHandler(BaseGraphQLWSHandler):
         get_context: Callable,
         get_root_value: Callable,
         request: web.Request,
-    ):
+    ) -> None:
         super().__init__(schema, debug, keep_alive, keep_alive_interval)
         self._get_context = get_context
         self._get_root_value = get_root_value

--- a/strawberry/aiohttp/views.py
+++ b/strawberry/aiohttp/views.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
 
 
 class AioHTTPRequestAdapter(AsyncHTTPRequestAdapter):
-    def __init__(self, request: web.Request):
+    def __init__(self, request: web.Request) -> None:
         self.request = request
 
     @property
@@ -100,7 +100,7 @@ class GraphQLView(
             GRAPHQL_WS_PROTOCOL,
         ),
         connection_init_wait_timeout: timedelta = timedelta(minutes=1),
-    ):
+    ) -> None:
         self.schema = schema
         self.allow_queries_via_get = allow_queries_via_get
         self.keep_alive = keep_alive

--- a/strawberry/annotation.py
+++ b/strawberry/annotation.py
@@ -61,7 +61,7 @@ class StrawberryAnnotation:
         annotation: Union[object, str],
         *,
         namespace: Optional[Dict[str, Any]] = None,
-    ):
+    ) -> None:
         self.raw_annotation = annotation
         self.namespace = namespace
 

--- a/strawberry/arguments.py
+++ b/strawberry/arguments.py
@@ -54,7 +54,7 @@ class StrawberryArgumentAnnotation:
         deprecation_reason: Optional[str] = None,
         directives: Iterable[object] = (),
         metadata: Optional[Mapping[Any, Any]] = None,
-    ):
+    ) -> None:
         self.description = description
         self.name = name
         self.deprecation_reason = deprecation_reason

--- a/strawberry/asgi/__init__.py
+++ b/strawberry/asgi/__init__.py
@@ -117,7 +117,7 @@ class GraphQL(
         else:
             self.graphql_ide = graphql_ide
 
-    async def __call__(self, scope: Scope, receive: Receive, send: Send):
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] == "http":
             return await self.handle_http(scope, receive, send)
 

--- a/strawberry/asgi/handlers/graphql_transport_ws_handler.py
+++ b/strawberry/asgi/handlers/graphql_transport_ws_handler.py
@@ -26,7 +26,7 @@ class GraphQLTransportWSHandler(BaseGraphQLTransportWSHandler):
         get_context: Callable,
         get_root_value: Callable,
         ws: WebSocket,
-    ):
+    ) -> None:
         super().__init__(schema, debug, connection_init_wait_timeout)
         self._get_context = get_context
         self._get_root_value = get_root_value

--- a/strawberry/asgi/handlers/graphql_ws_handler.py
+++ b/strawberry/asgi/handlers/graphql_ws_handler.py
@@ -25,7 +25,7 @@ class GraphQLWSHandler(BaseGraphQLWSHandler):
         get_context: Callable,
         get_root_value: Callable,
         ws: WebSocket,
-    ):
+    ) -> None:
         super().__init__(schema, debug, keep_alive, keep_alive_interval)
         self._get_context = get_context
         self._get_root_value = get_root_value

--- a/strawberry/asgi/test/client.py
+++ b/strawberry/asgi/test/client.py
@@ -46,5 +46,5 @@ class GraphQLTestClient(BaseGraphQLTestClient):
             headers=headers,
         )
 
-    def _decode(self, response: Any, type: Literal["multipart", "json"]):
+    def _decode(self, response: Any, type: Literal["multipart", "json"]) -> Any:
         return response.json()

--- a/strawberry/auto.py
+++ b/strawberry/auto.py
@@ -24,11 +24,11 @@ class StrawberryAutoMeta(type):
 
     """
 
-    def __init__(self, *args: str, **kwargs: Any):
+    def __init__(self, *args: str, **kwargs: Any) -> None:
         self._instance: Optional[StrawberryAuto] = None
         super().__init__(*args, **kwargs)
 
-    def __call__(cls, *args: str, **kwargs: Any):
+    def __call__(cls, *args: str, **kwargs: Any) -> None:
         if cls._instance is None:
             cls._instance = super().__call__(*args, **kwargs)
 
@@ -37,7 +37,7 @@ class StrawberryAutoMeta(type):
     def __instancecheck__(
         self,
         instance: Union[StrawberryAuto, StrawberryAnnotation, StrawberryType, type],
-    ):
+    ) -> bool:
         if isinstance(instance, StrawberryAnnotation):
             resolved = instance.raw_annotation
             if isinstance(resolved, str):
@@ -69,10 +69,10 @@ class StrawberryAutoMeta(type):
 
 
 class StrawberryAuto(metaclass=StrawberryAutoMeta):
-    def __str__(self):
+    def __str__(self) -> str:
         return "auto"
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<auto>"
 
 

--- a/strawberry/auto.py
+++ b/strawberry/auto.py
@@ -28,7 +28,7 @@ class StrawberryAutoMeta(type):
         self._instance: Optional[StrawberryAuto] = None
         super().__init__(*args, **kwargs)
 
-    def __call__(cls, *args: str, **kwargs: Any) -> None:
+    def __call__(cls, *args: str, **kwargs: Any) -> Any:
         if cls._instance is None:
             cls._instance = super().__call__(*args, **kwargs)
 

--- a/strawberry/chalice/views.py
+++ b/strawberry/chalice/views.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
 
 class ChaliceHTTPRequestAdapter(SyncHTTPRequestAdapter):
-    def __init__(self, request: Request):
+    def __init__(self, request: Request) -> None:
         self.request = request
 
     @property
@@ -62,7 +62,7 @@ class GraphQLView(
         graphiql: Optional[bool] = None,
         graphql_ide: Optional[GraphQL_IDE] = "graphiql",
         allow_queries_via_get: bool = True,
-    ):
+    ) -> None:
         self.allow_queries_via_get = allow_queries_via_get
         self.schema = schema
         if graphiql is not None:

--- a/strawberry/channels/handlers/base.py
+++ b/strawberry/channels/handlers/base.py
@@ -68,7 +68,7 @@ class ChannelsConsumer(AsyncConsumer):
     channel_layer: Optional[ChannelsLayer]
     channel_receive: Callable[[], Awaitable[dict]]
 
-    def __init__(self, *args: str, **kwargs: Any):
+    def __init__(self, *args: str, **kwargs: Any) -> None:
         self.listen_queues: DefaultDict[str, WeakSet[asyncio.Queue]] = defaultdict(
             WeakSet
         )

--- a/strawberry/channels/handlers/graphql_transport_ws_handler.py
+++ b/strawberry/channels/handlers/graphql_transport_ws_handler.py
@@ -23,7 +23,7 @@ class GraphQLTransportWSHandler(BaseGraphQLTransportWSHandler):
         get_context: Callable,
         get_root_value: Callable,
         ws: ChannelsWSConsumer,
-    ):
+    ) -> None:
         super().__init__(schema, debug, connection_init_wait_timeout)
         self._get_context = get_context
         self._get_root_value = get_root_value

--- a/strawberry/channels/handlers/graphql_ws_handler.py
+++ b/strawberry/channels/handlers/graphql_ws_handler.py
@@ -22,7 +22,7 @@ class GraphQLWSHandler(BaseGraphQLWSHandler):
         get_context: Callable,
         get_root_value: Callable,
         ws: ChannelsWSConsumer,
-    ):
+    ) -> None:
         super().__init__(schema, debug, keep_alive, keep_alive_interval)
         self._get_context = get_context
         self._get_root_value = get_root_value

--- a/strawberry/channels/handlers/http_handler.py
+++ b/strawberry/channels/handlers/http_handler.py
@@ -102,7 +102,7 @@ class ChannelsRequest:
 
 
 class BaseChannelsRequestAdapter:
-    def __init__(self, request: ChannelsRequest):
+    def __init__(self, request: ChannelsRequest) -> None:
         self.request = request
 
     @property
@@ -156,7 +156,7 @@ class BaseGraphQLHTTPConsumer(ChannelsConsumer, AsyncHttpConsumer):
         allow_queries_via_get: bool = True,
         subscriptions_enabled: bool = True,
         **kwargs: Any,
-    ):
+    ) -> None:
         self.schema = schema
         self.allow_queries_via_get = allow_queries_via_get
         self.subscriptions_enabled = subscriptions_enabled

--- a/strawberry/channels/handlers/ws_handler.py
+++ b/strawberry/channels/handlers/ws_handler.py
@@ -54,7 +54,7 @@ class GraphQLWSConsumer(ChannelsWSConsumer):
             GRAPHQL_WS_PROTOCOL,
         ),
         connection_init_wait_timeout: Optional[datetime.timedelta] = None,
-    ):
+    ) -> None:
         if connection_init_wait_timeout is None:
             connection_init_wait_timeout = datetime.timedelta(minutes=1)
         self.connection_init_wait_timeout = connection_init_wait_timeout

--- a/strawberry/channels/router.py
+++ b/strawberry/channels/router.py
@@ -48,7 +48,7 @@ class GraphQLProtocolTypeRouter(ProtocolTypeRouter):
         schema: BaseSchema,
         django_application: Optional[str] = None,
         url_pattern: str = "^graphql",
-    ):
+    ) -> None:
         http_urls = [re_path(url_pattern, GraphQLHTTPConsumer.as_asgi(schema=schema))]
         if django_application is not None:
             http_urls.append(re_path("^", django_application))

--- a/strawberry/channels/testing.py
+++ b/strawberry/channels/testing.py
@@ -71,7 +71,7 @@ class GraphQLWebsocketCommunicator(WebsocketCommunicator):
         protocol: str = GRAPHQL_TRANSPORT_WS_PROTOCOL,
         connection_params: dict = {},
         **kwargs: Any,
-    ):
+    ) -> None:
         """
 
         Args:

--- a/strawberry/codegen/query_codegen.py
+++ b/strawberry/codegen/query_codegen.py
@@ -152,7 +152,7 @@ class QueryCodegenPlugin:
 
 
 class ConsolePlugin:
-    def __init__(self, output_dir: Path):
+    def __init__(self, output_dir: Path) -> None:
         self.output_dir = output_dir
         self.files_generated: List[Path] = []
 
@@ -305,7 +305,7 @@ class QueryCodegen:
         schema: Schema,
         plugins: List[QueryCodegenPlugin],
         console_plugin: Optional[ConsolePlugin] = None,
-    ):
+    ) -> None:
         self.schema = schema
         self.plugin_manager = QueryCodegenPluginManager(plugins, console_plugin)
         self.types: List[GraphQLType] = []

--- a/strawberry/custom_scalar.py
+++ b/strawberry/custom_scalar.py
@@ -67,10 +67,10 @@ class ScalarDefinition(StrawberryType):
 class ScalarWrapper:
     _scalar_definition: ScalarDefinition
 
-    def __init__(self, wrap: Callable[[Any], Any]):
+    def __init__(self, wrap: Callable[[Any], Any]) -> None:
         self.wrap = wrap
 
-    def __call__(self, *args: str, **kwargs: Any):
+    def __call__(self, *args: str, **kwargs: Any) -> Any:
         return self.wrap(*args, **kwargs)
 
     def __or__(self, other: Union[StrawberryType, type]) -> StrawberryType:

--- a/strawberry/django/__init__.py
+++ b/strawberry/django/__init__.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 try:
     # import modules and objects from external strawberry-graphql-django
     # package so that it can be used through strawberry.django namespace
@@ -5,7 +7,7 @@ try:
 except ModuleNotFoundError:
     import importlib
 
-    def __getattr__(name: str):
+    def __getattr__(name: str) -> Any:
         # try to import submodule and raise exception only if it does not exist
         import_symbol = f"{__name__}.{name}"
         try:

--- a/strawberry/django/context.py
+++ b/strawberry/django/context.py
@@ -12,7 +12,7 @@ class StrawberryDjangoContext:
     request: HttpRequest
     response: HttpResponse
 
-    def __getitem__(self, key: str):
+    def __getitem__(self, key: str) -> Any:
         # __getitem__ override needed to avoid issues for who's
         # using info.context["request"]
         return super().__getattribute__(key)

--- a/strawberry/django/views.py
+++ b/strawberry/django/views.py
@@ -62,7 +62,7 @@ class TemporalHttpResponse(JsonResponse):
 
 
 class DjangoHTTPRequestAdapter(SyncHTTPRequestAdapter):
-    def __init__(self, request: HttpRequest):
+    def __init__(self, request: HttpRequest) -> None:
         self.request = request
 
     @property
@@ -97,7 +97,7 @@ class DjangoHTTPRequestAdapter(SyncHTTPRequestAdapter):
 
 
 class AsyncDjangoHTTPRequestAdapter(AsyncHTTPRequestAdapter):
-    def __init__(self, request: HttpRequest):
+    def __init__(self, request: HttpRequest) -> None:
         self.request = request
 
     @property
@@ -140,7 +140,7 @@ class BaseView:
         allow_queries_via_get: bool = True,
         subscriptions_enabled: bool = False,
         **kwargs: Any,
-    ):
+    ) -> None:
         self.schema = schema
         self.allow_queries_via_get = allow_queries_via_get
         self.subscriptions_enabled = subscriptions_enabled

--- a/strawberry/exceptions/__init__.py
+++ b/strawberry/exceptions/__init__.py
@@ -35,7 +35,7 @@ setup_exception_handler()
 class WrongReturnTypeForUnion(Exception):
     """The Union type cannot be resolved because it's not a field"""
 
-    def __init__(self, field_name: str, result_type: str):
+    def __init__(self, field_name: str, result_type: str) -> None:
         message = (
             f'The type "{result_type}" cannot be resolved for the field "{field_name}" '
             ", are you using a strawberry.field?"
@@ -50,7 +50,7 @@ class UnallowedReturnTypeForUnion(Exception):
 
     def __init__(
         self, field_name: str, result_type: str, allowed_types: Set[GraphQLObjectType]
-    ):
+    ) -> None:
         formatted_allowed_types = list(sorted(type_.name for type_ in allowed_types))
 
         message = (
@@ -63,7 +63,7 @@ class UnallowedReturnTypeForUnion(Exception):
 
 # TODO: this doesn't seem to be tested
 class InvalidTypeInputForUnion(Exception):
-    def __init__(self, annotation: GraphQLInputObjectType):
+    def __init__(self, annotation: GraphQLInputObjectType) -> None:
         message = f"Union for {annotation} is not supported because it is an Input type"
         super().__init__(message)
 
@@ -72,14 +72,14 @@ class InvalidTypeInputForUnion(Exception):
 class MissingTypesForGenericError(Exception):
     """Raised when a generic types was used without passing any type."""
 
-    def __init__(self, annotation: Union[StrawberryType, type]):
+    def __init__(self, annotation: Union[StrawberryType, type]) -> None:
         message = f'The type "{annotation!r}" is generic, but no type has been passed'
 
         super().__init__(message)
 
 
 class UnsupportedTypeError(StrawberryException):
-    def __init__(self, annotation: Union[StrawberryType, type]):
+    def __init__(self, annotation: Union[StrawberryType, type]) -> None:
         message = f"{annotation} conversion is not supported"
 
         super().__init__(message)
@@ -90,7 +90,7 @@ class UnsupportedTypeError(StrawberryException):
 
 
 class MultipleStrawberryArgumentsError(Exception):
-    def __init__(self, argument_name: str):
+    def __init__(self, argument_name: str) -> None:
         message = (
             f"Annotation for argument `{argument_name}` cannot have multiple "
             f"`strawberry.argument`s"
@@ -100,7 +100,7 @@ class MultipleStrawberryArgumentsError(Exception):
 
 
 class WrongNumberOfResultsReturned(Exception):
-    def __init__(self, expected: int, received: int):
+    def __init__(self, expected: int, received: int) -> None:
         message = (
             "Received wrong number of results in dataloader, "
             f"expected: {expected}, received: {received}"
@@ -110,7 +110,7 @@ class WrongNumberOfResultsReturned(Exception):
 
 
 class FieldWithResolverAndDefaultValueError(Exception):
-    def __init__(self, field_name: str, type_name: str):
+    def __init__(self, field_name: str, type_name: str) -> None:
         message = (
             f'Field "{field_name}" on type "{type_name}" cannot define a default '
             "value and a resolver."
@@ -120,7 +120,7 @@ class FieldWithResolverAndDefaultValueError(Exception):
 
 
 class FieldWithResolverAndDefaultFactoryError(Exception):
-    def __init__(self, field_name: str, type_name: str):
+    def __init__(self, field_name: str, type_name: str) -> None:
         message = (
             f'Field "{field_name}" on type "{type_name}" cannot define a '
             "default_factory and a resolver."
@@ -130,14 +130,14 @@ class FieldWithResolverAndDefaultFactoryError(Exception):
 
 
 class MissingQueryError(Exception):
-    def __init__(self):
+    def __init__(self) -> None:
         message = 'Request data is missing a "query" value'
 
         super().__init__(message)
 
 
 class InvalidDefaultFactoryError(Exception):
-    def __init__(self):
+    def __init__(self) -> None:
         message = "`default_factory` must be a callable that requires no arguments"
 
         super().__init__(message)
@@ -146,7 +146,7 @@ class InvalidDefaultFactoryError(Exception):
 class InvalidCustomContext(Exception):
     """Raised when a custom context object is of the wrong python type"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         message = (
             "The custom context must be either a class "
             "that inherits from BaseContext or a dictionary"

--- a/strawberry/exceptions/conflicting_arguments.py
+++ b/strawberry/exceptions/conflicting_arguments.py
@@ -17,7 +17,7 @@ class ConflictingArgumentsError(StrawberryException):
         self,
         resolver: StrawberryResolver,
         arguments: List[str],
-    ):
+    ) -> None:
         self.function = resolver.wrapped_func
         self.argument_names = arguments
 

--- a/strawberry/exceptions/duplicated_type_name.py
+++ b/strawberry/exceptions/duplicated_type_name.py
@@ -20,7 +20,7 @@ class DuplicatedTypeName(StrawberryException):
         first_cls: Optional[Type],
         second_cls: Optional[Type],
         duplicated_type_name: str,
-    ):
+    ) -> None:
         self.first_cls = first_cls
         self.second_cls = second_cls
 

--- a/strawberry/exceptions/handler.py
+++ b/strawberry/exceptions/handler.py
@@ -32,7 +32,7 @@ def _get_handler(exception_type: Type[BaseException]) -> ExceptionHandler:
                 exception_type: Type[BaseException],
                 exception: BaseException,
                 traceback: Optional[TracebackType],
-            ):
+            ) -> None:
                 try:
                     rich.print(exception)
 

--- a/strawberry/exceptions/invalid_argument_type.py
+++ b/strawberry/exceptions/invalid_argument_type.py
@@ -20,7 +20,7 @@ class InvalidArgumentTypeError(StrawberryException):
         self,
         resolver: StrawberryResolver,
         argument: StrawberryArgument,
-    ):
+    ) -> None:
         from strawberry.union import StrawberryUnion
 
         self.function = resolver.wrapped_func

--- a/strawberry/exceptions/missing_arguments_annotations.py
+++ b/strawberry/exceptions/missing_arguments_annotations.py
@@ -15,7 +15,11 @@ if TYPE_CHECKING:
 class MissingArgumentsAnnotationsError(StrawberryException):
     """The field is missing the annotation for one or more arguments"""
 
-    def __init__(self, resolver: StrawberryResolver, arguments: List[str]):
+    def __init__(
+        self,
+        resolver: StrawberryResolver,
+        arguments: List[str],
+    ) -> None:
         self.missing_arguments = arguments
         self.function = resolver.wrapped_func
         self.argument_name = arguments[0]

--- a/strawberry/exceptions/missing_field_annotation.py
+++ b/strawberry/exceptions/missing_field_annotation.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 
 class MissingFieldAnnotationError(StrawberryException):
-    def __init__(self, field_name: str, cls: Type):
+    def __init__(self, field_name: str, cls: Type) -> None:
         self.cls = cls
         self.field_name = field_name
 

--- a/strawberry/exceptions/missing_return_annotation.py
+++ b/strawberry/exceptions/missing_return_annotation.py
@@ -15,7 +15,11 @@ if TYPE_CHECKING:
 class MissingReturnAnnotationError(StrawberryException):
     """The field is missing the return annotation"""
 
-    def __init__(self, field_name: str, resolver: StrawberryResolver):
+    def __init__(
+        self,
+        field_name: str,
+        resolver: StrawberryResolver,
+    ) -> None:
         self.function = resolver.wrapped_func
 
         self.message = (

--- a/strawberry/exceptions/not_a_strawberry_enum.py
+++ b/strawberry/exceptions/not_a_strawberry_enum.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 
 class NotAStrawberryEnumError(StrawberryException):
-    def __init__(self, enum: EnumMeta):
+    def __init__(self, enum: EnumMeta) -> None:
         self.enum = enum
 
         self.message = f'Enum "{enum.__name__}" is not a Strawberry enum.'

--- a/strawberry/exceptions/object_is_not_a_class.py
+++ b/strawberry/exceptions/object_is_not_a_class.py
@@ -17,7 +17,7 @@ class ObjectIsNotClassError(StrawberryException):
         INTERFACE = "interface"
         TYPE = "type"
 
-    def __init__(self, obj: object, method_type: MethodType):
+    def __init__(self, obj: object, method_type: MethodType) -> None:
         self.obj = obj
         self.function = obj
 

--- a/strawberry/exceptions/object_is_not_an_enum.py
+++ b/strawberry/exceptions/object_is_not_an_enum.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 
 class ObjectIsNotAnEnumError(StrawberryException):
-    def __init__(self, cls: Type[Enum]):
+    def __init__(self, cls: Type[Enum]) -> None:
         self.cls = cls
         self.message = (
             "strawberry.enum can only be used with subclasses of Enum. "

--- a/strawberry/exceptions/permission_fail_silently_requires_optional.py
+++ b/strawberry/exceptions/permission_fail_silently_requires_optional.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
 
 class PermissionFailSilentlyRequiresOptionalError(StrawberryException):
-    def __init__(self, field: StrawberryField):
+    def __init__(self, field: StrawberryField) -> None:
         self.field = field
         self.message = (
             "Cannot use fail_silently=True with a non-optional " "or non-list field"

--- a/strawberry/exceptions/private_strawberry_field.py
+++ b/strawberry/exceptions/private_strawberry_field.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 
 class PrivateStrawberryFieldError(StrawberryException):
-    def __init__(self, field_name: str, cls: Type):
+    def __init__(self, field_name: str, cls: Type) -> None:
         self.cls = cls
         self.field_name = field_name
 

--- a/strawberry/exceptions/scalar_already_registered.py
+++ b/strawberry/exceptions/scalar_already_registered.py
@@ -19,7 +19,7 @@ class ScalarAlreadyRegisteredError(StrawberryException):
         self,
         scalar_definition: ScalarDefinition,
         other_scalar_definition: ScalarDefinition,
-    ):
+    ) -> None:
         self.scalar_definition = scalar_definition
 
         scalar_name = scalar_definition.name

--- a/strawberry/exceptions/unresolved_field_type.py
+++ b/strawberry/exceptions/unresolved_field_type.py
@@ -19,7 +19,7 @@ class UnresolvedFieldTypeError(StrawberryException):
         self,
         type_definition: StrawberryObjectDefinition,
         field: StrawberryField,
-    ):
+    ) -> None:
         self.type_definition = type_definition
         self.field = field
 

--- a/strawberry/experimental/pydantic/_compat.py
+++ b/strawberry/experimental/pydantic/_compat.py
@@ -237,7 +237,7 @@ class PydanticV1Compat:
 
 
 class PydanticCompat:
-    def __init__(self, is_v2: bool):
+    def __init__(self, is_v2: bool) -> None:
         if is_v2:
             self._compat = PydanticV2Compat()
         else:

--- a/strawberry/experimental/pydantic/conversion_types.py
+++ b/strawberry/experimental/pydantic/conversion_types.py
@@ -16,7 +16,7 @@ class StrawberryTypeFromPydantic(Protocol[PydanticModel]):
     """This class does not exist in runtime.
     It only makes the methods below visible for IDEs"""
 
-    def __init__(self, **kwargs: Any):
+    def __init__(self, **kwargs: Any) -> None:
         ...
 
     @staticmethod

--- a/strawberry/experimental/pydantic/exceptions.py
+++ b/strawberry/experimental/pydantic/exceptions.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 
 
 class MissingFieldsListError(Exception):
-    def __init__(self, type: Type[BaseModel]):
+    def __init__(self, type: Type[BaseModel]) -> None:
         message = (
             f"List of fields to copy from {type} is empty. Add fields with the "
             f"`auto` type annotation"
@@ -22,7 +22,7 @@ class UnsupportedTypeError(Exception):
 
 
 class UnregisteredTypeException(Exception):
-    def __init__(self, type: Type[BaseModel]):
+    def __init__(self, type: Type[BaseModel]) -> None:
         message = (
             f"Cannot find a Strawberry Type for {type} did you forget to register it?"
         )
@@ -31,7 +31,7 @@ class UnregisteredTypeException(Exception):
 
 
 class BothDefaultAndDefaultFactoryDefinedError(Exception):
-    def __init__(self, default: Any, default_factory: NoArgAnyCallable):
+    def __init__(self, default: Any, default_factory: NoArgAnyCallable) -> None:
         message = (
             f"Not allowed to specify both default and default_factory. "
             f"default:{default} default_factory:{default_factory}"
@@ -41,7 +41,12 @@ class BothDefaultAndDefaultFactoryDefinedError(Exception):
 
 
 class AutoFieldsNotInBaseModelError(Exception):
-    def __init__(self, fields: List[str], cls_name: str, model: Type[BaseModel]):
+    def __init__(
+        self,
+        fields: List[str],
+        cls_name: str,
+        model: Type[BaseModel],
+    ) -> None:
         message = (
             f"{cls_name} defines {fields} with strawberry.auto. "
             f"Field(s) not present in {model.__name__} BaseModel."

--- a/strawberry/ext/mypy_plugin.py
+++ b/strawberry/ext/mypy_plugin.py
@@ -114,8 +114,7 @@ def lazy_type_analyze_callback(ctx: AnalyzeTypeContext) -> Type:
 
 
 def _get_named_type(
-    name: str,
-    api: SemanticAnalyzerPluginInterface
+    name: str, api: SemanticAnalyzerPluginInterface
 ) -> Optional[Instance]:
     if "." in name:
         return api.named_type_or_none(name)

--- a/strawberry/ext/mypy_plugin.py
+++ b/strawberry/ext/mypy_plugin.py
@@ -113,9 +113,7 @@ def lazy_type_analyze_callback(ctx: AnalyzeTypeContext) -> Type:
     return type_
 
 
-def _get_named_type(
-    name: str, api: SemanticAnalyzerPluginInterface
-) -> Optional[Instance]:
+def _get_named_type(name: str, api: SemanticAnalyzerPluginInterface) -> Any:
     if "." in name:
         return api.named_type_or_none(name)
 

--- a/strawberry/ext/mypy_plugin.py
+++ b/strawberry/ext/mypy_plugin.py
@@ -113,7 +113,10 @@ def lazy_type_analyze_callback(ctx: AnalyzeTypeContext) -> Type:
     return type_
 
 
-def _get_named_type(name: str, api: SemanticAnalyzerPluginInterface):
+def _get_named_type(
+    name: str,
+    api: SemanticAnalyzerPluginInterface
+) -> Optional[Instance]:
     if "." in name:
         return api.named_type_or_none(name)
 

--- a/strawberry/extensions/__init__.py
+++ b/strawberry/extensions/__init__.py
@@ -1,4 +1,5 @@
 import warnings
+from typing import Type
 
 from .add_validation_rules import AddValidationRules
 from .base_extension import LifecycleStep, SchemaExtension
@@ -12,7 +13,7 @@ from .query_depth_limiter import IgnoreContext, QueryDepthLimiter
 from .validation_cache import ValidationCache
 
 
-def __getattr__(name: str):
+def __getattr__(name: str) -> Type[SchemaExtension]:
     if name == "Extension":
         warnings.warn(
             (

--- a/strawberry/extensions/add_validation_rules.py
+++ b/strawberry/extensions/add_validation_rules.py
@@ -38,7 +38,7 @@ class AddValidationRules(SchemaExtension):
 
     validation_rules: List[Type[ASTValidationRule]]
 
-    def __init__(self, validation_rules: List[Type[ASTValidationRule]]):
+    def __init__(self, validation_rules: List[Type[ASTValidationRule]]) -> None:
         self.validation_rules = validation_rules
 
     def on_operation(self) -> Iterator[None]:

--- a/strawberry/extensions/base_extension.py
+++ b/strawberry/extensions/base_extension.py
@@ -21,7 +21,7 @@ class LifecycleStep(Enum):
 class SchemaExtension:
     execution_context: ExecutionContext
 
-    def __init__(self, *, execution_context: ExecutionContext):
+    def __init__(self, *, execution_context: ExecutionContext) -> None:
         self.execution_context = execution_context
 
     def on_operation(

--- a/strawberry/extensions/context.py
+++ b/strawberry/extensions/context.py
@@ -9,8 +9,10 @@ from typing import (
     TYPE_CHECKING,
     Any,
     AsyncContextManager,
+    AsyncIterator,
     Callable,
     ContextManager,
+    Iterator,
     List,
     NamedTuple,
     Optional,
@@ -42,7 +44,7 @@ class ExtensionContextManagerBase:
         "exit_stack",
     )
 
-    def __init_subclass__(cls):
+    def __init_subclass__(cls) -> None:
         cls.DEPRECATION_MESSAGE = (
             f"Event driven styled extensions for "
             f"{cls.LEGACY_ENTER} or {cls.LEGACY_EXIT}"
@@ -54,7 +56,7 @@ class ExtensionContextManagerBase:
     LEGACY_ENTER: str
     LEGACY_EXIT: str
 
-    def __init__(self, extensions: List[SchemaExtension]):
+    def __init__(self, extensions: List[SchemaExtension]) -> None:
         self.hooks: List[WrappedHook] = []
         self.default_hook: Hook = getattr(SchemaExtension, self.HOOK_NAME)
         for extension in extensions:
@@ -114,7 +116,7 @@ class ExtensionContextManagerBase:
         if iscoroutinefunction(on_start) or iscoroutinefunction(on_end):
 
             @contextlib.asynccontextmanager
-            async def iterator():
+            async def iterator() -> AsyncIterator:
                 if on_start:
                     await await_maybe(on_start())
 
@@ -128,7 +130,7 @@ class ExtensionContextManagerBase:
         else:
 
             @contextlib.contextmanager
-            def iterator_async():
+            def iterator_async() -> Iterator[None]:
                 if on_start:
                     on_start()
 
@@ -147,7 +149,7 @@ class ExtensionContextManagerBase:
         if iscoroutinefunction(func):
 
             @contextlib.asynccontextmanager
-            async def iterator():
+            async def iterator() -> AsyncIterator[None]:
                 await func(extension)
                 yield
 
@@ -155,7 +157,7 @@ class ExtensionContextManagerBase:
         else:
 
             @contextlib.contextmanager
-            def iterator():
+            def iterator() -> Iterator[None]:
                 func(extension)
                 yield
 
@@ -180,7 +182,7 @@ class ExtensionContextManagerBase:
         exc_type: Optional[Type[BaseException]],
         exc_val: Optional[BaseException],
         exc_tb: Optional[TracebackType],
-    ):
+    ) -> None:
         self.exit_stack.__exit__(exc_type, exc_val, exc_tb)
 
     async def __aenter__(self) -> None:
@@ -199,7 +201,7 @@ class ExtensionContextManagerBase:
         exc_type: Optional[Type[BaseException]],
         exc_val: Optional[BaseException],
         exc_tb: Optional[TracebackType],
-    ):
+    ) -> None:
         await self.async_exit_stack.__aexit__(exc_type, exc_val, exc_tb)
 
 

--- a/strawberry/extensions/disable_validation.py
+++ b/strawberry/extensions/disable_validation.py
@@ -21,7 +21,7 @@ class DisableValidation(SchemaExtension):
 
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         # There aren't any arguments to this extension yet but we might add
         # some in the future
         pass

--- a/strawberry/extensions/mask_errors.py
+++ b/strawberry/extensions/mask_errors.py
@@ -18,7 +18,7 @@ class MaskErrors(SchemaExtension):
         self,
         should_mask_error: Callable[[GraphQLError], bool] = default_should_mask_error,
         error_message: str = "Unexpected error.",
-    ):
+    ) -> None:
         self.should_mask_error = should_mask_error
         self.error_message = error_message
 

--- a/strawberry/extensions/max_aliases.py
+++ b/strawberry/extensions/max_aliases.py
@@ -37,14 +37,14 @@ class MaxAliasesLimiter(AddValidationRules):
     def __init__(
         self,
         max_alias_count: int,
-    ):
+    ) -> None:
         validator = create_validator(max_alias_count)
         super().__init__([validator])
 
 
 def create_validator(max_alias_count: int) -> Type[ValidationRule]:
     class MaxAliasesValidator(ValidationRule):
-        def __init__(self, validation_context: ValidationContext):
+        def __init__(self, validation_context: ValidationContext) -> None:
             document = validation_context.document
             def_that_can_contain_alias = (
                 def_

--- a/strawberry/extensions/max_tokens.py
+++ b/strawberry/extensions/max_tokens.py
@@ -36,7 +36,7 @@ class MaxTokensLimiter(SchemaExtension):
     def __init__(
         self,
         max_token_count: int,
-    ):
+    ) -> None:
         self.max_token_count = max_token_count
 
     def on_operation(self) -> Iterator[None]:

--- a/strawberry/extensions/parser_cache.py
+++ b/strawberry/extensions/parser_cache.py
@@ -30,7 +30,7 @@ class ParserCache(SchemaExtension):
 
     """
 
-    def __init__(self, maxsize: Optional[int] = None):
+    def __init__(self, maxsize: Optional[int] = None) -> None:
         self.cached_parse_document = lru_cache(maxsize=maxsize)(parse_document)
 
     def on_parse(self) -> Iterator[None]:

--- a/strawberry/extensions/query_depth_limiter.py
+++ b/strawberry/extensions/query_depth_limiter.py
@@ -114,7 +114,7 @@ class QueryDepthLimiter(AddValidationRules):
         max_depth: int,
         callback: Optional[Callable[[Dict[str, int]], None]] = None,
         should_ignore: Optional[ShouldIgnoreType] = None,
-    ):
+    ) -> None:
         if should_ignore is not None and not callable(should_ignore):
             raise TypeError(
                 "The `should_ignore` argument to "
@@ -130,7 +130,7 @@ def create_validator(
     callback: Optional[Callable[[Dict[str, int]], None]] = None,
 ) -> Type[ValidationRule]:
     class DepthLimitValidator(ValidationRule):
-        def __init__(self, validation_context: ValidationContext):
+        def __init__(self, validation_context: ValidationContext) -> None:
             document = validation_context.document
             definitions = document.definitions
 

--- a/strawberry/extensions/runner.py
+++ b/strawberry/extensions/runner.py
@@ -28,7 +28,7 @@ class SchemaExtensionsRunner:
         extensions: Optional[
             List[Union[Type[SchemaExtension], SchemaExtension]]
         ] = None,
-    ):
+    ) -> None:
         self.execution_context = execution_context
 
         if not extensions:

--- a/strawberry/extensions/tracing/__init__.py
+++ b/strawberry/extensions/tracing/__init__.py
@@ -1,5 +1,5 @@
 import importlib
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from .apollo import ApolloTracingExtension, ApolloTracingExtensionSync
@@ -22,7 +22,7 @@ __all__ = [
 ]
 
 
-def __getattr__(name: str):
+def __getattr__(name: str) -> Any:
     if name in {"DatadogTracingExtension", "DatadogTracingExtensionSync"}:
         return getattr(importlib.import_module(".datadog", __name__), name)
 

--- a/strawberry/extensions/tracing/apollo.py
+++ b/strawberry/extensions/tracing/apollo.py
@@ -80,7 +80,7 @@ class ApolloTracingStats:
 
 
 class ApolloTracingExtension(SchemaExtension):
-    def __init__(self, execution_context: ExecutionContext):
+    def __init__(self, execution_context: ExecutionContext) -> None:
         self._resolver_stats: List[ApolloResolverStats] = []
         self.execution_context = execution_context
 

--- a/strawberry/extensions/tracing/datadog.py
+++ b/strawberry/extensions/tracing/datadog.py
@@ -21,12 +21,12 @@ class DatadogTracingExtension(SchemaExtension):
         self,
         *,
         execution_context: Optional[ExecutionContext] = None,
-    ):
+    ) -> None:
         if execution_context:
             self.execution_context = execution_context
 
     @cached_property
-    def _resource_name(self):
+    def _resource_name(self) -> str:
         assert self.execution_context.query
 
         query_hash = self.hash_query(self.execution_context.query)

--- a/strawberry/extensions/tracing/opentelemetry.py
+++ b/strawberry/extensions/tracing/opentelemetry.py
@@ -45,7 +45,7 @@ class OpenTelemetryExtension(SchemaExtension):
         *,
         execution_context: Optional[ExecutionContext] = None,
         arg_filter: Optional[ArgFilter] = None,
-    ):
+    ) -> None:
         self._arg_filter = arg_filter
         self._tracer = trace.get_tracer("strawberry")
         if execution_context:

--- a/strawberry/extensions/tracing/sentry.py
+++ b/strawberry/extensions/tracing/sentry.py
@@ -22,7 +22,7 @@ class SentryTracingExtension(SchemaExtension):
         self,
         *,
         execution_context: Optional[ExecutionContext] = None,
-    ):
+    ) -> None:
         warnings.warn(
             "The Sentry tracing extension is deprecated, please update to sentry>=1.32.0",
             DeprecationWarning,
@@ -33,7 +33,7 @@ class SentryTracingExtension(SchemaExtension):
             self.execution_context = execution_context
 
     @cached_property
-    def _resource_name(self):
+    def _resource_name(self) -> str:
         assert self.execution_context.query
 
         query_hash = self.hash_query(self.execution_context.query)

--- a/strawberry/extensions/validation_cache.py
+++ b/strawberry/extensions/validation_cache.py
@@ -30,7 +30,7 @@ class ValidationCache(SchemaExtension):
 
     """
 
-    def __init__(self, maxsize: Optional[int] = None):
+    def __init__(self, maxsize: Optional[int] = None) -> None:
         self.cached_validate_document = lru_cache(maxsize=maxsize)(validate_document)
 
     def on_validate(self) -> Iterator[None]:

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -52,7 +52,7 @@ if TYPE_CHECKING:
 
 
 class FastAPIRequestAdapter(AsyncHTTPRequestAdapter):
-    def __init__(self, request: Request):
+    def __init__(self, request: Request) -> None:
         self.request = request
 
     @property
@@ -89,7 +89,7 @@ class GraphQLRouter(
     request_adapter_class = FastAPIRequestAdapter
 
     @staticmethod
-    async def __get_root_value():
+    async def __get_root_value() -> None:
         return None
 
     @staticmethod
@@ -163,7 +163,7 @@ class GraphQLRouter(
         default: Optional[ASGIApp] = None,
         on_startup: Optional[Sequence[Callable[[], Any]]] = None,
         on_shutdown: Optional[Sequence[Callable[[], Any]]] = None,
-    ):
+    ) -> None:
         super().__init__(
             default=default,
             on_startup=on_startup,

--- a/strawberry/federation/schema.py
+++ b/strawberry/federation/schema.py
@@ -66,7 +66,7 @@ class Schema(BaseSchema):
         ] = None,
         schema_directives: Iterable[object] = (),
         enable_federation_2: bool = False,
-    ):
+    ) -> None:
         query = self._get_federation_query_type(query)
 
         super().__init__(

--- a/strawberry/federation/schema_directives.py
+++ b/strawberry/federation/schema_directives.py
@@ -92,7 +92,7 @@ class Link:
         as_: Optional[str] = UNSET,
         for_: Optional[LinkPurpose] = UNSET,
         import_: Optional[List[Optional[LinkImport]]] = UNSET,
-    ):
+    ) -> None:
         self.url = url
         self.as_ = as_
         self.for_ = for_

--- a/strawberry/field.py
+++ b/strawberry/field.py
@@ -90,7 +90,7 @@ class StrawberryField(dataclasses.Field):
         deprecation_reason: Optional[str] = None,
         directives: Sequence[object] = (),
         extensions: List[FieldExtension] = (),  # type: ignore
-    ):
+    ) -> None:
         # basic fields are fields with no provided resolver
         is_basic_field = not base_resolver
 
@@ -242,7 +242,7 @@ class StrawberryField(dataclasses.Field):
         return self._arguments
 
     @arguments.setter
-    def arguments(self, value: List[StrawberryArgument]):
+    def arguments(self, value: List[StrawberryArgument]) -> None:
         self._arguments = value
 
     @property

--- a/strawberry/flask/views.py
+++ b/strawberry/flask/views.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
 
 class FlaskHTTPRequestAdapter(SyncHTTPRequestAdapter):
-    def __init__(self, request: Request):
+    def __init__(self, request: Request) -> None:
         self.request = request
 
     @property
@@ -64,7 +64,7 @@ class BaseGraphQLView:
         graphiql: Optional[bool] = None,
         graphql_ide: Optional[GraphQL_IDE] = "graphiql",
         allow_queries_via_get: bool = True,
-    ):
+    ) -> None:
         self.schema = schema
         self.graphiql = graphiql
         self.allow_queries_via_get = allow_queries_via_get
@@ -119,7 +119,7 @@ class GraphQLView(
 
 
 class AsyncFlaskHTTPRequestAdapter(AsyncHTTPRequestAdapter):
-    def __init__(self, request: Request):
+    def __init__(self, request: Request) -> None:
         self.request = request
 
     @property

--- a/strawberry/http/exceptions.py
+++ b/strawberry/http/exceptions.py
@@ -1,4 +1,4 @@
 class HTTPException(Exception):
-    def __init__(self, status_code: int, reason: str):
+    def __init__(self, status_code: int, reason: str) -> None:
         self.status_code = status_code
         self.reason = reason

--- a/strawberry/lazy_type.py
+++ b/strawberry/lazy_type.py
@@ -4,7 +4,20 @@ import sys
 import warnings
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, ForwardRef, Generic, Optional, Tuple, Type, TypeVar, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ForwardRef,
+    Generic,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    cast,
+)
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
 
 TypeName = TypeVar("TypeName")
 Module = TypeVar("Module")
@@ -16,7 +29,7 @@ class LazyType(Generic[TypeName, Module]):
     module: str
     package: Optional[str] = None
 
-    def __class_getitem__(cls, params: Tuple[str, str]):
+    def __class_getitem__(cls, params: Tuple[str, str]) -> "Self":
         warnings.warn(
             (
                 "LazyType is deprecated, use "
@@ -63,7 +76,7 @@ class LazyType(Generic[TypeName, Module]):
     # this empty call method allows LazyTypes to be used in generic types
     # for example: List[LazyType["A", "module"]]
 
-    def __call__(self):  # pragma: no cover
+    def __call__(self) -> None:  # pragma: no cover
         return None
 
 

--- a/strawberry/litestar/controller.py
+++ b/strawberry/litestar/controller.py
@@ -325,10 +325,10 @@ class GraphQLController(
         context_ws: Any,
         root_value: Any,
     ) -> None:
-        async def _get_context():
+        async def _get_context() -> Any:
             return context_ws
 
-        async def _get_root_value():
+        async def _get_root_value() -> Any:
             return root_value
 
         preferred_protocol = self.pick_preferred_protocol(socket)

--- a/strawberry/litestar/handlers/graphql_transport_ws_handler.py
+++ b/strawberry/litestar/handlers/graphql_transport_ws_handler.py
@@ -20,7 +20,7 @@ class GraphQLTransportWSHandler(BaseGraphQLTransportWSHandler):
         get_context: Callable,
         get_root_value: Callable,
         ws: WebSocket,
-    ):
+    ) -> None:
         super().__init__(schema, debug, connection_init_wait_timeout)
         self._get_context = get_context
         self._get_root_value = get_root_value

--- a/strawberry/litestar/handlers/graphql_ws_handler.py
+++ b/strawberry/litestar/handlers/graphql_ws_handler.py
@@ -20,7 +20,7 @@ class GraphQLWSHandler(BaseGraphQLWSHandler):
         get_context: Callable,
         get_root_value: Callable,
         ws: WebSocket,
-    ):
+    ) -> None:
         super().__init__(schema, debug, keep_alive, keep_alive_interval)
         self._get_context = get_context
         self._get_root_value = get_root_value

--- a/strawberry/object_type.py
+++ b/strawberry/object_type.py
@@ -125,7 +125,7 @@ def _wrap_dataclass(cls: Type[Any]):
 
 
 def _process_type(
-    cls: Type,
+    cls: T,
     *,
     name: Optional[str] = None,
     is_input: bool = False,
@@ -133,7 +133,7 @@ def _process_type(
     description: Optional[str] = None,
     directives: Optional[Sequence[object]] = (),
     extend: bool = False,
-) -> Type:
+) -> T:
     name = name or to_camel_case(cls.__name__)
 
     interfaces = _get_interfaces(cls)
@@ -237,7 +237,7 @@ def type(
     >>>     field_abc: str = "ABC"
     """
 
-    def wrap(cls: Type) -> Type:
+    def wrap(cls: Type) -> T:
         if not inspect.isclass(cls):
             if is_input:
                 exc = ObjectIsNotClassError.input

--- a/strawberry/object_type.py
+++ b/strawberry/object_type.py
@@ -133,7 +133,7 @@ def _process_type(
     description: Optional[str] = None,
     directives: Optional[Sequence[object]] = (),
     extend: bool = False,
-):
+) -> Type:
     name = name or to_camel_case(cls.__name__)
 
     interfaces = _get_interfaces(cls)
@@ -237,7 +237,7 @@ def type(
     >>>     field_abc: str = "ABC"
     """
 
-    def wrap(cls: Type):
+    def wrap(cls: Type) -> Type:
         if not inspect.isclass(cls):
             if is_input:
                 exc = ObjectIsNotClassError.input

--- a/strawberry/permission.py
+++ b/strawberry/permission.py
@@ -109,7 +109,7 @@ class PermissionExtension(FieldExtension):
         permissions: List[BasePermission],
         use_directives: bool = True,
         fail_silently: bool = False,
-    ):
+    ) -> None:
         self.permissions = permissions
         self.fail_silently = fail_silently
         self.return_empty_list = False

--- a/strawberry/quart/views.py
+++ b/strawberry/quart/views.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
 
 class QuartHTTPRequestAdapter(AsyncHTTPRequestAdapter):
-    def __init__(self, request: Request):
+    def __init__(self, request: Request) -> None:
         self.request = request
 
     @property
@@ -61,7 +61,7 @@ class GraphQLView(
         graphiql: Optional[bool] = None,
         graphql_ide: Optional[GraphQL_IDE] = "graphiql",
         allow_queries_via_get: bool = True,
-    ):
+    ) -> None:
         self.schema = schema
         self.allow_queries_via_get = allow_queries_via_get
 

--- a/strawberry/relay/exceptions.py
+++ b/strawberry/relay/exceptions.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 
 class NodeIDAnnotationError(StrawberryException):
-    def __init__(self, message: str, cls: Type):
+    def __init__(self, message: str, cls: Type) -> None:
         self.cls = cls
 
         self.message = message
@@ -41,7 +41,7 @@ class NodeIDAnnotationError(StrawberryException):
 
 
 class RelayWrongAnnotationError(StrawberryException):
-    def __init__(self, field_name: str, cls: Type):
+    def __init__(self, field_name: str, cls: Type) -> None:
         self.cls = cls
         self.field_name = field_name
 
@@ -71,7 +71,7 @@ class RelayWrongAnnotationError(StrawberryException):
 
 
 class RelayWrongResolverAnnotationError(StrawberryException):
-    def __init__(self, field_name: str, resolver: StrawberryResolver):
+    def __init__(self, field_name: str, resolver: StrawberryResolver) -> None:
         self.function = resolver.wrapped_func
         self.field_name = field_name
 

--- a/strawberry/relay/types.py
+++ b/strawberry/relay/types.py
@@ -86,7 +86,7 @@ class GlobalID:
     type_name: str
     node_id: str
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if not isinstance(self.type_name, str):
             raise GlobalIDValueError(
                 f"type_name is expected to be a string, found {self.type_name!r}"
@@ -96,7 +96,7 @@ class GlobalID:
                 f"node_id is expected to be a string, found {self.node_id!r}"
             )
 
-    def __str__(self):
+    def __str__(self) -> str:
         return to_base64(self.type_name, self.node_id)
 
     @classmethod

--- a/strawberry/sanic/views.py
+++ b/strawberry/sanic/views.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 
 
 class SanicHTTPRequestAdapter(AsyncHTTPRequestAdapter):
-    def __init__(self, request: Request):
+    def __init__(self, request: Request) -> None:
         self.request = request
 
     @property
@@ -107,7 +107,7 @@ class GraphQLView(
         allow_queries_via_get: bool = True,
         json_encoder: Optional[Type[json.JSONEncoder]] = None,
         json_dumps_params: Optional[Dict[str, Any]] = None,
-    ):
+    ) -> None:
         self.schema = schema
         self.allow_queries_via_get = allow_queries_via_get
         self.json_encoder = json_encoder

--- a/strawberry/schema/config.py
+++ b/strawberry/schema/config.py
@@ -16,6 +16,6 @@ class StrawberryConfig:
     def __post_init__(
         self,
         auto_camel_case: bool,
-    ):
+    ) -> None:
         if auto_camel_case is not None:
             self.name_converter.auto_camel_case = auto_camel_case

--- a/strawberry/schema/exceptions.py
+++ b/strawberry/schema/exceptions.py
@@ -2,7 +2,7 @@ from strawberry.types.graphql import OperationType
 
 
 class InvalidOperationTypeError(Exception):
-    def __init__(self, operation_type: OperationType):
+    def __init__(self, operation_type: OperationType) -> None:
         self.operation_type = operation_type
 
     def as_http_error_reason(self, method: str) -> str:

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -82,7 +82,7 @@ class Schema(BaseSchema):
             Dict[object, Union[Type, ScalarWrapper, ScalarDefinition]]
         ] = None,
         schema_directives: Iterable[object] = (),
-    ):
+    ) -> None:
         self.query = query
         self.mutation = mutation
         self.subscription = subscription

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -146,7 +146,12 @@ def _get_thunk_mapping(
 # subclass the GraphQLEnumType class to enable returning Enum members from
 # resolvers.
 class CustomGraphQLEnumType(GraphQLEnumType):
-    def __init__(self, enum: EnumDefinition, *args: Any, **kwargs: Any):
+    def __init__(
+        self,
+        enum: EnumDefinition,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
         super().__init__(*args, **kwargs)
         self.wrapped_cls = enum.wrapped_cls
 
@@ -182,7 +187,7 @@ class GraphQLCoreConverter:
         config: StrawberryConfig,
         scalar_registry: Dict[object, Union[ScalarWrapper, ScalarDefinition]],
         get_fields: Callable[[StrawberryObjectDefinition], List[StrawberryField]],
-    ):
+    ) -> None:
         self.type_map: Dict[str, ConcreteType] = {}
         self.config = config
         self.scalar_registry = scalar_registry

--- a/strawberry/schema_codegen/__init__.py
+++ b/strawberry/schema_codegen/__init__.py
@@ -311,7 +311,7 @@ def _get_federation_arguments(
         argument_name: str,
         keyword_name: str | None = None,
         flatten: bool = True,
-    ):
+    ) -> None:
         keyword_name = keyword_name or directive
 
         if directive in directives:
@@ -507,7 +507,7 @@ def _get_schema_definition(
 
     args: list[cst.Arg] = []
 
-    def _get_arg(name: str, value: str):
+    def _get_arg(name: str, value: str) -> cst.Arg:
         return cst.Arg(
             keyword=cst.Name(name),
             value=cst.Name(value),

--- a/strawberry/starlite/controller.py
+++ b/strawberry/starlite/controller.py
@@ -119,7 +119,7 @@ class GraphQLTransportWSHandler(BaseGraphQLTransportWSHandler):
 
 
 class StarliteRequestAdapter(AsyncHTTPRequestAdapter):
-    def __init__(self, request: Request[Any, Any]):
+    def __init__(self, request: Request[Any, Any]) -> None:
         self.request = request
 
     @property
@@ -148,7 +148,7 @@ class StarliteRequestAdapter(AsyncHTTPRequestAdapter):
 
 
 class BaseContext:
-    def __init__(self):
+    def __init__(self) -> None:
         self.request: Optional[Union[Request, WebSocket]] = None
         self.response: Optional[Response] = None
 
@@ -176,7 +176,7 @@ def make_graphql_controller(
 
     if context_getter is None:
 
-        def custom_context_getter_():
+        def custom_context_getter_() -> None:
             return None
 
     else:
@@ -184,7 +184,7 @@ def make_graphql_controller(
 
     if root_value_getter is None:
 
-        def root_value_getter_():
+        def root_value_getter_() -> None:
             return None
 
     else:
@@ -331,10 +331,10 @@ def make_graphql_controller(
             context: CustomContext,
             root_value: Any,
         ) -> None:
-            async def _get_context():
+            async def _get_context() -> CustomContext:
                 return context
 
-            async def _get_root_value():
+            async def _get_root_value() -> Any:
                 return root_value
 
             preferred_protocol = self.pick_preferred_protocol(socket)

--- a/strawberry/starlite/handlers/graphql_transport_ws_handler.py
+++ b/strawberry/starlite/handlers/graphql_transport_ws_handler.py
@@ -19,7 +19,7 @@ class GraphQLTransportWSHandler(BaseGraphQLTransportWSHandler):
         get_context: Callable,
         get_root_value: Callable,
         ws: WebSocket,
-    ):
+    ) -> None:
         super().__init__(schema, debug, connection_init_wait_timeout)
         self._get_context = get_context
         self._get_root_value = get_root_value

--- a/strawberry/starlite/handlers/graphql_ws_handler.py
+++ b/strawberry/starlite/handlers/graphql_ws_handler.py
@@ -19,7 +19,7 @@ class GraphQLWSHandler(BaseGraphQLWSHandler):
         get_context: Callable,
         get_root_value: Callable,
         ws: WebSocket,
-    ):
+    ) -> None:
         super().__init__(schema, debug, keep_alive, keep_alive_interval)
         self._get_context = get_context
         self._get_root_value = get_root_value

--- a/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
@@ -4,7 +4,16 @@ import asyncio
 import logging
 from abc import ABC, abstractmethod
 from contextlib import suppress
-from typing import TYPE_CHECKING, Any, AsyncGenerator, Callable, Dict, List, Optional
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    Dict,
+    List,
+    Optional,
+)
 
 from graphql import ExecutionResult as GraphQLExecutionResult
 from graphql import GraphQLError, GraphQLSyntaxError, parse
@@ -32,6 +41,8 @@ if TYPE_CHECKING:
     from strawberry.subscriptions.protocols.graphql_transport_ws.types import (
         GraphQLTransportMessage,
     )
+    from strawberry.types import ExecutionResult
+
 
 
 class BaseGraphQLTransportWSHandler(ABC):
@@ -42,7 +53,7 @@ class BaseGraphQLTransportWSHandler(ABC):
         schema: BaseSchema,
         debug: bool,
         connection_init_wait_timeout: timedelta,
-    ):
+    ) -> None:
         self.schema = schema
         self.debug = debug
         self.connection_init_wait_timeout = connection_init_wait_timeout
@@ -245,7 +256,7 @@ class BaseGraphQLTransportWSHandler(ABC):
             )
         else:
             # create AsyncGenerator returning a single result
-            async def get_result_source():
+            async def get_result_source() -> AsyncIterator[ExecutionResult]:
                 yield await self.schema.execute(
                     query=message.payload.query,
                     variable_values=message.payload.variables,
@@ -383,7 +394,7 @@ class Operation:
         handler: BaseGraphQLTransportWSHandler,
         id: str,
         operation_type: OperationType,
-    ):
+    ) -> None:
         self.handler = handler
         self.id = id
         self.operation_type = operation_type

--- a/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
@@ -44,7 +44,6 @@ if TYPE_CHECKING:
     from strawberry.types import ExecutionResult
 
 
-
 class BaseGraphQLTransportWSHandler(ABC):
     task_logger: logging.Logger = logging.getLogger("strawberry.ws.task")
 

--- a/strawberry/subscriptions/protocols/graphql_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_ws/handlers.py
@@ -39,7 +39,7 @@ class BaseGraphQLWSHandler(ABC):
         debug: bool,
         keep_alive: bool,
         keep_alive_interval: float,
-    ):
+    ) -> None:
         self.schema = schema
         self.debug = debug
         self.keep_alive = keep_alive

--- a/strawberry/test/client.py
+++ b/strawberry/test/client.py
@@ -23,7 +23,11 @@ class Body(TypedDict, total=False):
 
 
 class BaseGraphQLTestClient(ABC):
-    def __init__(self, client, url: str = "/graphql/"):  # noqa: ANN001
+    def __init__(
+        self,
+        client: Any,
+        url: str = "/graphql/",
+    ) -> None:
         self._client = client
         self.url = url
 
@@ -159,7 +163,7 @@ class BaseGraphQLTestClient(ABC):
         map_without_vars = {k: v for k, v in map.items() if k in files}
         return map_without_vars
 
-    def _decode(self, response: Any, type: Literal["multipart", "json"]):
+    def _decode(self, response: Any, type: Literal["multipart", "json"]) -> Any:
         if type == "multipart":
             return json.loads(response.content.decode())
         return response.json()

--- a/strawberry/type.py
+++ b/strawberry/type.py
@@ -80,7 +80,7 @@ class StrawberryType(ABC):
 class StrawberryContainer(StrawberryType):
     def __init__(
         self, of_type: Union[StrawberryType, Type[WithStrawberryObjectDefinition], type]
-    ):
+    ) -> None:
         self.of_type = of_type
 
     def __hash__(self) -> int:
@@ -152,7 +152,7 @@ class StrawberryOptional(StrawberryContainer):
 
 
 class StrawberryTypeVar(StrawberryType):
-    def __init__(self, type_var: TypeVar):
+    def __init__(self, type_var: TypeVar) -> None:
         self.type_var = type_var
 
     def copy_with(
@@ -179,7 +179,7 @@ class StrawberryTypeVar(StrawberryType):
 
         return super().__eq__(other)
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(self.type_var)
 
 

--- a/strawberry/types/execution.py
+++ b/strawberry/types/execution.py
@@ -52,7 +52,7 @@ class ExecutionContext:
     errors: Optional[List[GraphQLError]] = None
     result: Optional[GraphQLExecutionResult] = None
 
-    def __post_init__(self, provided_operation_name: str | None):
+    def __post_init__(self, provided_operation_name: str | None) -> None:
         self._provided_operation_name = provided_operation_name
 
     @property

--- a/strawberry/types/fields/resolver.py
+++ b/strawberry/types/fields/resolver.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
 
 
 class Parameter(inspect.Parameter):
-    def __hash__(self):
+    def __hash__(self) -> int:
         """Override to exclude default value from hash.
 
         This adds compatibility for using unhashable default values in resolvers such as
@@ -187,7 +187,7 @@ class StrawberryResolver(Generic[T]):
         *,
         description: Optional[str] = None,
         type_override: Optional[Union[StrawberryType, type]] = None,
-    ):
+    ) -> None:
         self.wrapped_func = func
         self._description = description
         self._type_override = type_override
@@ -396,7 +396,7 @@ class StrawberryResolver(Generic[T]):
 
 
 class UncallableResolverError(Exception):
-    def __init__(self, resolver: StrawberryResolver):
+    def __init__(self, resolver: StrawberryResolver) -> None:
         message = (
             f"Attempted to call resolver {resolver} with uncallable function "
             f"{resolver.wrapped_func}"

--- a/strawberry/types/types.py
+++ b/strawberry/types/types.py
@@ -61,7 +61,7 @@ class StrawberryObjectDefinition(StrawberryType):
         default_factory=dict
     )
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         # resolve `Self` annotation with the origin type
         for index, field in enumerate(self.fields):
             if isinstance(field.type, StrawberryType) and field.type.has_generic(Self):  # type: ignore

--- a/strawberry/union.py
+++ b/strawberry/union.py
@@ -60,7 +60,7 @@ class StrawberryUnion(StrawberryType):
         type_annotations: Tuple[StrawberryAnnotation, ...] = tuple(),
         description: Optional[str] = None,
         directives: Iterable[object] = (),
-    ):
+    ) -> None:
         self.graphql_name = name
         self.type_annotations = type_annotations
         self.description = description
@@ -102,7 +102,7 @@ class StrawberryUnion(StrawberryType):
 
     @property
     def type_params(self) -> List[TypeVar]:
-        def _get_type_params(type_: StrawberryType):
+        def _get_type_params(type_: StrawberryType) -> list[TypeVar]:
             if isinstance(type_, LazyType):
                 type_ = cast("StrawberryType", type_.resolve_type())
 

--- a/strawberry/unset.py
+++ b/strawberry/unset.py
@@ -17,13 +17,13 @@ class UnsetType:
         else:
             return cls.__instance
 
-    def __str__(self):
+    def __str__(self) -> str:
         return ""
 
     def __repr__(self) -> str:
         return "UNSET"
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         return False
 
 

--- a/strawberry/utils/aio.py
+++ b/strawberry/utils/aio.py
@@ -24,7 +24,7 @@ async def aenumerate(
     i = 0
     async for element in iterable:
         yield i, element
-        i += 1  # noqa: SIM113
+        i += 1
 
 
 async def aislice(

--- a/strawberry/utils/aio.py
+++ b/strawberry/utils/aio.py
@@ -24,7 +24,7 @@ async def aenumerate(
     i = 0
     async for element in iterable:
         yield i, element
-        i += 1
+        i += 1  # noqa: SIM113
 
 
 async def aislice(

--- a/tests/cli/snapshots/unions.py
+++ b/tests/cli/snapshots/unions.py
@@ -1,5 +1,6 @@
-import strawberry
 from typing import Annotated
+
+import strawberry
 
 # create a few types and then a union type
 

--- a/tests/cli/snapshots/unions.py
+++ b/tests/cli/snapshots/unions.py
@@ -1,6 +1,5 @@
-from typing import Annotated
-
 import strawberry
+from typing import Annotated
 
 # create a few types and then a union type
 

--- a/tests/cli/snapshots/unions_py38.py
+++ b/tests/cli/snapshots/unions_py38.py
@@ -1,5 +1,6 @@
-import strawberry
 from typing import Annotated, Union
+
+import strawberry
 
 # create a few types and then a union type
 

--- a/tests/cli/snapshots/unions_py38.py
+++ b/tests/cli/snapshots/unions_py38.py
@@ -1,6 +1,5 @@
-from typing import Annotated, Union
-
 import strawberry
+from typing import Annotated, Union
 
 # create a few types and then a union type
 

--- a/tests/cli/snapshots/unions_typing_extension.py
+++ b/tests/cli/snapshots/unions_typing_extension.py
@@ -1,5 +1,6 @@
-import strawberry
 from typing_extensions import Annotated
+
+import strawberry
 
 # create a few types and then a union type
 

--- a/tests/cli/snapshots/unions_typing_extension.py
+++ b/tests/cli/snapshots/unions_typing_extension.py
@@ -1,6 +1,5 @@
-from typing_extensions import Annotated
-
 import strawberry
+from typing_extensions import Annotated
 
 # create a few types and then a union type
 

--- a/tests/http/clients/base.py
+++ b/tests/http/clients/base.py
@@ -246,7 +246,7 @@ class WebSocketClient(abc.ABC):
 
 class DebuggableGraphQLTransportWSMixin:
     @staticmethod
-    def on_init(self):
+    def on_init(self) -> None:
         """
         This method can be patched by unittests to get the instance of the
         transport handler when it is initialized

--- a/tests/schema_codegen/snapshots/long_descriptions.py
+++ b/tests/schema_codegen/snapshots/long_descriptions.py
@@ -1,5 +1,6 @@
 import strawberry
 
+
 @strawberry.type(description="A connection to a list of items.")
 class FilmCharactersConnection:
     page_info: PageInfo = strawberry.field(description="Information to aid in pagination.")

--- a/tests/schema_codegen/snapshots/long_descriptions.py
+++ b/tests/schema_codegen/snapshots/long_descriptions.py
@@ -1,6 +1,5 @@
 import strawberry
 
-
 @strawberry.type(description="A connection to a list of items.")
 class FilmCharactersConnection:
     page_info: PageInfo = strawberry.field(description="Information to aid in pagination.")


### PR DESCRIPTION
## Description

Adds missing typing info (mostly returns) to some functions and methods  
Initially I simply ran into an issue with `GraphQL` not having a `-> None` on it's `__init__` but decided to fix that everywhere

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
