### PR TITLE
Fix unclear error when missing dependencies

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+Release type: minor
+
+When calling the CLI without all the necessary dependencies installed,
+a `MissingOptionalDependenciesError` will be raised instead of a
+`ModuleNotFoundError`. This new exception will provide a more helpful
+hint regarding how to fix the problem.

--- a/strawberry/cli/__init__.py
+++ b/strawberry/cli/__init__.py
@@ -1,11 +1,15 @@
-from .commands.codegen import codegen as codegen  # noqa
-from .commands.export_schema import export_schema as export_schema  # noqa
-from .commands.server import server as server  # noqa
-from .commands.upgrade import upgrade as upgrade  # noqa
-from .commands.schema_codegen import schema_codegen as schema_codegen  # noqa
+try:
+    from .app import app
+    from .commands.codegen import codegen as codegen  # noqa
+    from .commands.export_schema import export_schema as export_schema  # noqa
+    from .commands.schema_codegen import schema_codegen as schema_codegen  # noqa
+    from .commands.server import server as server  # noqa
+    from .commands.upgrade import upgrade as upgrade  # noqa
 
-from .app import app
+    def run() -> None:
+        app()
 
+except ModuleNotFoundError as exc:
+    from strawberry.exceptions import MissingOptionalDependenciesError
 
-def run() -> None:
-    app()
+    raise MissingOptionalDependenciesError(extras=["cli"]) from exc

--- a/strawberry/exceptions/__init__.py
+++ b/strawberry/exceptions/__init__.py
@@ -12,6 +12,7 @@ from .handler import setup_exception_handler
 from .invalid_argument_type import InvalidArgumentTypeError
 from .invalid_union_type import InvalidTypeForUnionMergeError, InvalidUnionTypeError
 from .missing_arguments_annotations import MissingArgumentsAnnotationsError
+from .missing_dependencies import MissingOptionalDependenciesError
 from .missing_field_annotation import MissingFieldAnnotationError
 from .missing_return_annotation import MissingReturnAnnotationError
 from .not_a_strawberry_enum import NotAStrawberryEnumError
@@ -186,4 +187,5 @@ __all__ = [
     "MissingFieldAnnotationError",
     "DuplicatedTypeName",
     "StrawberryGraphQLError",
+    "MissingOptionalDependenciesError",
 ]

--- a/strawberry/exceptions/missing_dependencies.py
+++ b/strawberry/exceptions/missing_dependencies.py
@@ -2,10 +2,8 @@ from __future__ import annotations
 
 from typing import Optional
 
-from .exception import StrawberryException
 
-
-class MissingOptionalDependenciesError(StrawberryException):
+class MissingOptionalDependenciesError(Exception):
     """Some optional dependencies that are required for a particular
     task are missing."""
 

--- a/strawberry/exceptions/missing_dependencies.py
+++ b/strawberry/exceptions/missing_dependencies.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from .exception import StrawberryException
+
+
+class MissingOptionalDependenciesError(StrawberryException):
+    """Some optional dependencies that are required for a particular
+    task are missing."""
+
+    def __init__(
+        self,
+        *,
+        packages: Optional[list[str]] = None,
+        extras: Optional[list[str]] = None,
+    ) -> None:
+        packages = packages or []
+        if extras:
+            packages.append(f"'strawberry-graphql[{','.join(extras)}]'")
+        hint = f" (hint: pip install {' '.join(packages)})" if packages else ""
+        self.message = f"Some optional dependencies are missing{hint}"

--- a/tests/exceptions/classes/test_exception_class_missing_optional_dependencies_error.py
+++ b/tests/exceptions/classes/test_exception_class_missing_optional_dependencies_error.py
@@ -7,7 +7,7 @@ def test_missing_optional_dependencies_error():
     with pytest.raises(MissingOptionalDependenciesError) as exc_info:
         raise MissingOptionalDependenciesError()
 
-    assert str(exc_info.value) == "Some optional dependencies are missing"
+    assert exc_info.value.message == "Some optional dependencies are missing"
 
 
 def test_missing_optional_dependencies_error_packages():
@@ -15,9 +15,16 @@ def test_missing_optional_dependencies_error_packages():
         raise MissingOptionalDependenciesError(packages=["a", "b"])
 
     assert (
-        str(exc_info.value)
+        exc_info.value.message
         == "Some optional dependencies are missing (hint: pip install a b)"
     )
+
+
+def test_missing_optional_dependencies_error_empty_packages():
+    with pytest.raises(MissingOptionalDependenciesError) as exc_info:
+        raise MissingOptionalDependenciesError(packages=[])
+
+    assert exc_info.value.message == "Some optional dependencies are missing"
 
 
 def test_missing_optional_dependencies_error_extras():
@@ -25,9 +32,16 @@ def test_missing_optional_dependencies_error_extras():
         raise MissingOptionalDependenciesError(extras=["dev", "test"])
 
     assert (
-        str(exc_info.value)
+        exc_info.value.message
         == "Some optional dependencies are missing (hint: pip install 'strawberry-graphql[dev,test]')"
     )
+
+
+def test_missing_optional_dependencies_error_empty_extras():
+    with pytest.raises(MissingOptionalDependenciesError) as exc_info:
+        raise MissingOptionalDependenciesError(extras=[])
+
+    assert exc_info.value.message == "Some optional dependencies are missing"
 
 
 def test_missing_optional_dependencies_error_packages_and_extras():
@@ -38,6 +52,6 @@ def test_missing_optional_dependencies_error_packages_and_extras():
         )
 
     assert (
-        str(exc_info.value)
+        exc_info.value.message
         == "Some optional dependencies are missing (hint: pip install a b 'strawberry-graphql[dev,test]')"
     )

--- a/tests/exceptions/classes/test_exception_class_missing_optional_dependencies_error.py
+++ b/tests/exceptions/classes/test_exception_class_missing_optional_dependencies_error.py
@@ -1,0 +1,43 @@
+import pytest
+
+from strawberry.exceptions import MissingOptionalDependenciesError
+
+
+def test_missing_optional_dependencies_error():
+    with pytest.raises(MissingOptionalDependenciesError) as exc_info:
+        raise MissingOptionalDependenciesError()
+
+    assert str(exc_info.value) == "Some optional dependencies are missing"
+
+
+def test_missing_optional_dependencies_error_packages():
+    with pytest.raises(MissingOptionalDependenciesError) as exc_info:
+        raise MissingOptionalDependenciesError(packages=["a", "b"])
+
+    assert (
+        str(exc_info.value)
+        == "Some optional dependencies are missing (hint: pip install a b)"
+    )
+
+
+def test_missing_optional_dependencies_error_extras():
+    with pytest.raises(MissingOptionalDependenciesError) as exc_info:
+        raise MissingOptionalDependenciesError(extras=["dev", "test"])
+
+    assert (
+        str(exc_info.value)
+        == "Some optional dependencies are missing (hint: pip install 'strawberry-graphql[dev,test]')"
+    )
+
+
+def test_missing_optional_dependencies_error_packages_and_extras():
+    with pytest.raises(MissingOptionalDependenciesError) as exc_info:
+        raise MissingOptionalDependenciesError(
+            packages=["a", "b"],
+            extras=["dev", "test"],
+        )
+
+    assert (
+        str(exc_info.value)
+        == "Some optional dependencies are missing (hint: pip install a b 'strawberry-graphql[dev,test]')"
+    )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

This PR adds a new `MissingOptionalDependenciesError` and puts it to work in the `cli` module.

This was motivated by the previous `ModuleNotFoundError` causing confusion as to the exact cause of the error (especially as this would become a chain of six errors for the CLI). The new error emits a more helpful message, telling the user what they need to install to resolve the issue. It also makes it clearer that there are optional dependencies at work, especially in the case a user installs `strawberry` expecting the CLI to work out of the box.

The exception class is only in use in the CLI here as I'm not familiar enough with the rest of the code to implement it there (though if maintainers have any shortcuts for working out where it needs to be, happy to do that). The exception class is also futureproofed to hell (arguably overly so lmao) to allow seamless introduction wherever else seems fitting.

It's also tested, despite there not being a precedent to test exception classes. I took a punt at a best standard for this, but if maintainers want this removed or changed let me know.

I've also set this to `minor` instead of `patch` as it _could_ cause breaking changes for a few users if they've gone about handling this themselves.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

None.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
