### PR TITLE
Updates StrawberryField documentation warning to include stable fields

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+Release type: patch
+
+This releases updates the `field-extensions` documentation's `StrawberryField` stability warning to include stable features.
+
+The release is marked as patch because it only changes documentation.

--- a/docs/guides/field-extensions.md
+++ b/docs/guides/field-extensions.md
@@ -56,8 +56,9 @@ query {
 
 <Warning>
 
-The `StrawberryField` API is not stable and might change in the future without
-warning.
+Most of the `StrawberryField` API is not stable and might change in the future
+without warning. Stable features include: `StrawberryField.type`,
+`StrawberryField.python_name`, and `StrawberryField.arguments`.
 
 </Warning>
 


### PR DESCRIPTION
## Description

Updates the stability warning on the field extensions [documentation page](https://strawberry.rocks/docs/guides/field-extensions#field-extensions) to include stable features. Confirmed with @patrick91 that the `type`, `python_name`, and `arguments` features are stable ([discord thread](https://discord.com/channels/689806334337482765/1230212734021275819/1230212734021275819)).

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
