### PR TITLE
Check multipart subscriptions using accept header

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+This release fixes how we check for multipart subscriptions to be
+in line with the latest changes in the spec.

--- a/tests/http/test_multipart_subscription.py
+++ b/tests/http/test_multipart_subscription.py
@@ -64,7 +64,8 @@ async def test_multipart_subscription(
         method=method,
         query='subscription { echo(message: "Hello world", delay: 0.2) }',
         headers={
-            "content-type": "multipart/mixed;boundary=graphql;subscriptionSpec=1.0,application/json",
+            "accept": "multipart/mixed;boundary=graphql;subscriptionSpec=1.0,application/json",
+            "content-type": "application/json",
         },
     )
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the multipart subscription detection logic to use the 'accept' header instead of the 'content-type' header, ensuring compliance with the latest specification. Adjust the corresponding test to reflect this change and document the fix in the release notes.

Bug Fixes:
- Fix the detection of multipart subscriptions by checking the 'accept' header instead of the 'content-type' header to align with the latest specification changes.

Documentation:
- Add a release note indicating the patch release that fixes multipart subscription checks to comply with the latest specification.

Tests:
- Update the test for multipart subscriptions to use the 'accept' header for protocol detection.

<!-- Generated by sourcery-ai[bot]: end summary -->