### PR TITLE
fix: Fix Python 3.8 type error

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+This release fixes a TypeError on Python 3.8 due to us using a
+`asyncio.Queue[Tuple[bool, Any]](1)` instead of `asyncio.Queue(1)`.

--- a/strawberry/http/async_base_view.py
+++ b/strawberry/http/async_base_view.py
@@ -233,7 +233,7 @@ class AsyncBaseHTTPView(
         self, stream: Callable[[], AsyncGenerator[str, None]]
     ) -> Callable[[], AsyncGenerator[str, None]]:
         """Adds a heartbeat to the stream, to prevent the connection from closing when there are no messages being sent."""
-        queue: "asyncio.Queue[Tuple[bool, Any]]" = asyncio.Queue(1)
+        queue: asyncio.Queue[Tuple[bool, Any]] = asyncio.Queue(1)
 
         cancelling = False
 

--- a/strawberry/http/async_base_view.py
+++ b/strawberry/http/async_base_view.py
@@ -233,7 +233,7 @@ class AsyncBaseHTTPView(
         self, stream: Callable[[], AsyncGenerator[str, None]]
     ) -> Callable[[], AsyncGenerator[str, None]]:
         """Adds a heartbeat to the stream, to prevent the connection from closing when there are no messages being sent."""
-        queue = asyncio.Queue[Tuple[bool, Any]](1)
+        queue: "asyncio.Queue[Tuple[bool, Any]]" = asyncio.Queue(1)
 
         cancelling = False
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Make type hint a string so that it is not evaluated at runtime, where it would cause a `TypeError` in Python 3.8.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #3614

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix a type error in Python 3.8 by converting a type hint to a string in the async_base_view.py file.

Bug Fixes:
- Fix a type error in Python 3.8 by converting a type hint to a string to prevent runtime evaluation.

<!-- Generated by sourcery-ai[bot]: end summary -->