### PR TITLE
Make it easier to debug close reason assertions

### DIFF
--- a/tests/http/clients/aiohttp.py
+++ b/tests/http/clients/aiohttp.py
@@ -218,5 +218,6 @@ class AioWebSocketClient(WebSocketClient):
         assert self.ws.close_code is not None
         return self.ws.close_code
 
-    def assert_reason(self, reason: str) -> None:
-        assert self._reason == reason
+    @property
+    def close_reason(self) -> Optional[str]:
+        return self._reason

--- a/tests/http/clients/asgi.py
+++ b/tests/http/clients/asgi.py
@@ -229,5 +229,6 @@ class AsgiWebSocketClient(WebSocketClient):
         assert self._close_code is not None
         return self._close_code
 
-    def assert_reason(self, reason: str) -> None:
-        assert self._close_reason == reason
+    @property
+    def close_reason(self) -> Optional[str]:
+        return self._close_reason

--- a/tests/http/clients/base.py
+++ b/tests/http/clients/base.py
@@ -293,8 +293,9 @@ class WebSocketClient(abc.ABC):
     @abc.abstractmethod
     def close_code(self) -> int: ...
 
+    @property
     @abc.abstractmethod
-    def assert_reason(self, reason: str) -> None: ...
+    def close_reason(self) -> Optional[str]: ...
 
     async def __aiter__(self) -> AsyncGenerator[Message, None]:
         while not self.closed:

--- a/tests/http/clients/channels.py
+++ b/tests/http/clients/channels.py
@@ -324,5 +324,6 @@ class ChannelsWebSocketClient(WebSocketClient):
         assert self._close_code is not None
         return self._close_code
 
-    def assert_reason(self, reason: str) -> None:
-        assert self._close_reason == reason
+    @property
+    def close_reason(self) -> Optional[str]:
+        return self._close_reason

--- a/tests/http/clients/litestar.py
+++ b/tests/http/clients/litestar.py
@@ -234,5 +234,6 @@ class LitestarWebSocketClient(WebSocketClient):
         assert self._close_code is not None
         return self._close_code
 
-    def assert_reason(self, reason: str) -> None:
-        assert self._close_reason == reason
+    @property
+    def close_reason(self) -> Optional[str]:
+        return self._close_reason

--- a/tests/websockets/test_graphql_transport_ws.py
+++ b/tests/websockets/test_graphql_transport_ws.py
@@ -76,7 +76,7 @@ async def test_unknown_message_type(ws_raw: WebSocketClient):
     data = await ws.receive(timeout=2)
     assert ws.closed
     assert ws.close_code == 4400
-    ws.assert_reason("Unknown message type: NOT_A_MESSAGE_TYPE")
+    assert ws.close_reason == "Unknown message type: NOT_A_MESSAGE_TYPE"
 
 
 async def test_missing_message_type(ws_raw: WebSocketClient):
@@ -87,7 +87,7 @@ async def test_missing_message_type(ws_raw: WebSocketClient):
     data = await ws.receive(timeout=2)
     assert ws.closed
     assert ws.close_code == 4400
-    ws.assert_reason("Failed to parse message")
+    assert ws.close_reason == "Failed to parse message"
 
 
 async def test_parsing_an_invalid_message(ws_raw: WebSocketClient):
@@ -98,7 +98,7 @@ async def test_parsing_an_invalid_message(ws_raw: WebSocketClient):
     data = await ws.receive(timeout=2)
     assert ws.closed
     assert ws.close_code == 4400
-    ws.assert_reason("Failed to parse message")
+    assert ws.close_reason == "Failed to parse message"
 
 
 async def test_parsing_an_invalid_payload(ws_raw: WebSocketClient):
@@ -109,7 +109,7 @@ async def test_parsing_an_invalid_payload(ws_raw: WebSocketClient):
     data = await ws.receive(timeout=2)
     assert ws.closed
     assert ws.close_code == 4400
-    ws.assert_reason("Failed to parse message")
+    assert ws.close_reason == "Failed to parse message"
 
 
 async def test_ws_messages_must_be_text(ws_raw: WebSocketClient):
@@ -120,7 +120,7 @@ async def test_ws_messages_must_be_text(ws_raw: WebSocketClient):
     await ws.receive(timeout=2)
     assert ws.closed
     assert ws.close_code == 4400
-    ws.assert_reason("WebSocket message type must be text")
+    assert ws.close_reason == "WebSocket message type must be text"
 
 
 async def test_ws_messages_must_be_json(ws_raw: WebSocketClient):
@@ -131,7 +131,7 @@ async def test_ws_messages_must_be_json(ws_raw: WebSocketClient):
     await ws.receive(timeout=2)
     assert ws.closed
     assert ws.close_code == 4400
-    ws.assert_reason("WebSocket message type must be text")
+    assert ws.close_reason == "WebSocket message type must be text"
 
 
 async def test_ws_message_frame_types_cannot_be_mixed(ws_raw: WebSocketClient):
@@ -156,7 +156,7 @@ async def test_ws_message_frame_types_cannot_be_mixed(ws_raw: WebSocketClient):
     await ws.receive(timeout=2)
     assert ws.closed
     assert ws.close_code == 4400
-    ws.assert_reason("WebSocket message type must be text")
+    assert ws.close_reason == "WebSocket message type must be text"
 
 
 async def test_connection_init_timeout(
@@ -180,7 +180,7 @@ async def test_connection_init_timeout(
         data = await ws.receive(timeout=2)
         assert ws.closed
         assert ws.close_code == 4408
-        ws.assert_reason("Connection initialisation timeout")
+        assert ws.close_reason == "Connection initialisation timeout"
 
 
 @pytest.mark.flaky
@@ -240,7 +240,7 @@ async def test_close_twice(
         await ws.receive(timeout=0.5)
         assert ws.closed
         assert ws.close_code == 4400
-        ws.assert_reason("Invalid connection init payload")
+        assert ws.close_reason == "Invalid connection init payload"
         transport_close.assert_not_called()
 
 
@@ -249,7 +249,7 @@ async def test_too_many_initialisation_requests(ws: WebSocketClient):
     data = await ws.receive(timeout=2)
     assert ws.closed
     assert ws.close_code == 4429
-    ws.assert_reason("Too many initialisation requests")
+    assert ws.close_reason == "Too many initialisation requests"
 
 
 async def test_ping_pong(ws: WebSocketClient):
@@ -320,7 +320,7 @@ async def test_unauthorized_subscriptions(ws_raw: WebSocketClient):
     data = await ws.receive(timeout=2)
     assert ws.closed
     assert ws.close_code == 4401
-    ws.assert_reason("Unauthorized")
+    assert ws.close_reason == "Unauthorized"
 
 
 async def test_duplicated_operation_ids(ws: WebSocketClient):
@@ -345,7 +345,7 @@ async def test_duplicated_operation_ids(ws: WebSocketClient):
     data = await ws.receive(timeout=2)
     assert ws.closed
     assert ws.close_code == 4409
-    ws.assert_reason("Subscriber for sub1 already exists")
+    assert ws.close_reason == "Subscriber for sub1 already exists"
 
 
 async def test_reused_operation_ids(ws: WebSocketClient):
@@ -409,7 +409,7 @@ async def test_subscription_syntax_error(ws: WebSocketClient):
     data = await ws.receive(timeout=2)
     assert ws.closed
     assert ws.close_code == 4400
-    ws.assert_reason("Syntax Error: Expected Name, found <EOF>.")
+    assert ws.close_reason == "Syntax Error: Expected Name, found <EOF>."
 
 
 async def test_subscription_field_errors(ws: WebSocketClient):
@@ -663,7 +663,7 @@ async def test_single_result_invalid_operation_selection(ws: WebSocketClient):
     data = await ws.receive(timeout=2)
     assert ws.closed
     assert ws.close_code == 4400
-    ws.assert_reason("Can't get GraphQL operation type")
+    assert ws.close_reason == "Can't get GraphQL operation type"
 
 
 async def test_single_result_execution_error(ws: WebSocketClient):
@@ -743,7 +743,7 @@ async def test_single_result_duplicate_ids_sub(ws: WebSocketClient):
     data = await ws.receive(timeout=2)
     assert ws.closed
     assert ws.close_code == 4409
-    ws.assert_reason("Subscriber for sub1 already exists")
+    assert ws.close_reason == "Subscriber for sub1 already exists"
 
 
 async def test_single_result_duplicate_ids_query(ws: WebSocketClient):
@@ -774,7 +774,7 @@ async def test_single_result_duplicate_ids_query(ws: WebSocketClient):
     data = await ws.receive(timeout=2)
     assert ws.closed
     assert ws.close_code == 4409
-    ws.assert_reason("Subscriber for sub1 already exists")
+    assert ws.close_reason == "Subscriber for sub1 already exists"
 
 
 async def test_injects_connection_params(ws_raw: WebSocketClient):
@@ -804,7 +804,7 @@ async def test_rejects_connection_params_not_dict(ws_raw: WebSocketClient):
     data = await ws.receive(timeout=2)
     assert ws.closed
     assert ws.close_code == 4400
-    ws.assert_reason("Invalid connection init payload")
+    assert ws.close_reason == "Invalid connection init payload"
 
 
 @pytest.mark.parametrize(
@@ -820,7 +820,7 @@ async def test_rejects_connection_params_with_wrong_type(
     data = await ws.receive(timeout=2)
     assert ws.closed
     assert ws.close_code == 4400
-    ws.assert_reason("Invalid connection init payload")
+    assert ws.close_reason == "Invalid connection init payload"
 
 
 # timings can sometimes fail currently.  Until this test is rewritten when

--- a/tests/websockets/test_graphql_ws.py
+++ b/tests/websockets/test_graphql_ws.py
@@ -289,7 +289,7 @@ async def test_ws_messages_must_be_text(ws_raw: WebSocketClient):
     await ws.receive(timeout=2)
     assert ws.closed
     assert ws.close_code == 1002
-    ws.assert_reason("WebSocket message type must be text")
+    assert ws.close_reason == "WebSocket message type must be text"
 
 
 async def test_ws_messages_must_be_json(ws_raw: WebSocketClient):
@@ -300,7 +300,7 @@ async def test_ws_messages_must_be_json(ws_raw: WebSocketClient):
     await ws.receive(timeout=2)
     assert ws.closed
     assert ws.close_code == 1002
-    ws.assert_reason("WebSocket message type must be text")
+    assert ws.close_reason == "WebSocket message type must be text"
 
 
 async def test_ws_message_frame_types_cannot_be_mixed(ws_raw: WebSocketClient):
@@ -326,7 +326,7 @@ async def test_ws_message_frame_types_cannot_be_mixed(ws_raw: WebSocketClient):
     await ws.receive(timeout=2)
     assert ws.closed
     assert ws.close_code == 1002
-    ws.assert_reason("WebSocket message type must be text")
+    assert ws.close_reason == "WebSocket message type must be text"
 
 
 async def test_unknown_protocol_messages_are_ignored(ws_raw: WebSocketClient):

--- a/tests/websockets/test_websockets.py
+++ b/tests/websockets/test_websockets.py
@@ -14,7 +14,7 @@ async def test_turning_off_graphql_ws(http_client_class: Type[HttpClient]):
         await ws.receive(timeout=2)
         assert ws.closed
         assert ws.close_code == 4406
-        ws.assert_reason("Subprotocol not acceptable")
+        assert ws.close_reason == "Subprotocol not acceptable"
 
 
 async def test_turning_off_graphql_transport_ws(http_client_class: Type[HttpClient]):
@@ -27,7 +27,7 @@ async def test_turning_off_graphql_transport_ws(http_client_class: Type[HttpClie
         await ws.receive(timeout=2)
         assert ws.closed
         assert ws.close_code == 4406
-        ws.assert_reason("Subprotocol not acceptable")
+        assert ws.close_reason == "Subprotocol not acceptable"
 
 
 async def test_turning_off_all_subprotocols(http_client_class: Type[HttpClient]):
@@ -40,7 +40,7 @@ async def test_turning_off_all_subprotocols(http_client_class: Type[HttpClient])
         await ws.receive(timeout=2)
         assert ws.closed
         assert ws.close_code == 4406
-        ws.assert_reason("Subprotocol not acceptable")
+        assert ws.close_reason == "Subprotocol not acceptable"
 
     async with http_client.ws_connect(
         "/graphql", protocols=[GRAPHQL_WS_PROTOCOL]
@@ -48,7 +48,7 @@ async def test_turning_off_all_subprotocols(http_client_class: Type[HttpClient])
         await ws.receive(timeout=2)
         assert ws.closed
         assert ws.close_code == 4406
-        ws.assert_reason("Subprotocol not acceptable")
+        assert ws.close_reason == "Subprotocol not acceptable"
 
 
 async def test_generally_unsupported_subprotocols_are_rejected(http_client: HttpClient):
@@ -58,7 +58,7 @@ async def test_generally_unsupported_subprotocols_are_rejected(http_client: Http
         await ws.receive(timeout=2)
         assert ws.closed
         assert ws.close_code == 4406
-        ws.assert_reason("Subprotocol not acceptable")
+        assert ws.close_reason == "Subprotocol not acceptable"
 
 
 async def test_clients_can_prefer_subprotocols(http_client_class: Type[HttpClient]):


### PR DESCRIPTION
## Description

Before this PR, Pytest could not display the diff between the expected and actual close reason because the assertion was hidden behind an `assert_reason` method.
Now, Pytest shows a pretty diff, making it easier to debug unexpected WebSocket close reasons in tests.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Summary by Sourcery

Enhance WebSocket test assertions by replacing the `assert_reason` method with a `close_reason` property, enabling Pytest to show detailed diffs for assertion errors, thus improving the debugging process.

Enhancements:
- Replace the `assert_reason` method with a `close_reason` property to improve the readability of assertion errors in WebSocket tests.

Tests:
- Update WebSocket test assertions to use the `close_reason` property instead of the `assert_reason` method, allowing Pytest to display a detailed diff for easier debugging.