### PR TITLE
Fix default cache dataloader raise key error on non-existing key

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,12 @@
+Release type: patch
+
+Calling `.clean(key)` on default dataloader with non-existing `key` will not throw `KeyError` error anymore. Example:
+```python
+async def load_data(keys):
+    return [str(key) for key in keys]
+
+dataloader = DataLoader(load_fn=load_data)
+dataloader.clean(42) # does not throw KeyError anymore
+```
+
+This is a patch release, so no breaking changes.

--- a/strawberry/dataloader.py
+++ b/strawberry/dataloader.py
@@ -84,7 +84,7 @@ class DefaultCache(AbstractCache[K, T]):
         self.cache_map[self.cache_key_fn(key)] = value
 
     def delete(self, key: K) -> None:
-        del self.cache_map[self.cache_key_fn(key)]
+        self.cache_map.pop(self.cache_key_fn(key), default=None)
 
     def clear(self) -> None:
         self.cache_map.clear()

--- a/tests/test_dataloaders.py
+++ b/tests/test_dataloaders.py
@@ -301,6 +301,8 @@ async def test_clear_nocache():
 
     loader = DataLoader(load_fn=idx, cache=False)
 
+    loader.clean(1) # no effect on non-cached values
+
     assert await loader.load_many([1, 2, 3]) == [(1, 1), (2, 1), (3, 1)]
 
     loader.clear(1)


### PR DESCRIPTION
## Description

Right now, calling the `.clean(key)` method on a non-cached key will raise a `KeyError` exception. There are several ways to solve this problem:
1. Create a custom `CustomDefaultCache` class and override the `delete` method to first check if the key exists.
2. Check if the key is cached before deleting it each time the `.clean` method is called.
3. Cache the key before calling `.clean`.
4. Set the default behavior to be exception-free.
Among these options, the fourth solution seems to be the best, so these changes are proposed.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR
* #2464

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
