### PR TITLE
Fix status code for multipart subscriptions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,7 @@
+Release type: patch
+
+This release fixes an issue with the http multipart subscription where the
+status code would be returned as `None`, instead of 200.
+
+We also took the opportunity to update the internals to better support
+additional protocols in future.

--- a/strawberry/aiohttp/views.py
+++ b/strawberry/aiohttp/views.py
@@ -189,18 +189,18 @@ class GraphQLView(
 
         return sub_response
 
-    async def create_multipart_response(
+    async def create_streaming_response(
         self,
         request: web.Request,
         stream: Callable[[], AsyncGenerator[str, None]],
         sub_response: web.Response,
+        headers: Dict[str, str],
     ) -> web.StreamResponse:
         response = web.StreamResponse(
             status=sub_response.status,
             headers={
                 **sub_response.headers,
-                "Transfer-Encoding": "chunked",
-                "Content-type": "multipart/mixed;boundary=graphql;subscriptionSpec=1.0,application/json",
+                **headers,
             },
         )
 

--- a/strawberry/asgi/__init__.py
+++ b/strawberry/asgi/__init__.py
@@ -229,7 +229,7 @@ class GraphQL(
     ) -> Response:
         return StreamingResponse(
             stream(),
-            status_code=sub_response.status_code,
+            status_code=sub_response.status_code or status.HTTP_200_OK,
             headers={
                 **sub_response.headers,
                 "Transfer-Encoding": "chunked",

--- a/strawberry/asgi/__init__.py
+++ b/strawberry/asgi/__init__.py
@@ -7,6 +7,7 @@ from typing import (
     Any,
     AsyncIterator,
     Callable,
+    Dict,
     Mapping,
     Optional,
     Sequence,
@@ -221,18 +222,18 @@ class GraphQL(
 
         return response
 
-    async def create_multipart_response(
+    async def create_streaming_response(
         self,
         request: Request | WebSocket,
         stream: Callable[[], AsyncIterator[str]],
         sub_response: Response,
+        headers: Dict[str, str],
     ) -> Response:
         return StreamingResponse(
             stream(),
             status_code=sub_response.status_code or status.HTTP_200_OK,
             headers={
                 **sub_response.headers,
-                "Transfer-Encoding": "chunked",
-                "Content-type": "multipart/mixed;boundary=graphql;subscriptionSpec=1.0,application/json",
+                **headers,
             },
         )

--- a/strawberry/channels/handlers/http_handler.py
+++ b/strawberry/channels/handlers/http_handler.py
@@ -282,10 +282,14 @@ class GraphQLHTTPConsumer(
     ) -> MultipartChannelsResponse:
         status = sub_response.status_code or 200
 
-        headers = {k.encode(): v.encode() for k, v in sub_response.headers.items()}
-        headers.update({k.encode(): v.encode() for k, v in headers.items()})
+        response_headers = {
+            k.encode(): v.encode() for k, v in sub_response.headers.items()
+        }
+        response_headers.update({k.encode(): v.encode() for k, v in headers.items()})
 
-        return MultipartChannelsResponse(stream=stream, status=status, headers=headers)
+        return MultipartChannelsResponse(
+            stream=stream, status=status, headers=response_headers
+        )
 
     async def render_graphql_ide(self, request: ChannelsRequest) -> ChannelsResponse:
         return ChannelsResponse(

--- a/strawberry/channels/handlers/http_handler.py
+++ b/strawberry/channels/handlers/http_handler.py
@@ -273,14 +273,18 @@ class GraphQLHTTPConsumer(
     async def get_sub_response(self, request: ChannelsRequest) -> TemporalResponse:
         return TemporalResponse()
 
-    async def create_multipart_response(
+    async def create_streaming_response(
         self,
         request: ChannelsRequest,
         stream: Callable[[], AsyncGenerator[str, None]],
         sub_response: TemporalResponse,
+        headers: Dict[str, str],
     ) -> MultipartChannelsResponse:
         status = sub_response.status_code or 200
+
         headers = {k.encode(): v.encode() for k, v in sub_response.headers.items()}
+        headers.update({k.encode(): v.encode() for k, v in headers.items()})
+
         return MultipartChannelsResponse(stream=stream, status=status, headers=headers)
 
     async def render_graphql_ide(self, request: ChannelsRequest) -> ChannelsResponse:

--- a/strawberry/django/views.py
+++ b/strawberry/django/views.py
@@ -7,6 +7,7 @@ from typing import (
     Any,
     AsyncIterator,
     Callable,
+    Dict,
     Mapping,
     Optional,
     Union,
@@ -185,19 +186,19 @@ class BaseView:
 
         return response
 
-    async def create_multipart_response(
+    async def create_streaming_response(
         self,
         request: HttpRequest,
         stream: Callable[[], AsyncIterator[Any]],
         sub_response: TemporalHttpResponse,
+        headers: Dict[str, str],
     ) -> HttpResponseBase:
         return StreamingHttpResponse(
             streaming_content=stream(),
             status=sub_response.status_code,
             headers={
                 **sub_response.headers,
-                "Transfer-Encoding": "chunked",
-                "Content-type": "multipart/mixed;boundary=graphql;subscriptionSpec=1.0,application/json",
+                **headers,
             },
         )
 

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -332,6 +332,7 @@ class GraphQLRouter(
 
         return response
 
+    # TODO: rename this to just streaming response?
     async def create_multipart_response(
         self,
         request: Request,
@@ -340,7 +341,7 @@ class GraphQLRouter(
     ) -> Response:
         return StreamingResponse(
             stream(),
-            status_code=sub_response.status_code,
+            status_code=sub_response.status_code or status.HTTP_200_OK,
             headers={
                 **sub_response.headers,
                 "Transfer-Encoding": "chunked",

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -332,20 +332,19 @@ class GraphQLRouter(
 
         return response
 
-    # TODO: rename this to just streaming response?
-    async def create_multipart_response(
+    async def create_streaming_response(
         self,
         request: Request,
         stream: Callable[[], AsyncIterator[str]],
         sub_response: Response,
+        headers: Dict[str, str],
     ) -> Response:
         return StreamingResponse(
             stream(),
             status_code=sub_response.status_code or status.HTTP_200_OK,
             headers={
                 **sub_response.headers,
-                "Transfer-Encoding": "chunked",
-                "Content-type": "multipart/mixed;boundary=graphql;subscriptionSpec=1.0,application/json",
+                **headers,
             },
         )
 

--- a/strawberry/litestar/controller.py
+++ b/strawberry/litestar/controller.py
@@ -280,19 +280,19 @@ class GraphQLController(
 
         return response
 
-    async def create_multipart_response(
+    async def create_streaming_response(
         self,
         request: Request,
         stream: Callable[[], AsyncIterator[str]],
         sub_response: Response,
+        headers: Dict[str, str],
     ) -> Response:
         return Stream(
             stream(),
             status_code=sub_response.status_code,
             headers={
                 **sub_response.headers,
-                "Transfer-Encoding": "chunked",
-                "Content-type": "multipart/mixed;boundary=graphql;subscriptionSpec=1.0,application/json",
+                **headers,
             },
         )
 

--- a/strawberry/quart/views.py
+++ b/strawberry/quart/views.py
@@ -1,6 +1,6 @@
 import warnings
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, AsyncGenerator, Callable, Optional, cast
+from typing import TYPE_CHECKING, AsyncGenerator, Callable, Dict, Optional, cast
 
 from quart import Request, Response, request
 from quart.views import View
@@ -103,19 +103,19 @@ class GraphQLView(
                 status=e.status_code,
             )
 
-    async def create_multipart_response(
+    async def create_streaming_response(
         self,
         request: Request,
         stream: Callable[[], AsyncGenerator[str, None]],
         sub_response: Response,
+        headers: Dict[str, str],
     ) -> Response:
         return (
             stream(),
             sub_response.status_code,
             {  # type: ignore
                 **sub_response.headers,
-                "Transfer-Encoding": "chunked",
-                "Content-type": "multipart/mixed;boundary=graphql;subscriptionSpec=1.0,application/json",
+                **headers,
             },
         )
 

--- a/strawberry/sanic/views.py
+++ b/strawberry/sanic/views.py
@@ -178,18 +178,18 @@ class GraphQLView(
         except HTTPException as e:
             return HTTPResponse(e.reason, status=e.status_code)
 
-    async def create_multipart_response(
+    async def create_streaming_response(
         self,
         request: Request,
         stream: Callable[[], AsyncGenerator[str, None]],
         sub_response: TemporalResponse,
+        headers: Dict[str, str],
     ) -> HTTPResponse:
         response = await self.request.respond(
-            content_type="multipart/mixed;boundary=graphql;subscriptionSpec=1.0,application/json",
             status=sub_response.status_code,
             headers={
                 **sub_response.headers,
-                "Transfer-Encoding": "chunked",
+                **headers,
             },
         )
 

--- a/tests/http/test_multipart_subscription.py
+++ b/tests/http/test_multipart_subscription.py
@@ -71,3 +71,5 @@ async def test_multipart_subscription(
     data = [d async for d in response.streaming_json()]
 
     assert data == [{"payload": {"data": {"echo": "Hello world"}}}]
+
+    assert response.status_code == 200


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Improve the multipart subscription handling by ensuring a default HTTP 200 OK status code is used when not explicitly set, and update tests to verify this behavior.

Bug Fixes:
- Ensure that the status code defaults to HTTP 200 OK if not provided in multipart responses.

Tests:
- Add an assertion to verify that the response status code is 200 in the multipart subscription test.

<!-- Generated by sourcery-ai[bot]: end summary -->