### PR TITLE
Fix missing quotes in issue manager config

### DIFF
--- a/.github/workflows/issue-manager.yml
+++ b/.github/workflows/issue-manager.yml
@@ -24,7 +24,7 @@ jobs:
           config: >
             {
               "info-needed": {
-                "delay": P14D,
+                "delay": "P14D",
                 "message": "Hi, this issue requires extra info to be actionable. We're closing this issue because it has not been actionable for a while now. Feel free to provide the requested information and we'll happily open it again! 😊"
               }
             }


### PR DESCRIPTION
## Description

Forgot to add quotes during the last minute switch from a seconds based period to an ISO 8601 based period for the delay in #3556 :melting_face:

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request fixes a configuration issue in the issue manager workflow by adding missing quotes around the ISO 8601 period in the 'delay' field.

- **Bug Fixes**:
    - Fixed missing quotes in the 'delay' field of the issue manager configuration to ensure proper parsing of the ISO 8601 period.

<!-- Generated by sourcery-ai[bot]: end summary -->