### PR TITLE
Add issue manager workflow

### DIFF
--- a/.github/workflows/issue-manager.yml
+++ b/.github/workflows/issue-manager.yml
@@ -24,7 +24,7 @@ jobs:
           config: >
             {
               "info-needed": {
-                "delay": 1209600,
+                "delay": P14D,
                 "message": "Hi, this issue requires extra info to be actionable. We're closing this issue because it has not been actionable for a while now. Feel free to provide the requested information and we'll happily open it again! 😊"
               }
             }

--- a/.github/workflows/issue-manager.yml
+++ b/.github/workflows/issue-manager.yml
@@ -1,0 +1,30 @@
+name: Issue Manager
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  issue_comment:
+    types:
+      - created
+  issues:
+    types:
+      - labeled
+  pull_request_target:
+    types:
+      - labeled
+  workflow_dispatch:
+
+jobs:
+  issue-manager:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: tiangolo/issue-manager@0.5.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          config: >
+            {
+              "info-needed": {
+                "delay": 1209600,
+                "message": "Hi, this issue requires extra info to be actionable. We're closing this issue because it has not been actionable for a while now. Feel free to provide the requested information and we'll happily open it again! 😊"
+              }
+            }


### PR DESCRIPTION
## Description

This is the issue manager Erik proposed. I configured it with one of our existing labels "info-needed". Issues which have the "info-needed" label will automatically be closed with a message after two weeks of inactivity.

We can easily extend the delay (it's in seconds), I went with 14 days for nor particular reason. We could also configure this for more labels, but I guess this is the most useful one.

