### PR TITLE
Rename misleading test client argument name

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: minor
+
+The AIOHTTP, ASGI, and Django test clients' `asserts_errors` option has been renamed to `assert_no_errors` to better reflect its purpose.
+This change is backwards-compatible, but the old option name will raise a deprecation warning.

--- a/strawberry/aiohttp/test/client.py
+++ b/strawberry/aiohttp/test/client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from typing import (
     Any,
     Dict,
@@ -16,8 +17,9 @@ class GraphQLTestClient(BaseGraphQLTestClient):
         query: str,
         variables: Optional[Dict[str, Mapping]] = None,
         headers: Optional[Dict[str, object]] = None,
-        asserts_errors: Optional[bool] = True,
+        asserts_errors: Optional[bool] = None,
         files: Optional[Dict[str, object]] = None,
+        assert_no_errors: Optional[bool] = True,
     ) -> Response:
         body = self._build_body(query, variables, files)
 
@@ -29,7 +31,19 @@ class GraphQLTestClient(BaseGraphQLTestClient):
             data=data.get("data"),
             extensions=data.get("extensions"),
         )
-        if asserts_errors:
+
+        if asserts_errors is not None:
+            warnings.warn(
+                "The `asserts_errors` argument has been renamed to `assert_no_errors`",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+        assert_no_errors = (
+            assert_no_errors if asserts_errors is None else asserts_errors
+        )
+
+        if assert_no_errors:
             assert resp.status == 200
             assert response.errors is None
 

--- a/strawberry/test/client.py
+++ b/strawberry/test/client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import warnings
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Coroutine, Dict, List, Mapping, Optional, Union
@@ -36,8 +37,9 @@ class BaseGraphQLTestClient(ABC):
         query: str,
         variables: Optional[Dict[str, Mapping]] = None,
         headers: Optional[Dict[str, object]] = None,
-        asserts_errors: Optional[bool] = True,
+        asserts_errors: Optional[bool] = None,
         files: Optional[Dict[str, object]] = None,
+        assert_no_errors: Optional[bool] = True,
     ) -> Union[Coroutine[Any, Any, Response], Response]:
         body = self._build_body(query, variables, files)
 
@@ -49,7 +51,19 @@ class BaseGraphQLTestClient(ABC):
             data=data.get("data"),
             extensions=data.get("extensions"),
         )
-        if asserts_errors:
+
+        if asserts_errors is not None:
+            warnings.warn(
+                "The `asserts_errors` argument has been renamed to `assert_no_errors`",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+        assert_no_errors = (
+            assert_no_errors if asserts_errors is None else asserts_errors
+        )
+
+        if assert_no_errors:
             assert response.errors is None
 
         return response

--- a/tests/django/test_graphql_test_client.py
+++ b/tests/django/test_graphql_test_client.py
@@ -1,7 +1,0 @@
-def test_assertion_error_not_raised_when_asserts_errors_is_false(graphql_client):
-    query = "{  }"
-
-    try:
-        graphql_client.query(query, asserts_errors=False)
-    except AssertionError:
-        raise AssertionError

--- a/tests/test/conftest.py
+++ b/tests/test/conftest.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING, AsyncGenerator
+
+import pytest
+from django.test.client import Client
+from starlette.testclient import TestClient as AsgiTestClient
+
+import aiohttp.web
+from aiohttp.test_utils import TestClient as AiohttpTestClient
+from aiohttp.test_utils import TestServer
+from strawberry.aiohttp.test import GraphQLTestClient as AiohttpGraphQLTestClient
+from strawberry.aiohttp.views import GraphQLView
+from strawberry.asgi import GraphQL
+from strawberry.asgi.test import GraphQLTestClient as AsgiGraphQLTestClient
+from strawberry.django.test import GraphQLTestClient as DjangoGraphQLTestClient
+from tests.views.schema import schema
+
+if TYPE_CHECKING:
+    from strawberry.test import BaseGraphQLTestClient
+
+
+@asynccontextmanager
+async def aiohttp_graphql_client() -> AsyncGenerator[AiohttpGraphQLTestClient]:
+    view = GraphQLView(schema=schema)
+    app = aiohttp.web.Application()
+    app.router.add_route("*", "/graphql/", view)
+
+    async with AiohttpTestClient(TestServer(app)) as client:
+        yield AiohttpGraphQLTestClient(client)
+
+
+@asynccontextmanager
+async def asgi_graphql_client() -> AsyncGenerator[AsgiGraphQLTestClient]:
+    yield AsgiGraphQLTestClient(AsgiTestClient(GraphQL(schema)))
+
+
+@asynccontextmanager
+async def django_graphql_client() -> AsyncGenerator[DjangoGraphQLTestClient]:
+    yield DjangoGraphQLTestClient(Client())
+
+
+@pytest.fixture(
+    params=[
+        pytest.param(aiohttp_graphql_client, marks=[pytest.mark.aiohttp]),
+        pytest.param(asgi_graphql_client, marks=[pytest.mark.asgi]),
+        pytest.param(django_graphql_client, marks=[pytest.mark.django]),
+    ]
+)
+async def graphql_client(request) -> AsyncGenerator[BaseGraphQLTestClient]:
+    async with request.param() as graphql_client:
+        yield graphql_client

--- a/tests/test/test_client.py
+++ b/tests/test/test_client.py
@@ -1,0 +1,34 @@
+from contextlib import nullcontext
+
+import pytest
+
+from strawberry.utils.await_maybe import await_maybe
+
+
+@pytest.mark.parametrize("asserts_errors", [True, False])
+async def test_query_asserts_errors_option_is_deprecated(
+    graphql_client, asserts_errors
+):
+    with pytest.warns(
+        DeprecationWarning,
+        match="The `asserts_errors` argument has been renamed to `assert_no_errors`",
+    ):
+        await await_maybe(
+            graphql_client.query("{ hello }", asserts_errors=asserts_errors)
+        )
+
+
+@pytest.mark.parametrize("option_name", ["asserts_errors", "assert_no_errors"])
+@pytest.mark.parametrize(
+    ("assert_no_errors", "expectation"),
+    [(True, pytest.raises(AssertionError)), (False, nullcontext())],
+)
+async def test_query_with_assert_no_errors_option(
+    graphql_client, option_name, assert_no_errors, expectation
+):
+    query = "{ ThisIsNotAValidQuery }"
+
+    with expectation:
+        await await_maybe(
+            graphql_client.query(query, **{option_name: assert_no_errors})
+        )


### PR DESCRIPTION
## Description

This PR renames the `asserts_errors` of our user-facing test clients to `assert_no_errors` as proposed in #3580. The old option is still available but will raise a deprecation warning.

Also, before this PR, only the Django test client had tests. Now, all test clients share the tests. (That's why this PR is a little bigger than one might expect).

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #3580

## Summary by Sourcery

Rename the `asserts_errors` argument to `assert_no_errors` in test clients for clarity, add shared tests for all clients, and document the change with a release note.

Enhancements:
- Rename the `asserts_errors` argument to `assert_no_errors` in test clients to better reflect its purpose, while maintaining backward compatibility with a deprecation warning for the old argument.

Documentation:
- Add a release note documenting the renaming of the `asserts_errors` option to `assert_no_errors` in test clients, highlighting the backward compatibility and deprecation warning.

Tests:
- Add shared tests for all test clients, including AIHOTTP, ASGI, and Django, to ensure consistent behavior across different environments.
- Introduce tests to verify the deprecation warning for the `asserts_errors` argument and the functionality of the `assert_no_errors` option.