### PR TITLE
Fix create multiple directives

### DIFF
--- a/strawberry/permission.py
+++ b/strawberry/permission.py
@@ -158,9 +158,12 @@ class PermissionExtension(FieldExtension):
     def apply(self, field: StrawberryField) -> None:
         """Applies all of the permission directives to the schema and sets up silent permissions."""
         if self.use_directives:
-            field.directives.extend(
-                p.schema_directive for p in self.permissions if p.schema_directive
-            )
+            # Dedupe multiple directives
+            # https://github.com/strawberry-graphql/strawberry/issues/3596
+            permission_directives = {p.schema_directive for p in self.permissions if p.schema_directive}
+            existing_field_directives = set(field.directives)
+            extend_directives = permission_directives - existing_field_directives
+            field.directives.extend(extend_directives)
         # We can only fail silently if the field is optional or a list
         if self.fail_silently:
             if isinstance(field.type, StrawberryOptional):


### PR DESCRIPTION
## Description

Directives are added multiple times leading to VSC errors like `The directive "@featuresRequired" can only be used once at this location.`

![image](https://github.com/user-attachments/assets/3182a298-0a3f-4985-99e9-4d2b5b296e92)


Another option to fix this would be to make field.directives a `set` but this is used on multiple places and I don't think it's worth the rework. If the fix is ok for you I'll add a test with e.g. [this sandbox setup](https://play.strawberry.rocks/?gist=b865d07a2ac9aa6211d4f6bd0d3ec291)


## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Check if the directive is already set on the field as directive

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).