### PR TITLE
Fix minor typo in relay guide docs

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: minor
+
+Fix a typo `defined **in in**` in relay guide docs.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,0 @@
-Release type: minor
-
-Fix a typo `defined **in in**` in relay guide docs.

--- a/docs/guides/relay.mdx
+++ b/docs/guides/relay.mdx
@@ -194,7 +194,7 @@ The connection resolver for `relay.ListConnection` should return one of those:
 As demonstrated above, the `Node` field can be used to retrieve/refetch any
 object in the schema that implements the `Node` interface.
 
-It can be defined in in the `Query` objects in 4 ways:
+It can be defined in the `Query` objects in 4 ways:
 
 - `node: Node`: This will define a field that accepts a `GlobalID!` and returns
   a `Node` instance. This is the most basic way to define it.


### PR DESCRIPTION
Hello strawberry team!

This pull request fixes a very very minor typo in `relay.mdx` docs.

Thanks for your review in advance!

## Description

## Before
```mdx
It can be defined **in in** the `Query` objects in 4 ways:
```

## After
```mdx
It can be defined **in** the `Query` objects in 4 ways:
```

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix a minor typo in the relay guide documentation.

Documentation:
- Correct a minor typo in the relay guide documentation, changing 'in in' to 'in'.

<!-- Generated by sourcery-ai[bot]: end summary -->