### PR TITLE
Fix result source was never awaited if clients disconnect fast

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+This release fixes the issue that some coroutines in the WebSocket protocol handlers were never awaited if clients disconnected shortly after starting an operation.


### PR DESCRIPTION
## Description

While working on #3685, pytest showed me a warning stating `RuntimeWarning: coroutine 'Schema.subscribe' was never awaited` while testing WebSockets. The source of the issue lies in the following sequence:

1. create an awaitable (`result_source`)
2. yield from the event loop
3. await `result_source` in a task 

If the WebSocket client disconnects after we yield from the event loop and before we await `result_source`, the task will be cancelled and the awaitable will never be awaited. This PR fixes this issue by not yielding anymore between creating and awaiting the awaitable.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Summary by Sourcery

Fix coroutine awaiting issue in WebSocket protocol handlers by ensuring awaitables are awaited even if clients disconnect quickly.

Bug Fixes:
- Fix issue where coroutines in WebSocket protocol handlers were not awaited if clients disconnected shortly after starting an operation.

Documentation:
- Add a release note indicating a patch release to fix coroutine awaiting issue in WebSocket protocol handlers.