### PR TITLE
Add benchmark for generic inputs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
             .nox
           key:
             ${{ runner.os }}-nox-${{ matrix.session.session }}-${{
-            hashFiles('**/poetry.lock') }}-${{ hashFiles('**/noxfile.py') }}-3
+            hashFiles('**/poetry.lock') }}-${{ hashFiles('**/noxfile.py') }}-4
 
       - run: pip install poetry nox nox-poetry
       - run: nox -r -t tests -s "${{ matrix.session.session }}"

--- a/tests/benchmarks/test_generic_input.py
+++ b/tests/benchmarks/test_generic_input.py
@@ -35,7 +35,7 @@ class Book:
     @strawberry.field
     async def authors(
         self,
-        name: GraphQLFilter[str] | None = None,
+        name: Optional[GraphQLFilter[str]] = None,
     ) -> List[Author]:
         return [Author(name="F. Scott Fitzgerald")]
 

--- a/tests/benchmarks/test_generic_input.py
+++ b/tests/benchmarks/test_generic_input.py
@@ -43,7 +43,7 @@ class Book:
 def get_books():
     return [
         Book(title="The Great Gatsby"),
-    ] * 10000
+    ] * 1000
 
 
 @strawberry.type

--- a/tests/benchmarks/test_generic_input.py
+++ b/tests/benchmarks/test_generic_input.py
@@ -1,0 +1,75 @@
+import asyncio
+from typing import Generic, List, Optional, TypeVar
+
+from pytest_codspeed.plugin import BenchmarkFixture
+
+import strawberry
+
+T = TypeVar("T")
+
+
+@strawberry.input(description="Filter for GraphQL queries")
+class GraphQLFilter(Generic[T]):
+    """EXTERNAL Filter for GraphQL queries"""
+
+    eq: Optional[T] = None
+    in_: Optional[List[T]] = None
+    nin: Optional[List[T]] = None
+    gt: Optional[T] = None
+    gte: Optional[T] = None
+    lt: Optional[T] = None
+    lte: Optional[T] = None
+    contains: Optional[T] = None
+    icontains: Optional[T] = None
+
+
+@strawberry.type
+class Author:
+    name: str
+
+
+@strawberry.type
+class Book:
+    title: str
+
+    @strawberry.field
+    async def authors(
+        self,
+        name: GraphQLFilter[str] | None = None,
+    ) -> List[Author]:
+        return [Author(name="F. Scott Fitzgerald")]
+
+
+def get_books():
+    return [
+        Book(title="The Great Gatsby"),
+    ] * 10000
+
+
+@strawberry.type
+class Query:
+    books: List[Book] = strawberry.field(resolver=get_books)
+
+
+schema = strawberry.Schema(query=Query)
+
+query = """{
+    books {
+        title
+        authors(name: {eq: "F. Scott Fitzgerald"}) {
+            name
+        }
+    }
+}
+"""
+
+
+def test_execute_generic_input(benchmark: BenchmarkFixture):
+    def run():
+        coroutine = schema.execute(query)
+
+        return asyncio.run(coroutine)
+
+    result = benchmark(run)
+
+    assert not result.errors


### PR DESCRIPTION
Only added a benchmark so far, based on #3544

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Introduced a new benchmark test to evaluate the performance of generic GraphQL input handling, specifically focusing on filtering and querying operations.

- **Tests**:
    - Added a benchmark test for generic GraphQL input handling, including a new test file `test_generic_input.py`.

<!-- Generated by sourcery-ai[bot]: end summary -->