### PR TITLE
Move argument metadata docs

### DIFF
--- a/docs/general/queries.md
+++ b/docs/general/queries.md
@@ -77,24 +77,3 @@ class Query:
                 return fruit
         return None
 ```
-
-Additional metadata can be added to arguments, for example a custom name and
-description using `strawberry.argument` with
-[typing.Annotated](https://docs.python.org/3/library/typing.html#typing.Annotated):
-
-```python
-@strawberry.type
-class Query:
-    @strawberry.field
-    def fruits(
-        self,
-        is_tasty: Annotated[
-            bool | None,
-            strawberry.argument(
-                description="Filters out fruits by whenever they're tasty or not",
-                deprecation_reason="isTasty argument is deprecated, "
-                "use fruits(taste:SWEET) instead",
-            ),
-        ] = None,
-    ) -> list[str]: ...
-```

--- a/docs/types/resolvers.md
+++ b/docs/types/resolvers.md
@@ -203,6 +203,33 @@ Like this you will get the following responses:
 
 </CodeGrid>
 
+### Annotated Arguments
+
+Additional metadata can be added to arguments, for example a custom name or
+deprecation reason, using `strawberry.argument` with
+[typing.Annotated](https://docs.python.org/3/library/typing.html#typing.Annotated):
+
+```python
+from typing import Optional, Annotated
+import strawberry
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def greet(
+        self,
+        name: Optional[str] = strawberry.UNSET,
+        is_morning: Annotated[
+            Optional[bool],
+            strawberry.argument(
+                name="morning",
+                deprecation_reason="The field now automatically detects if it's morning or not",
+            ),
+        ] = None,
+    ) -> str: ...
+```
+
 ## Accessing execution information
 
 Sometimes it is useful to access the information for the current execution


### PR DESCRIPTION
## Description

This PR moves the resolver arguments metadata documentation from the general queries docs to the arguments section in the resolvers docs.

I noticed the docs were in a strange location while addressing this issue: #3587

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

* Closes #3587

## Summary by Sourcery

Documentation:
- Relocate the resolver arguments metadata documentation from the general queries section to the arguments section in the resolvers documentation.