### PR TITLE
Add support for generic unions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Attempt to merge union types during schema conversion.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,3 @@
-Release type: patch
+Release type: minor
 
 Attempt to merge union types during schema conversion.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,20 @@
 Release type: minor
 
-Attempt to merge union types during schema conversion.
+This release adds support for using strawberry.union with generics, like in this
+example:
+
+```python
+@strawberry.type
+class ObjectQueries[T]:
+    @strawberry.field
+    def by_id(
+        self, id: strawberry.ID
+    ) -> Union[T, Annotated[NotFoundError, strawberry.union("ByIdResult")]]: ...
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def some_type_queries(self, id: strawberry.ID) -> ObjectQueries[SomeType]: ...
+```
+
+which, now, creates a correct union type named `SomeTypeByIdResult`

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,6 +11,7 @@ class ObjectQueries[T]:
         self, id: strawberry.ID
     ) -> Union[T, Annotated[NotFoundError, strawberry.union("ByIdResult")]]: ...
 
+
 @strawberry.type
 class Query:
     @strawberry.field

--- a/strawberry/schema/name_converter.py
+++ b/strawberry/schema/name_converter.py
@@ -106,7 +106,7 @@ class NameConverter:
             return union.graphql_name
 
         name = ""
-        types = union.types
+        types: List[Union[StrawberryType, type]] = union.types
 
         if union.concrete_of and union.concrete_of.graphql_name:
             concrete_of_types = set(union.concrete_of.types)

--- a/strawberry/schema/name_converter.py
+++ b/strawberry/schema/name_converter.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional, Union, cast
+from typing import TYPE_CHECKING, Optional, Tuple, Union, cast
 from typing_extensions import Protocol
 
 from strawberry.directive import StrawberryDirective
@@ -106,12 +106,12 @@ class NameConverter:
             return union.graphql_name
 
         name = ""
-        types: List[Union[StrawberryType, type]] = union.types
+        types: Tuple[StrawberryType, ...] = union.types
 
         if union.concrete_of and union.concrete_of.graphql_name:
             concrete_of_types = set(union.concrete_of.types)
 
-            types = [type_ for type_ in types if type_ not in concrete_of_types]
+            types = tuple(type_ for type_ in types if type_ not in concrete_of_types)
 
         for type_ in types:
             if isinstance(type_, LazyType):

--- a/strawberry/schema/name_converter.py
+++ b/strawberry/schema/name_converter.py
@@ -106,8 +106,14 @@ class NameConverter:
             return union.graphql_name
 
         name = ""
+        types = union.types
 
-        for type_ in union.types:
+        if union.concrete_of and union.concrete_of.graphql_name:
+            concrete_of_types = set(union.concrete_of.types)
+
+            types = [type_ for type_ in types if type_ not in concrete_of_types]
+
+        for type_ in types:
             if isinstance(type_, LazyType):
                 type_ = cast("StrawberryType", type_.resolve_type())  # noqa: PLW2901
 
@@ -119,6 +125,9 @@ class NameConverter:
                 type_name = self.from_type(type_)
 
             name += type_name
+
+        if union.concrete_of and union.concrete_of.graphql_name:
+            name += union.concrete_of.graphql_name
 
         return name
 
@@ -132,12 +141,12 @@ class NameConverter:
         names: list[str] = []
 
         for type_ in types:
-            name = self.get_from_type(type_)
+            name = self.get_name_from_type(type_)
             names.append(name)
 
         return "".join(names) + generic_type_name
 
-    def get_from_type(self, type_: Union[StrawberryType, type]) -> str:
+    def get_name_from_type(self, type_: Union[StrawberryType, type]) -> str:
         type_ = eval_type(type_)
 
         if isinstance(type_, LazyType):
@@ -147,9 +156,9 @@ class NameConverter:
         elif isinstance(type_, StrawberryUnion):
             name = type_.graphql_name if type_.graphql_name else self.from_union(type_)
         elif isinstance(type_, StrawberryList):
-            name = self.get_from_type(type_.of_type) + "List"
+            name = self.get_name_from_type(type_.of_type) + "List"
         elif isinstance(type_, StrawberryOptional):
-            name = self.get_from_type(type_.of_type) + "Optional"
+            name = self.get_name_from_type(type_.of_type) + "Optional"
         elif hasattr(type_, "_scalar_definition"):
             strawberry_type = type_._scalar_definition
 

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -870,9 +870,13 @@ class GraphQLCoreConverter:
 
             if isinstance(graphql_type, GraphQLInputObjectType):
                 raise InvalidTypeInputForUnion(graphql_type)
-            assert isinstance(graphql_type, GraphQLObjectType)
+            assert isinstance(graphql_type, GraphQLObjectType | GraphQLUnionType)
 
-            graphql_types.append(graphql_type)
+            if isinstance(graphql_type, GraphQLUnionType):
+                # merge child types
+                graphql_types += list(graphql_type.types)
+            else:
+                graphql_types.append(graphql_type)
 
         graphql_union = GraphQLUnionType(
             name=union_name,

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -873,7 +873,7 @@ class GraphQLCoreConverter:
             assert isinstance(graphql_type, GraphQLObjectType | GraphQLUnionType)
 
             if isinstance(graphql_type, GraphQLUnionType):
-                # merge child types
+                # Add the child types of the GraphQLUnionType to the list of graphql_types
                 graphql_types.extend(graphql_type.types)
             else:
                 graphql_types.append(graphql_type)

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -870,7 +870,7 @@ class GraphQLCoreConverter:
 
             if isinstance(graphql_type, GraphQLInputObjectType):
                 raise InvalidTypeInputForUnion(graphql_type)
-            assert isinstance(graphql_type, GraphQLObjectType | GraphQLUnionType)
+            assert isinstance(graphql_type, (GraphQLObjectType, GraphQLUnionType))
 
             # If the graphql_type is a GraphQLUnionType, merge its child types
             if isinstance(graphql_type, GraphQLUnionType):

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -872,6 +872,7 @@ class GraphQLCoreConverter:
                 raise InvalidTypeInputForUnion(graphql_type)
             assert isinstance(graphql_type, GraphQLObjectType | GraphQLUnionType)
 
+            # If the graphql_type is a GraphQLUnionType, merge its child types
             if isinstance(graphql_type, GraphQLUnionType):
                 # Add the child types of the GraphQLUnionType to the list of graphql_types
                 graphql_types.extend(graphql_type.types)

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -865,6 +865,7 @@ class GraphQLCoreConverter:
             return graphql_union
 
         graphql_types: list[GraphQLObjectType] = []
+
         for type_ in union.types:
             graphql_type = self.from_type(type_)
 

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -874,7 +874,7 @@ class GraphQLCoreConverter:
 
             if isinstance(graphql_type, GraphQLUnionType):
                 # merge child types
-                graphql_types += list(graphql_type.types)
+                graphql_types.extend(graphql_type.types)
             else:
                 graphql_types.append(graphql_type)
 

--- a/strawberry/types/union.py
+++ b/strawberry/types/union.py
@@ -64,6 +64,7 @@ class StrawberryUnion(StrawberryType):
         self.directives = directives
         self._source_file = None
         self._source_line = None
+        self.concrete_of: Optional[StrawberryUnion] = None
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, StrawberryType):
@@ -136,6 +137,7 @@ class StrawberryUnion(StrawberryType):
             return self
 
         new_types = []
+
         for type_ in self.types:
             new_type: Union[StrawberryType, type]
 
@@ -151,10 +153,13 @@ class StrawberryUnion(StrawberryType):
 
             new_types.append(new_type)
 
-        return StrawberryUnion(
+        new_union = StrawberryUnion(
             type_annotations=tuple(map(StrawberryAnnotation, new_types)),
             description=self.description,
         )
+        new_union.concrete_of = self
+
+        return new_union
 
     def __call__(self, *args: str, **kwargs: Any) -> NoReturn:
         """Do not use.

--- a/tests/schema/test_union.py
+++ b/tests/schema/test_union.py
@@ -842,7 +842,6 @@ def test_single_union():
     assert result.data["something"] == {"__typename": "A", "a": 5}
 
 
-@pytest.mark.xfail(reason="Not supported yet")
 def test_generic_union_with_annotated():
     @strawberry.type
     class SomeType:
@@ -871,7 +870,6 @@ def test_generic_union_with_annotated():
 
     schema = strawberry.Schema(Query)
 
-    # TODO: check the name
     assert (
         str(schema)
         == textwrap.dedent(
@@ -882,7 +880,7 @@ def test_generic_union_with_annotated():
             }
 
             type Query {
-              someTypeQueries(id: ID!): SomeTypeByIdResult!
+              someTypeQueries(id: ID!): SomeTypeObjectQueries!
             }
 
             type SomeType {
@@ -890,7 +888,7 @@ def test_generic_union_with_annotated():
               name: String!
             }
 
-            union SomeTypeNotFoundError = SomeType | NotFoundError
+            union SomeTypeByIdResult = SomeType | NotFoundError
 
             type SomeTypeObjectQueries {
               byId(id: ID!): SomeTypeByIdResult!

--- a/tests/schema/test_union.py
+++ b/tests/schema/test_union.py
@@ -866,7 +866,7 @@ def test_generic_union_with_annotated():
     class Query:
         @strawberry.field
         def some_type_queries(self, id: strawberry.ID) -> ObjectQueries[SomeType]:
-            raise NotImplementedError()
+            raise NotImplementedError
 
     schema = strawberry.Schema(Query)
 

--- a/tests/schema/test_union.py
+++ b/tests/schema/test_union.py
@@ -921,8 +921,7 @@ def test_generic_union_with_annotated_inside():
     @strawberry.type
     class Query:
         @strawberry.field
-        def some_type_queries(self, id: strawberry.ID) -> ObjectQueries[SomeType]:
-            return ObjectQueries(SomeType)
+        def some_type_queries(self, id: strawberry.ID) -> ObjectQueries[SomeType]: ...
 
     schema = strawberry.Schema(Query)
 
@@ -984,8 +983,7 @@ def test_annoted_union_with_two_generics():
         @strawberry.field
         def some_type_queries(
             self, id: strawberry.ID
-        ) -> UnionObjectQueries[SomeType, OtherType]:
-            return UnionObjectQueries()
+        ) -> UnionObjectQueries[SomeType, OtherType]: ...
 
     schema = strawberry.Schema(Query)
 

--- a/tests/schema/test_union.py
+++ b/tests/schema/test_union.py
@@ -975,7 +975,9 @@ def test_annoted_union_with_two_generics():
         @strawberry.field
         def by_id(
             self, id: strawberry.ID
-        ) -> T | Annotated[U | NotFoundError, strawberry.union("ByIdResult")]: ...
+        ) -> Union[
+            T, Annotated[Union[U, NotFoundError], strawberry.union("ByIdResult")]
+        ]: ...
 
     @strawberry.type
     class Query:


### PR DESCRIPTION

## Description

This PR merges union types in `strawberry.schema.schema_converter.GraphQLCoreCoverter:from_union`. This allows creating a more stable interface, as a union can be created between a TypeVar and an annotated union. In the examples in #3393, this changes `SomeTypeByIdNotFoundError` => `SomeTypeByIdResult`, the latter of which won't change as more error cases are added.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #3393 - The related issues have been checked as well, but this doesn't seem to fix them; except for #2959 which seems to have already been fixed as far as I can tell.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
