### PR TITLE
Add support for native enum docstring

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,24 @@
+Release type: patch
+
+Use native enum `__doc__` as the description for the schema enum type.
+
+```py
+# somewhere.py
+from enum import Enum
+
+
+class AnimalKind(Enum):
+    """The kind of animal."""
+
+    AXOLOTL, CAPYBARA = range(2)
+```
+
+This will generate the following schema:
+
+```graphql
+"""The kind of animal."""
+enum AnimalKind {
+  AXOLOTL
+  CAPYBARA
+}
+```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,9 @@ Release type: patch
 
 Use native enum `__doc__` as the description for the schema enum type.
 
+This change improves consistency between Python enums and schema representations,
+and leverages existing documentation for better maintainability and clarity.
+
 ```py
 # somewhere.py
 from enum import Enum

--- a/strawberry/annotation.py
+++ b/strawberry/annotation.py
@@ -187,7 +187,9 @@ class StrawberryAnnotation:
         try:
             return evaled_type._enum_definition
         except AttributeError:
-            return strawberry_enum(evaled_type)._enum_definition
+            return strawberry_enum(
+                evaled_type, description=evaled_type.__doc__
+            )._enum_definition
 
     def create_list(self, evaled_type: Any) -> StrawberryList:
         item_type, *_ = get_args(evaled_type)

--- a/tests/enums/test_enum.py
+++ b/tests/enums/test_enum.py
@@ -200,3 +200,20 @@ def test_default_enum_with_enum_value() -> None:
     assert not res.errors
     assert res.data
     assert res.data["foo"] == "baz"
+
+
+def test_default_enum_with_docstring() -> None:
+    class Foo(Enum):
+        """This is a Foo enum."""
+
+        BAR = "bar"
+        BAZ = "baz"
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def foo(self, foo: Foo) -> str:
+            return foo.value
+
+    definition = get_object_definition(Query, strict=True)
+    assert definition.fields[0].arguments[0].type.description == Foo.__doc__


### PR DESCRIPTION
# Apologies

I wasn't thorough in my research before creating this PR. I wanted to simplify the codebase by removing many enum decorators and moving the description to docstrings where I would expect it. As I appreciate maintainers time, I would understand if this PR gets closed without any comment. If you find this PR useful please continue in the discussion https://github.com/strawberry-graphql/strawberry/issues/653.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Adds support for native enum `__doc__`.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* partially addresses https://github.com/strawberry-graphql/strawberry/issues/653 for Enums only

* https://github.com/strawberry-graphql/strawberry/pull/1645

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation. ❔ 
- [ ] I have updated the documentation accordingly. ❓ 
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage). 🤞

## Summary by Sourcery

Introduce support for using native enum docstrings as descriptions in schema enum types, enhance the enum creation process to incorporate these docstrings, and add corresponding tests and documentation.

New Features:
- Add support for using native enum `__doc__` as the description for schema enum types.

Enhancements:
- Enhance the `create_enum` function to utilize the native enum `__doc__` for descriptions.

Documentation:
- Add a `RELEASE.md` file documenting the use of native enum `__doc__` for schema descriptions.

Tests:
- Add a test to verify that the native enum `__doc__` is correctly used as the description in the schema.