### PR TITLE
Stop micromanaging WS support in IDEs

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: minor
+
+This release removes the dated `subscriptions_enabled` setting from the Django and Channels integrations.
+Instead, WebSocket support is now enabled by default in all GraphQL IDEs.

--- a/docs/integrations/channels.md
+++ b/docs/integrations/channels.md
@@ -522,8 +522,6 @@ GraphQLWebsocketCommunicator(
   to disable it by passing `None`.
 - `allow_queries_via_get`: optional, defaults to `True`, whether to enable
   queries via `GET` requests
-- `subscriptions_enabled`: optional boolean paramenter enabling subscriptions in
-  the GraphiQL interface, defaults to `True`
 - `multipart_uploads_enabled`: optional, defaults to `False`, controls whether
   to enable multipart uploads. Please make sure to consider the
   [security implications mentioned in the GraphQL Multipart Request Specification](https://github.com/jaydenseric/graphql-multipart-request-spec/blob/master/readme.md#security)

--- a/docs/integrations/django.md
+++ b/docs/integrations/django.md
@@ -39,8 +39,6 @@ The `GraphQLView` accepts the following arguments:
   to disable it by passing `None`.
 - `allow_queries_via_get`: optional, defaults to `True`, whether to enable
   queries via `GET` requests
-- `subscriptions_enabled`: optional boolean paramenter enabling subscriptions in
-  the GraphiQL interface, defaults to `False`.
 - `multipart_uploads_enabled`: optional, defaults to `False`, controls whether
   to enable multipart uploads. Please make sure to consider the
   [security implications mentioned in the GraphQL Multipart Request Specification](https://github.com/jaydenseric/graphql-multipart-request-spec/blob/master/readme.md#security)
@@ -182,8 +180,6 @@ The `AsyncGraphQLView` accepts the following arguments:
   to disable it by passing `None`.
 - `allow_queries_via_get`: optional, defaults to `True`, whether to enable
   queries via `GET` requests
-- `subscriptions_enabled`: optional boolean paramenter enabling subscriptions in
-  the GraphiQL interface, defaults to `False`.
 
 ## Extending the view
 

--- a/strawberry/chalice/views.py
+++ b/strawberry/chalice/views.py
@@ -54,7 +54,6 @@ class GraphQLView(
 ):
     allow_queries_via_get: bool = True
     request_adapter_class = ChaliceHTTPRequestAdapter
-    _ide_subscription_enabled = False
 
     def __init__(
         self,

--- a/strawberry/channels/handlers/http_handler.py
+++ b/strawberry/channels/handlers/http_handler.py
@@ -167,14 +167,11 @@ class BaseGraphQLHTTPConsumer(ChannelsConsumer, AsyncHttpConsumer):
         graphiql: Optional[bool] = None,
         graphql_ide: Optional[GraphQL_IDE] = "graphiql",
         allow_queries_via_get: bool = True,
-        subscriptions_enabled: bool = True,
         multipart_uploads_enabled: bool = False,
         **kwargs: Any,
     ) -> None:
         self.schema = schema
         self.allow_queries_via_get = allow_queries_via_get
-        self.subscriptions_enabled = subscriptions_enabled
-        self._ide_subscriptions_enabled = subscriptions_enabled
         self.multipart_uploads_enabled = multipart_uploads_enabled
 
         if graphiql is not None:

--- a/strawberry/django/views.py
+++ b/strawberry/django/views.py
@@ -25,7 +25,6 @@ from django.http import (
     StreamingHttpResponse,
 )
 from django.http.response import HttpResponseBase
-from django.template import RequestContext, Template
 from django.template.exceptions import TemplateDoesNotExist
 from django.template.loader import render_to_string
 from django.template.response import TemplateResponse

--- a/strawberry/django/views.py
+++ b/strawberry/django/views.py
@@ -27,7 +27,6 @@ from django.http import (
 from django.http.response import HttpResponseBase
 from django.template.exceptions import TemplateDoesNotExist
 from django.template.loader import render_to_string
-from django.template.response import TemplateResponse
 from django.utils.decorators import classonlymethod
 from django.views.generic import View
 
@@ -43,6 +42,8 @@ from strawberry.http.typevars import (
 from .context import StrawberryDjangoContext
 
 if TYPE_CHECKING:
+    from django.template.response import TemplateResponse
+
     from strawberry.http import GraphQLHTTPResponse
     from strawberry.http.ides import GraphQL_IDE
 

--- a/strawberry/django/views.py
+++ b/strawberry/django/views.py
@@ -137,7 +137,6 @@ class AsyncDjangoHTTPRequestAdapter(AsyncHTTPRequestAdapter):
 
 
 class BaseView:
-    _ide_replace_variables = False
     graphql_ide_html: str
 
     def __init__(
@@ -146,13 +145,11 @@ class BaseView:
         graphiql: Optional[str] = None,
         graphql_ide: Optional[GraphQL_IDE] = "graphiql",
         allow_queries_via_get: bool = True,
-        subscriptions_enabled: bool = False,
         multipart_uploads_enabled: bool = False,
         **kwargs: Any,
     ) -> None:
         self.schema = schema
         self.allow_queries_via_get = allow_queries_via_get
-        self.subscriptions_enabled = subscriptions_enabled
         self.multipart_uploads_enabled = multipart_uploads_enabled
 
         if graphiql is not None:
@@ -215,7 +212,6 @@ class GraphQLView(
     ],
     View,
 ):
-    subscriptions_enabled = False
     graphiql: Optional[bool] = None
     graphql_ide: Optional[GraphQL_IDE] = "graphiql"
     allow_queries_via_get = True
@@ -244,16 +240,11 @@ class GraphQLView(
 
     def render_graphql_ide(self, request: HttpRequest) -> HttpResponse:
         try:
-            template = Template(render_to_string("graphql/graphiql.html"))
+            content = render_to_string("graphql/graphiql.html")
         except TemplateDoesNotExist:
-            template = Template(self.graphql_ide_html)
+            content = self.graphql_ide_html
 
-        context = {"SUBSCRIPTION_ENABLED": json.dumps(self.subscriptions_enabled)}
-
-        response = TemplateResponse(request=request, template=None, context=context)
-        response.content = template.render(RequestContext(request, context))
-
-        return response
+        return HttpResponse(content)
 
 
 class AsyncGraphQLView(
@@ -269,7 +260,6 @@ class AsyncGraphQLView(
     ],
     View,
 ):
-    subscriptions_enabled = False
     graphiql: Optional[bool] = None
     graphql_ide: Optional[GraphQL_IDE] = "graphiql"
     allow_queries_via_get = True
@@ -308,16 +298,11 @@ class AsyncGraphQLView(
 
     async def render_graphql_ide(self, request: HttpRequest) -> HttpResponse:
         try:
-            template = Template(render_to_string("graphql/graphiql.html"))
+            content = render_to_string("graphql/graphiql.html")
         except TemplateDoesNotExist:
-            template = Template(self.graphql_ide_html)
+            content = self.graphql_ide_html
 
-        context = {"SUBSCRIPTION_ENABLED": json.dumps(self.subscriptions_enabled)}
-
-        response = TemplateResponse(request=request, template=None, context=context)
-        response.content = template.render(RequestContext(request, context))
-
-        return response
+        return HttpResponse(content=content)
 
     def is_websocket_request(self, request: HttpRequest) -> TypeGuard[HttpRequest]:
         return False

--- a/strawberry/flask/views.py
+++ b/strawberry/flask/views.py
@@ -63,7 +63,6 @@ class FlaskHTTPRequestAdapter(SyncHTTPRequestAdapter):
 
 
 class BaseGraphQLView:
-    _ide_subscription_enabled = False
     graphql_ide: Optional[GraphQL_IDE]
 
     def __init__(

--- a/strawberry/http/base.py
+++ b/strawberry/http/base.py
@@ -25,10 +25,6 @@ class BaseView(Generic[Request]):
     graphql_ide: Optional[GraphQL_IDE]
     multipart_uploads_enabled: bool = False
 
-    # TODO: we might remove this in future :)
-    _ide_replace_variables: bool = True
-    _ide_subscription_enabled: bool = True
-
     def should_render_graphql_ide(self, request: BaseRequestProtocol) -> bool:
         return (
             request.method == "GET"
@@ -64,11 +60,7 @@ class BaseView(Generic[Request]):
 
     @property
     def graphql_ide_html(self) -> str:
-        return get_graphql_ide_html(
-            subscription_enabled=self._ide_subscription_enabled,
-            replace_variables=self._ide_replace_variables,
-            graphql_ide=self.graphql_ide,
-        )
+        return get_graphql_ide_html(graphql_ide=self.graphql_ide)
 
     def _is_multipart_subscriptions(
         self, content_type: str, params: Dict[str, str]

--- a/strawberry/http/ides.py
+++ b/strawberry/http/ides.py
@@ -1,4 +1,3 @@
-import json
 import pathlib
 from typing import Optional
 from typing_extensions import Literal

--- a/strawberry/http/ides.py
+++ b/strawberry/http/ides.py
@@ -7,8 +7,6 @@ GraphQL_IDE = Literal["graphiql", "apollo-sandbox", "pathfinder"]
 
 
 def get_graphql_ide_html(
-    subscription_enabled: bool = True,
-    replace_variables: bool = True,
     graphql_ide: Optional[GraphQL_IDE] = "graphiql",
 ) -> str:
     here = pathlib.Path(__file__).parents[1]
@@ -21,11 +19,6 @@ def get_graphql_ide_html(
         path = here / "static/graphiql.html"
 
     template = path.read_text(encoding="utf-8")
-
-    if replace_variables:
-        template = template.replace(
-            "{{ SUBSCRIPTION_ENABLED }}", json.dumps(subscription_enabled)
-        )
 
     return template
 

--- a/strawberry/quart/views.py
+++ b/strawberry/quart/views.py
@@ -52,8 +52,6 @@ class GraphQLView(
     ],
     View,
 ):
-    _ide_subscription_enabled = False
-
     methods = ["GET", "POST"]
     allow_queries_via_get: bool = True
     request_adapter_class = QuartHTTPRequestAdapter

--- a/strawberry/static/graphiql.html
+++ b/strawberry/static/graphiql.html
@@ -131,10 +131,7 @@
         headers["x-csrftoken"] = csrfToken;
       }
 
-      const subscriptionsEnabled = JSON.parse("{{ SUBSCRIPTION_ENABLED }}");
-      const subscriptionUrl = subscriptionsEnabled
-        ? httpUrlToWebSockeUrl(fetchURL)
-        : null;
+      const subscriptionUrl = httpUrlToWebSockeUrl(fetchURL);
 
       const fetcher = GraphiQL.createFetcher({
         url: fetchURL,


### PR DESCRIPTION
## Description

This PR removes the `subscriptions_enabled` flag from the Django and Channels views. It also removes two internal flags with the same purpose from all other views.

These flags were originally added to address #334. However, the behavior described in that issue has since been changed in Graph**i**QL, making our flag useless. (Tested locally using the Django integration, setting `subscriptions_enabled` to true, opening GraphiQL, and observing the browser's network tab).

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #2051

## Summary by Sourcery

Remove the `subscriptions_enabled` flag from various views and update the documentation accordingly. Enable WebSocket support by default in all GraphQL IDEs, simplifying the configuration process.

Enhancements:
- Remove the `subscriptions_enabled` flag from Django and Channels views, as well as from other internal views, to simplify the configuration and enable WebSocket support by default.

Documentation:
- Update the documentation to reflect the removal of the `subscriptions_enabled` parameter from the GraphQLView and AsyncGraphQLView in Django and Channels integrations.

Chores:
- Add a RELEASE.md file to document the changes in this release, indicating the removal of the `subscriptions_enabled` setting and the default enabling of WebSocket support.