### PR TITLE
fix(datadog): Fix datadog `AssertionError` upon empty query

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,11 @@
+Release type: patch
+
+Fix `AssertionError` caused by the `DatadogTracingExtension` whenever the query is unavailable.
+
+The bug in question was reported by issue [#3150](https://github.com/strawberry-graphql/strawberry/issues/3150).
+The datadog extension would throw an `AssertionError` whenever there was no query available. This could happen if,
+for example, a user POSTed something to `/graphql` with a JSON that doesn't contain a `query` field as per the
+GraphQL spec.
+
+The fix consists of adding `invalid` to the `operation_type` tag, and also adding `invalid` to the resource name.
+It also makes it easier to look for logs of users making invalid queries by searching for `invalid` in Datadog.

--- a/strawberry/extensions/tracing/datadog.py
+++ b/strawberry/extensions/tracing/datadog.py
@@ -27,7 +27,8 @@ class DatadogTracingExtension(SchemaExtension):
 
     @cached_property
     def _resource_name(self) -> str:
-        assert self.execution_context.query
+        if self.execution_context.query is None:
+            return "invalid"
 
         query_hash = self.hash_query(self.execution_context.query)
 
@@ -78,13 +79,15 @@ class DatadogTracingExtension(SchemaExtension):
         )
         self.request_span.set_tag("graphql.operation_name", self._operation_name)
 
-        assert self.execution_context.query
+        if self.execution_context.query is not None:
+            operation_type = "query"
+            if self.execution_context.query.strip().startswith("mutation"):
+                operation_type = "mutation"
+            elif self.execution_context.query.strip().startswith("subscription"):
+                operation_type = "subscription"
+        else:
+            operation_type = "invalid"
 
-        operation_type = "query"
-        if self.execution_context.query.strip().startswith("mutation"):
-            operation_type = "mutation"
-        elif self.execution_context.query.strip().startswith("subscription"):
-            operation_type = "subscription"
         self.request_span.set_tag("graphql.operation_type", operation_type)
         yield
         self.request_span.finish()

--- a/tests/schema/extensions/test_datadog.py
+++ b/tests/schema/extensions/test_datadog.py
@@ -289,3 +289,28 @@ async def test_create_span_override(datadog_extension):
     await schema.execute(query)
 
     mock.tracer.trace().set_tag.assert_any_call("graphql.query", query)
+
+
+@pytest.mark.asyncio
+async def test_uses_invalid_operation_if_no_query(datadog_extension, mocker):
+    """Avoid regression of https://github.com/strawberry-graphql/strawberry/issues/3150"""
+    extension, mock = datadog_extension
+
+    schema = strawberry.Schema(query=Query, mutation=Mutation, extensions=[extension])
+
+    # A missing query error is expected here, but the extension will run anyways
+    with pytest.raises(strawberry.exceptions.MissingQueryError):
+        await schema.execute(None)
+
+    mock.tracer.assert_has_calls(
+        [
+            mocker.call.trace(
+                "Anonymous Query",
+                resource="invalid",
+                span_type="graphql",
+                service="strawberry",
+            ),
+            mocker.call.trace().set_tag("graphql.operation_name", None),
+            mocker.call.trace().set_tag("graphql.operation_type", "invalid"),
+        ]
+    )


### PR DESCRIPTION
## Description
This PR fixes the `AssertionError` that was raised by the Datadog extension in case there was no query in the current execution context.

## Changes
The change I made was to add `invalid` as the `operation_type` tag and `resource` in that case. This will also make it easier to look for logs of users making invalid queries by just looking for `invalid` in those fields when searching for logs in Datadog.

I also added a test that validates that the extension doesn't raise `AssertionError` in that case.

## Demo repo for testing
I created [this repo](https://github.com/serramatutu/strawberry-issue-3150) with a sample Strawberry app that you can clone yourself and verify that:
- before the fix: the Datadog raises `AssertionError` upon empty query
- after the fix: strawberry behaves the same way it would without the extension in that case

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

#3150 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
- [X] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
