### PR TITLE
Fix graphql ws did not ignore parsing errors

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+Release type: minor
+
+This release fixes a regression in the legacy GraphQL over WebSocket protocol.
+Legacy protocol implementations should ignore client message parsing errors.
+During a recent refactor, Strawberry changed this behavior to match the new protocol, where parsing errors must close the WebSocket connection.
+The expected behavior is restored and adequately tested in this release.

--- a/strawberry/aiohttp/views.py
+++ b/strawberry/aiohttp/views.py
@@ -91,7 +91,7 @@ class AioHTTPWebSocketAdapter(AsyncWebSocketAdapter):
         self.ws = ws
 
     async def iter_json(
-        self, ignore_parsing_errors: bool
+        self, *, ignore_parsing_errors: bool = False
     ) -> AsyncGenerator[Dict[str, object], None]:
         async for ws_message in self.ws:
             if ws_message.type == http.WSMsgType.TEXT:

--- a/strawberry/aiohttp/views.py
+++ b/strawberry/aiohttp/views.py
@@ -26,7 +26,11 @@ from strawberry.http.async_base_view import (
     AsyncHTTPRequestAdapter,
     AsyncWebSocketAdapter,
 )
-from strawberry.http.exceptions import HTTPException, NonJsonMessageReceived
+from strawberry.http.exceptions import (
+    HTTPException,
+    NonJsonMessageReceived,
+    NonTextMessageReceived,
+)
 from strawberry.http.types import FormData, HTTPMethod, QueryParams
 from strawberry.http.typevars import (
     Context,
@@ -86,16 +90,19 @@ class AioHTTPWebSocketAdapter(AsyncWebSocketAdapter):
         self.request = request
         self.ws = ws
 
-    async def iter_json(self) -> AsyncGenerator[Dict[str, object], None]:
+    async def iter_json(
+        self, ignore_parsing_errors: bool
+    ) -> AsyncGenerator[Dict[str, object], None]:
         async for ws_message in self.ws:
             if ws_message.type == http.WSMsgType.TEXT:
                 try:
                     yield ws_message.json()
                 except JSONDecodeError:
-                    raise NonJsonMessageReceived()
+                    if not ignore_parsing_errors:
+                        raise NonJsonMessageReceived()
 
             elif ws_message.type == http.WSMsgType.BINARY:
-                raise NonJsonMessageReceived()
+                raise NonTextMessageReceived()
 
     async def send_json(self, message: Mapping[str, object]) -> None:
         await self.ws.send_json(message)

--- a/strawberry/asgi/__init__.py
+++ b/strawberry/asgi/__init__.py
@@ -90,7 +90,7 @@ class ASGIWebSocketAdapter(AsyncWebSocketAdapter):
         self.ws = response
 
     async def iter_json(
-        self, ignore_parsing_errors: bool
+        self, *, ignore_parsing_errors: bool = False
     ) -> AsyncGenerator[Dict[str, object], None]:
         try:
             while self.ws.application_state != WebSocketState.DISCONNECTED:

--- a/strawberry/channels/handlers/ws_handler.py
+++ b/strawberry/channels/handlers/ws_handler.py
@@ -32,7 +32,7 @@ class ChannelsWebSocketAdapter(AsyncWebSocketAdapter):
         self.ws_consumer = response
 
     async def iter_json(
-        self, ignore_parsing_errors: bool
+        self, *, ignore_parsing_errors: bool = False
     ) -> AsyncGenerator[Dict[str, object], None]:
         while True:
             message = await self.ws_consumer.message_queue.get()

--- a/strawberry/channels/handlers/ws_handler.py
+++ b/strawberry/channels/handlers/ws_handler.py
@@ -16,7 +16,7 @@ from typing import (
 from typing_extensions import TypeGuard
 
 from strawberry.http.async_base_view import AsyncBaseHTTPView, AsyncWebSocketAdapter
-from strawberry.http.exceptions import NonJsonMessageReceived
+from strawberry.http.exceptions import NonJsonMessageReceived, NonTextMessageReceived
 from strawberry.http.typevars import Context, RootValue
 from strawberry.subscriptions import GRAPHQL_TRANSPORT_WS_PROTOCOL, GRAPHQL_WS_PROTOCOL
 
@@ -31,7 +31,9 @@ class ChannelsWebSocketAdapter(AsyncWebSocketAdapter):
     def __init__(self, request: GraphQLWSConsumer, response: GraphQLWSConsumer) -> None:
         self.ws_consumer = response
 
-    async def iter_json(self) -> AsyncGenerator[Dict[str, object], None]:
+    async def iter_json(
+        self, ignore_parsing_errors: bool
+    ) -> AsyncGenerator[Dict[str, object], None]:
         while True:
             message = await self.ws_consumer.message_queue.get()
 
@@ -39,12 +41,13 @@ class ChannelsWebSocketAdapter(AsyncWebSocketAdapter):
                 break
 
             if message["message"] is None:
-                raise NonJsonMessageReceived()
+                raise NonTextMessageReceived()
 
             try:
                 yield json.loads(message["message"])
             except json.JSONDecodeError:
-                raise NonJsonMessageReceived()
+                if not ignore_parsing_errors:
+                    raise NonJsonMessageReceived()
 
     async def send_json(self, message: Mapping[str, object]) -> None:
         serialized_message = json.dumps(message)

--- a/strawberry/http/async_base_view.py
+++ b/strawberry/http/async_base_view.py
@@ -82,7 +82,7 @@ class AsyncHTTPRequestAdapter(abc.ABC):
 class AsyncWebSocketAdapter(abc.ABC):
     @abc.abstractmethod
     def iter_json(
-        self, ignore_parsing_errors: bool
+        self, *, ignore_parsing_errors: bool = False
     ) -> AsyncGenerator[Dict[str, object], None]: ...
 
     @abc.abstractmethod

--- a/strawberry/http/async_base_view.py
+++ b/strawberry/http/async_base_view.py
@@ -81,7 +81,9 @@ class AsyncHTTPRequestAdapter(abc.ABC):
 
 class AsyncWebSocketAdapter(abc.ABC):
     @abc.abstractmethod
-    def iter_json(self) -> AsyncGenerator[Dict[str, object], None]: ...
+    def iter_json(
+        self, ignore_parsing_errors: bool
+    ) -> AsyncGenerator[Dict[str, object], None]: ...
 
     @abc.abstractmethod
     async def send_json(self, message: Mapping[str, object]) -> None: ...

--- a/strawberry/http/exceptions.py
+++ b/strawberry/http/exceptions.py
@@ -4,6 +4,10 @@ class HTTPException(Exception):
         self.reason = reason
 
 
+class NonTextMessageReceived(Exception):
+    pass
+
+
 class NonJsonMessageReceived(Exception):
     pass
 

--- a/strawberry/litestar/controller.py
+++ b/strawberry/litestar/controller.py
@@ -197,7 +197,7 @@ class LitestarWebSocketAdapter(AsyncWebSocketAdapter):
         self.ws = response
 
     async def iter_json(
-        self, ignore_parsing_errors: bool
+        self, *, ignore_parsing_errors: bool = False
     ) -> AsyncGenerator[Dict[str, object], None]:
         try:
             while self.ws.connection_state != "disconnect":

--- a/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
@@ -76,7 +76,7 @@ class BaseGraphQLTransportWSHandler:
         self.on_request_accepted()
 
         try:
-            async for message in self.websocket.iter_json(ignore_parsing_errors=False):
+            async for message in self.websocket.iter_json():
                 await self.handle_message(message)
         except NonTextMessageReceived:
             await self.handle_invalid_message("WebSocket message type must be text")

--- a/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
@@ -15,7 +15,7 @@ from typing import (
 
 from graphql import GraphQLError, GraphQLSyntaxError, parse
 
-from strawberry.http.exceptions import NonJsonMessageReceived
+from strawberry.http.exceptions import NonJsonMessageReceived, NonTextMessageReceived
 from strawberry.subscriptions.protocols.graphql_transport_ws.types import (
     CompleteMessage,
     ConnectionAckMessage,
@@ -76,10 +76,12 @@ class BaseGraphQLTransportWSHandler:
         self.on_request_accepted()
 
         try:
-            async for message in self.websocket.iter_json():
+            async for message in self.websocket.iter_json(ignore_parsing_errors=False):
                 await self.handle_message(message)
-        except NonJsonMessageReceived:
+        except NonTextMessageReceived:
             await self.handle_invalid_message("WebSocket message type must be text")
+        except NonJsonMessageReceived:
+            await self.handle_invalid_message("WebSocket message must be valid JSON")
         finally:
             await self.shutdown()
 

--- a/strawberry/subscriptions/protocols/graphql_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_ws/handlers.py
@@ -11,7 +11,7 @@ from typing import (
     cast,
 )
 
-from strawberry.http.exceptions import NonJsonMessageReceived
+from strawberry.http.exceptions import NonTextMessageReceived
 from strawberry.subscriptions.protocols.graphql_ws import (
     GQL_COMPLETE,
     GQL_CONNECTION_ACK,
@@ -65,9 +65,9 @@ class BaseGraphQLWSHandler:
 
     async def handle(self) -> None:
         try:
-            async for message in self.websocket.iter_json():
+            async for message in self.websocket.iter_json(ignore_parsing_errors=True):
                 await self.handle_message(cast(OperationMessage, message))
-        except NonJsonMessageReceived:
+        except NonTextMessageReceived:
             await self.websocket.close(
                 code=1002, reason="WebSocket message type must be text"
             )

--- a/tests/websockets/test_graphql_transport_ws.py
+++ b/tests/websockets/test_graphql_transport_ws.py
@@ -112,7 +112,7 @@ async def test_parsing_an_invalid_payload(ws_raw: WebSocketClient):
     assert ws.close_reason == "Failed to parse message"
 
 
-async def test_ws_messages_must_be_text(ws_raw: WebSocketClient):
+async def test_non_text_ws_messages_result_in_socket_closure(ws_raw: WebSocketClient):
     ws = ws_raw
 
     await ws.send_bytes(json.dumps(ConnectionInitMessage().as_dict()).encode())
@@ -123,7 +123,7 @@ async def test_ws_messages_must_be_text(ws_raw: WebSocketClient):
     assert ws.close_reason == "WebSocket message type must be text"
 
 
-async def test_ws_messages_must_be_json(ws_raw: WebSocketClient):
+async def test_non_json_ws_messages_result_in_socket_closure(ws_raw: WebSocketClient):
     ws = ws_raw
 
     await ws.send_text("not valid json")
@@ -131,7 +131,7 @@ async def test_ws_messages_must_be_json(ws_raw: WebSocketClient):
     await ws.receive(timeout=2)
     assert ws.closed
     assert ws.close_code == 4400
-    assert ws.close_reason == "WebSocket message type must be text"
+    assert ws.close_reason == "WebSocket message must be valid JSON"
 
 
 async def test_ws_message_frame_types_cannot_be_mixed(ws_raw: WebSocketClient):

--- a/tests/websockets/test_graphql_ws.py
+++ b/tests/websockets/test_graphql_ws.py
@@ -295,12 +295,36 @@ async def test_non_text_ws_messages_result_in_socket_closure(ws_raw: WebSocketCl
 async def test_non_json_ws_messages_are_ignored(ws_raw: WebSocketClient):
     ws = ws_raw
 
-    await ws.send_text("not valid json")
+    await ws.send_text("NOT VALID JSON")
     await ws.send_json({"type": GQL_CONNECTION_INIT})
 
     response = await ws.receive_json()
     assert response["type"] == GQL_CONNECTION_ACK
 
+    await ws.send_text("NOT VALID JSON")
+    await ws.send_json(
+        {
+            "type": GQL_START,
+            "id": "demo",
+            "payload": {
+                "query": 'subscription { echo(message: "Hi") }',
+            },
+        }
+    )
+
+    response = await ws.receive_json()
+    assert response["type"] == GQL_DATA
+    assert response["id"] == "demo"
+    assert response["payload"]["data"] == {"echo": "Hi"}
+
+    await ws.send_text("NOT VALID JSON")
+    await ws.send_json({"type": GQL_STOP, "id": "demo"})
+
+    response = await ws.receive_json()
+    assert response["type"] == GQL_COMPLETE
+    assert response["id"] == "demo"
+
+    await ws.send_text("NOT VALID JSON")
     await ws.send_json({"type": GQL_CONNECTION_TERMINATE})
     await ws.receive(timeout=2)  # receive close
     assert ws.closed

--- a/tests/websockets/test_graphql_ws.py
+++ b/tests/websockets/test_graphql_ws.py
@@ -281,7 +281,7 @@ async def test_subscription_syntax_error(ws: WebSocketClient):
     }
 
 
-async def test_ws_messages_must_be_text(ws_raw: WebSocketClient):
+async def test_non_text_ws_messages_result_in_socket_closure(ws_raw: WebSocketClient):
     ws = ws_raw
 
     await ws.send_bytes(json.dumps({"type": GQL_CONNECTION_INIT}).encode())
@@ -292,15 +292,18 @@ async def test_ws_messages_must_be_text(ws_raw: WebSocketClient):
     assert ws.close_reason == "WebSocket message type must be text"
 
 
-async def test_ws_messages_must_be_json(ws_raw: WebSocketClient):
+async def test_non_json_ws_messages_are_ignored(ws_raw: WebSocketClient):
     ws = ws_raw
 
     await ws.send_text("not valid json")
+    await ws.send_json({"type": GQL_CONNECTION_INIT})
 
-    await ws.receive(timeout=2)
+    response = await ws.receive_json()
+    assert response["type"] == GQL_CONNECTION_ACK
+
+    await ws.send_json({"type": GQL_CONNECTION_TERMINATE})
+    await ws.receive(timeout=2)  # receive close
     assert ws.closed
-    assert ws.close_code == 1002
-    assert ws.close_reason == "WebSocket message type must be text"
 
 
 async def test_ws_message_frame_types_cannot_be_mixed(ws_raw: WebSocketClient):


### PR DESCRIPTION
## Description

The legacy WS protocol dictates that servers should ignore text messages sent by clients that are not valid JSON. Here's the [relevant section](https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md#gql_connection_error) from the legacy protocol specification:

> GQL_CONNECTION_ERROR
> 
> [...]
> 
> It server also respond with this message in case of a parsing errors of the message (which does not disconnect the client, just ignore the message).

I accidentally changed this behavior in a recent refactor to match the newer protocol, which requires servers to close the WebSocket in this case.

This PR restores the intended behavior and updates the relevant tests.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Summary by Sourcery

Fix the handling of non-JSON messages in the legacy GraphQL WebSocket protocol to ignore parsing errors instead of closing the connection, and update tests to reflect this behavior.

Bug Fixes:
- Restore the behavior of ignoring non-JSON messages in the legacy GraphQL WebSocket protocol, aligning with the legacy protocol specification.

Documentation:
- Add a RELEASE.md file documenting the fix for the regression in the legacy GraphQL WebSocket protocol.

Tests:
- Update tests to ensure non-JSON WebSocket messages are ignored rather than causing a connection closure in the legacy protocol.