### PR TITLE
fix: show 405 error if request is GET and queries are not allowed

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+This release fixes an issue where a GET request is processed despite it being disallowed.

--- a/strawberry/http/async_base_view.py
+++ b/strawberry/http/async_base_view.py
@@ -184,6 +184,9 @@ class AsyncBaseHTTPView(
             else:
                 raise HTTPException(404, "Not Found")
 
+        if request_adapter.method == "GET" and not self.allow_queries_via_get:
+            raise HTTPException(404, "Not Found")
+
         sub_response = await self.get_sub_response(request)
         context = (
             await self.get_context(request, response=sub_response)

--- a/strawberry/http/async_base_view.py
+++ b/strawberry/http/async_base_view.py
@@ -2,6 +2,7 @@ import abc
 import asyncio
 import contextlib
 import json
+from http import HTTPStatus
 from typing import (
     Any,
     AsyncGenerator,
@@ -185,7 +186,7 @@ class AsyncBaseHTTPView(
                 raise HTTPException(404, "Not Found")
 
         if request_adapter.method == "GET" and not self.allow_queries_via_get:
-            raise HTTPException(404, "Not Found")
+            raise HTTPException(HTTPStatus.METHOD_NOT_ALLOWED, HTTPStatus.METHOD_NOT_ALLOWED.phrase)
 
         sub_response = await self.get_sub_response(request)
         context = (

--- a/strawberry/http/async_base_view.py
+++ b/strawberry/http/async_base_view.py
@@ -187,7 +187,8 @@ class AsyncBaseHTTPView(
 
         if request_adapter.method == "GET" and not self.allow_queries_via_get:
             raise HTTPException(
-                HTTPStatus.METHOD_NOT_ALLOWED, HTTPStatus.METHOD_NOT_ALLOWED.phrase
+                HTTPStatus.METHOD_NOT_ALLOWED,
+                HTTPStatus.METHOD_NOT_ALLOWED.phrase,
             )
 
         sub_response = await self.get_sub_response(request)

--- a/strawberry/http/async_base_view.py
+++ b/strawberry/http/async_base_view.py
@@ -186,7 +186,9 @@ class AsyncBaseHTTPView(
                 raise HTTPException(404, "Not Found")
 
         if request_adapter.method == "GET" and not self.allow_queries_via_get:
-            raise HTTPException(HTTPStatus.METHOD_NOT_ALLOWED, HTTPStatus.METHOD_NOT_ALLOWED.phrase)
+            raise HTTPException(
+                HTTPStatus.METHOD_NOT_ALLOWED, HTTPStatus.METHOD_NOT_ALLOWED.phrase
+            )
 
         sub_response = await self.get_sub_response(request)
         context = (

--- a/strawberry/http/sync_base_view.py
+++ b/strawberry/http/sync_base_view.py
@@ -180,6 +180,9 @@ class SyncBaseHTTPView(
             else:
                 raise HTTPException(404, "Not Found")
 
+        if request_adapter.method == "GET" and not self.allow_queries_via_get:
+            raise HTTPException(404, "Not Found")
+
         sub_response = self.get_sub_response(request)
         context = (
             self.get_context(request, response=sub_response)

--- a/strawberry/http/sync_base_view.py
+++ b/strawberry/http/sync_base_view.py
@@ -1,5 +1,6 @@
 import abc
 import json
+from http import HTTPStatus
 from typing import (
     Any,
     Callable,
@@ -181,7 +182,7 @@ class SyncBaseHTTPView(
                 raise HTTPException(404, "Not Found")
 
         if request_adapter.method == "GET" and not self.allow_queries_via_get:
-            raise HTTPException(404, "Not Found")
+            raise HTTPException(HTTPStatus.METHOD_NOT_ALLOWED, HTTPStatus.METHOD_NOT_ALLOWED.phrase)
 
         sub_response = self.get_sub_response(request)
         context = (

--- a/strawberry/http/sync_base_view.py
+++ b/strawberry/http/sync_base_view.py
@@ -182,7 +182,9 @@ class SyncBaseHTTPView(
                 raise HTTPException(404, "Not Found")
 
         if request_adapter.method == "GET" and not self.allow_queries_via_get:
-            raise HTTPException(HTTPStatus.METHOD_NOT_ALLOWED, HTTPStatus.METHOD_NOT_ALLOWED.phrase)
+            raise HTTPException(
+                HTTPStatus.METHOD_NOT_ALLOWED, HTTPStatus.METHOD_NOT_ALLOWED.phrase
+            )
 
         sub_response = self.get_sub_response(request)
         context = (

--- a/strawberry/http/sync_base_view.py
+++ b/strawberry/http/sync_base_view.py
@@ -183,7 +183,8 @@ class SyncBaseHTTPView(
 
         if request_adapter.method == "GET" and not self.allow_queries_via_get:
             raise HTTPException(
-                HTTPStatus.METHOD_NOT_ALLOWED, HTTPStatus.METHOD_NOT_ALLOWED.phrase
+                HTTPStatus.METHOD_NOT_ALLOWED,
+                HTTPStatus.METHOD_NOT_ALLOWED.phrase,
             )
 
         sub_response = self.get_sub_response(request)

--- a/tests/http/test_query_via_get.py
+++ b/tests/http/test_query_via_get.py
@@ -43,4 +43,4 @@ async def test_fails_if_allow_queries_via_get_false(http_client_class):
     response = await http_client.query(method="get", query="{ hello }")
 
     assert response.status_code == HTTPStatus.METHOD_NOT_ALLOWED
-    assert response.text == HTTPStatus.METHOD_NOT_ALLOWED.phrase
+    assert HTTPStatus.METHOD_NOT_ALLOWED.phrase in response.text

--- a/tests/http/test_query_via_get.py
+++ b/tests/http/test_query_via_get.py
@@ -1,3 +1,5 @@
+from http import HTTPStatus
+
 from .clients.base import HttpClient
 
 
@@ -40,5 +42,5 @@ async def test_fails_if_allow_queries_via_get_false(http_client_class):
 
     response = await http_client.query(method="get", query="{ hello }")
 
-    assert response.status_code == 400
-    assert "queries are not allowed when using GET" in response.text
+    assert response.status_code == HTTPStatus.METHOD_NOT_ALLOWED
+    assert response.text == HTTPStatus.METHOD_NOT_ALLOWED.phrase


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

When `allow_queries_via_get` is `False`, `GET` requests are processed despite the fact that queries are disallowed. Currently the response is "400: No GraphQL query found in the request" which is raised at a deeper level. I believe such requests should be rejected immediately as they needlessly consume resources.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the handling of GET requests by returning a 404 error when queries are disallowed, instead of processing them and returning a 400 error at a deeper level.

Bug Fixes:
- Return a 404 error for GET requests when queries are not allowed, preventing unnecessary resource consumption.

<!-- Generated by sourcery-ai[bot]: end summary -->