### PR TITLE
add `packaging` as a dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4723,4 +4723,4 @@ sanic = ["sanic"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "655ae06cb9be42aee33c24aa577f1c9fb36162e0add14d52286af559edb3be26"
+content-hash = "33376b196aa0e140589caafdf0e697ff01512394faec201b53b9117afd3bcab1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ build-backend = "poetry.masonry.api"
 python = "^3.8"
 graphql-core = ">=3.2.0,<3.4.0"
 typing-extensions = ">=4.5.0"
+packaging = ">=14.5"
 python-dateutil = "^2.7.0"
 starlette = {version = ">=0.18.0", optional = true}
 typer = {version = ">=0.7.0", optional = true}


### PR DESCRIPTION
## Description
An unconditional import of `packaging` was added in `0.24.0` to [`strawberry.utils`](https://github.com/strawberry-graphql/strawberry/blob/0.240.0/strawberry/utils/__init__.py). As not _every_ project uses `poetry`, this should likely be a hard dependency, which this adds.

The lower version bound is likely ludicrously low, but a look at the `blame` suggested that part of the API has been stable since then, so probably _technically_ accurate.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* seemed simpler to just make a PR

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
