### PR TITLE
Fix missing return annotation in get_customer docs

### DIFF
--- a/docs/types/schema.md
+++ b/docs/types/schema.md
@@ -91,7 +91,7 @@ class Query:
     @strawberry.field
     def get_customer(
         self, id: strawberry.ID
-    ):  # -> Customer   note we're returning the interface here
+    ) -> Customer:  # note we're returning the interface here
         if id == "mark":
             return Individual(name="Mark", date_of_birth=date(1984, 5, 14))
 


### PR DESCRIPTION
## Description
The example under: "Defining extra types when using Interfaces" on https://strawberry.rocks/docs/types/schema contains an example, which does not run.

Using the documentation as-is produces this error:
```
MissingReturnAnnotationError: Return annotation missing for field "get_customer", did you forget to add it?
```


## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [X] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Correct the return annotation in the 'get_customer' function example in the documentation to prevent runtime errors and improve clarity.

Documentation:
- Fix the missing return annotation in the 'get_customer' function example in the documentation to ensure it runs without errors.

<!-- Generated by sourcery-ai[bot]: end summary -->