### PR TITLE
Introducing Strawberry GraphQL Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![CircleCI](https://img.shields.io/circleci/token/307b40d5e152e074d34f84d30d226376a15667d5/project/github/strawberry-graphql/strawberry/main.svg?style=for-the-badge)](https://circleci.com/gh/strawberry-graphql/strawberry/tree/main)
 [![Discord](https://img.shields.io/discord/689806334337482765?label=discord&logo=discord&logoColor=white&style=for-the-badge&color=blue)](https://discord.gg/ZkRTEJQ)
 [![PyPI](https://img.shields.io/pypi/v/strawberry-graphql?logo=pypi&logoColor=white&style=for-the-badge)](https://pypi.org/project/strawberry-graphql/)
+[![](https://img.shields.io/badge/Gurubase-Ask%20Strawberry%20GraphQL%20Guru-006BFF?style=for-the-badge)](https://gurubase.io/g/strawberry-graphql)
 
 ## Installation ( Quick Start )
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CircleCI](https://img.shields.io/circleci/token/307b40d5e152e074d34f84d30d226376a15667d5/project/github/strawberry-graphql/strawberry/main.svg?style=for-the-badge)](https://circleci.com/gh/strawberry-graphql/strawberry/tree/main)
 [![Discord](https://img.shields.io/discord/689806334337482765?label=discord&logo=discord&logoColor=white&style=for-the-badge&color=blue)](https://discord.gg/ZkRTEJQ)
 [![PyPI](https://img.shields.io/pypi/v/strawberry-graphql?logo=pypi&logoColor=white&style=for-the-badge)](https://pypi.org/project/strawberry-graphql/)
-[![](https://img.shields.io/badge/Gurubase-Ask%20Strawberry%20GraphQL%20Guru-006BFF?style=for-the-badge)](https://gurubase.io/g/strawberry-graphql)
+[![Gurubase: Ask Strawberry GraphQL Guru](https://img.shields.io/badge/Gurubase-Ask%20Strawberry%20GraphQL%20Guru-006BFF?style=for-the-badge)](https://gurubase.io/g/strawberry-graphql)
 
 ## Installation ( Quick Start )
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Strawberry GraphQL Guru](https://gurubase.io/g/strawberry-graphql) to Gurubase. Strawberry GraphQL Guru uses the data from this repo and data from the [docs](https://strawberry.rocks/docs) to answer questions by leveraging the LLM.

In this PR, I showcased the "Strawberry GraphQL Guru", which highlights that Strawberry GraphQL now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Strawberry GraphQL Guru in Gurubase, just let me know that's totally fine.

## Summary by Sourcery

Documentation:
- Add a badge to the README linking to the Strawberry GraphQL Guru on Gurubase.io.