### PR TITLE
GH-3521: Provide a more powerful Info class to resolve_reference

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,32 @@
+Release type: patch
+
+Strawberry will now inject `strawberry.Info` instances to `resolve_reference` classmethods instead of `GraphQLResolveInfo` instances.
+
+This allows for the use of the additional functionality provided by `strawberry.Info`, such as filtering what's resolved based on the selected fields:
+
+```py
+@strawberry.federation.type(keys=["id"])
+class User:
+    id: strawberry.ID
+    email: str
+    orders: list[Order] = strawberry.field(default_factory=list)
+
+    @classmethod
+    def resolve_reference(cls, id: strawberry.ID, info: strawberry.Info) -> Self:
+        user = db.session.query(User).filter(User.id == id).first()
+        kwargs = {"id": user.id, "email": user.email}
+
+        for field in info.selected_fields:
+            for selection in field.selections:
+                if selection.name == "orders":
+                    orders = (
+                        db.session.query(Order)
+                        .filter(Order.customer_id == User.id)
+                        .all()
+                    )
+                    kwargs["orders"] = orders
+
+        return cls(**kwargs)
+```
+
+Note that field-related attributes will always return `None`.

--- a/strawberry/federation/schema.py
+++ b/strawberry/federation/schema.py
@@ -30,7 +30,7 @@ from graphql.type.definition import GraphQLArgument
 
 from strawberry.printer import print_schema
 from strawberry.schema import Schema as BaseSchema
-from strawberry.types.info import PartialInfo
+from strawberry.types.info import Info
 from strawberry.types.types import StrawberryObjectDefinition
 from strawberry.utils.inspect import get_func_args
 
@@ -193,7 +193,7 @@ class Schema(BaseSchema):
 
                 # TODO: use the same logic we use for other resolvers
                 if "info" in func_args:
-                    kwargs["info"] = PartialInfo(_raw_info=info)
+                    kwargs["info"] = Info(_raw_info=info)
 
                 get_result = partial(resolve_reference, **kwargs)
             else:

--- a/strawberry/federation/schema.py
+++ b/strawberry/federation/schema.py
@@ -30,6 +30,7 @@ from graphql.type.definition import GraphQLArgument
 
 from strawberry.printer import print_schema
 from strawberry.schema import Schema as BaseSchema
+from strawberry.types.info import PartialInfo
 from strawberry.types.types import StrawberryObjectDefinition
 from strawberry.utils.inspect import get_func_args
 
@@ -37,7 +38,7 @@ from .schema_directive import StrawberryFederationSchemaDirective
 
 if TYPE_CHECKING:
     from graphql import ExecutionContext as GraphQLExecutionContext
-    from graphql import GraphQLObjectType
+    from graphql import GraphQLObjectType, GraphQLResolveInfo
 
     from strawberry.custom_scalar import ScalarDefinition, ScalarWrapper
     from strawberry.enum import EnumDefinition
@@ -173,7 +174,7 @@ class Schema(BaseSchema):
     def entities_resolver(
         self,
         root,  # noqa: ANN001
-        info,  # noqa: ANN001
+        info: "GraphQLResolveInfo",
         representations,  # noqa: ANN001
     ) -> List[object]:
         results = []
@@ -192,7 +193,7 @@ class Schema(BaseSchema):
 
                 # TODO: use the same logic we use for other resolvers
                 if "info" in func_args:
-                    kwargs["info"] = info
+                    kwargs["info"] = PartialInfo(_raw_info=info)
 
                 get_result = partial(resolve_reference, **kwargs)
             else:

--- a/strawberry/types/info.py
+++ b/strawberry/types/info.py
@@ -3,17 +3,7 @@ from __future__ import annotations
 import dataclasses
 import warnings
 from functools import cached_property
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    Generic,
-    List,
-    Optional,
-    Tuple,
-    Type,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Dict, Generic, List, Optional, Tuple, Type, Union
 from typing_extensions import TypeVar
 
 from .nodes import convert_selections
@@ -35,9 +25,8 @@ RootValueType = TypeVar("RootValueType", default=Any)
 
 
 @dataclasses.dataclass
-class Info(Generic[ContextType, RootValueType]):
+class PartialInfo(Generic[ContextType, RootValueType]):
     _raw_info: GraphQLResolveInfo
-    _field: StrawberryField
 
     def __class_getitem__(cls, types: Union[type, Tuple[type, ...]]) -> Type[Info]:
         """Workaround for when passing only one type.
@@ -89,6 +78,21 @@ class Info(Generic[ContextType, RootValueType]):
     def variable_values(self) -> Dict[str, Any]:
         return self._raw_info.variable_values
 
+    # TODO: create an abstraction on these fields
+    @property
+    def operation(self) -> OperationDefinitionNode:
+        return self._raw_info.operation
+
+    @property
+    def path(self) -> Path:
+        return self._raw_info.path
+
+
+@dataclasses.dataclass
+class Info(PartialInfo, Generic[ContextType, RootValueType]):
+    _raw_info: GraphQLResolveInfo
+    _field: StrawberryField
+
     @property
     def return_type(
         self,
@@ -98,15 +102,6 @@ class Info(Generic[ContextType, RootValueType]):
     @property
     def python_name(self) -> str:
         return self._field.python_name
-
-    # TODO: create an abstraction on these fields
-    @property
-    def operation(self) -> OperationDefinitionNode:
-        return self._raw_info.operation
-
-    @property
-    def path(self) -> Path:
-        return self._raw_info.path
 
     # TODO: parent_type as strawberry types
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

This PR modifies the `Info` class such that instances are able to be injected into `resolve_reference` classmethods instead of `GraphQLResolveInfo` instances.

This provides more functionality, primarily enabling users to get the selected fields of the query where they weren't able to before. Some attributes (anything related to `self._field`) are unavailable in this state and just return `None`.

It doesn't attempt to port over the converter logic from the unfederated `Schema` class as it was not necessary for this fix, and is more suitable for a follow-up.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Closes #3521.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
