### PR TITLE
use graphql's built-in version object

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+release type: patch
+
+This release updates how we check for GraphQL core's version to remove a dependency on the `packaging` package.

--- a/TWEET.md
+++ b/TWEET.md
@@ -1,4 +1,6 @@
-Release type: patch
+🆕 Release $version is out! Thanks to $contributor for the PR 👏
 
 This release updates how we check for GraphQL core's version to remove a
 dependency on the `packaging` package.
+
+Get it here 👉 $release_url

--- a/strawberry/utils/__init__.py
+++ b/strawberry/utils/__init__.py
@@ -1,5 +1,4 @@
-import graphql
-from packaging.version import Version
+from graphql.version import version_info, VersionInfo
 
-IS_GQL_33 = Version(graphql.__version__) >= Version("3.3.0a")
+IS_GQL_33 = version_info >= VersionInfo.from_str("3.3.0a0")
 IS_GQL_32 = not IS_GQL_33

--- a/strawberry/utils/__init__.py
+++ b/strawberry/utils/__init__.py
@@ -1,4 +1,4 @@
-from graphql.version import version_info, VersionInfo
+from graphql.version import VersionInfo, version_info
 
 IS_GQL_33 = version_info >= VersionInfo.from_str("3.3.0a0")
 IS_GQL_32 = not IS_GQL_33


### PR DESCRIPTION
## Description

Alternative to to #3621.

Uses `graphql.version.VersionInfo` instead of `packaging` to do version sniffing instead of `packaging` (or even `importlib.metadata.version`, as that only provides strings).

That API has been there for five years, certainly above the current minimum dependency.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* n/a

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Use GraphQL's built-in `VersionInfo` for version checking instead of the `packaging` library, simplifying dependencies and ensuring compatibility with GraphQL core.

Bug Fixes:
- Replace the use of the `packaging` library with `graphql.version.VersionInfo` for version checking, ensuring compatibility with GraphQL core's built-in version object.

Chores:
- Add a `RELEASE.md` file to document the release type as a patch and note the update in version checking.

<!-- Generated by sourcery-ai[bot]: end summary -->