### PR TITLE
Let legacy ws clients know about invalid data frames

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+Release type: patch
+
+Starting with this release, clients using the legacy graphql-ws subprotocol will receive an error when they try to send binary data frames.
+Before, binary data frames were silently ignored.
+
+While vaguely defined in the protocol, the legacy graphql-ws subprotocol is generally understood to only support text data frames.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,4 @@
-Release type: patch
+Release type: minor
 
 Starting with this release, clients using the legacy graphql-ws subprotocol will receive an error when they try to send binary data frames.
 Before, binary data frames were silently ignored.

--- a/strawberry/aiohttp/handlers/graphql_ws_handler.py
+++ b/strawberry/aiohttp/handlers/graphql_ws_handler.py
@@ -50,6 +50,10 @@ class GraphQLWSHandler(BaseGraphQLWSHandler):
                 if ws_message.type == http.WSMsgType.TEXT:
                     message: OperationMessage = ws_message.json()
                     await self.handle_message(message)
+                else:
+                    await self.close(
+                        code=1002, reason="WebSocket message type must be text"
+                    )
         finally:
             if self.keep_alive_task:
                 self.keep_alive_task.cancel()

--- a/strawberry/asgi/handlers/graphql_ws_handler.py
+++ b/strawberry/asgi/handlers/graphql_ws_handler.py
@@ -51,7 +51,9 @@ class GraphQLWSHandler(BaseGraphQLWSHandler):
                 try:
                     message = await self._ws.receive_json()
                 except KeyError:  # noqa: PERF203
-                    await self.close(code=1002, reason="WebSocket message type must be text")
+                    await self.close(
+                        code=1002, reason="WebSocket message type must be text"
+                    )
                 else:
                     await self.handle_message(message)
         except WebSocketDisconnect:  # pragma: no cover

--- a/strawberry/asgi/handlers/graphql_ws_handler.py
+++ b/strawberry/asgi/handlers/graphql_ws_handler.py
@@ -51,8 +51,7 @@ class GraphQLWSHandler(BaseGraphQLWSHandler):
                 try:
                     message = await self._ws.receive_json()
                 except KeyError:  # noqa: PERF203
-                    # Ignore non-text messages
-                    continue
+                    await self.close(code=1002, reason="WebSocket message type must be text")
                 else:
                     await self.handle_message(message)
         except WebSocketDisconnect:  # pragma: no cover

--- a/strawberry/channels/handlers/graphql_ws_handler.py
+++ b/strawberry/channels/handlers/graphql_ws_handler.py
@@ -66,7 +66,7 @@ class GraphQLWSHandler(BaseGraphQLWSHandler):
         # This is not part of the BaseGraphQLWSHandler's interface, but the
         # channels integration is a high level wrapper that forwards this to
         # both us and the BaseGraphQLTransportWSHandler.
-        pass
+        await self.close(code=1002, reason=error_message)
 
 
 __all__ = ["GraphQLWSHandler"]

--- a/strawberry/channels/handlers/ws_handler.py
+++ b/strawberry/channels/handlers/ws_handler.py
@@ -106,8 +106,9 @@ class GraphQLWSConsumer(ChannelsWSConsumer):
         # Overriding this so that we can pass the errors to handle_invalid_message
         try:
             await super().receive(*args, **kwargs)
-        except ValueError as e:
-            await self._handler.handle_invalid_message(str(e))
+        except ValueError:
+            reason = "WebSocket message type must be text"
+            await self._handler.handle_invalid_message(reason)
 
     async def receive_json(self, content: Any, **kwargs: Any) -> None:
         await self._handler.handle_message(content)

--- a/strawberry/litestar/handlers/graphql_ws_handler.py
+++ b/strawberry/litestar/handlers/graphql_ws_handler.py
@@ -46,7 +46,9 @@ class GraphQLWSHandler(BaseGraphQLWSHandler):
                 try:
                     message = await self._ws.receive_json()
                 except (SerializationException, ValueError):  # noqa: PERF203
-                    await self.close(code=1002, reason="WebSocket message type must be text")
+                    await self.close(
+                        code=1002, reason="WebSocket message type must be text"
+                    )
                 else:
                     await self.handle_message(message)
         except WebSocketDisconnect:  # pragma: no cover

--- a/strawberry/litestar/handlers/graphql_ws_handler.py
+++ b/strawberry/litestar/handlers/graphql_ws_handler.py
@@ -46,8 +46,7 @@ class GraphQLWSHandler(BaseGraphQLWSHandler):
                 try:
                     message = await self._ws.receive_json()
                 except (SerializationException, ValueError):  # noqa: PERF203
-                    # Ignore non-text messages
-                    continue
+                    await self.close(code=1002, reason="WebSocket message type must be text")
                 else:
                     await self.handle_message(message)
         except WebSocketDisconnect:  # pragma: no cover

--- a/tests/websockets/test_graphql_transport_ws.py
+++ b/tests/websockets/test_graphql_transport_ws.py
@@ -117,13 +117,10 @@ async def test_ws_messages_must_be_text(ws_raw: WebSocketClient):
 
     await ws.send_bytes(json.dumps(ConnectionInitMessage().as_dict()).encode())
 
-    data = await ws.receive(timeout=2)
+    await ws.receive(timeout=2)
     assert ws.closed
     assert ws.close_code == 4400
-    if ws.name() == "channels":
-        ws.assert_reason("No text section for incoming WebSocket frame!")
-    else:
-        ws.assert_reason("WebSocket message type must be text")
+    ws.assert_reason("WebSocket message type must be text")
 
 
 async def test_ws_message_frame_types_cannot_be_mixed(ws_raw: WebSocketClient):

--- a/tests/websockets/test_graphql_transport_ws.py
+++ b/tests/websockets/test_graphql_transport_ws.py
@@ -126,6 +126,31 @@ async def test_ws_messages_must_be_text(ws_raw: WebSocketClient):
         ws.assert_reason("WebSocket message type must be text")
 
 
+async def test_ws_message_frame_types_cannot_be_mixed(ws_raw: WebSocketClient):
+    ws = ws_raw
+
+    await ws.send_json(ConnectionInitMessage().as_dict())
+
+    response = await ws.receive_json()
+    assert response == ConnectionAckMessage().as_dict()
+
+    await ws.send_bytes(
+        json.dumps(
+            SubscribeMessage(
+                id="sub1",
+                payload=SubscribeMessagePayload(
+                    query="subscription { debug { isConnectionInitTimeoutTaskDone } }"
+                ),
+            ).as_dict()
+        ).encode()
+    )
+
+    await ws.receive(timeout=2)
+    assert ws.closed
+    assert ws.close_code == 4400
+    ws.assert_reason("WebSocket message type must be text")
+
+
 async def test_connection_init_timeout(
     request: Any, http_client_class: Type[HttpClient]
 ):

--- a/tests/websockets/test_graphql_ws.py
+++ b/tests/websockets/test_graphql_ws.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from typing import TYPE_CHECKING, AsyncGenerator
 from unittest import mock
 
@@ -280,42 +281,44 @@ async def test_subscription_syntax_error(ws: WebSocketClient):
     }
 
 
-async def test_non_text_ws_messages_are_ignored(ws_raw: WebSocketClient):
+async def test_ws_messages_must_be_text(ws_raw: WebSocketClient):
     ws = ws_raw
-    await ws.send_bytes(b"foo")
-    await ws.send_json({"type": GQL_CONNECTION_INIT})
 
-    await ws.send_bytes(b"bar")
-    await ws.send_json(
-        {
-            "type": GQL_START,
-            "id": "demo",
-            "payload": {
-                "query": 'subscription { echo(message: "Hi") }',
-            },
-        }
-    )
+    await ws.send_bytes(json.dumps({"type": GQL_CONNECTION_INIT}).encode())
+
+    await ws.receive(timeout=2)
+    assert ws.closed
+    assert ws.close_code == 1002
+    if ws.name() == "channels":
+        ws.assert_reason("No text section for incoming WebSocket frame!")
+    else:
+        ws.assert_reason("WebSocket message type must be text")
+
+
+async def test_ws_message_frame_types_cannot_be_mixed(ws_raw: WebSocketClient):
+    ws = ws_raw
+
+    await ws.send_json({"type": GQL_CONNECTION_INIT})
 
     response = await ws.receive_json()
     assert response["type"] == GQL_CONNECTION_ACK
 
-    response = await ws.receive_json()
-    assert response["type"] == GQL_DATA
-    assert response["id"] == "demo"
-    assert response["payload"]["data"] == {"echo": "Hi"}
+    await ws.send_bytes(
+        json.dumps(
+            {
+                "type": GQL_START,
+                "id": "demo",
+                "payload": {
+                    "query": 'subscription { echo(message: "Hi") }',
+                },
+            }
+        ).encode()
+    )
 
-    await ws.send_bytes(b"gaz")
-    await ws.send_json({"type": GQL_STOP, "id": "demo"})
-    response = await ws.receive_json()
-    assert response["type"] == GQL_COMPLETE
-    assert response["id"] == "demo"
-
-    await ws.send_bytes(b"wat")
-    await ws.send_json({"type": GQL_CONNECTION_TERMINATE})
-
-    # make sure the WebSocket is disconnected now
-    await ws.receive(timeout=2)  # receive close
+    await ws.receive(timeout=2)
     assert ws.closed
+    assert ws.close_code == 1002
+    ws.assert_reason("WebSocket message type must be text")
 
 
 async def test_unknown_protocol_messages_are_ignored(ws_raw: WebSocketClient):

--- a/tests/websockets/test_graphql_ws.py
+++ b/tests/websockets/test_graphql_ws.py
@@ -289,10 +289,7 @@ async def test_ws_messages_must_be_text(ws_raw: WebSocketClient):
     await ws.receive(timeout=2)
     assert ws.closed
     assert ws.close_code == 1002
-    if ws.name() == "channels":
-        ws.assert_reason("No text section for incoming WebSocket frame!")
-    else:
-        ws.assert_reason("WebSocket message type must be text")
+    ws.assert_reason("WebSocket message type must be text")
 
 
 async def test_ws_message_frame_types_cannot_be_mixed(ws_raw: WebSocketClient):


### PR DESCRIPTION
Starting with this PR, we will let legacy WS clients know when they send data frames (e.g., binary instead of text data frames) that are not supported by the protocol instead of simply ignoring them.

## Description

While working on unifying all WebSocket implementations, I noticed that our implementation of the legacy WS protocol currently silently ignores unsupported data frames (i.e., binary data frames). So, I rechecked the protocol specs. They say only "stringified" JSON messages are allowed. That's the same formulation used in the newer WS protocol, where it is used to indicate that only text data frames are supported (related discussion: https://github.com/enisdenjo/graphql-ws/issues/409).

Starting with this PR, we report the use of unsupported data frames to clients (before, we ignored them). This should not cause any disruption to clients since they usually operate in text or binary mode. If they operate in text mode, everything will keep working. If they operate in binary mode, they never worked but will receive an error message now.

Close code `1002` was chosen because that code is also used in the reference implementation of the legacy protocol to signal protocol violations. The generally vague specs don't stipulate any more specific code for this scenario.

While at it, I unified the error message across both protocols and all integrations. (With the upcoming unification PR this would have been the case anyways).

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Enhance the legacy WebSocket protocol implementation to notify clients when unsupported binary data frames are sent, closing the connection with a specific error code and reason. Update tests to reflect this change and add documentation to inform users of the new behavior.

Enhancements:
- Notify legacy WebSocket clients of unsupported binary data frames by closing the connection with code 1002 and a specific reason.

Documentation:
- Add a release note indicating that legacy graphql-ws clients will now receive an error for binary data frames instead of them being ignored.

Tests:
- Update tests to verify that non-text WebSocket messages result in a connection closure with the appropriate close code and reason.

<!-- Generated by sourcery-ai[bot]: end summary -->