### PR TITLE
Fix SentryTracingExtension deprecation warning

### DIFF
--- a/strawberry/extensions/tracing/sentry.py
+++ b/strawberry/extensions/tracing/sentry.py
@@ -24,7 +24,7 @@ class SentryTracingExtension(SchemaExtension):
         execution_context: Optional[ExecutionContext] = None,
     ) -> None:
         warnings.warn(
-            "The Sentry tracing extension is deprecated, please update to sentry>=1.32.0",
+            "The Sentry tracing extension is deprecated, please update to sentry-sdk>=1.32.0",
             DeprecationWarning,
             stacklevel=2,
         )


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The deprecation warning advises users to upgrade to `sentry>=1.32.0`, when in fact, the Sentry SDK package is named [`sentry-sdk`](https://pypi.org/project/sentry-sdk/), not `sentry`.

Update the message to advise users to upgrade to `sentry-sdk>=1.32.0`, instead.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [X] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes. (probably not needed)
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
