### PR TITLE
Take oneOf directive into account in codegen module

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,53 @@
+Release type: minor
+
+The Query Codegen system now supports the `@oneOf` directive.
+
+When writing plugins, you can now access `GraphQLObjectType.is_one_of` to determine if the object being worked with has a `@oneOf` directive.
+
+The default plugins have been updated to take advantage of the new attribute.
+
+For example, given this schema:
+
+```python
+@strawberry.input(one_of=True)
+class OneOfInput:
+    a: Optional[str] = strawberry.UNSET
+    b: Optional[str] = strawberry.UNSET
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def one_of(self, value: OneOfInput) -> str: ...
+
+
+schema = strawberry.Schema(Query)
+```
+
+And this query:
+
+```graphql
+query OneOfTest($value: OneOfInput!) {
+  oneOf(value: $value)
+}
+```
+
+The query codegen can now generate this Typescript file:
+
+```typescript
+type OneOfTestResult = {
+    one_of: string
+}
+
+type OneOfInput = {
+    a: string,
+    b: never
+} | {
+    a: never,
+    b: string
+}
+
+type OneOfTestVariables = {
+    value: OneOfInput
+}
+```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -39,13 +39,8 @@ type OneOfTestResult = {
     one_of: string
 }
 
-type OneOfInput = {
-    a: string,
-    b: never
-} | {
-    a: never,
-    b: string
-}
+type OneOfInput = { a: string, b?: never }
+    | { a?: never, b: string }
 
 type OneOfTestVariables = {
     value: OneOfInput

--- a/strawberry/codegen/plugins/python.py
+++ b/strawberry/codegen/plugins/python.py
@@ -109,16 +109,22 @@ class PythonPlugin(QueryCodegenPlugin):
 
         return type_.name
 
-    def _print_field(self, field: GraphQLField) -> str:
+    def _print_field(self, field: GraphQLField, as_oneof_member: bool = False) -> str:
         name = field.name
 
         if field.alias:
             name = f"# alias for {field.name}\n{field.alias}"
 
         default_value = ""
-        if field.default_value is not None:
+        if field.default_value is not None and not as_oneof_member:
             default_value = f" = {self._print_argument_value(field.default_value)}"
-        return f"{name}: {self._get_type_name(field.type)}{default_value}"
+
+        if as_oneof_member and isinstance(field.type, GraphQLOptional):
+            type_ = field.type.of_type
+        else:
+            type_ = field.type
+
+        return f"{name}: {self._get_type_name(type_)}{default_value}"
 
     def _print_argument_value(self, argval: GraphQLArgumentValue) -> str:
         if hasattr(argval, "values"):
@@ -173,6 +179,35 @@ class PythonPlugin(QueryCodegenPlugin):
         lines.append(textwrap.indent(fields, indent))
 
         return "\n".join(lines)
+    
+    def _get_oneof_class_name(self, parent_type: GraphQLObjectType, member_field: GraphQLField):
+        return "{type_.name}{field.name.title()}"
+
+    def _print_oneof_object_type(self, type_: GraphQLObjectType) -> str:
+        fields = [
+            field
+            for field in sorted(type_.fields, key=lambda f: f.default_value is not None) # MODIFIED - make sure default fields are last
+            if field.name != "__typename"
+        ]
+
+        indent = 4 * " "
+
+        lines = []
+        for field in fields:
+            lines.append(f"class {self._get_oneof_class_name(type_, field)}:")
+            lines.append(textwrap.indent(self._print_field(field, as_oneof_member=True), indent))
+
+        lines.append(f"{type_.name} = Union[{','.join(
+            [
+                self._get_oneof_class_name(type_, field)
+                for field in fields
+            ]
+        )}]")
+
+        if type_.graphql_typename:
+            lines.append(f"# typename: {type_.graphql_typename}")
+        
+        return "\n".join(lines)
 
     def _print_enum_type(self, type_: GraphQLEnum) -> str:
         values = "\n".join(self._print_enum_value(value) for value in type_.values)
@@ -202,7 +237,10 @@ class PythonPlugin(QueryCodegenPlugin):
             return self._print_union_type(type_)
 
         if isinstance(type_, GraphQLObjectType):
-            return self._print_object_type(type_)
+            if type_.is_one_of:
+                return self._print_oneof_object_type(type_)
+            else:
+                return self._print_object_type(type_)
 
         if isinstance(type_, GraphQLEnum):
             return self._print_enum_type(type_)

--- a/strawberry/codegen/plugins/python.py
+++ b/strawberry/codegen/plugins/python.py
@@ -207,7 +207,7 @@ class PythonPlugin(QueryCodegenPlugin):
             lines.append("")
 
         # Create a union of the classes we just created
-        type_list = ",".join(
+        type_list = ", ".join(
             [self._get_oneof_class_name(type_, field) for field in fields]
         )
         lines.append(f"{type_.name} = Union[{type_list}]")

--- a/strawberry/codegen/plugins/python.py
+++ b/strawberry/codegen/plugins/python.py
@@ -212,11 +212,6 @@ class PythonPlugin(QueryCodegenPlugin):
         )
         lines.append(f"{type_.name} = Union[{type_list}]")
 
-        if type_.graphql_typename:
-            # Shouldn't run, inputs can't be fragments
-            # Keeping it here just in case
-            lines.append(f"# typename: {type_.graphql_typename}")  # pragma: no cover
-
         return "\n".join(lines)
 
     def _print_enum_type(self, type_: GraphQLEnum) -> str:

--- a/strawberry/codegen/plugins/python.py
+++ b/strawberry/codegen/plugins/python.py
@@ -205,7 +205,8 @@ class PythonPlugin(QueryCodegenPlugin):
         lines.append(f"{type_.name} = Union[{type_list}]")
 
         if type_.graphql_typename:
-            lines.append(f"# typename: {type_.graphql_typename}")
+            # Shouldn't run, inputs can't be fragments
+            lines.append(f"# typename: {type_.graphql_typename}")  # pragma: no cover
 
         return "\n".join(lines)
 

--- a/strawberry/codegen/plugins/python.py
+++ b/strawberry/codegen/plugins/python.py
@@ -204,6 +204,7 @@ class PythonPlugin(QueryCodegenPlugin):
             lines.append(
                 textwrap.indent(self._print_field(field, as_oneof_member=True), indent)
             )
+            lines.append("")
 
         # Create a union of the classes we just created
         type_list = ",".join(

--- a/strawberry/codegen/plugins/python.py
+++ b/strawberry/codegen/plugins/python.py
@@ -197,12 +197,11 @@ class PythonPlugin(QueryCodegenPlugin):
             lines.append(f"class {self._get_oneof_class_name(type_, field)}:")
             lines.append(textwrap.indent(self._print_field(field, as_oneof_member=True), indent))
 
-        lines.append(f"{type_.name} = Union[{','.join(
-            [
-                self._get_oneof_class_name(type_, field)
-                for field in fields
-            ]
-        )}]")
+        type_list = ','.join([
+            self._get_oneof_class_name(type_, field)
+            for field in fields
+        ])
+        lines.append(f"{type_.name} = Union[{type_list}]")
 
         if type_.graphql_typename:
             lines.append(f"# typename: {type_.graphql_typename}")

--- a/strawberry/codegen/plugins/typescript.py
+++ b/strawberry/codegen/plugins/typescript.py
@@ -111,12 +111,12 @@ class TypeScriptPlugin(QueryCodegenPlugin):
                     field_row = self._print_oneof_field(field)
                 else:
                     # ... and the rest set to `never` to prevent multiple from being set
-                    field_row = f"{field.name}: never"
-                option_fields.append(textwrap.indent(field_row, " " * 4))
-            options.append("{\n" + ",\n".join(option_fields) + "\n}")
+                    field_row = f"{field.name}?: never"
+                option_fields.append(field_row)
+            options.append("{ " + ", ".join(option_fields) + " }")
 
         # Union all the options together
-        all_options = " | ".join(options)
+        all_options = "\n    | ".join(options)
 
         return f"type {type_.name} = {all_options}"
 

--- a/strawberry/codegen/plugins/typescript.py
+++ b/strawberry/codegen/plugins/typescript.py
@@ -80,11 +80,6 @@ class TypeScriptPlugin(QueryCodegenPlugin):
     def _print_oneof_field(self, field: GraphQLField) -> str:
         name = field.name
 
-        if field.alias:
-            # Shouldn't run, aliases can't exist on inputs
-            # Keeping it here just in case
-            name = f"// alias for {field.name}\n{field.alias}"  # pragma: no cover
-
         if isinstance(field.type, GraphQLOptional):
             # Use the non-null version of the type because we're using unions instead
             output_type = field.type.of_type

--- a/strawberry/codegen/plugins/typescript.py
+++ b/strawberry/codegen/plugins/typescript.py
@@ -81,12 +81,14 @@ class TypeScriptPlugin(QueryCodegenPlugin):
         name = field.name
 
         if field.alias:
-            name = f"// alias for {field.name}\n{field.alias}"
+            # Shouldn't run, aliases can't exist on inputs
+            name = f"// alias for {field.name}\n{field.alias}"  # pragma: no cover
 
         if isinstance(field.type, GraphQLOptional):
             output_type = field.type.of_type
         else:
-            output_type = field.type
+            # Shouldn't run, oneOf types are always nullable
+            output_type = field.type  # pragma: no cover
         return f"{name}: {self._get_type_name(output_type)}"
 
     def _print_enum_value(self, value: str) -> str:

--- a/strawberry/codegen/query_codegen.py
+++ b/strawberry/codegen/query_codegen.py
@@ -582,6 +582,7 @@ class QueryCodegen:
             type_ = GraphQLObjectType(
                 strawberry_type.name,
                 [],
+                is_one_of=strawberry_type.is_one_of,
             )
 
             for field in strawberry_type.fields:

--- a/strawberry/codegen/types.py
+++ b/strawberry/codegen/types.py
@@ -44,6 +44,7 @@ class GraphQLObjectType:
     name: str
     fields: List[GraphQLField] = field(default_factory=list)
     graphql_typename: Optional[str] = None
+    is_one_of: bool = False
 
 
 # Subtype of GraphQLObjectType.

--- a/tests/codegen/conftest.py
+++ b/tests/codegen/conftest.py
@@ -134,12 +134,10 @@ class Query:
         return LifeContainer([person], [dinosaur])
 
     @strawberry.field
-    def one_of(self, value: OneOfInput) -> str:
-        return "some value"
+    def one_of(self, value: OneOfInput) -> str: ...
 
     @strawberry.field
-    def one_of_typename(self, value: OneOfInput) -> PersonOrAnimal:
-        return Person(name="Name", age=22)
+    def one_of_typename(self, value: OneOfInput) -> PersonOrAnimal: ...
 
 
 @strawberry.input

--- a/tests/codegen/conftest.py
+++ b/tests/codegen/conftest.py
@@ -134,8 +134,12 @@ class Query:
         return LifeContainer([person], [dinosaur])
 
     @strawberry.field
-    def one_of(value: OneOfInput) -> str:
+    def one_of(self, value: OneOfInput) -> str:
         return "some value"
+
+    @strawberry.field
+    def one_of_typename(self, value: OneOfInput) -> PersonOrAnimal:
+        return Person(name="Name", age=22)
 
 
 @strawberry.input

--- a/tests/codegen/conftest.py
+++ b/tests/codegen/conftest.py
@@ -134,10 +134,12 @@ class Query:
         return LifeContainer([person], [dinosaur])
 
     @strawberry.field
-    def one_of(self, value: OneOfInput) -> str: ...
+    def one_of(self, value: OneOfInput) -> str: ...  # pragma: no cover
 
     @strawberry.field
-    def one_of_typename(self, value: OneOfInput) -> PersonOrAnimal: ...
+    def one_of_typename(
+        self, value: OneOfInput
+    ) -> PersonOrAnimal: ...  # pragma: no cover
 
 
 @strawberry.input

--- a/tests/codegen/conftest.py
+++ b/tests/codegen/conftest.py
@@ -83,6 +83,12 @@ class ExampleInput:
     optional_people: Optional[List[PersonInput]]
 
 
+@strawberry.input(one_of=True)
+class OneOfInput:
+    a: Optional[str] = strawberry.UNSET
+    b: Optional[str] = strawberry.UNSET
+
+
 @strawberry.type
 class Query:
     id: strawberry.ID
@@ -126,6 +132,10 @@ class Query:
         person = Person(name="Henry", age=10)
         dinosaur = Animal(name="rex", age=66_000_000)
         return LifeContainer([person], [dinosaur])
+
+    @strawberry.field
+    def one_of(value: OneOfInput) -> str:
+        return "some value"
 
 
 @strawberry.input

--- a/tests/codegen/queries/oneof.graphql
+++ b/tests/codegen/queries/oneof.graphql
@@ -1,0 +1,4 @@
+
+query OneOfTest ($value: OneOfInput!) {
+    oneOf(value: $value)
+}

--- a/tests/codegen/queries/oneof.graphql
+++ b/tests/codegen/queries/oneof.graphql
@@ -1,4 +1,3 @@
-
-query OneOfTest ($value: OneOfInput!) {
-    oneOf(value: $value)
+query OneOfTest($value: OneOfInput!) {
+  oneOf(value: $value)
 }

--- a/tests/codegen/queries/oneof_typename.graphql
+++ b/tests/codegen/queries/oneof_typename.graphql
@@ -1,0 +1,8 @@
+query OneOfTypenameTest($value: OneOfInput!) {
+  alias: oneOfTypename(value: $value) {
+    ... on Person {
+      name
+      age
+    }
+  }
+}

--- a/tests/codegen/snapshots/python/oneof.py
+++ b/tests/codegen/snapshots/python/oneof.py
@@ -5,8 +5,10 @@ class OneOfTestResult:
 
 class OneOfInputA:
     a: str
+
 class OneOfInputB:
     b: str
+
 OneOfInput = Union[OneOfInputA,OneOfInputB]
 
 class OneOfTestVariables:

--- a/tests/codegen/snapshots/python/oneof.py
+++ b/tests/codegen/snapshots/python/oneof.py
@@ -9,7 +9,7 @@ class OneOfInputA:
 class OneOfInputB:
     b: str
 
-OneOfInput = Union[OneOfInputA,OneOfInputB]
+OneOfInput = Union[OneOfInputA, OneOfInputB]
 
 class OneOfTestVariables:
     value: OneOfInput

--- a/tests/codegen/snapshots/python/oneof.py
+++ b/tests/codegen/snapshots/python/oneof.py
@@ -1,0 +1,13 @@
+from typing import Union
+
+class OneOfTestResult:
+    one_of: str
+
+class OneOfInputA:
+    a: str
+class OneOfInputB:
+    b: str
+OneOfInput = Union[OneOfInputA,OneOfInputB]
+
+class OneOfTestVariables:
+    value: OneOfInput

--- a/tests/codegen/snapshots/python/oneof_typename.py
+++ b/tests/codegen/snapshots/python/oneof_typename.py
@@ -15,7 +15,7 @@ class OneOfInputA:
 class OneOfInputB:
     b: str
 
-OneOfInput = Union[OneOfInputA,OneOfInputB]
+OneOfInput = Union[OneOfInputA, OneOfInputB]
 
 class OneOfTypenameTestVariables:
     value: OneOfInput

--- a/tests/codegen/snapshots/python/oneof_typename.py
+++ b/tests/codegen/snapshots/python/oneof_typename.py
@@ -1,0 +1,19 @@
+from typing import Union
+
+class OneOfTypenameTestResultOneOfTypenamePerson:
+    # typename: Person
+    name: str
+    age: int
+
+class OneOfTypenameTestResult:
+    # alias for one_of_typename
+    alias: OneOfTypenameTestResultOneOfTypenamePerson
+
+class OneOfInputA:
+    a: str
+class OneOfInputB:
+    b: str
+OneOfInput = Union[OneOfInputA,OneOfInputB]
+
+class OneOfTypenameTestVariables:
+    value: OneOfInput

--- a/tests/codegen/snapshots/python/oneof_typename.py
+++ b/tests/codegen/snapshots/python/oneof_typename.py
@@ -11,8 +11,10 @@ class OneOfTypenameTestResult:
 
 class OneOfInputA:
     a: str
+
 class OneOfInputB:
     b: str
+
 OneOfInput = Union[OneOfInputA,OneOfInputB]
 
 class OneOfTypenameTestVariables:

--- a/tests/codegen/snapshots/typescript/oneof.ts
+++ b/tests/codegen/snapshots/typescript/oneof.ts
@@ -2,13 +2,8 @@ type OneOfTestResult = {
     one_of: string
 }
 
-type OneOfInput = {
-    a: string,
-    b: never
-} | {
-    a: never,
-    b: string
-}
+type OneOfInput = { a: string, b?: never }
+    | { a?: never, b: string }
 
 type OneOfTestVariables = {
     value: OneOfInput

--- a/tests/codegen/snapshots/typescript/oneof.ts
+++ b/tests/codegen/snapshots/typescript/oneof.ts
@@ -1,0 +1,15 @@
+type OneOfTestResult = {
+    one_of: string
+}
+
+type OneOfInput = {
+    a: string,
+    b: never
+} | {
+    a: never,
+    b: string
+}
+
+type OneOfTestVariables = {
+    value: OneOfInput
+}

--- a/tests/codegen/snapshots/typescript/oneof_typename.ts
+++ b/tests/codegen/snapshots/typescript/oneof_typename.ts
@@ -8,13 +8,8 @@ type OneOfTypenameTestResult = {
     alias: OneOfTypenameTestResultOneOfTypenamePerson
 }
 
-type OneOfInput = {
-    a: string,
-    b: never
-} | {
-    a: never,
-    b: string
-}
+type OneOfInput = { a: string, b?: never }
+    | { a?: never, b: string }
 
 type OneOfTypenameTestVariables = {
     value: OneOfInput

--- a/tests/codegen/snapshots/typescript/oneof_typename.ts
+++ b/tests/codegen/snapshots/typescript/oneof_typename.ts
@@ -1,0 +1,21 @@
+type OneOfTypenameTestResultOneOfTypenamePerson = {
+    name: string
+    age: number
+}
+
+type OneOfTypenameTestResult = {
+    // alias for one_of_typename
+    alias: OneOfTypenameTestResultOneOfTypenamePerson
+}
+
+type OneOfInput = {
+    a: string,
+    b: never
+} | {
+    a: never,
+    b: string
+}
+
+type OneOfTypenameTestVariables = {
+    value: OneOfInput
+}


### PR DESCRIPTION
## Description

Adds support for `oneOf` to the `codegen` module

- The codegen manager now passes `is_one_of` to `GraphQLObjectType` making it part of the codegen plugin api
- Python plugin has been updated to output oneOf types as a union of classes with one field each
- Typescript plugin has been updated to output oneOf types as a union of objects where in each all but one field has a type of `never`

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* None

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Implement support for the `oneOf` directive in the code generation module, enhancing the Python and TypeScript plugins to handle `oneOf` types as unions. Add corresponding tests and snapshots to verify the new functionality.

New Features:
- Add support for the `oneOf` directive in the code generation module, allowing the generation of union types for `oneOf` fields in both Python and TypeScript plugins.

Enhancements:
- Update the Python plugin to output `oneOf` types as a union of classes, each with one field.
- Update the TypeScript plugin to output `oneOf` types as a union of objects, where each object has all but one field typed as `never`.

Tests:
- Add new test cases and snapshots for the `oneOf` directive in both Python and TypeScript code generation to ensure correct functionality.

<!-- Generated by sourcery-ai[bot]: end summary -->