### PR TITLE
chore(docs): document all built-in scalar types. Closes #3404

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4641,11 +4641,11 @@ will print the following SDL:
 directive @specifiedBy(name: String!) on SCALAR
 
 """
-The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+The `JSON` scalar type represents JSON values as specified by [ECMA-404](https://ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf).
 """
 scalar JSON
   @specifiedBy(
-    url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf"
+    url: "https://ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf"
   )
 
 type Query {

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,4 @@
 Release type: patch
 
 Add description of scalar types JSON, Base16, Base32, Base64.
-All scalar types are documented after this release. 
+All scalar types are documented after this release.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,5 @@
-Release type: patch
+Release type: minor
 
-Add description of scalar types JSON, Base16, Base32, Base64.
-All scalar types are documented after this release.
+This releases updates the JSON scalar definition to have the updated `specifiedBy` URL.
+
+The release is marked as minor because it will change the generated schema if you're using the JSON scalar.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+Add description of scalar types JSON, Base16, Base32, Base64.
+All scalar types are documented after this release. 

--- a/docs/types/scalars.md
+++ b/docs/types/scalars.md
@@ -50,7 +50,8 @@ There are several built-in scalars, and you can define custom scalars too.
   standard, maps to Python’s `dict`
 - `Base16`, `Base32`, `Base64`, represents hexadecimal strings encoded with
   `Base16`/`Base32`/`Base64`. As specified in
-  [RFC4648](https://datatracker.ietf.org/doc/html/rfc4648.html)
+  [RFC4648](https://datatracker.ietf.org/doc/html/rfc4648.html). Maps to
+  Python’s `str`
 
 Fields can return built-in scalars by using the Python equivalent:
 

--- a/docs/types/scalars.md
+++ b/docs/types/scalars.md
@@ -45,10 +45,12 @@ There are several built-in scalars, and you can define custom scalars too.
 - `UUID`, a [UUID](https://docs.python.org/3/library/uuid.html#uuid.UUID) value
   serialized as a string
 - `Void`, always null, maps to Python’s `None`
-- `JSON`, a JSON value as specified in [ECMA-404](https://ecma-international.org/publications-and-standards/standards/ecma-404/)
+- `JSON`, a JSON value as specified in
+  [ECMA-404](https://ecma-international.org/publications-and-standards/standards/ecma-404/)
   standard, maps to Python’s `dict`
-- `Base16`, `Base32`, `Base64`, represents hexadecimal strings encoded 
-  with `Base16`/`Base32`/`Base64`. As specified in [RFC4648](https://datatracker.ietf.org/doc/html/rfc4648.html)
+- `Base16`, `Base32`, `Base64`, represents hexadecimal strings encoded with
+  `Base16`/`Base32`/`Base64`. As specified in
+  [RFC4648](https://datatracker.ietf.org/doc/html/rfc4648.html)
 
 Fields can return built-in scalars by using the Python equivalent:
 

--- a/docs/types/scalars.md
+++ b/docs/types/scalars.md
@@ -45,6 +45,10 @@ There are several built-in scalars, and you can define custom scalars too.
 - `UUID`, a [UUID](https://docs.python.org/3/library/uuid.html#uuid.UUID) value
   serialized as a string
 - `Void`, always null, maps to Python’s `None`
+- `JSON`, a JSON value as specified in [ECMA-404](https://ecma-international.org/publications-and-standards/standards/ecma-404/)
+  standard, maps to Python’s `dict`
+- `Base16`, `Base32`, `Base64`, represents hexadecimal strings encoded 
+  with `Base16`/`Base32`/`Base64`. As specified in [RFC4648](https://datatracker.ietf.org/doc/html/rfc4648.html)
 
 Fields can return built-in scalars by using the Python equivalent:
 

--- a/strawberry/scalars.py
+++ b/strawberry/scalars.py
@@ -16,10 +16,10 @@ JSON = scalar(
     description=(
         "The `JSON` scalar type represents JSON values as specified by "
         "[ECMA-404]"
-        "(http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf)."
+        "(https://ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf)."
     ),
     specified_by_url=(
-        "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf"
+        "https://ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf"
     ),
     serialize=lambda v: v,
     parse_value=lambda v: v,

--- a/tests/schema/test_scalars.py
+++ b/tests/schema/test_scalars.py
@@ -176,9 +176,9 @@ def test_json():
     expected_schema = dedent(
         '''
         """
-        The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+        The `JSON` scalar type represents JSON values as specified by [ECMA-404](https://ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf).
         """
-        scalar JSON @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
+        scalar JSON @specifiedBy(url: "https://ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf")
 
         type Query {
           echoJson(data: JSON!): JSON!

--- a/tests/test_forward_references.py
+++ b/tests/test_forward_references.py
@@ -30,9 +30,9 @@ def test_forward_reference():
 
     expected_representation = '''
     """
-    The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+    The `JSON` scalar type represents JSON values as specified by [ECMA-404](https://ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf).
     """
-    scalar JSON @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
+    scalar JSON @specifiedBy(url: "https://ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf")
 
     type MyType {
       id: ID!

--- a/tests/test_printer/test_basic.py
+++ b/tests/test_printer/test_basic.py
@@ -240,9 +240,9 @@ def test_input_defaults_scalars():
 
     expected_type = """
     \"\"\"
-    The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+    The `JSON` scalar type represents JSON values as specified by [ECMA-404](https://ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf).
     \"\"\"
-    scalar JSON @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
+    scalar JSON @specifiedBy(url: "https://ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf")
 
     input MyInput {
       j: JSON! = {}
@@ -285,9 +285,9 @@ def test_arguments_scalar():
 
     expected_type = """
     \"\"\"
-    The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+    The `JSON` scalar type represents JSON values as specified by [ECMA-404](https://ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf).
     \"\"\"
-    scalar JSON @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
+    scalar JSON @specifiedBy(url: "https://ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf")
 
     type Query {
       search(j: JSON! = {}): JSON!


### PR DESCRIPTION
Documents all scalar types which are built-in in Strawberry.

## Description
1. Added description of scalar types `JSON`, `Base16`, `Base32`, `Base64`
2. Updated link of JSON standart definition. Old (http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf) is 404 by now. I considered two links for replacement: https://ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf or https://ecma-international.org/publications-and-standards/standards/ecma-404/. While the latter one is more board, which will result in less probability of resulting to 404 in future, the first one is direct PDF file. I've added the PDF link, but feel free to request a change

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

* Closes #3404

## Checklist

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

I've updated tests which are referring to old JSON specification link