### PR TITLE
fix: pydantic ^2.9.0 needs 2 extra fields on to_argument

### DIFF
--- a/.alexrc
+++ b/.alexrc
@@ -11,6 +11,7 @@
     "execution",
     "special",
     "primitive",
-    "invalid"
+    "invalid",
+    "crash",
   ]
 }

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,3 @@
 Release type: patch
 
-Fix pydantic ^2.9.0 needs 2 extra fields on to_argument
-It was causing mypy crash
+This releases adds support for Pydantic 2.9.0's Mypy plugin

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+Fix pydantic ^2.9.0 needs 2 extra fields on to_argument
+It was causing mypy crash

--- a/strawberry/ext/mypy_plugin.py
+++ b/strawberry/ext/mypy_plugin.py
@@ -482,8 +482,13 @@ def strawberry_pydantic_class_callback(ctx: ClassDefContext) -> None:
                         # https://github.com/pydantic/pydantic/pull/9606/files#diff-469037bbe55bbf9aa359480a16040d368c676adad736e133fb07e5e20d6ac523R1066
                         extra["force_typevars_invariant"] = False
                     if PYDANTIC_VERSION >= (2, 9, 0):
-                        extra["model_strict"] = model_type.type.metadata[PYDANTIC_METADATA_KEY]["config"].get("strict", False)
-                        extra["is_root_model_root"] = any("pydantic.root_model.RootModel" in base.fullname for base in model_type.type.mro[:-1])
+                        extra["model_strict"] = model_type.type.metadata[
+                            PYDANTIC_METADATA_KEY
+                        ]["config"].get("strict", False)
+                        extra["is_root_model_root"] = any(
+                            "pydantic.root_model.RootModel" in base.fullname
+                            for base in model_type.type.mro[:-1]
+                        )
                 add_method(
                     ctx,
                     "to_pydantic",

--- a/strawberry/ext/mypy_plugin.py
+++ b/strawberry/ext/mypy_plugin.py
@@ -481,7 +481,9 @@ def strawberry_pydantic_class_callback(ctx: ClassDefContext) -> None:
                         # Based on pydantic's default value
                         # https://github.com/pydantic/pydantic/pull/9606/files#diff-469037bbe55bbf9aa359480a16040d368c676adad736e133fb07e5e20d6ac523R1066
                         extra["force_typevars_invariant"] = False
-
+                    if PYDANTIC_VERSION >= (2, 9, 0):
+                        extra["model_strict"] = model_type.type.metadata[PYDANTIC_METADATA_KEY]["config"].get("strict", False)
+                        extra["is_root_model_root"] = any("pydantic.root_model.RootModel" in base.fullname for base in model_type.type.mro[:-1])
                 add_method(
                     ctx,
                     "to_pydantic",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

when using to_pydantic with pydantic 2.9.0 it causes a mypy crash. Simmilar to what happend in this case: https://github.com/strawberry-graphql/strawberry/issues/3436

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #3620

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix a mypy crash by adding necessary fields to the to_pydantic method for compatibility with Pydantic 2.9.0.

Bug Fixes:
- Fix a mypy crash when using to_pydantic with Pydantic version 2.9.0 by adding two extra fields: 'model_strict' and 'is_root_model_root'.

<!-- Generated by sourcery-ai[bot]: end summary -->