### PR TITLE
Make the CI lint job pass again

### DIFF
--- a/strawberry/channels/testing.py
+++ b/strawberry/channels/testing.py
@@ -111,15 +111,17 @@ class GraphQLWebsocketCommunicator(WebsocketCommunicator):
             await self.send_json_to(
                 ConnectionInitMessage(payload=self.connection_params).as_dict()
             )
-            response = await self.receive_json_from()
-            assert response == ConnectionAckMessage().as_dict()
+            graphql_transport_ws_response = await self.receive_json_from()
+            assert graphql_transport_ws_response == ConnectionAckMessage().as_dict()
         else:
             assert res == (True, GRAPHQL_WS_PROTOCOL)
             await self.send_json_to(
                 GraphQLWSConnectionInitMessage({"type": "connection_init"})
             )
-            response: GraphQLWSConnectionAckMessage = await self.receive_json_from()
-            assert response["type"] == "connection_ack"
+            graphql_ws_response: GraphQLWSConnectionAckMessage = (
+                await self.receive_json_from()
+            )
+            assert graphql_ws_response["type"] == "connection_ack"
 
     # Actual `ExecutionResult`` objects are not available client-side, since they
     # get transformed into `FormattedExecutionResult` on the wire, but we attempt

--- a/strawberry/experimental/pydantic/object_type.py
+++ b/strawberry/experimental/pydantic/object_type.py
@@ -105,7 +105,7 @@ def _build_dataclass_creation_fields(
 
     return DataclassCreationFields(
         name=field.name,
-        field_type=field_type,
+        field_type=field_type,  # type: ignore
         field=strawberry_field,
     )
 
@@ -198,7 +198,7 @@ def type(
         all_model_fields = [
             DataclassCreationFields(
                 name=field.name,
-                field_type=field.type,
+                field_type=field.type,  # type: ignore
                 field=field,
             )
             for field in extra_fields + private_fields

--- a/strawberry/subscriptions/protocols/graphql_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_ws/handlers.py
@@ -169,16 +169,17 @@ class BaseGraphQLWSHandler:
                 await self.websocket.send_json(error_message)
             else:
                 self.subscriptions[operation_id] = agen_or_err
+
                 async for result in agen_or_err:
                     await self.send_data(result, operation_id)
-                complete_message: CompleteMessage = {
-                    "type": "complete",
-                    "id": operation_id,
-                }
-                await self.websocket.send_json(complete_message)
+
+                await self.websocket.send_json(
+                    CompleteMessage({"type": "complete", "id": operation_id})
+                )
         except asyncio.CancelledError:
-            complete_message: CompleteMessage = {"type": "complete", "id": operation_id}
-            await self.websocket.send_json(complete_message)
+            await self.websocket.send_json(
+                CompleteMessage({"type": "complete", "id": operation_id})
+            )
 
     async def cleanup_operation(self, operation_id: str) -> None:
         if operation_id in self.subscriptions:


### PR DESCRIPTION
## Description

This PR makes the linter job pass again. A few weeks ago it started complaining about parts of the pydantic integration and codegen modules. I ignored it for too long and therefore didn't notice that my last PR introduced two minor issues. Time to fix it.

The first commit fixes variable redefinitions introduced in my last PR.
The other two commits aren't my proudest work but the best we can do short term to get CI pass again.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Summary by Sourcery

Fix variable redefinitions and update type annotations to resolve mypy complaints and ensure the CI linter job passes.

Bug Fixes:
- Fix variable redefinitions in the codebase to resolve issues introduced in the previous PR.

Enhancements:
- Update type annotations and assertions to improve compatibility with mypy and ensure the linter job passes.