### PR TITLE
fix: Fix optional lazy types resolution when using future annotations

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,22 @@
+Release type: patch
+
+This release fixes an issue where optional lazy types using `| None` were
+failing to be correctly resolved inside modules using future annotations, e.g.
+
+```python
+from __future__ import annotations
+
+from typing import Annotated, TYPE_CHECKING
+
+import strawberry
+
+if TYPE_CHECKING:
+    from types import Group
+
+
+@strawberry.type
+class Person:
+    group: Annotated["Group", strawberry.lazy("types.group")] | None
+```
+
+This should now work as expected.

--- a/strawberry/types/lazy_type.py
+++ b/strawberry/types/lazy_type.py
@@ -5,7 +5,6 @@ import warnings
 from dataclasses import dataclass
 from pathlib import Path
 from typing import (
-    TYPE_CHECKING,
     Any,
     ForwardRef,
     Generic,
@@ -13,14 +12,14 @@ from typing import (
     Tuple,
     Type,
     TypeVar,
+    Union,
     cast,
 )
-
-if TYPE_CHECKING:
-    from typing_extensions import Self
+from typing_extensions import Self
 
 TypeName = TypeVar("TypeName")
 Module = TypeVar("Module")
+Other = TypeVar("Other")
 
 
 @dataclass(frozen=True)
@@ -58,6 +57,9 @@ class LazyType(Generic[TypeName, Module]):
             package = current_frame.f_back.f_globals["__package__"]
 
         return cls(type_name, module, package)
+
+    def __or__(self, other: Other) -> Union[Self, Other]:
+        return Union[self, other]
 
     def resolve_type(self) -> Type[Any]:
         module = importlib.import_module(self.module, self.package)

--- a/tests/types/test_lazy_types_future_annotations.py
+++ b/tests/types/test_lazy_types_future_annotations.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import textwrap
+from typing_extensions import Annotated
+
+import strawberry
+
+
+def test_optional_lazy_type_using_or_operator():
+    from tests.schema.test_lazy.type_a import TypeA
+
+    global SomeType, AnotherType
+
+    try:
+
+        @strawberry.type
+        class SomeType:
+            foo: (
+                Annotated[TypeA, strawberry.lazy("tests.schema.test_lazy.type_a")]
+                | None
+            )
+
+        @strawberry.type
+        class AnotherType:
+            foo: TypeA | None = None
+
+        @strawberry.type
+        class Query:
+            some_type: SomeType
+            another_type: AnotherType
+
+        schema = strawberry.Schema(query=Query)
+        expected = """\
+        type AnotherType {
+          foo: TypeA
+        }
+
+        type Query {
+          someType: SomeType!
+          anotherType: AnotherType!
+        }
+
+        type SomeType {
+          foo: TypeA
+        }
+
+        type TypeA {
+          listOfB: [TypeB!]
+          typeB: TypeB!
+        }
+
+        type TypeB {
+          typeA: TypeA!
+          typeAList: [TypeA!]!
+          typeCList: [TypeC!]!
+        }
+
+        type TypeC {
+          name: String!
+        }
+        """
+        assert str(schema).strip() == textwrap.dedent(expected).strip()
+    finally:
+        del SomeType, AnotherType


### PR DESCRIPTION
When using future annotations, our `eval_type` converts `Annotated[foo, strawberry.lazy("xxx.foo")]`
into `LazyType` already, as can be seen in the following places:

- https://github.com/strawberry-graphql/strawberry/blob/main/strawberry/utils/typing.py#L369
- https://github.com/strawberry-graphql/strawberry/blob/main/strawberry/utils/typing.py#L308

Because of that, a code that works without future annotations like `Annotated[foo, strawberry.lazy("xxx.foo")] | None`
will be converted to `LazyType | None`, and would fail because `LazyType` doesn't implement `__or__`.

This is adding `__or__` to it, allowing the code to work as expected.

Fix #3572

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request fixes the resolution of optional lazy types using the `| None` operator when future annotations are enabled. It introduces the `__or__` method to `LazyType` to support this functionality and includes new tests to ensure the fix works as expected. Additionally, a release note has been added to document this patch.

- **Bug Fixes**:
    - Fixed an issue where optional lazy types using `| None` were failing to resolve correctly when using future annotations by adding `__or__` method to `LazyType`.
- **Documentation**:
    - Added a release note documenting the patch fix for optional lazy types using `| None` with future annotations.
- **Tests**:
    - Added tests to verify the correct resolution of optional lazy types using the `| None` operator with and without future annotations.

<!-- Generated by sourcery-ai[bot]: end summary -->