### PR TITLE
Fix CI with new Ubuntu LTS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,8 +86,9 @@ jobs:
 
   benchmarks:
     name: 📈 Benchmarks
-    # Using this version because CodSpeed doesn't support Ubuntu 24.04 LTS yet.
-    runs-on: ubuntu-22.04 
+
+    # Using this version because CodSpeed doesn't support Ubuntu 24.04 LTS yet
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,10 +24,12 @@ jobs:
       sessions: ${{ steps.set-matrix.outputs.sessions }}
     steps:
       - uses: actions/checkout@v4
-      - run: pip install poetry nox nox-poetry
+      - run: python3 -m venv .venv
       - id: set-matrix
         shell: bash
         run: |
+          . .venv/bin/activate 
+          pip install poetry nox nox-poetry
           echo sessions=$(
             nox --json -t tests -l |
             jq 'map(
@@ -82,7 +84,7 @@ jobs:
 
   benchmarks:
     name: 📈 Benchmarks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04 # Using this version because CodSpeed doesn't support Ubuntu 24.04 LTS yet.
 
     steps:
       - uses: actions/checkout@v4
@@ -99,7 +101,7 @@ jobs:
         if: steps.setup-python.outputs.cache-hit != 'true'
 
       - name: Run benchmarks
-        uses: CodSpeedHQ/action@v2
+        uses: CodSpeedHQ/action@v3
         with:
           token: ${{ secrets.CODSPEED_TOKEN }}
           run: poetry run pytest tests/benchmarks --codspeed

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,12 +24,14 @@ jobs:
       sessions: ${{ steps.set-matrix.outputs.sessions }}
     steps:
       - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
       - run: python3 -m venv .venv
       - id: set-matrix
         shell: bash
         run: |
           . .venv/bin/activate 
-          pip install poetry nox nox-poetry
+          uv install poetry nox nox-poetry
           echo sessions=$(
             nox --json -t tests -l |
             jq 'map(

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,7 +84,8 @@ jobs:
 
   benchmarks:
     name: 📈 Benchmarks
-    runs-on: ubuntu-22.04 # Using this version because CodSpeed doesn't support Ubuntu 24.04 LTS yet.
+    # Using this version because CodSpeed doesn't support Ubuntu 24.04 LTS yet.
+    runs-on: ubuntu-22.04 
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,12 +26,12 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install uv
         uses: astral-sh/setup-uv@v3
-      - run: python3 -m venv .venv
+      - run: uv venv
+      - run: uv pip install poetry nox nox-poetry
       - id: set-matrix
         shell: bash
         run: |
-          . .venv/bin/activate 
-          uv install poetry nox nox-poetry
+          . .venv/bin/activate
           echo sessions=$(
             nox --json -t tests -l |
             jq 'map(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Our CI started getting some new erros, I've checked that CodSpeed doesn't support Ubuntu 24.04 LTS (lastest LTS).
This PR fixes `Unit tests / 💻 Generate test matrix (pull_request)` and `Unit tests / 📈 Benchmarks (pull_request)` workflows by bring back ubuntu 22.04 on `Benchmarks` and using a Virtual Enviroment on `Generate Test Matrix` to follow [PEP 668 on new ubuntu version](https://peps.python.org/pep-0668/).

Is also important see that 22.04 LTS will be updated until [April 2027](https://ubuntu.com/about/release-cycle)

![image](https://github.com/user-attachments/assets/56728bf3-9b45-4083-a18c-072f7e92c8fd)

![image](https://github.com/user-attachments/assets/2e26c051-24cd-49ea-aafd-47084f7b79c3)


## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Update CI workflows to address compatibility issues with the latest Ubuntu LTS by reverting to Ubuntu 22.04 for benchmarks and using a virtual environment for test matrix generation.

CI:
- Fix the 'Generate Test Matrix' workflow by using a virtual environment to comply with PEP 668 on the new Ubuntu version.
- Revert the 'Benchmarks' workflow to use Ubuntu 22.04 LTS due to lack of support for Ubuntu 24.04 LTS by CodSpeed.