### PR TITLE
[DRAFT] Tweak annotation population to better maintain field definition ordering

### DIFF
--- a/strawberry/object_type.py
+++ b/strawberry/object_type.py
@@ -53,10 +53,16 @@ def _check_field_annotations(cls: Type[Any]) -> None:
 
     https://github.com/python/cpython/blob/6fed3c85402c5ca704eb3f3189ca3f5c67a08d19/Lib/dataclasses.py#L881-L884
     """
-    cls_annotations = cls.__dict__.get("__annotations__", {})
+    original_annotations = cls.__dict__.get("__annotations__", {})
+    cls_annotations = {
+        a: t for a, t in original_annotations.items() if a not in cls.__dict__
+    }
     cls.__annotations__ = cls_annotations
 
     for field_name, field_ in cls.__dict__.items():
+        if field_name in original_annotations:
+            cls_annotations[field_name] = original_annotations[field_name]
+
         if not isinstance(field_, (StrawberryField, dataclasses.Field)):
             # Not a dataclasses.Field, nor a StrawberryField. Ignore
             continue


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This change explores tweaking field annotation population to better maintain field ordering.

As-is (without this change), this is the behavior:
```python
import strawberry

@strawberry.type
class A:
    type_1a: str = "type_1a"
    type_1b: str = strawberry.field()
    type_1c: str = strawberry.field(resolver=lambda: "type_1c")
    
    @strawberry.field
    def type_2(self) -> str:
        return "type_2"

    another_type_1: str
    another_type_1b: str = strawberry.field()
    another_type_1c: str = strawberry.field(resolver=lambda: "type_1c")

print(
    [f.name for f in A.__strawberry_definition__.fields]
)
# ['type_1a', 'type_1b', 'type_1c', 'another_type_1', 'another_type_1b', 'another_type_1c', 'type_2']
```

Ideally `type_2` would be defined in the middle, matching the order of the field on the model.

Exploring potential solutions, it seems like without adding a metaclass or doing AST traversal it's pretty hard to get the actual definition order. In this PR I've tried to approximate it a little better without a major change.

The proposed change here does not work for maintaining ordering of bare annotations defined in the middle of other fields (e.g. `another_type_1: str` above). However, for other field definition styles it appears to work correctly. So if ordering is important in the schema there's then a simple solution to add `= strawberry.field()` to otherwise bare annotations.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

None, question was asked on [discord](https://discord.com/channels/689806334337482765/1259867790119010324/1259867790119010324).

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
