### PR TITLE
Fix incorrect docstring for `to_base64` Relay util

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+This release fixes a minor issue where the docstring for the relay util `to_base64` described the return type incorrectly.

--- a/strawberry/relay/utils.py
+++ b/strawberry/relay/utils.py
@@ -41,7 +41,7 @@ def to_base64(type_: Union[str, type, StrawberryObjectDefinition], node_id: Any)
             The node id itself
 
     Returns:
-        A tuple of (TypeName, NodeID).
+        A GlobalID, which is a string resulting from base64 encoding <TypeName>:<NodeID>.
 
     Raises:
         ValueError:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This change fixes the docstring for the `to_base64` function in the Relay utils module. The docstring incorrectly stated that the return type was a tuple, but it is actually the base64 encoded global ID string. I think this was a copy/paste mistake from the `from_base64` function.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
