### PR TITLE
Use explicit response code to avoid type error

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+This release tweaks the Flask integration's `render_graphql_ide` method to be stricter typed internally, making type checkers ever so slightly happier.

--- a/strawberry/flask/views.py
+++ b/strawberry/flask/views.py
@@ -187,7 +187,8 @@ class AsyncGraphQLView(
             )
 
     async def render_graphql_ide(self, request: Request) -> Response:
-        return render_template_string(self.graphql_ide_html)  # type: ignore
+        content = render_template_string(self.graphql_ide_html)
+        return Response(content, status=200, content_type="text/html")
 
     def is_websocket_request(self, request: Request) -> TypeGuard[Request]:
         return False


### PR DESCRIPTION
## Description

This PR removes an unneeded `type: ignore` I just stumbled upon and couldn't get out of my head.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Summary by Sourcery

Refactor the Flask integration's `render_graphql_ide` method to use explicit response parameters, improving type safety and removing an unnecessary `type: ignore` comment. Document the change in a new `RELEASE.md` file.

Enhancements:
- Refactor the `render_graphql_ide` method in the Flask integration to use an explicit response code and content type, removing the need for a `type: ignore` comment.

Documentation:
- Add a `RELEASE.md` file to document the patch release, highlighting the stricter typing in the Flask integration.