### PR TITLE
Fix heading levels of options/subclassing docs

### DIFF
--- a/docs/integrations/aiohttp.md
+++ b/docs/integrations/aiohttp.md
@@ -52,7 +52,7 @@ methods:
 - `async process_result(self, request: aiohttp.web.Request, result: ExecutionResult) -> GraphQLHTTPResponse`
 - `def encode_json(self, data: GraphQLHTTPResponse) -> str`
 
-## get_context
+### get_context
 
 By overriding `GraphQLView.get_context` you can provide a custom context object
 for your resolvers. You can return anything here; by default GraphQLView returns
@@ -83,7 +83,7 @@ called `"example"`.
 Then we can use the context in a resolver. In this case the resolver will return
 `1`.
 
-## get_root_value
+### get_root_value
 
 By overriding `GraphQLView.get_root_value` you can provide a custom root value
 for your schema. This is probably not used a lot but it might be useful in
@@ -110,7 +110,7 @@ class Query:
 Here we configure a Query where requesting the `name` field will return
 `"Patrick"` through the custom root value.
 
-## process_result
+### process_result
 
 By overriding `GraphQLView.process_result` you can customize and/or process
 results before they are sent to a client. This can be useful for logging errors,
@@ -141,7 +141,7 @@ class MyGraphQLView(GraphQLView):
 In this case we are doing the default processing of the result, but it can be
 tweaked based on your needs.
 
-## encode_json
+### encode_json
 
 `encode_json` allows to customize the encoding of the JSON response. By default
 we use `json.dumps` but you can override this method to use a different encoder.

--- a/docs/integrations/asgi.md
+++ b/docs/integrations/asgi.md
@@ -51,7 +51,7 @@ We allow to extend the base `GraphQL` app, by overriding the following methods:
 - `async process_result(self, request: Request, result: ExecutionResult) -> GraphQLHTTPResponse`
 - `def encode_json(self, response_data: GraphQLHTTPResponse) -> str`
 
-## get_context
+### get_context
 
 `get_context` allows to provide a custom context object that can be used in your
 resolver. You can return anything here, by default we return a dictionary with
@@ -78,7 +78,7 @@ called "example".
 Then we use the context in a resolver, the resolver will return "1" in this
 case.
 
-### Setting response headers
+#### Setting response headers
 
 It is possible to use `get_context` to set response headers. A common use case
 might be cookie-based user authentication, where your login mutation resolver
@@ -97,7 +97,7 @@ class Mutation:
         return True
 ```
 
-### Setting background tasks
+#### Setting background tasks
 
 Similarly, [background tasks](https://www.starlette.io/background/) can be set
 on the response via the context:
@@ -116,7 +116,7 @@ class Mutation:
         info.context["response"].background = BackgroundTask(notify_new_flavour, name)
 ```
 
-## get_root_value
+### get_root_value
 
 `get_root_value` allows to provide a custom root value for your schema, this is
 probably not used a lot but it might be useful in certain situations.
@@ -137,7 +137,7 @@ class Query:
 Here we are returning a Query where the name is "Patrick", so we when requesting
 the field name we'll return "Patrick" in this case.
 
-## process_result
+### process_result
 
 `process_result` allows to customize and/or process results before they are sent
 to the clients. This can be useful logging errors or hiding them (for example to
@@ -166,7 +166,7 @@ class MyGraphQL(GraphQL):
 In this case we are doing the default processing of the result, but it can be
 tweaked based on your needs.
 
-## encode_json
+### encode_json
 
 `encode_json` allows to customize the encoding of the JSON response. By default
 we use `json.dumps` but you can override this method to use a different encoder.

--- a/docs/integrations/chalice.md
+++ b/docs/integrations/chalice.md
@@ -77,7 +77,7 @@ We allow to extend the base `GraphQLView`, by overriding the following methods:
 - `process_result(self, request: Request, result: ExecutionResult) -> GraphQLHTTPResponse`
 - `encode_json(self, response_data: GraphQLHTTPResponse) -> str`
 
-## get_context
+### get_context
 
 `get_context` allows to provide a custom context object that can be used in your
 resolver. You can return anything here, by default we return a dictionary with
@@ -103,7 +103,7 @@ called "example".
 Then we use the context in a resolver, the resolver will return "1" in this
 case.
 
-## get_root_value
+### get_root_value
 
 `get_root_value` allows to provide a custom root value for your schema, this is
 probably not used a lot but it might be useful in certain situations.
@@ -124,7 +124,7 @@ class Query:
 Here we are returning a Query where the name is "Patrick", so we when requesting
 the field name we'll return "Patrick" in this case.
 
-## process_result
+### process_result
 
 `process_result` allows to customize and/or process results before they are sent
 to the clients. This can be useful logging errors or hiding them (for example to
@@ -151,7 +151,7 @@ class MyGraphQLView(GraphQLView):
 In this case we are doing the default processing of the result, but it can be
 tweaked based on your needs.
 
-## encode_json
+### encode_json
 
 `encode_json` allows to customize the encoding of the JSON response. By default
 we use `json.dumps` but you can override this method to use a different encoder.

--- a/docs/integrations/django.md
+++ b/docs/integrations/django.md
@@ -191,7 +191,7 @@ methods:
 - `async process_result(self, request: HttpRequest, result: ExecutionResult) -> GraphQLHTTPResponse`
 - `def encode_json(self, data: GraphQLHTTPResponse) -> str`
 
-## get_context
+### get_context
 
 `get_context` allows to provide a custom context object that can be used in your
 resolver. You can return anything here, by default we return a dictionary with
@@ -216,7 +216,7 @@ called "example".
 Then we use the context in a resolver, the resolver will return "1" in this
 case.
 
-## get_root_value
+### get_root_value
 
 `get_root_value` allows to provide a custom root value for your schema, this is
 probably not used a lot but it might be useful in certain situations.
@@ -237,7 +237,7 @@ class Query:
 Here we are returning a Query where the name is "Patrick", so we when requesting
 the field name we'll return "Patrick" in this case.
 
-## process_result
+### process_result
 
 `process_result` allows to customize and/or process results before they are sent
 to the clients. This can be useful logging errors or hiding them (for example to
@@ -266,7 +266,7 @@ class MyGraphQLView(AsyncGraphQLView):
 In this case we are doing the default processing of the result, but it can be
 tweaked based on your needs.
 
-## encode_json
+### encode_json
 
 `encode_json` allows to customize the encoding of the JSON response. By default
 we use `json.dumps` but you can override this method to use a different encoder.

--- a/docs/integrations/fastapi.md
+++ b/docs/integrations/fastapi.md
@@ -59,7 +59,7 @@ The `GraphQLRouter` accepts the following options:
   [security implications mentioned in the GraphQL Multipart Request Specification](https://github.com/jaydenseric/graphql-multipart-request-spec/blob/master/readme.md#security)
   when enabling this feature.
 
-## context_getter
+### context_getter
 
 The `context_getter` option allows you to provide a custom context object that
 can be used in your resolver. `context_getter` is a
@@ -178,7 +178,7 @@ requires `.request` indexing.
 Then we use the context in a resolver. The resolver will return “Hello John, you
 rock!” in this case.
 
-### Setting background tasks
+#### Setting background tasks
 
 Similarly,
 [background tasks](https://fastapi.tiangolo.com/tutorial/background-tasks/?h=background)
@@ -221,7 +221,7 @@ app.include_router(graphql_app, prefix="/graphql")
 If using a custom context class, then background tasks should be stored within
 the class object as `.background_tasks`.
 
-## root_value_getter
+### root_value_getter
 
 The `root_value_getter` option allows you to provide a custom root value for
 your schema. This is most likely a rare usecase but might be useful in certain
@@ -259,7 +259,7 @@ app.include_router(graphql_app, prefix="/graphql")
 Here we are returning a Query where the name is "Patrick", so when we request
 the field name we'll return "Patrick".
 
-## process_result
+### process_result
 
 The `process_result` option allows you to customize and/or process results
 before they are sent to the clients. This can be useful for logging errors or
@@ -290,7 +290,7 @@ class MyGraphQLRouter(GraphQLRouter):
 In this case we are doing the default processing of the result, but it can be
 tweaked based on your needs.
 
-## encode_json
+### encode_json
 
 `encode_json` allows to customize the encoding of the JSON response. By default
 we use `json.dumps` but you can override this method to use a different encoder.

--- a/docs/integrations/flask.md
+++ b/docs/integrations/flask.md
@@ -64,7 +64,7 @@ async functions.
 
 </Note>
 
-## get_context
+### get_context
 
 `get_context` allows to provide a custom context object that can be used in your
 resolver. You can return anything here, by default we return a dictionary with
@@ -90,7 +90,7 @@ called "example".
 Then we use the context in a resolver, the resolver will return "1" in this
 case.
 
-## get_root_value
+### get_root_value
 
 `get_root_value` allows to provide a custom root value for your schema, this is
 probably not used a lot but it might be useful in certain situations.
@@ -111,7 +111,7 @@ class Query:
 Here we are returning a Query where the name is "Patrick", so we when requesting
 the field name we'll return "Patrick" in this case.
 
-## process_result
+### process_result
 
 `process_result` allows to customize and/or process results before they are sent
 to the clients. This can be useful logging errors or hiding them (for example to
@@ -138,7 +138,7 @@ class MyGraphQLView(GraphQLView):
 In this case we are doing the default processing of the result, but it can be
 tweaked based on your needs.
 
-## encode_json
+### encode_json
 
 `encode_json` allows to customize the encoding of the JSON response. By default
 we use `json.dumps` but you can override this method to use a different encoder.

--- a/docs/integrations/litestar.md
+++ b/docs/integrations/litestar.md
@@ -66,7 +66,7 @@ The `make_graphql_controller` function accepts the following options:
   [security implications mentioned in the GraphQL Multipart Request Specification](https://github.com/jaydenseric/graphql-multipart-request-spec/blob/master/readme.md#security)
   when enabling this feature.
 
-## context_getter
+### context_getter
 
 The `context_getter` option allows you to provide a Litestar dependency that
 return a custom context object that can be used in your resolver.
@@ -188,7 +188,7 @@ GraphQLController = make_graphql_controller(
 app = Litestar(route_handlers=[GraphQLController])
 ```
 
-### Context typing
+#### Context typing
 
 In our previous example using class based context, the actual runtime context a
 `CustomContext` type. Because it inherits from `BaseContext`, the `request`,
@@ -283,7 +283,7 @@ GraphQLController = make_graphql_controller(
 app = Litestar(route_handlers=[GraphQLController])
 ```
 
-## root_value_getter
+### root_value_getter
 
 The `root_value_getter` option allows you to provide a custom root value that
 can be used in your resolver

--- a/docs/integrations/quart.md
+++ b/docs/integrations/quart.md
@@ -48,7 +48,7 @@ We allow to extend the base `GraphQLView`, by overriding the following methods:
 - `process_result(self, result: ExecutionResult) -> GraphQLHTTPResponse`
 - `encode_json(self, response_data: GraphQLHTTPResponse) -> str`
 
-## get_context
+### get_context
 
 `get_context` allows to provide a custom context object that can be used in your
 resolver. You can return anything here, by default we return a dictionary with
@@ -74,7 +74,7 @@ called "example".
 Then we use the context in a resolver, the resolver will return "1" in this
 case.
 
-## get_root_value
+### get_root_value
 
 `get_root_value` allows to provide a custom root value for your schema, this is
 probably not used a lot but it might be useful in certain situations.
@@ -95,7 +95,7 @@ class Query:
 Here we are returning a Query where the name is "Patrick", so we when requesting
 the field name we'll return "Patrick" in this case.
 
-## process_result
+### process_result
 
 `process_result` allows to customize and/or process results before they are sent
 to the clients. This can be useful logging errors or hiding them (for example to
@@ -122,7 +122,7 @@ class MyGraphQLView(GraphQLView):
 In this case we are doing the default processing of the result, but it can be
 tweaked based on your needs.
 
-## encode_json
+### encode_json
 
 `encode_json` allows to customize the encoding of the JSON response. By default
 we use `json.dumps` but you can override this method to use a different encoder.

--- a/docs/integrations/sanic.md
+++ b/docs/integrations/sanic.md
@@ -44,7 +44,7 @@ methods:
 - `async get_root_value(self, request: Request) -> Any`
 - `async process_result(self, result: ExecutionResult) -> GraphQLHTTPResponse`
 
-## get_context
+### get_context
 
 By overriding `GraphQLView.get_context` you can provide a custom context object
 for your resolvers. You can return anything here; by default GraphQLView returns
@@ -69,7 +69,7 @@ called `"example"`.
 Then we can use the context in a resolver. In this case the resolver will return
 `1`.
 
-## get_root_value
+### get_root_value
 
 By overriding `GraphQLView.get_root_value` you can provide a custom root value
 for your schema. This is probably not used a lot but it might be useful in
@@ -91,7 +91,7 @@ class Query:
 Here we configure a Query where requesting the `name` field will return
 `"Patrick"` through the custom root value.
 
-## process_result
+### process_result
 
 By overriding `GraphQLView.process_result` you can customize and/or process
 results before they are sent to a client. This can be useful for logging errors,
@@ -120,7 +120,7 @@ class MyGraphQLView(GraphQLView):
 In this case we are doing the default processing of the result, but it can be
 tweaked based on your needs.
 
-## encode_json
+### encode_json
 
 `encode_json` allows to customize the encoding of the JSON response. By default
 we use `json.dumps` but you can override this method to use a different encoder.


### PR DESCRIPTION
## Description

I noticed the heading level hirachies were not quite right. The view and subclassing options should be one level below the options/subclassing sections.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Summary by Sourcery

Correct heading levels in the documentation for integration guides to improve readability and maintain a consistent structure across all sections.

Documentation:
- Adjust heading levels in the documentation for various integrations to ensure consistent hierarchy, making sub-sections like 'get_context', 'get_root_value', 'process_result', and 'encode_json' appear as sub-headings under their respective main sections.