### PR TITLE
Fix "Failing to pass a value to the type_params parameter of typing._eval_type"

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,11 @@
+Release type: patch
+
+This release fixes the following deprecation warning:
+
+```
+Failing to pass a value to the 'type_params' parameter of 'typing._eval_type' is deprecated,
+as it leads to incorrect behaviour when calling typing._eval_type on a stringified annotation
+that references a PEP 695 type parameter. It will be disallowed in Python 3.15.
+```
+
+This was only trigger in Python 3.13 and above.

--- a/strawberry/utils/typing.py
+++ b/strawberry/utils/typing.py
@@ -350,7 +350,7 @@ def eval_type(
         assert ast_unparse
         type_ = ForwardRef(ast_unparse(ast_obj))
 
-        extra = {}
+        extra: Dict[str, Any] = {}
 
         if sys.version_info >= (3, 13):
             extra = {"type_params": None}

--- a/strawberry/utils/typing.py
+++ b/strawberry/utils/typing.py
@@ -350,7 +350,12 @@ def eval_type(
         assert ast_unparse
         type_ = ForwardRef(ast_unparse(ast_obj))
 
-        return _eval_type(type_, globalns, localns)
+        extra = {}
+
+        if sys.version_info >= (3, 13):
+            extra = {"type_params": None}
+
+        return _eval_type(type_, globalns, localns, **extra)
 
     origin = get_origin(type_)
     if origin is not None:


### PR DESCRIPTION
Closes #3690

## Summary by Sourcery

Bug Fixes:
- Fix the issue where the 'type_params' parameter was not being passed to the '_eval_type' function in 'strawberry/utils/typing.py'.