### PR TITLE
Handle websocket disconnects more gracefully

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Starting with this release, both websocket-based protocols will handle unexpected socket disconnections more gracefully.

--- a/strawberry/aiohttp/views.py
+++ b/strawberry/aiohttp/views.py
@@ -30,6 +30,7 @@ from strawberry.http.exceptions import (
     HTTPException,
     NonJsonMessageReceived,
     NonTextMessageReceived,
+    WebSocketDisconnected,
 )
 from strawberry.http.types import FormData, HTTPMethod, QueryParams
 from strawberry.http.typevars import (
@@ -105,7 +106,10 @@ class AioHTTPWebSocketAdapter(AsyncWebSocketAdapter):
                 raise NonTextMessageReceived()
 
     async def send_json(self, message: Mapping[str, object]) -> None:
-        await self.ws.send_json(message)
+        try:
+            await self.ws.send_json(message)
+        except RuntimeError as exc:
+            raise WebSocketDisconnected from exc
 
     async def close(self, code: int, reason: str) -> None:
         await self.ws.close(code=code, message=reason.encode())

--- a/strawberry/asgi/__init__.py
+++ b/strawberry/asgi/__init__.py
@@ -37,6 +37,7 @@ from strawberry.http.exceptions import (
     HTTPException,
     NonJsonMessageReceived,
     NonTextMessageReceived,
+    WebSocketDisconnected,
 )
 from strawberry.http.types import FormData, HTTPMethod, QueryParams
 from strawberry.http.typevars import (
@@ -105,7 +106,10 @@ class ASGIWebSocketAdapter(AsyncWebSocketAdapter):
             pass
 
     async def send_json(self, message: Mapping[str, object]) -> None:
-        await self.ws.send_json(message)
+        try:
+            await self.ws.send_json(message)
+        except WebSocketDisconnect as exc:
+            raise WebSocketDisconnected from exc
 
     async def close(self, code: int, reason: str) -> None:
         await self.ws.close(code=code, reason=reason)

--- a/strawberry/http/exceptions.py
+++ b/strawberry/http/exceptions.py
@@ -12,4 +12,8 @@ class NonJsonMessageReceived(Exception):
     pass
 
 
+class WebSocketDisconnected(Exception):
+    pass
+
+
 __all__ = ["HTTPException"]

--- a/strawberry/litestar/controller.py
+++ b/strawberry/litestar/controller.py
@@ -53,6 +53,7 @@ from strawberry.http.exceptions import (
     HTTPException,
     NonJsonMessageReceived,
     NonTextMessageReceived,
+    WebSocketDisconnected,
 )
 from strawberry.http.types import FormData, HTTPMethod, QueryParams
 from strawberry.http.typevars import Context, RootValue
@@ -216,7 +217,10 @@ class LitestarWebSocketAdapter(AsyncWebSocketAdapter):
             pass
 
     async def send_json(self, message: Mapping[str, object]) -> None:
-        await self.ws.send_json(message)
+        try:
+            await self.ws.send_json(message)
+        except WebSocketDisconnect as exc:
+            raise WebSocketDisconnected from exc
 
     async def close(self, code: int, reason: str) -> None:
         await self.ws.close(code=code, reason=reason)


### PR DESCRIPTION
## Description

We now explicitly handle unexpected websocket disconnects so that they no longer show up in Sentry. Unexpected exceptions were already handled before this PR but would still bubble up to show up in error monitoring tools.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #3678

## Summary by Sourcery

Handle unexpected websocket disconnects gracefully by preventing them from being logged as errors and improving message handling efficiency. Add tests to verify the new behavior and update documentation with a release note.

Bug Fixes:
- Fix unexpected websocket disconnects to prevent them from appearing in error monitoring tools like Sentry.

Enhancements:
- Improve websocket message handling by removing redundant handler assignments and directly calling message handling functions.

Documentation:
- Add a release note indicating that websocket-based protocols now handle unexpected socket disconnections more gracefully.

Tests:
- Add tests to ensure that unexpected client disconnects are handled gracefully without triggering error processing.