### PR TITLE
Improved error message when supplying GlobalID with invalid or unknown type name component

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Improved error message when supplying GlobalID with invalid or unknown type name component

--- a/strawberry/relay/types.py
+++ b/strawberry/relay/types.py
@@ -234,7 +234,7 @@ class GlobalID:
         if not issubclass(origin, Node):
             raise GlobalIDValueError(
                 f"Cannot resolve. GlobalID requires a GraphQL Node type, "
-                f"received {self.type_name}."
+                f"received `{self.type_name}`."
             )
         return origin
 

--- a/strawberry/relay/types.py
+++ b/strawberry/relay/types.py
@@ -223,7 +223,7 @@ class GlobalID:
         if not isinstance(type_def, StrawberryObjectDefinition):
             raise GlobalIDValueError(
                 f"Cannot resolve. GlobalID requires a GraphQL type, "
-                f"received {self.type_name}."
+                f"received `{self.type_name}`."
             )
 
         origin = (

--- a/strawberry/relay/types.py
+++ b/strawberry/relay/types.py
@@ -220,14 +220,22 @@ class GlobalID:
 
         """
         type_def = info.schema.get_type_by_name(self.type_name)
-        assert isinstance(type_def, StrawberryObjectDefinition)
+        if not isinstance(type_def, StrawberryObjectDefinition):
+            raise GlobalIDValueError(
+                f"Cannot resolve. GlobalID requires a GraphQL type, "
+                f"received {self.type_name}."
+            )
 
         origin = (
             type_def.origin.resolve_type
             if isinstance(type_def.origin, LazyType)
             else type_def.origin
         )
-        assert issubclass(origin, Node)
+        if not issubclass(origin, Node):
+            raise GlobalIDValueError(
+                f"Cannot resolve. GlobalID requires a GraphQL Node type, "
+                f"received {self.type_name}."
+            )
         return origin
 
     @overload

--- a/tests/relay/test_exceptions.py
+++ b/tests/relay/test_exceptions.py
@@ -3,7 +3,7 @@ from typing import List
 import pytest
 
 import strawberry
-from strawberry import relay, Info
+from strawberry import Info, relay
 from strawberry.relay import GlobalID
 from strawberry.relay.exceptions import (
     NodeIDAnnotationError,
@@ -22,7 +22,7 @@ def test_raises_error_on_unknown_node_type_in_global_id():
     class Query:
         @strawberry.field()
         def test(self, info: Info) -> GlobalID:
-            _id = GlobalID('foo', 'bar')
+            _id = GlobalID("foo", "bar")
             _id.resolve_type(info)
             return _id
 
@@ -34,7 +34,10 @@ def test_raises_error_on_unknown_node_type_in_global_id():
         }
     """)
     assert len(result.errors) == 1
-    assert result.errors[0].message == 'Cannot resolve. GlobalID requires a GraphQL type, received foo.'
+    assert (
+        result.errors[0].message
+        == "Cannot resolve. GlobalID requires a GraphQL type, received foo."
+    )
 
 
 @pytest.mark.raises_strawberry_exception(

--- a/tests/relay/test_exceptions.py
+++ b/tests/relay/test_exceptions.py
@@ -36,7 +36,7 @@ def test_raises_error_on_unknown_node_type_in_global_id():
     assert len(result.errors) == 1
     assert (
         result.errors[0].message
-        == "Cannot resolve. GlobalID requires a GraphQL type, received foo."
+        == "Cannot resolve. GlobalID requires a GraphQL type, received `foo`."
     )
 
 

--- a/tests/relay/test_exceptions.py
+++ b/tests/relay/test_exceptions.py
@@ -40,6 +40,29 @@ def test_raises_error_on_unknown_node_type_in_global_id():
     )
 
 
+def test_raises_error_on_non_node_type_in_global_id():
+    @strawberry.type
+    class Query:
+        @strawberry.field()
+        def test(self, info: Info) -> GlobalID:
+            _id = GlobalID("NonNodeType", "bar")
+            _id.resolve_type(info)
+            return _id
+
+    schema = strawberry.Schema(query=Query, types=(NonNodeType, ))
+
+    result = schema.execute_sync("""
+        query TestQuery {
+            test
+        }
+    """)
+    assert len(result.errors) == 1
+    assert (
+        result.errors[0].message == "Cannot resolve. GlobalID requires a GraphQL Node "
+                                    "type, received `NonNodeType`."
+    )
+
+
 @pytest.mark.raises_strawberry_exception(
     NodeIDAnnotationError,
     match='No field annotated with `NodeID` found in "Fruit"',

--- a/tests/relay/test_exceptions.py
+++ b/tests/relay/test_exceptions.py
@@ -3,7 +3,8 @@ from typing import List
 import pytest
 
 import strawberry
-from strawberry import relay
+from strawberry import relay, Info
+from strawberry.relay import GlobalID
 from strawberry.relay.exceptions import (
     NodeIDAnnotationError,
     RelayWrongAnnotationError,
@@ -14,6 +15,26 @@ from strawberry.relay.exceptions import (
 @strawberry.type
 class NonNodeType:
     foo: str
+
+
+def test_raises_error_on_unknown_node_type_in_global_id():
+    @strawberry.type
+    class Query:
+        @strawberry.field()
+        def test(self, info: Info) -> GlobalID:
+            _id = GlobalID('foo', 'bar')
+            _id.resolve_type(info)
+            return _id
+
+    schema = strawberry.Schema(query=Query)
+
+    result = schema.execute_sync("""
+        query TestQuery {
+            test
+        }
+    """)
+    assert len(result.errors) == 1
+    assert result.errors[0].message == 'Cannot resolve. GlobalID requires a GraphQL type, received foo.'
 
 
 @pytest.mark.raises_strawberry_exception(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Improves the error generated when invalid input is supplied to `GlobalID`.
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

Fixes #3532 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
- [X] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request enhances the error handling for GlobalID by providing more informative error messages when an invalid or unknown type name is supplied. Additionally, a new test has been added to ensure the correct error is raised in such scenarios.

* **Bug Fixes**:
    - Improved error message when supplying GlobalID with an invalid or unknown type name component.
* **Tests**:
    - Added a test to verify that an appropriate error is raised when an unknown node type is supplied to GlobalID.

<!-- Generated by sourcery-ai[bot]: end summary -->