### PR TITLE
perf(listconnection): only resolve edges when edges or pageInfo are selected

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,8 @@
+Release type: patch
+
+This release adds an optimization to `ListConnection` such that only queries with
+`edges` or `pageInfo` in their selected fields triggers `resolve_edges`.
+
+This change is particularly useful for the `strawberry-django` extension's
+`ListConnectionWithTotalCount` and the only selected field is `totalCount`. An
+extraneous SQL query is prevented with this optimization.

--- a/strawberry/relay/types.py
+++ b/strawberry/relay/types.py
@@ -38,7 +38,7 @@ from strawberry.utils.aio import aenumerate, aislice, resolve_awaitable
 from strawberry.utils.inspect import in_async_context
 from strawberry.utils.typing import eval_type, is_classvar
 
-from .utils import from_base64, to_base64
+from .utils import from_base64, should_resolve_list_connection_edges, to_base64
 
 if TYPE_CHECKING:
     from strawberry.scalars import ID
@@ -931,6 +931,17 @@ class ListConnection(Connection[NodeType]):
                 nodes,
                 start,
                 overfetch,
+            )
+
+        if not should_resolve_list_connection_edges(info):
+            return cls(
+                edges=[],
+                page_info=PageInfo(
+                    start_cursor=None,
+                    end_cursor=None,
+                    has_previous_page=False,
+                    has_next_page=False,
+                ),
             )
 
         edges = [

--- a/strawberry/relay/utils.py
+++ b/strawberry/relay/utils.py
@@ -2,6 +2,8 @@ import base64
 from typing import Any, Tuple, Union
 from typing_extensions import assert_never
 
+from strawberry.types.info import Info
+from strawberry.types.nodes import InlineFragment
 from strawberry.types.types import StrawberryObjectDefinition
 
 
@@ -61,3 +63,25 @@ def to_base64(type_: Union[str, type, StrawberryObjectDefinition], node_id: Any)
         raise ValueError(f"{type_} is not a valid GraphQL type or name") from e
 
     return base64.b64encode(f"{type_name}:{node_id}".encode()).decode()
+
+
+def should_resolve_list_connection_edges(info: Info) -> bool:
+    """Check if the user requested to resolve the `edges` field of a connection.
+
+    Args:
+        info:
+            The strawberry execution info resolve the type name from
+
+    Returns:
+        True if the user requested to resolve the `edges` field of a connection, False otherwise.
+
+    """
+    resolve_for_field_names = {"edges", "pageInfo"}
+    for selection_field in info.selected_fields:
+        for selection in selection_field.selections:
+            if (
+                not isinstance(selection, InlineFragment)
+                and selection.name in resolve_for_field_names
+            ):
+                return True
+    return False


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The issue fixed by this PR does a good job of describing the SQL performance optimization made by this PR. 

Before resolving edges in a `ListConnection`, first check that either `edges` or `pageInfo` are in the selected fields list. This optimization prevents extraneous SQL queries when using `ListConnectionWithTotalCount`.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

https://github.com/strawberry-graphql/strawberry-django/issues/397

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
