### PR TITLE
Fix incorrect query params type

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+This release removes an unnecessary check from our internal GET query parsing logic making it simpler and (insignificantly) faster.

--- a/strawberry/flask/views.py
+++ b/strawberry/flask/views.py
@@ -26,7 +26,7 @@ class FlaskHTTPRequestAdapter(SyncHTTPRequestAdapter):
         self.request = request
 
     @property
-    def query_params(self) -> Mapping[str, Union[str, Optional[List[str]]]]:
+    def query_params(self) -> QueryParams:
         return self.request.args.to_dict()
 
     @property

--- a/strawberry/flask/views.py
+++ b/strawberry/flask/views.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, Any, List, Mapping, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Mapping, Optional, Union, cast
 
 from flask import Request, Response, render_template_string, request
 from flask.views import View

--- a/strawberry/http/base.py
+++ b/strawberry/http/base.py
@@ -4,7 +4,7 @@ from typing_extensions import Protocol
 
 from strawberry.http import GraphQLHTTPResponse
 from strawberry.http.ides import GraphQL_IDE, get_graphql_ide_html
-from strawberry.http.types import HTTPMethod
+from strawberry.http.types import HTTPMethod, QueryParams
 
 from .exceptions import HTTPException
 from .typevars import Request
@@ -50,16 +50,11 @@ class BaseView(Generic[Request]):
     def encode_json(self, response_data: GraphQLHTTPResponse) -> str:
         return json.dumps(response_data)
 
-    def parse_query_params(
-        self, params: Mapping[str, Optional[Union[str, List[str]]]]
-    ) -> Dict[str, Any]:
+    def parse_query_params(self, params: QueryParams) -> Dict[str, Any]:
         params = dict(params)
 
         if "variables" in params:
             variables = params["variables"]
-
-            if isinstance(variables, list):
-                variables = variables[0]
 
             if variables:
                 params["variables"] = self.parse_json(variables)

--- a/strawberry/http/types.py
+++ b/strawberry/http/types.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Mapping, Optional, Union
+from typing import Any, Mapping, Optional
 from typing_extensions import Literal, TypedDict
 
 HTTPMethod = Literal[

--- a/strawberry/http/types.py
+++ b/strawberry/http/types.py
@@ -5,7 +5,7 @@ HTTPMethod = Literal[
     "GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS", "TRACE"
 ]
 
-QueryParams = Mapping[str, Optional[Union[str, List[str]]]]
+QueryParams = Mapping[str, Optional[str]]
 
 
 class FormData(TypedDict):

--- a/strawberry/sanic/views.py
+++ b/strawberry/sanic/views.py
@@ -43,12 +43,8 @@ class SanicHTTPRequestAdapter(AsyncHTTPRequestAdapter):
         # the keys are the unique variable names and the values are lists
         # of values for each variable name. To ensure consistency, we're
         # enforcing the use of the first value in each list.
-
-        args = cast(
-            Dict[str, Optional[List[str]]],
-            self.request.get_args(keep_blank_values=True),
-        )
-
+        
+        args = self.request.get_args(keep_blank_values=True)
         return {k: args.get(k, None) for k in args}
 
     @property

--- a/strawberry/sanic/views.py
+++ b/strawberry/sanic/views.py
@@ -6,7 +6,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Dict,
-    List,
     Mapping,
     Optional,
     Type,
@@ -43,7 +42,6 @@ class SanicHTTPRequestAdapter(AsyncHTTPRequestAdapter):
         # the keys are the unique variable names and the values are lists
         # of values for each variable name. To ensure consistency, we're
         # enforcing the use of the first value in each list.
-        
         args = self.request.get_args(keep_blank_values=True)
         return {k: args.get(k, None) for k in args}
 

--- a/tests/http/test_query.py
+++ b/tests/http/test_query.py
@@ -170,10 +170,11 @@ async def test_passing_invalid_json_get(http_client: HttpClient):
 
 async def test_query_parameters_are_never_interpreted_as_list(http_client: HttpClient):
     response = await http_client.get(
-        url="/graphql?query={ hello }&variables={}&variables={}",
+        url='/graphql?query=query($name: String!) { hello(name: $name) }&variables={"name": "Jake"}&variables={"name": "Jake"}',
     )
 
     assert response.status_code == 200
+    assert response.json["data"] == {"hello": "Hello Jake"}
 
 
 async def test_missing_query(http_client: HttpClient):

--- a/tests/http/test_query.py
+++ b/tests/http/test_query.py
@@ -168,6 +168,14 @@ async def test_passing_invalid_json_get(http_client: HttpClient):
     assert "Unable to parse request body as JSON" in response.text
 
 
+async def test_query_parameters_are_never_interpreted_as_list(http_client: HttpClient):
+    response = await http_client.get(
+        url="/graphql?query={ hello }&variables={}&variables={}",
+    )
+
+    assert response.status_code == 200
+
+
 async def test_missing_query(http_client: HttpClient):
     response = await http_client.post(
         url="/graphql",


### PR DESCRIPTION
## Description

This is the result of my deep-dive into [this comment](https://github.com/strawberry-graphql/strawberry/pull/3461#discussion_r1667711061).

Our GET query parsing method incorrectly assumed that our query parameters could be lists. As a result some of our types were sligtly incorrect and we had an unnecessary block handling the case.

Generally it would be correct that GET query parameters could contain lists (e.g. `?variables={}&variables={}` could be parsed as a list). The sanic integration even contains a [warning](https://github.com/strawberry-graphql/strawberry/blob/d2c0fb4d2d363929c9ac10161884d004ab9cf555/strawberry/sanic/views.py#L39-L52) about this. However, it turns out none of our integrations interprets query parameters which are defined multiple times as lists by default (not even sanic). I manually checked every integration and also added a test to prove this. Also double-checked the graphql http spec to verify the "variables" query parameter must indeed not be a list.

(fyi: most of these frameworks provide a `getlist` method which can be used to explicitly interpret multi-defined GET query parameters as a list).

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request fixes the incorrect type handling of query parameters in GET requests by ensuring they are not interpreted as lists. It simplifies the internal GET query parsing logic by removing unnecessary checks, adds a test to verify the correct behavior, and includes a release note documenting the changes.

- **Bug Fixes**:
    - Fixed incorrect type handling of query parameters in GET requests, ensuring they are not interpreted as lists.
- **Enhancements**:
    - Simplified the internal GET query parsing logic by removing unnecessary checks for list types, improving code clarity and performance.
- **Documentation**:
    - Added a release note to document the patch release and the changes made to the GET query parsing logic.
- **Tests**:
    - Added a test to verify that query parameters are never interpreted as lists across all integrations.

<!-- Generated by sourcery-ai[bot]: end summary -->