### PR TITLE
Let FastAPI reuse the ASGI request adapter

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+This release makes the ASGI and FastAPI integrations share their HTTP request adapter code, making Strawberry ever so slightly smaller and easier to maintain.

--- a/strawberry/asgi/__init__.py
+++ b/strawberry/asgi/__init__.py
@@ -44,7 +44,7 @@ class ASGIRequestAdapter(AsyncHTTPRequestAdapter):
 
     @property
     def query_params(self) -> QueryParams:
-        return dict(self.request.query_params)
+        return self.request.query_params
 
     @property
     def method(self) -> HTTPMethod:

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -10,7 +10,6 @@ from typing import (
     Callable,
     Dict,
     List,
-    Mapping,
     Optional,
     Sequence,
     Type,
@@ -33,19 +32,14 @@ from fastapi import APIRouter, Depends, params
 from fastapi.datastructures import Default
 from fastapi.routing import APIRoute
 from fastapi.utils import generate_unique_id
+from strawberry.asgi import ASGIRequestAdapter
 from strawberry.exceptions import InvalidCustomContext
 from strawberry.fastapi.context import BaseContext, CustomContext
 from strawberry.fastapi.handlers import GraphQLTransportWSHandler, GraphQLWSHandler
-from strawberry.http import (
-    process_result,
-)
-from strawberry.http.async_base_view import AsyncBaseHTTPView, AsyncHTTPRequestAdapter
+from strawberry.http import process_result
+from strawberry.http.async_base_view import AsyncBaseHTTPView
 from strawberry.http.exceptions import HTTPException
-from strawberry.http.types import FormData, HTTPMethod, QueryParams
-from strawberry.http.typevars import (
-    Context,
-    RootValue,
-)
+from strawberry.http.typevars import Context, RootValue
 from strawberry.subscriptions import GRAPHQL_TRANSPORT_WS_PROTOCOL, GRAPHQL_WS_PROTOCOL
 
 if TYPE_CHECKING:
@@ -61,42 +55,13 @@ if TYPE_CHECKING:
     from strawberry.types import ExecutionResult
 
 
-class FastAPIRequestAdapter(AsyncHTTPRequestAdapter):
-    def __init__(self, request: Request) -> None:
-        self.request = request
-
-    @property
-    def query_params(self) -> QueryParams:
-        return dict(self.request.query_params)
-
-    @property
-    def method(self) -> HTTPMethod:
-        return cast(HTTPMethod, self.request.method.upper())
-
-    @property
-    def headers(self) -> Mapping[str, str]:
-        return self.request.headers
-
-    @property
-    def content_type(self) -> Optional[str]:
-        return self.request.headers.get("Content-Type", None)
-
-    async def get_body(self) -> bytes:
-        return await self.request.body()
-
-    async def get_form_data(self) -> FormData:
-        multipart_data = await self.request.form()
-
-        return FormData(files=multipart_data, form=multipart_data)
-
-
 class GraphQLRouter(
     AsyncBaseHTTPView[Request, Response, Response, Context, RootValue], APIRouter
 ):
     graphql_ws_handler_class = GraphQLWSHandler
     graphql_transport_ws_handler_class = GraphQLTransportWSHandler
     allow_queries_via_get = True
-    request_adapter_class = FastAPIRequestAdapter
+    request_adapter_class = ASGIRequestAdapter
 
     @staticmethod
     async def __get_root_value() -> None:


### PR DESCRIPTION
## Description

Both FastAPI and our ASGI integrations are based on Starlette making their http request adapters identical and shareable. This PR simply removes the duplicate implementation and reuses the ASGI request adapter.

(I'm currently working on integrating the websocket handlers into the async base http view. Whenever I notice something small and somewhat unrelated like this I'll make an separate PR to keep the upcoming websocket PR smaller and easier to review.)

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request refactors the FastAPI integration to reuse the ASGI request adapter, removing duplicate code and enhancing maintainability. Additionally, a RELEASE.md file has been added to document the changes and specify the release type.

- **Enhancements**:
    - Refactored FastAPI integration to reuse the ASGI request adapter, eliminating duplicate code and improving maintainability.
- **Documentation**:
    - Added a RELEASE.md file to document the changes and specify the release type as a patch.

<!-- Generated by sourcery-ai[bot]: end summary -->