### PR TITLE
Fix the asgi handler's scope argument type

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+This release fixes the type of the ASGI request handler's `scope` argument, making type checkers ever so slightly happier.

--- a/strawberry/asgi/__init__.py
+++ b/strawberry/asgi/__init__.py
@@ -117,12 +117,12 @@ class GraphQL(
         else:
             self.graphql_ide = graphql_ide
 
-    async def __call__(self, scope: Request, receive: Receive, send: Send) -> None:
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] == "http":
-            return await self.handle_http(scope, receive, send)  # type: ignore
+            return await self.handle_http(scope, receive, send)
 
         elif scope["type"] == "websocket":
-            ws = WebSocket(scope, receive=receive, send=send)  # type: ignore
+            ws = WebSocket(scope, receive=receive, send=send)
             preferred_protocol = self.pick_preferred_protocol(ws)
 
             if preferred_protocol == GRAPHQL_TRANSPORT_WS_PROTOCOL:


### PR DESCRIPTION
## Description

This PR fixes a little type error I stumbled across while working on something unrelated. Didn't want to forget about it.

@patrick91 I believe this was accidentally done in #3546? Am I missing something here?

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request fixes a type error in the ASGI request handler by correcting the type of the `scope` argument. Additionally, it includes a `RELEASE.md` file to document the patch release.

- **Bug Fixes**:
    - Corrected the type of the ASGI request handler's `scope` argument from `Request` to `Scope`.
- **Documentation**:
    - Added a `RELEASE.md` file to document the patch release.

<!-- Generated by sourcery-ai[bot]: end summary -->