### PR TITLE
fix: on_operation hooks unable to modify result on error.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+This release fixes an issue that prevented extensions to receive the result from
+the execution context when executing operations in async.

--- a/strawberry/schema/execute.py
+++ b/strawberry/schema/execute.py
@@ -201,6 +201,8 @@ async def execute(
             return await _handle_execution_result(
                 execution_context, result, extensions_runner, process_errors
             )
+    except (MissingQueryError, InvalidOperationTypeError) as e:
+        raise e
     except Exception as exc:
         return PreExecutionError(data=None, errors=[_coerce_error(exc)])
 

--- a/strawberry/schema/execute.py
+++ b/strawberry/schema/execute.py
@@ -183,10 +183,19 @@ async def execute(
                                 execution_context_class=execution_context_class,
                             )
                         )
-
+                        execution_context.result = result
                     else:
                         result = execution_context.result
+                    # Also set errors on the execution_context so that it's easier
+                    # to access in extensions
+                    if result.errors:
+                        execution_context.errors = result.errors
 
+                        # Run the `Schema.process_errors` function here before
+                        # extensions have a chance to modify them (see the MaskErrors
+                        # extension). That way we can log the original errors but
+                        # only return a sanitised version to the client.
+                        process_errors(result.errors, execution_context)
 
 
     except (MissingQueryError, InvalidOperationTypeError) as e:

--- a/strawberry/schema/execute.py
+++ b/strawberry/schema/execute.py
@@ -158,7 +158,6 @@ async def execute(
 ) -> ExecutionResult | PreExecutionError:
     try:
         async with extensions_runner.operation():
-            try:
                 # Note: In graphql-core the schema would be validated here but in
                 # Strawberry we are validating it at initialisation time instead
 
@@ -188,24 +187,21 @@ async def execute(
                     else:
                         result = execution_context.result
 
-            except (MissingQueryError, InvalidOperationTypeError) as e:
-                raise e
-            except Exception as exc:
-                return await _handle_execution_result(
-                    execution_context,
-                    PreExecutionError(data=None, errors=[_coerce_error(exc)]),
-                    extensions_runner,
-                    process_errors,
-                )
-                # return results after all the operation completed.
-            return await _handle_execution_result(
-                execution_context, result, extensions_runner, process_errors
-            )
+
+
     except (MissingQueryError, InvalidOperationTypeError) as e:
         raise e
     except Exception as exc:
-        return PreExecutionError(data=None, errors=[_coerce_error(exc)])
-
+        return await _handle_execution_result(
+            execution_context,
+            PreExecutionError(data=None, errors=[_coerce_error(exc)]),
+            extensions_runner,
+            process_errors,
+        )
+    # return results after all the operation completed.
+    return await _handle_execution_result(
+        execution_context, result, extensions_runner, process_errors
+    )
 
 def execute_sync(
     schema: GraphQLSchema,

--- a/strawberry/schema/execute.py
+++ b/strawberry/schema/execute.py
@@ -156,9 +156,9 @@ async def execute(
     middleware_manager: MiddlewareManager,
     execution_context_class: Optional[Type[GraphQLExecutionContext]] = None,
 ) -> ExecutionResult | PreExecutionError:
+    try:
         async with extensions_runner.operation():
             try:
-
                 # Note: In graphql-core the schema would be validated here but in
                 # Strawberry we are validating it at initialisation time instead
 
@@ -188,7 +188,6 @@ async def execute(
                     else:
                         result = execution_context.result
 
-
             except (MissingQueryError, InvalidOperationTypeError) as e:
                 raise e
             except Exception as exc:
@@ -198,10 +197,13 @@ async def execute(
                     extensions_runner,
                     process_errors,
                 )
-                            # return results after all the operation completed.
+                # return results after all the operation completed.
             return await _handle_execution_result(
                 execution_context, result, extensions_runner, process_errors
             )
+    except Exception as exc:
+        return PreExecutionError(data=None, errors=[_coerce_error(exc)])
+
 
 def execute_sync(
     schema: GraphQLSchema,

--- a/tests/schema/extensions/test_mask_errors.py
+++ b/tests/schema/extensions/test_mask_errors.py
@@ -29,7 +29,6 @@ def test_mask_all_errors():
     ]
 
 
-
 async def test_mask_all_errors_async():
     @strawberry.type
     class Query:
@@ -51,6 +50,8 @@ async def test_mask_all_errors_async():
             "path": ["hiddenError"],
         }
     ]
+
+
 def test_mask_some_errors():
     class VisibleError(Exception):
         pass


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

fix: #3625 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Refactor the execute function to ensure on_operation hooks can modify the result on error and add a test to verify error masking in asynchronous operations.

Bug Fixes:
- Fix the issue where on_operation hooks were unable to modify the result on error by restructuring the error handling logic in the execute function.

Tests:
- Add an asynchronous test to verify that errors are correctly masked when executing a query with hidden errors.

<!-- Generated by sourcery-ai[bot]: end summary -->