### PR TITLE
fix: Fix specialize_type_vars resolution for generic aliases

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,12 @@
+Release type: patch
+
+This release fixes an issue when trying to retrieve specialized type vars from a
+generic type that has been aliased to a name, in cases like:
+
+```python
+@strawberry.type
+class Fruit(Generic[T]): ...
+
+
+SpecializedFruit = Fruit[str]
+```

--- a/strawberry/utils/inspect.py
+++ b/strawberry/utils/inspect.py
@@ -8,10 +8,12 @@ from typing import (
     List,
     Optional,
     TypeVar,
+    get_origin,
 )
 from typing_extensions import get_args
 
 from strawberry.type import has_object_definition
+from strawberry.utils.typing import is_generic_alias
 
 
 def in_async_context() -> bool:
@@ -77,8 +79,12 @@ def get_specialized_type_var_map(cls: type) -> Optional[Dict[str, type]]:
     """
     orig_bases = getattr(cls, "__orig_bases__", None)
     if orig_bases is None:
-        # Not a specialized type
-        return None
+        # Specialized generic aliases will not have __orig_bases__
+        if get_origin(cls) is not None and is_generic_alias(cls):
+            orig_bases = (cls,)
+        else:
+            # Not a specialized type
+            return None
 
     type_var_map = {}
 
@@ -88,9 +94,10 @@ def get_specialized_type_var_map(cls: type) -> Optional[Dict[str, type]]:
 
     for base in orig_bases:
         # Recursively get type var map from base classes
-        base_type_var_map = get_specialized_type_var_map(base)
-        if base_type_var_map is not None:
-            type_var_map.update(base_type_var_map)
+        if base is not cls:
+            base_type_var_map = get_specialized_type_var_map(base)
+            if base_type_var_map is not None:
+                type_var_map.update(base_type_var_map)
 
         args = get_args(base)
         origin = getattr(base, "__origin__", None)

--- a/tests/plugins/strawberry_exceptions.py
+++ b/tests/plugins/strawberry_exceptions.py
@@ -126,7 +126,7 @@ class StrawberryExceptionsPlugin:
         else:
             text += f"\n``````\n{exception_text.strip()}\n``````\n\n"
 
-        documentation_path = DOCS_FOLDER / f"{raised_exception.documentation_path}.md"
+        documentation_path = DOCS_FOLDER / f"{raised_exception.documentation_path}.mdx"
 
         if not documentation_path.exists():
             pytest.fail(

--- a/tests/python_312/test_inspect.py
+++ b/tests/python_312/test_inspect.py
@@ -28,6 +28,27 @@ def test_get_specialized_type_var_map_generic():
     assert get_specialized_type_var_map(Bar) == {"_T": int}
 
 
+def test_get_specialized_type_var_map_from_alias():
+    @strawberry.type
+    class Foo[_T]: ...
+
+    SpecializedFoo = Foo[int]
+
+    assert get_specialized_type_var_map(SpecializedFoo) == {"_T": int}
+
+
+def test_get_specialized_type_var_map_from_alias_with_inheritance():
+    @strawberry.type
+    class Foo[_T]: ...
+
+    SpecializedFoo = Foo[int]
+
+    @strawberry.type
+    class Bar(SpecializedFoo): ...
+
+    assert get_specialized_type_var_map(Bar) == {"_T": int}
+
+
 def test_get_specialized_type_var_map_generic_subclass():
     @strawberry.type
     class Foo[_T]: ...

--- a/tests/utils/test_inspect.py
+++ b/tests/utils/test_inspect.py
@@ -31,6 +31,27 @@ def test_get_specialized_type_var_map_generic():
     assert get_specialized_type_var_map(Bar) == {"_T": int}
 
 
+def test_get_specialized_type_var_map_from_alias():
+    @strawberry.type
+    class Foo(Generic[_T]): ...
+
+    SpecializedFoo = Foo[int]
+
+    assert get_specialized_type_var_map(SpecializedFoo) == {"_T": int}
+
+
+def test_get_specialized_type_var_map_from_alias_with_inheritance():
+    @strawberry.type
+    class Foo(Generic[_T]): ...
+
+    SpecializedFoo = Foo[int]
+
+    @strawberry.type
+    class Bar(SpecializedFoo): ...
+
+    assert get_specialized_type_var_map(Bar) == {"_T": int}
+
+
 def test_get_specialized_type_var_map_generic_subclass():
     @strawberry.type
     class Foo(Generic[_T]): ...


### PR DESCRIPTION
While trying to debug https://github.com/strawberry-graphql/strawberry-django/issues/535 I discovered this.

There's still another bug on strawberry-django itself, but it needs this to be fixed first.
