### PR TITLE
Document `graphql_type` on `@strawberry.field`

### DIFF
--- a/docs/general/queries.md
+++ b/docs/general/queries.md
@@ -55,6 +55,30 @@ class Query:
         return "Strawberry"
 ```
 
+The decorator syntax supports specifying a `graphql_type` for cases when the
+return type of the function does not match the GraphQL type:
+
+```python
+class User:
+    id: str
+    name: str
+
+    def __init__(self, id: str, name: str):
+        self.id = id
+        self.name = name
+
+@strawberry.type(name="User")
+class UserType:
+    id: strawberry.ID
+    name: str
+
+@strawberry.type
+class Query:
+    @strawberry.field(graphql_type=UserType)
+    def user(self) -> User
+        return User(id="ringo", name="Ringo")
+```
+
 ## Arguments
 
 GraphQL fields can accept arguments, usually to filter out or retrieve specific


### PR DESCRIPTION
## Description

This documents a use case where the GraphQL type is not the same as data being used. This is useful if you are using an ORM for your data and building an API layer against it.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Documentation:
- Document the use of `graphql_type` in the `@strawberry.field` decorator to handle cases where the GraphQL type differs from the data type, particularly useful for ORM-based data models.