### PR TITLE
Migrate graphql-transport-ws types to TypedDicts

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+Release type: minor
+
+In this release, we migrated the `graphql-transport-ws` types from data classes to typed dicts.
+Using typed dicts enabled us to precisely model `null` versus `undefined` values, which are common in that protocol.
+As a result, we could remove custom conversion methods handling these cases and simplify the codebase.

--- a/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
@@ -148,7 +148,7 @@ class BaseGraphQLTransportWSHandler:
                 await self.handle_complete(message)
 
             else:
-                error_message = f"Unknown message type: {message["type"]}"
+                error_message = f"Unknown message type: {message['type']}"
                 await self.handle_invalid_message(error_message)
 
         except KeyError:
@@ -211,7 +211,7 @@ class BaseGraphQLTransportWSHandler:
             return
 
         if message["id"] in self.operations:
-            reason = f"Subscriber for {message["id"]} already exists"
+            reason = f"Subscriber for {message['id']} already exists"
             await self.websocket.close(code=4409, reason=reason)
             return
 

--- a/strawberry/subscriptions/protocols/graphql_transport_ws/types.py
+++ b/strawberry/subscriptions/protocols/graphql_transport_ws/types.py
@@ -1,108 +1,91 @@
-from __future__ import annotations
+from typing import Dict, List, TypedDict, Union
+from typing_extensions import Literal, NotRequired
 
-from dataclasses import asdict, dataclass
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, TypedDict
-
-from strawberry.types.unset import UNSET
-
-if TYPE_CHECKING:
-    from graphql import GraphQLFormattedError
+from graphql import GraphQLFormattedError
 
 
-@dataclass
-class GraphQLTransportMessage:
-    def as_dict(self) -> dict:
-        data = asdict(self)
-        if getattr(self, "payload", None) is UNSET:
-            # Unset fields must have a JSON value of "undefined" not "null"
-            data.pop("payload")
-        return data
-
-
-@dataclass
-class ConnectionInitMessage(GraphQLTransportMessage):
+class ConnectionInitMessage(TypedDict):
     """Direction: Client -> Server."""
 
-    payload: Optional[Dict[str, Any]] = UNSET
-    type: str = "connection_init"
+    type: Literal["connection_init"]
+    payload: NotRequired[Union[Dict[str, object], None]]
 
 
-@dataclass
-class ConnectionAckMessage(GraphQLTransportMessage):
+class ConnectionAckMessage(TypedDict):
     """Direction: Server -> Client."""
 
-    payload: Optional[Dict[str, Any]] = UNSET
-    type: str = "connection_ack"
+    type: Literal["connection_ack"]
+    payload: NotRequired[Union[Dict[str, object], None]]
 
 
-@dataclass
-class PingMessage(GraphQLTransportMessage):
+class PingMessage(TypedDict):
     """Direction: bidirectional."""
 
-    payload: Optional[Dict[str, Any]] = UNSET
-    type: str = "ping"
+    type: Literal["ping"]
+    payload: NotRequired[Union[Dict[str, object], None]]
 
 
-@dataclass
-class PongMessage(GraphQLTransportMessage):
+class PongMessage(TypedDict):
     """Direction: bidirectional."""
 
-    payload: Optional[Dict[str, Any]] = UNSET
-    type: str = "pong"
+    type: Literal["pong"]
+    payload: NotRequired[Union[Dict[str, object], None]]
 
 
-@dataclass
-class SubscribeMessagePayload:
+class SubscribeMessagePayload(TypedDict):
+    operationName: NotRequired[Union[str, None]]
     query: str
-    operationName: Optional[str] = None
-    variables: Optional[Dict[str, Any]] = None
-    extensions: Optional[Dict[str, Any]] = None
+    variables: NotRequired[Union[Dict[str, object], None]]
+    extensions: NotRequired[Union[Dict[str, object], None]]
 
 
-@dataclass
-class SubscribeMessage(GraphQLTransportMessage):
+class SubscribeMessage(TypedDict):
     """Direction: Client -> Server."""
 
     id: str
+    type: Literal["subscribe"]
     payload: SubscribeMessagePayload
-    type: str = "subscribe"
 
 
-class NextPayload(TypedDict, total=False):
-    data: Any
-
-    # Optional list of formatted graphql.GraphQLError objects
-    errors: Optional[List[GraphQLFormattedError]]
-    extensions: Optional[Dict[str, Any]]
+class NextMessagePayload(TypedDict):
+    errors: NotRequired[List[GraphQLFormattedError]]
+    data: NotRequired[Union[Dict[str, object], None]]
+    extensions: NotRequired[Dict[str, object]]
 
 
-@dataclass
-class NextMessage(GraphQLTransportMessage):
+class NextMessage(TypedDict):
     """Direction: Server -> Client."""
 
     id: str
-    payload: NextPayload
-    type: str = "next"
-
-    def as_dict(self) -> dict:
-        return {"id": self.id, "payload": self.payload, "type": self.type}
+    type: Literal["next"]
+    payload: NextMessagePayload
 
 
-@dataclass
-class ErrorMessage(GraphQLTransportMessage):
+class ErrorMessage(TypedDict):
     """Direction: Server -> Client."""
 
     id: str
+    type: Literal["error"]
     payload: List[GraphQLFormattedError]
-    type: str = "error"
 
 
-@dataclass
-class CompleteMessage(GraphQLTransportMessage):
+class CompleteMessage(TypedDict):
     """Direction: bidirectional."""
 
     id: str
-    type: str = "complete"
+    type: Literal["complete"]
+
+
+Message = Union[
+    ConnectionInitMessage,
+    ConnectionAckMessage,
+    PingMessage,
+    PongMessage,
+    SubscribeMessage,
+    NextMessage,
+    ErrorMessage,
+    CompleteMessage,
+]
 
 
 __all__ = [
@@ -114,4 +97,5 @@ __all__ = [
     "NextMessage",
     "ErrorMessage",
     "CompleteMessage",
+    "Message",
 ]

--- a/tests/channels/test_layers.py
+++ b/tests/channels/test_layers.py
@@ -12,7 +12,6 @@ from strawberry.subscriptions.protocols.graphql_transport_ws.types import (
     ConnectionInitMessage,
     NextMessage,
     SubscribeMessage,
-    SubscribeMessagePayload,
 )
 from tests.views.schema import schema
 
@@ -62,25 +61,30 @@ async def test_no_layers():
 async def test_channel_listen(ws: WebsocketCommunicator):
     from channels.layers import get_channel_layer
 
-    await ws.send_json_to(ConnectionInitMessage().as_dict())
+    await ws.send_json_to(ConnectionInitMessage({"type": "connection_init"}))
 
-    response = await ws.receive_json_from()
-    assert response == ConnectionAckMessage().as_dict()
+    connection_ack_message: ConnectionAckMessage = await ws.receive_json_from()
+    assert connection_ack_message == {"type": "connection_ack"}
 
     await ws.send_json_to(
         SubscribeMessage(
-            id="sub1",
-            payload=SubscribeMessagePayload(
-                query="subscription { listener }",
-            ),
-        ).as_dict()
+            {
+                "id": "sub1",
+                "type": "subscribe",
+                "payload": {
+                    "query": "subscription { listener }",
+                },
+            }
+        )
     )
 
     channel_layer = get_channel_layer()
     assert channel_layer
 
-    response = await ws.receive_json_from()
-    channel_name = response["payload"]["data"]["listener"]
+    next_message1: NextMessage = await ws.receive_json_from()
+    assert "data" in next_message1["payload"]
+    assert next_message1["payload"]["data"] is not None
+    channel_name = next_message1["payload"]["data"]["listener"]
 
     await channel_layer.send(
         channel_name,
@@ -90,47 +94,52 @@ async def test_channel_listen(ws: WebsocketCommunicator):
         },
     )
 
-    response = await ws.receive_json_from()
-    assert (
-        response
-        == NextMessage(
-            id="sub1",
-            payload={
-                "data": {"listener": "Hello there!"},
-                "extensions": {"example": "example"},
-            },
-        ).as_dict()
-    )
+    next_message2: NextMessage = await ws.receive_json_from()
+    assert next_message2 == {
+        "id": "sub1",
+        "type": "next",
+        "payload": {
+            "data": {"listener": "Hello there!"},
+            "extensions": {"example": "example"},
+        },
+    }
 
-    await ws.send_json_to(CompleteMessage(id="sub1").as_dict())
+    await ws.send_json_to(CompleteMessage({"id": "sub1", "type": "complete"}))
 
 
 async def test_channel_listen_with_confirmation(ws: WebsocketCommunicator):
     from channels.layers import get_channel_layer
 
-    await ws.send_json_to(ConnectionInitMessage().as_dict())
+    await ws.send_json_to(ConnectionInitMessage({"type": "connection_init"}))
 
-    response = await ws.receive_json_from()
-    assert response == ConnectionAckMessage().as_dict()
+    connection_ack_message: ConnectionAckMessage = await ws.receive_json_from()
+    assert connection_ack_message == {"type": "connection_ack"}
 
     await ws.send_json_to(
         SubscribeMessage(
-            id="sub1",
-            payload=SubscribeMessagePayload(
-                query="subscription { listenerWithConfirmation }",
-            ),
-        ).as_dict()
+            {
+                "id": "sub1",
+                "type": "subscribe",
+                "payload": {
+                    "query": "subscription { listenerWithConfirmation }",
+                },
+            }
+        )
     )
 
     channel_layer = get_channel_layer()
     assert channel_layer
 
-    response = await ws.receive_json_from()
-    confirmation = response["payload"]["data"]["listenerWithConfirmation"]
+    next_message1: NextMessage = await ws.receive_json_from()
+    assert "data" in next_message1["payload"]
+    assert next_message1["payload"]["data"] is not None
+    confirmation = next_message1["payload"]["data"]["listenerWithConfirmation"]
     assert confirmation is None
 
-    response = await ws.receive_json_from()
-    channel_name = response["payload"]["data"]["listenerWithConfirmation"]
+    next_message2: NextMessage = await ws.receive_json_from()
+    assert "data" in next_message2["payload"]
+    assert next_message2["payload"]["data"] is not None
+    channel_name = next_message2["payload"]["data"]["listenerWithConfirmation"]
 
     await channel_layer.send(
         channel_name,
@@ -140,103 +149,118 @@ async def test_channel_listen_with_confirmation(ws: WebsocketCommunicator):
         },
     )
 
-    response = await ws.receive_json_from()
-    assert (
-        response
-        == NextMessage(
-            id="sub1",
-            payload={
-                "data": {"listenerWithConfirmation": "Hello there!"},
-                "extensions": {"example": "example"},
-            },
-        ).as_dict()
-    )
+    next_message3: NextMessage = await ws.receive_json_from()
+    assert next_message3 == {
+        "id": "sub1",
+        "type": "next",
+        "payload": {
+            "data": {"listenerWithConfirmation": "Hello there!"},
+            "extensions": {"example": "example"},
+        },
+    }
 
-    await ws.send_json_to(CompleteMessage(id="sub1").as_dict())
+    await ws.send_json_to(CompleteMessage({"id": "sub1", "type": "complete"}))
 
 
 async def test_channel_listen_timeout(ws: WebsocketCommunicator):
     from channels.layers import get_channel_layer
 
-    await ws.send_json_to(ConnectionInitMessage().as_dict())
+    await ws.send_json_to(ConnectionInitMessage({"type": "connection_init"}))
 
-    response = await ws.receive_json_from()
-    assert response == ConnectionAckMessage().as_dict()
+    connection_ack_message: ConnectionAckMessage = await ws.receive_json_from()
+    assert connection_ack_message == {"type": "connection_ack"}
 
     await ws.send_json_to(
         SubscribeMessage(
-            id="sub1",
-            payload=SubscribeMessagePayload(
-                query="subscription { listener(timeout: 0.5) }",
-            ),
-        ).as_dict()
+            {
+                "id": "sub1",
+                "type": "subscribe",
+                "payload": {
+                    "query": "subscription { listener(timeout: 0.5) }",
+                },
+            }
+        )
     )
 
     channel_layer = get_channel_layer()
     assert channel_layer
 
-    response = await ws.receive_json_from()
-    channel_name = response["payload"]["data"]["listener"]
+    next_message: NextMessage = await ws.receive_json_from()
+    assert "data" in next_message["payload"]
+    assert next_message["payload"]["data"] is not None
+    channel_name = next_message["payload"]["data"]["listener"]
     assert channel_name
 
-    response = await ws.receive_json_from()
-    assert response == CompleteMessage(id="sub1").as_dict()
+    complete_message = await ws.receive_json_from()
+    assert complete_message == {"id": "sub1", "type": "complete"}
 
 
 async def test_channel_listen_timeout_cm(ws: WebsocketCommunicator):
     from channels.layers import get_channel_layer
 
-    await ws.send_json_to(ConnectionInitMessage().as_dict())
+    await ws.send_json_to(ConnectionInitMessage({"type": "connection_init"}))
 
-    response = await ws.receive_json_from()
-    assert response == ConnectionAckMessage().as_dict()
+    connection_ack_message: ConnectionAckMessage = await ws.receive_json_from()
+    assert connection_ack_message == {"type": "connection_ack"}
 
     await ws.send_json_to(
         SubscribeMessage(
-            id="sub1",
-            payload=SubscribeMessagePayload(
-                query="subscription { listenerWithConfirmation(timeout: 0.5) }",
-            ),
-        ).as_dict()
+            {
+                "id": "sub1",
+                "type": "subscribe",
+                "payload": {
+                    "query": "subscription { listenerWithConfirmation(timeout: 0.5) }",
+                },
+            }
+        )
     )
 
     channel_layer = get_channel_layer()
     assert channel_layer
 
-    response = await ws.receive_json_from()
-    confirmation = response["payload"]["data"]["listenerWithConfirmation"]
+    next_message1: NextMessage = await ws.receive_json_from()
+    assert "data" in next_message1["payload"]
+    assert next_message1["payload"]["data"] is not None
+    confirmation = next_message1["payload"]["data"]["listenerWithConfirmation"]
     assert confirmation is None
 
-    response = await ws.receive_json_from()
-    channel_name = response["payload"]["data"]["listenerWithConfirmation"]
+    next_message2 = await ws.receive_json_from()
+    assert "data" in next_message2["payload"]
+    assert next_message2["payload"]["data"] is not None
+    channel_name = next_message2["payload"]["data"]["listenerWithConfirmation"]
     assert channel_name
 
-    response = await ws.receive_json_from()
-    assert response == CompleteMessage(id="sub1").as_dict()
+    complete_message: CompleteMessage = await ws.receive_json_from()
+    assert complete_message == {"id": "sub1", "type": "complete"}
 
 
 async def test_channel_listen_no_message_on_channel(ws: WebsocketCommunicator):
     from channels.layers import get_channel_layer
 
-    await ws.send_json_to(ConnectionInitMessage().as_dict())
+    await ws.send_json_to(ConnectionInitMessage({"type": "connection_init"}))
 
-    response = await ws.receive_json_from()
-    assert response == ConnectionAckMessage().as_dict()
+    connection_ack_message: ConnectionAckMessage = await ws.receive_json_from()
+    assert connection_ack_message == {"type": "connection_ack"}
 
     await ws.send_json_to(
         SubscribeMessage(
-            id="sub1",
-            payload=SubscribeMessagePayload(
-                query="subscription { listener(timeout: 0.5) }",
-            ),
-        ).as_dict()
+            {
+                "id": "sub1",
+                "type": "subscribe",
+                "payload": {
+                    "query": "subscription { listener(timeout: 0.5) }",
+                },
+            }
+        )
     )
 
     channel_layer = get_channel_layer()
     assert channel_layer
 
-    response = await ws.receive_json_from()
-    channel_name = response["payload"]["data"]["listener"]
+    next_message: NextMessage = await ws.receive_json_from()
+    assert "data" in next_message["payload"]
+    assert next_message["payload"]["data"] is not None
+    channel_name = next_message["payload"]["data"]["listener"]
     assert channel_name
 
     await channel_layer.send(
@@ -247,36 +271,43 @@ async def test_channel_listen_no_message_on_channel(ws: WebsocketCommunicator):
         },
     )
 
-    response = await ws.receive_json_from()
-    assert response == CompleteMessage(id="sub1").as_dict()
+    complete_message: CompleteMessage = await ws.receive_json_from()
+    assert complete_message == {"id": "sub1", "type": "complete"}
 
 
 async def test_channel_listen_no_message_on_channel_cm(ws: WebsocketCommunicator):
     from channels.layers import get_channel_layer
 
-    await ws.send_json_to(ConnectionInitMessage().as_dict())
+    await ws.send_json_to(ConnectionInitMessage({"type": "connection_init"}))
 
-    response = await ws.receive_json_from()
-    assert response == ConnectionAckMessage().as_dict()
+    connection_ack_message: ConnectionAckMessage = await ws.receive_json_from()
+    assert connection_ack_message == {"type": "connection_ack"}
 
     await ws.send_json_to(
         SubscribeMessage(
-            id="sub1",
-            payload=SubscribeMessagePayload(
-                query="subscription { listenerWithConfirmation(timeout: 0.5) }",
-            ),
-        ).as_dict()
+            {
+                "id": "sub1",
+                "type": "subscribe",
+                "payload": {
+                    "query": "subscription { listenerWithConfirmation(timeout: 0.5) }",
+                },
+            }
+        )
     )
 
     channel_layer = get_channel_layer()
     assert channel_layer
 
-    response = await ws.receive_json_from()
-    confirmation = response["payload"]["data"]["listenerWithConfirmation"]
+    next_message1: NextMessage = await ws.receive_json_from()
+    assert "data" in next_message1["payload"]
+    assert next_message1["payload"]["data"] is not None
+    confirmation = next_message1["payload"]["data"]["listenerWithConfirmation"]
     assert confirmation is None
 
-    response = await ws.receive_json_from()
-    channel_name = response["payload"]["data"]["listenerWithConfirmation"]
+    next_message2 = await ws.receive_json_from()
+    assert "data" in next_message2["payload"]
+    assert next_message2["payload"]["data"] is not None
+    channel_name = next_message2["payload"]["data"]["listenerWithConfirmation"]
     assert channel_name
 
     await channel_layer.send(
@@ -287,32 +318,37 @@ async def test_channel_listen_no_message_on_channel_cm(ws: WebsocketCommunicator
         },
     )
 
-    response = await ws.receive_json_from()
-    assert response == CompleteMessage(id="sub1").as_dict()
+    complete_message: CompleteMessage = await ws.receive_json_from()
+    assert complete_message == {"id": "sub1", "type": "complete"}
 
 
 async def test_channel_listen_group(ws: WebsocketCommunicator):
     from channels.layers import get_channel_layer
 
-    await ws.send_json_to(ConnectionInitMessage().as_dict())
+    await ws.send_json_to(ConnectionInitMessage({"type": "connection_init"}))
 
-    response = await ws.receive_json_from()
-    assert response == ConnectionAckMessage().as_dict()
+    connection_ack_message: ConnectionAckMessage = await ws.receive_json_from()
+    assert connection_ack_message == {"type": "connection_ack"}
 
     await ws.send_json_to(
         SubscribeMessage(
-            id="sub1",
-            payload=SubscribeMessagePayload(
-                query='subscription { listener(group: "foobar") }',
-            ),
-        ).as_dict()
+            {
+                "id": "sub1",
+                "type": "subscribe",
+                "payload": {
+                    "query": 'subscription { listener(group: "foobar") }',
+                },
+            }
+        )
     )
 
     channel_layer = get_channel_layer()
     assert channel_layer
 
-    response = await ws.receive_json_from()
-    channel_name = response["payload"]["data"]["listener"]
+    next_message1 = await ws.receive_json_from()
+    assert "data" in next_message1["payload"]
+    assert next_message1["payload"]["data"] is not None
+    channel_name = next_message1["payload"]["data"]["listener"]
 
     # Sent at least once to the consumer to make sure the groups were registered
     await channel_layer.send(
@@ -322,17 +358,16 @@ async def test_channel_listen_group(ws: WebsocketCommunicator):
             "text": "Hello there!",
         },
     )
-    response = await ws.receive_json_from()
-    assert (
-        response
-        == NextMessage(
-            id="sub1",
-            payload={
-                "data": {"listener": "Hello there!"},
-                "extensions": {"example": "example"},
-            },
-        ).as_dict()
-    )
+
+    next_message2: NextMessage = await ws.receive_json_from()
+    assert next_message2 == {
+        "id": "sub1",
+        "type": "next",
+        "payload": {
+            "data": {"listener": "Hello there!"},
+            "extensions": {"example": "example"},
+        },
+    }
 
     await channel_layer.group_send(
         "foobar",
@@ -342,47 +377,52 @@ async def test_channel_listen_group(ws: WebsocketCommunicator):
         },
     )
 
-    response = await ws.receive_json_from()
-    assert (
-        response
-        == NextMessage(
-            id="sub1",
-            payload={
-                "data": {"listener": "Hello there!"},
-                "extensions": {"example": "example"},
-            },
-        ).as_dict()
-    )
+    next_message3: NextMessage = await ws.receive_json_from()
+    assert next_message3 == {
+        "id": "sub1",
+        "type": "next",
+        "payload": {
+            "data": {"listener": "Hello there!"},
+            "extensions": {"example": "example"},
+        },
+    }
 
-    await ws.send_json_to(CompleteMessage(id="sub1").as_dict())
+    await ws.send_json_to(CompleteMessage({"id": "sub1", "type": "complete"}))
 
 
 async def test_channel_listen_group_cm(ws: WebsocketCommunicator):
     from channels.layers import get_channel_layer
 
-    await ws.send_json_to(ConnectionInitMessage().as_dict())
+    await ws.send_json_to(ConnectionInitMessage({"type": "connection_init"}))
 
-    response = await ws.receive_json_from()
-    assert response == ConnectionAckMessage().as_dict()
+    connection_ack_message: ConnectionAckMessage = await ws.receive_json_from()
+    assert connection_ack_message == {"type": "connection_ack"}
 
     await ws.send_json_to(
         SubscribeMessage(
-            id="sub1",
-            payload=SubscribeMessagePayload(
-                query='subscription { listenerWithConfirmation(group: "foobar") }',
-            ),
-        ).as_dict()
+            {
+                "id": "sub1",
+                "type": "subscribe",
+                "payload": {
+                    "query": 'subscription { listenerWithConfirmation(group: "foobar") }',
+                },
+            }
+        )
     )
 
     channel_layer = get_channel_layer()
     assert channel_layer
 
-    response = await ws.receive_json_from()
-    confirmation = response["payload"]["data"]["listenerWithConfirmation"]
+    next_message1: NextMessage = await ws.receive_json_from()
+    assert "data" in next_message1["payload"]
+    assert next_message1["payload"]["data"] is not None
+    confirmation = next_message1["payload"]["data"]["listenerWithConfirmation"]
     assert confirmation is None
 
-    response = await ws.receive_json_from()
-    channel_name = response["payload"]["data"]["listenerWithConfirmation"]
+    next_message2 = await ws.receive_json_from()
+    assert "data" in next_message2["payload"]
+    assert next_message2["payload"]["data"] is not None
+    channel_name = next_message2["payload"]["data"]["listenerWithConfirmation"]
 
     # Sent at least once to the consumer to make sure the groups were registered
     await channel_layer.send(
@@ -392,17 +432,16 @@ async def test_channel_listen_group_cm(ws: WebsocketCommunicator):
             "text": "Hello there!",
         },
     )
-    response = await ws.receive_json_from()
-    assert (
-        response
-        == NextMessage(
-            id="sub1",
-            payload={
-                "data": {"listenerWithConfirmation": "Hello there!"},
-                "extensions": {"example": "example"},
-            },
-        ).as_dict()
-    )
+
+    next_message3: NextMessage = await ws.receive_json_from()
+    assert next_message3 == {
+        "id": "sub1",
+        "type": "next",
+        "payload": {
+            "data": {"listenerWithConfirmation": "Hello there!"},
+            "extensions": {"example": "example"},
+        },
+    }
 
     await channel_layer.group_send(
         "foobar",
@@ -412,56 +451,62 @@ async def test_channel_listen_group_cm(ws: WebsocketCommunicator):
         },
     )
 
-    response = await ws.receive_json_from()
-    assert (
-        response
-        == NextMessage(
-            id="sub1",
-            payload={
-                "data": {"listenerWithConfirmation": "Hello there!"},
-                "extensions": {"example": "example"},
-            },
-        ).as_dict()
-    )
+    next_message4: NextMessage = await ws.receive_json_from()
+    assert next_message4 == {
+        "id": "sub1",
+        "type": "next",
+        "payload": {
+            "data": {"listenerWithConfirmation": "Hello there!"},
+            "extensions": {"example": "example"},
+        },
+    }
 
-    await ws.send_json_to(CompleteMessage(id="sub1").as_dict())
+    await ws.send_json_to(CompleteMessage({"id": "sub1", "type": "complete"}))
 
 
 async def test_channel_listen_group_twice(ws: WebsocketCommunicator):
     from channels.layers import get_channel_layer
 
-    await ws.send_json_to(ConnectionInitMessage().as_dict())
+    await ws.send_json_to(ConnectionInitMessage({"type": "connection_init"}))
 
-    response = await ws.receive_json_from()
-    assert response == ConnectionAckMessage().as_dict()
+    connection_ack_message: ConnectionAckMessage = await ws.receive_json_from()
+    assert connection_ack_message == {"type": "connection_ack"}
 
     await ws.send_json_to(
         SubscribeMessage(
-            id="sub1",
-            payload=SubscribeMessagePayload(
-                query='subscription { listener(group: "group1") }',
-            ),
-        ).as_dict()
+            {
+                "id": "sub1",
+                "type": "subscribe",
+                "payload": {
+                    "query": 'subscription { listener(group: "group1") }',
+                },
+            }
+        )
     )
 
     await ws.send_json_to(
         SubscribeMessage(
-            id="sub2",
-            payload=SubscribeMessagePayload(
-                query='subscription { listener(group: "group2") }',
-            ),
-        ).as_dict()
+            {
+                "id": "sub2",
+                "type": "subscribe",
+                "payload": {
+                    "query": 'subscription { listener(group: "group2") }',
+                },
+            }
+        )
     )
 
     channel_layer = get_channel_layer()
     assert channel_layer
 
     # Wait for channel subscriptions to start
-    response1, response2 = await asyncio.gather(
-        ws.receive_json_from(), ws.receive_json_from()
-    )
-    assert {"sub1", "sub2"} == {response1["id"], response2["id"]}
-    channel_name = response1["payload"]["data"]["listener"]
+    next_message1: NextMessage = await ws.receive_json_from()
+    next_message2: NextMessage = await ws.receive_json_from()
+    assert {"sub1", "sub2"} == {next_message1["id"], next_message2["id"]}
+
+    assert "data" in next_message1["payload"]
+    assert next_message1["payload"]["data"] is not None
+    channel_name = next_message1["payload"]["data"]["listener"]
 
     # Sent at least once to the consumer to make sure the groups were registered
     await channel_layer.send(
@@ -471,12 +516,18 @@ async def test_channel_listen_group_twice(ws: WebsocketCommunicator):
             "text": "Hello there!",
         },
     )
-    response1, response2 = await asyncio.gather(
-        ws.receive_json_from(), ws.receive_json_from()
-    )
-    assert {"sub1", "sub2"} == {response1["id"], response2["id"]}
-    assert response1["payload"]["data"]["listener"] == "Hello there!"
-    assert response2["payload"]["data"]["listener"] == "Hello there!"
+
+    next_message3: NextMessage = await ws.receive_json_from()
+    next_message4: NextMessage = await ws.receive_json_from()
+    assert {"sub1", "sub2"} == {next_message3["id"], next_message4["id"]}
+
+    assert "data" in next_message3["payload"]
+    assert next_message3["payload"]["data"] is not None
+    assert next_message3["payload"]["data"]["listener"] == "Hello there!"
+
+    assert "data" in next_message4["payload"]
+    assert next_message4["payload"]["data"] is not None
+    assert next_message4["payload"]["data"]["listener"] == "Hello there!"
 
     # We now have two channel_listen AsyncGenerators waiting, one for id="sub1"
     # and one for id="sub2". This group message will be received by both of them
@@ -491,12 +542,17 @@ async def test_channel_listen_group_twice(ws: WebsocketCommunicator):
         },
     )
 
-    response1, response2 = await asyncio.gather(
-        ws.receive_json_from(), ws.receive_json_from()
-    )
-    assert {"sub1", "sub2"} == {response1["id"], response2["id"]}
-    assert response1["payload"]["data"]["listener"] == "Hello group 1!"
-    assert response2["payload"]["data"]["listener"] == "Hello group 1!"
+    next_message5: NextMessage = await ws.receive_json_from()
+    next_message6: NextMessage = await ws.receive_json_from()
+    assert {"sub1", "sub2"} == {next_message5["id"], next_message6["id"]}
+
+    assert "data" in next_message5["payload"]
+    assert next_message5["payload"]["data"] is not None
+    assert next_message5["payload"]["data"]["listener"] == "Hello group 1!"
+
+    assert "data" in next_message6["payload"]
+    assert next_message6["payload"]["data"] is not None
+    assert next_message6["payload"]["data"]["listener"] == "Hello group 1!"
 
     await channel_layer.group_send(
         "group2",
@@ -506,48 +562,59 @@ async def test_channel_listen_group_twice(ws: WebsocketCommunicator):
         },
     )
 
-    response1, response2 = await asyncio.gather(
-        ws.receive_json_from(), ws.receive_json_from()
-    )
-    assert {"sub1", "sub2"} == {response1["id"], response2["id"]}
-    assert response1["payload"]["data"]["listener"] == "Hello group 2!"
-    assert response2["payload"]["data"]["listener"] == "Hello group 2!"
+    next_message7: NextMessage = await ws.receive_json_from()
+    next_message8: NextMessage = await ws.receive_json_from()
+    assert {"sub1", "sub2"} == {next_message7["id"], next_message8["id"]}
 
-    await ws.send_json_to(CompleteMessage(id="sub1").as_dict())
-    await ws.send_json_to(CompleteMessage(id="sub2").as_dict())
+    assert "data" in next_message7["payload"]
+    assert next_message7["payload"]["data"] is not None
+    assert next_message7["payload"]["data"]["listener"] == "Hello group 2!"
+
+    assert "data" in next_message8["payload"]
+    assert next_message8["payload"]["data"] is not None
+    assert next_message8["payload"]["data"]["listener"] == "Hello group 2!"
+
+    await ws.send_json_to(CompleteMessage({"id": "sub1", "type": "complete"}))
+    await ws.send_json_to(CompleteMessage({"id": "sub2", "type": "complete"}))
 
 
 async def test_channel_listen_group_twice_cm(ws: WebsocketCommunicator):
     from channels.layers import get_channel_layer
 
-    await ws.send_json_to(ConnectionInitMessage().as_dict())
+    await ws.send_json_to(ConnectionInitMessage({"type": "connection_init"}))
 
-    response = await ws.receive_json_from()
-    assert response == ConnectionAckMessage().as_dict()
+    connection_ack_message: ConnectionAckMessage = await ws.receive_json_from()
+    assert connection_ack_message == {"type": "connection_ack"}
 
     await ws.send_json_to(
         SubscribeMessage(
-            id="sub1",
-            payload=SubscribeMessagePayload(
-                query='subscription { listenerWithConfirmation(group: "group1") }',
-            ),
-        ).as_dict()
+            {
+                "id": "sub1",
+                "type": "subscribe",
+                "payload": {
+                    "query": 'subscription { listenerWithConfirmation(group: "group1") }',
+                },
+            }
+        )
     )
 
     await ws.send_json_to(
         SubscribeMessage(
-            id="sub2",
-            payload=SubscribeMessagePayload(
-                query='subscription { listenerWithConfirmation(group: "group2") }',
-            ),
-        ).as_dict()
+            {
+                "id": "sub2",
+                "type": "subscribe",
+                "payload": {
+                    "query": 'subscription { listenerWithConfirmation(group: "group2") }',
+                },
+            }
+        )
     )
 
     channel_layer = get_channel_layer()
     assert channel_layer
 
     # Wait for confirmation for channel subscriptions
-    responses = await asyncio.gather(
+    messages = await asyncio.gather(
         ws.receive_json_from(),
         ws.receive_json_from(),
         ws.receive_json_from(),
@@ -555,27 +622,28 @@ async def test_channel_listen_group_twice_cm(ws: WebsocketCommunicator):
     )
     confirmation1 = next(
         i
-        for i in responses
+        for i in messages
         if not i["payload"]["data"]["listenerWithConfirmation"] and i["id"] == "sub1"
     )
     confirmation2 = next(
         i
-        for i in responses
+        for i in messages
         if not i["payload"]["data"]["listenerWithConfirmation"] and i["id"] == "sub2"
     )
     channel_name1 = next(
         i
-        for i in responses
+        for i in messages
         if i["payload"]["data"]["listenerWithConfirmation"] and i["id"] == "sub1"
     )
     channel_name2 = next(
         i
-        for i in responses
+        for i in messages
         if i["payload"]["data"]["listenerWithConfirmation"] and i["id"] == "sub2"
     )
+
     # Ensure correct ordering of responses
-    assert responses.index(confirmation1) < responses.index(channel_name1)
-    assert responses.index(confirmation2) < responses.index(channel_name2)
+    assert messages.index(confirmation1) < messages.index(channel_name1)
+    assert messages.index(confirmation2) < messages.index(channel_name2)
     channel_name = channel_name1["payload"]["data"]["listenerWithConfirmation"]
 
     # Sent at least once to the consumer to make sure the groups were registered
@@ -586,12 +654,22 @@ async def test_channel_listen_group_twice_cm(ws: WebsocketCommunicator):
             "text": "Hello there!",
         },
     )
-    response1, response2 = await asyncio.gather(
-        ws.receive_json_from(), ws.receive_json_from()
+
+    next_message1: NextMessage = await ws.receive_json_from()
+    next_message2: NextMessage = await ws.receive_json_from()
+    assert {"sub1", "sub2"} == {next_message1["id"], next_message2["id"]}
+
+    assert "data" in next_message1["payload"]
+    assert next_message1["payload"]["data"] is not None
+    assert (
+        next_message1["payload"]["data"]["listenerWithConfirmation"] == "Hello there!"
     )
-    assert {"sub1", "sub2"} == {response1["id"], response2["id"]}
-    assert response1["payload"]["data"]["listenerWithConfirmation"] == "Hello there!"
-    assert response2["payload"]["data"]["listenerWithConfirmation"] == "Hello there!"
+
+    assert "data" in next_message2["payload"]
+    assert next_message2["payload"]["data"] is not None
+    assert (
+        next_message2["payload"]["data"]["listenerWithConfirmation"] == "Hello there!"
+    )
 
     # We now have two channel_listen AsyncGenerators waiting, one for id="sub1"
     # and one for id="sub2". This group message will be received by both of them
@@ -606,12 +684,21 @@ async def test_channel_listen_group_twice_cm(ws: WebsocketCommunicator):
         },
     )
 
-    response1, response2 = await asyncio.gather(
-        ws.receive_json_from(), ws.receive_json_from()
+    next_message3: NextMessage = await ws.receive_json_from()
+    next_message4: NextMessage = await ws.receive_json_from()
+    assert {"sub1", "sub2"} == {next_message3["id"], next_message4["id"]}
+
+    assert "data" in next_message3["payload"]
+    assert next_message3["payload"]["data"] is not None
+    assert (
+        next_message3["payload"]["data"]["listenerWithConfirmation"] == "Hello group 1!"
     )
-    assert {"sub1", "sub2"} == {response1["id"], response2["id"]}
-    assert response1["payload"]["data"]["listenerWithConfirmation"] == "Hello group 1!"
-    assert response2["payload"]["data"]["listenerWithConfirmation"] == "Hello group 1!"
+
+    assert "data" in next_message4["payload"]
+    assert next_message4["payload"]["data"] is not None
+    assert (
+        next_message4["payload"]["data"]["listenerWithConfirmation"] == "Hello group 1!"
+    )
 
     await channel_layer.group_send(
         "group2",
@@ -621,12 +708,21 @@ async def test_channel_listen_group_twice_cm(ws: WebsocketCommunicator):
         },
     )
 
-    response1, response2 = await asyncio.gather(
-        ws.receive_json_from(), ws.receive_json_from()
-    )
-    assert {"sub1", "sub2"} == {response1["id"], response2["id"]}
-    assert response1["payload"]["data"]["listenerWithConfirmation"] == "Hello group 2!"
-    assert response2["payload"]["data"]["listenerWithConfirmation"] == "Hello group 2!"
+    next_message5: NextMessage = await ws.receive_json_from()
+    next_message6: NextMessage = await ws.receive_json_from()
+    assert {"sub1", "sub2"} == {next_message5["id"], next_message6["id"]}
 
-    await ws.send_json_to(CompleteMessage(id="sub1").as_dict())
-    await ws.send_json_to(CompleteMessage(id="sub2").as_dict())
+    assert "data" in next_message5["payload"]
+    assert next_message5["payload"]["data"] is not None
+    assert (
+        next_message5["payload"]["data"]["listenerWithConfirmation"] == "Hello group 2!"
+    )
+
+    assert "data" in next_message6["payload"]
+    assert next_message6["payload"]["data"] is not None
+    assert (
+        next_message6["payload"]["data"]["listenerWithConfirmation"] == "Hello group 2!"
+    )
+
+    await ws.send_json_to(CompleteMessage({"id": "sub1", "type": "complete"}))
+    await ws.send_json_to(CompleteMessage({"id": "sub2", "type": "complete"}))

--- a/tests/http/clients/base.py
+++ b/tests/http/clients/base.py
@@ -24,6 +24,9 @@ from strawberry.http.ides import GraphQL_IDE
 from strawberry.subscriptions.protocols.graphql_transport_ws.handlers import (
     BaseGraphQLTransportWSHandler,
 )
+from strawberry.subscriptions.protocols.graphql_transport_ws.types import (
+    Message as GraphQLTransportWSMessage,
+)
 from strawberry.subscriptions.protocols.graphql_ws.handlers import BaseGraphQLWSHandler
 from strawberry.types import ExecutionResult
 
@@ -300,6 +303,9 @@ class WebSocketClient(abc.ABC):
     async def __aiter__(self) -> AsyncGenerator[Message, None]:
         while not self.closed:
             yield await self.receive()
+
+    async def send_message(self, message: GraphQLTransportWSMessage) -> None:
+        await self.send_json(message)
 
 
 class DebuggableGraphQLTransportWSHandler(BaseGraphQLTransportWSHandler):

--- a/tests/views/schema.py
+++ b/tests/views/schema.py
@@ -158,7 +158,7 @@ class Subscription:
     @strawberry.subscription
     async def request_ping(self, info: strawberry.Info) -> AsyncGenerator[bool, None]:
         ws = info.context["ws"]
-        await ws.send_json(PingMessage().as_dict())
+        await ws.send_json(PingMessage({"type": "ping"}))
         yield True
 
     @strawberry.subscription

--- a/tests/websockets/test_graphql_transport_ws.py
+++ b/tests/websockets/test_graphql_transport_ws.py
@@ -5,7 +5,7 @@ import contextlib
 import json
 import time
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any, AsyncGenerator, Dict, Optional, Type
+from typing import TYPE_CHECKING, AsyncGenerator, Dict, Optional, Type, Union
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -22,7 +22,6 @@ from strawberry.subscriptions.protocols.graphql_transport_ws.types import (
     PingMessage,
     PongMessage,
     SubscribeMessage,
-    SubscribeMessagePayload,
 )
 from tests.http.clients.base import DebuggableGraphQLTransportWSHandler
 from tests.views.schema import MyExtension, Schema
@@ -43,29 +42,31 @@ async def ws_raw(http_client: HttpClient) -> AsyncGenerator[WebSocketClient, Non
 
 @pytest_asyncio.fixture
 async def ws(ws_raw: WebSocketClient) -> WebSocketClient:
-    await ws_raw.send_json(ConnectionInitMessage().as_dict())
-    response = await ws_raw.receive_json()
-    assert response == ConnectionAckMessage().as_dict()
+    await ws_raw.send_json(ConnectionInitMessage({"type": "connection_init"}))
+    connection_ack_message: ConnectionAckMessage = await ws_raw.receive_json()
+    assert connection_ack_message == {"type": "connection_ack"}
     return ws_raw
 
 
 def assert_next(
-    response: dict[str, Any],
+    next_message: NextMessage,
     id: str,
-    data: Dict[str, Any],
-    extensions: Optional[Dict[str, Any]] = None,
+    data: Dict[str, object],
+    extensions: Optional[Dict[str, object]] = None,
 ):
     """
     Assert that the NextMessage payload contains the provided data.
     If extensions is provided, it will also assert that the
     extensions are present
     """
-    assert response["type"] == "next"
-    assert response["id"] == id
-    assert set(response["payload"].keys()) <= {"data", "errors", "extensions"}
-    assert response["payload"]["data"] == data
+    assert next_message["type"] == "next"
+    assert next_message["id"] == id
+    assert set(next_message["payload"].keys()) <= {"data", "errors", "extensions"}
+    assert "data" in next_message["payload"]
+    assert next_message["payload"]["data"] == data
     if extensions is not None:
-        assert response["payload"]["extensions"] == extensions
+        assert "extensions" in next_message["payload"]
+        assert next_message["payload"]["extensions"] == extensions
 
 
 async def test_unknown_message_type(ws_raw: WebSocketClient):
@@ -73,7 +74,7 @@ async def test_unknown_message_type(ws_raw: WebSocketClient):
 
     await ws.send_json({"type": "NOT_A_MESSAGE_TYPE"})
 
-    data = await ws.receive(timeout=2)
+    await ws.receive(timeout=2)
     assert ws.closed
     assert ws.close_code == 4400
     assert ws.close_reason == "Unknown message type: NOT_A_MESSAGE_TYPE"
@@ -84,29 +85,16 @@ async def test_missing_message_type(ws_raw: WebSocketClient):
 
     await ws.send_json({"notType": None})
 
-    data = await ws.receive(timeout=2)
+    await ws.receive(timeout=2)
     assert ws.closed
     assert ws.close_code == 4400
     assert ws.close_reason == "Failed to parse message"
 
 
-async def test_parsing_an_invalid_message(ws_raw: WebSocketClient):
-    ws = ws_raw
-
+async def test_parsing_an_invalid_message(ws: WebSocketClient):
     await ws.send_json({"type": "subscribe", "notPayload": None})
 
-    data = await ws.receive(timeout=2)
-    assert ws.closed
-    assert ws.close_code == 4400
-    assert ws.close_reason == "Failed to parse message"
-
-
-async def test_parsing_an_invalid_payload(ws_raw: WebSocketClient):
-    ws = ws_raw
-
-    await ws.send_json({"type": "subscribe", "payload": {"unexpectedField": 42}})
-
-    data = await ws.receive(timeout=2)
+    await ws.receive(timeout=2)
     assert ws.closed
     assert ws.close_code == 4400
     assert ws.close_reason == "Failed to parse message"
@@ -115,7 +103,9 @@ async def test_parsing_an_invalid_payload(ws_raw: WebSocketClient):
 async def test_non_text_ws_messages_result_in_socket_closure(ws_raw: WebSocketClient):
     ws = ws_raw
 
-    await ws.send_bytes(json.dumps(ConnectionInitMessage().as_dict()).encode())
+    await ws.send_bytes(
+        json.dumps(ConnectionInitMessage({"type": "connection_init"})).encode()
+    )
 
     await ws.receive(timeout=2)
     assert ws.closed
@@ -137,19 +127,22 @@ async def test_non_json_ws_messages_result_in_socket_closure(ws_raw: WebSocketCl
 async def test_ws_message_frame_types_cannot_be_mixed(ws_raw: WebSocketClient):
     ws = ws_raw
 
-    await ws.send_json(ConnectionInitMessage().as_dict())
+    await ws.send_json(ConnectionInitMessage({"type": "connection_init"}))
 
-    response = await ws.receive_json()
-    assert response == ConnectionAckMessage().as_dict()
+    ack_message: ConnectionAckMessage = await ws.receive_json()
+    assert ack_message == {"type": "connection_ack"}
 
     await ws.send_bytes(
         json.dumps(
             SubscribeMessage(
-                id="sub1",
-                payload=SubscribeMessagePayload(
-                    query="subscription { debug { isConnectionInitTimeoutTaskDone } }"
-                ),
-            ).as_dict()
+                {
+                    "id": "sub1",
+                    "type": "subscribe",
+                    "payload": {
+                        "query": "subscription { debug { isConnectionInitTimeoutTaskDone } }"
+                    },
+                }
+            )
         ).encode()
     )
 
@@ -160,7 +153,7 @@ async def test_ws_message_frame_types_cannot_be_mixed(ws_raw: WebSocketClient):
 
 
 async def test_connection_init_timeout(
-    request: Any, http_client_class: Type[HttpClient]
+    request: object, http_client_class: Type[HttpClient]
 ):
     with contextlib.suppress(ImportError):
         from tests.http.clients.aiohttp import AioHttpClient
@@ -177,7 +170,7 @@ async def test_connection_init_timeout(
     async with test_client.ws_connect(
         "/graphql", protocols=[GRAPHQL_TRANSPORT_WS_PROTOCOL]
     ) as ws:
-        data = await ws.receive(timeout=2)
+        await ws.receive(timeout=2)
         assert ws.closed
         assert ws.close_code == 4408
         assert ws.close_reason == "Connection initialisation timeout"
@@ -190,27 +183,32 @@ async def test_connection_init_timeout_cancellation(
     # Verify that the timeout task is cancelled after the connection Init
     # message is received
     ws = ws_raw
-    await ws.send_json(ConnectionInitMessage().as_dict())
+    await ws.send_json(ConnectionInitMessage({"type": "connection_init"}))
 
-    response = await ws.receive_json()
-    assert response == ConnectionAckMessage().as_dict()
+    connection_ack_message: ConnectionAckMessage = await ws.receive_json()
+    assert connection_ack_message == {"type": "connection_ack"}
 
     await ws.send_json(
         SubscribeMessage(
-            id="sub1",
-            payload=SubscribeMessagePayload(
-                query="subscription { debug { isConnectionInitTimeoutTaskDone } }"
-            ),
-        ).as_dict()
+            {
+                "id": "sub1",
+                "type": "subscribe",
+                "payload": {
+                    "query": "subscription { debug { isConnectionInitTimeoutTaskDone } }"
+                },
+            }
+        )
     )
 
-    response = await ws.receive_json()
-    assert_next(response, "sub1", {"debug": {"isConnectionInitTimeoutTaskDone": True}})
+    next_message: NextMessage = await ws.receive_json()
+    assert_next(
+        next_message, "sub1", {"debug": {"isConnectionInitTimeoutTaskDone": True}}
+    )
 
 
 @pytest.mark.xfail(reason="This test is flaky")
 async def test_close_twice(
-    mocker: MockerFixture, request: Any, http_client_class: Type[HttpClient]
+    mocker: MockerFixture, request: object, http_client_class: Type[HttpClient]
 ):
     test_client = http_client_class()
     test_client.create_app(connection_init_wait_timeout=timedelta(seconds=0.25))
@@ -222,9 +220,7 @@ async def test_close_twice(
 
         # We set payload is set to "invalid value" to force a invalid payload error
         # which will close the connection
-        await ws.send_json(
-            ConnectionInitMessage(payload="invalid value").as_dict(),  # type: ignore
-        )
+        await ws.send_json({"type": "connection_init", "payload": "invalid value"})
         # Yield control so that ._close can be called
         await asyncio.sleep(0)
 
@@ -245,17 +241,17 @@ async def test_close_twice(
 
 
 async def test_too_many_initialisation_requests(ws: WebSocketClient):
-    await ws.send_json(ConnectionInitMessage().as_dict())
-    data = await ws.receive(timeout=2)
+    await ws.send_json(ConnectionInitMessage({"type": "connection_init"}))
+    await ws.receive(timeout=2)
     assert ws.closed
     assert ws.close_code == 4429
     assert ws.close_reason == "Too many initialisation requests"
 
 
 async def test_ping_pong(ws: WebSocketClient):
-    await ws.send_json(PingMessage().as_dict())
-    response = await ws.receive_json()
-    assert response == PongMessage().as_dict()
+    await ws.send_json(PingMessage({"type": "ping"}))
+    pong_message: PongMessage = await ws.receive_json()
+    assert pong_message == {"type": "pong"}
 
 
 async def test_can_send_payload_with_additional_things(ws_raw: WebSocketClient):
@@ -263,24 +259,28 @@ async def test_can_send_payload_with_additional_things(ws_raw: WebSocketClient):
 
     # send  init
 
-    await ws.send_json(ConnectionInitMessage().as_dict())
+    await ws.send_json(ConnectionInitMessage({"type": "connection_init"}))
 
     await ws.receive(timeout=2)
 
     await ws.send_json(
-        {
-            "type": "subscribe",
-            "payload": {
-                "query": 'subscription { echo(message: "Hi") }',
-                "some": "other thing",
-            },
-            "id": "1",
-        }
+        SubscribeMessage(
+            {
+                "type": "subscribe",
+                "payload": {
+                    "query": 'subscription { echo(message: "Hi") }',
+                    "extensions": {
+                        "some": "other thing",
+                    },
+                },
+                "id": "1",
+            }
+        )
     )
 
-    data = await ws.receive(timeout=2)
+    next_message: NextMessage = await ws.receive_json(timeout=2)
 
-    assert json.loads(data.data) == {
+    assert next_message == {
         "type": "next",
         "id": "1",
         "payload": {"data": {"echo": "Hi"}, "extensions": {"example": "example"}},
@@ -290,34 +290,39 @@ async def test_can_send_payload_with_additional_things(ws_raw: WebSocketClient):
 async def test_server_sent_ping(ws: WebSocketClient):
     await ws.send_json(
         SubscribeMessage(
-            id="sub1",
-            payload=SubscribeMessagePayload(query="subscription { requestPing }"),
-        ).as_dict()
+            {
+                "id": "sub1",
+                "type": "subscribe",
+                "payload": {"query": "subscription { requestPing }"},
+            }
+        )
     )
 
-    response = await ws.receive_json()
-    assert response == PingMessage().as_dict()
+    ping_message: PingMessage = await ws.receive_json()
+    assert ping_message == {"type": "ping"}
 
-    await ws.send_json(PongMessage().as_dict())
+    await ws.send_json(PongMessage({"type": "pong"}))
 
-    response = await ws.receive_json()
-    assert_next(response, "sub1", {"requestPing": True})
-    response = await ws.receive_json()
-    assert response == CompleteMessage(id="sub1").as_dict()
+    next_message: NextMessage = await ws.receive_json()
+    assert_next(next_message, "sub1", {"requestPing": True})
+
+    complete_message: CompleteMessage = await ws.receive_json()
+    assert complete_message == {"id": "sub1", "type": "complete"}
 
 
 async def test_unauthorized_subscriptions(ws_raw: WebSocketClient):
     ws = ws_raw
     await ws.send_json(
         SubscribeMessage(
-            id="sub1",
-            payload=SubscribeMessagePayload(
-                query='subscription { echo(message: "Hi") }'
-            ),
-        ).as_dict()
+            {
+                "id": "sub1",
+                "type": "subscribe",
+                "payload": {"query": 'subscription { echo(message: "Hi") }'},
+            }
+        )
     )
 
-    data = await ws.receive(timeout=2)
+    await ws.receive(timeout=2)
     assert ws.closed
     assert ws.close_code == 4401
     assert ws.close_reason == "Unauthorized"
@@ -326,23 +331,25 @@ async def test_unauthorized_subscriptions(ws_raw: WebSocketClient):
 async def test_duplicated_operation_ids(ws: WebSocketClient):
     await ws.send_json(
         SubscribeMessage(
-            id="sub1",
-            payload=SubscribeMessagePayload(
-                query='subscription { echo(message: "Hi", delay: 5) }'
-            ),
-        ).as_dict()
+            {
+                "id": "sub1",
+                "type": "subscribe",
+                "payload": {"query": 'subscription { echo(message: "Hi", delay: 5) }'},
+            }
+        )
     )
 
     await ws.send_json(
         SubscribeMessage(
-            id="sub1",
-            payload=SubscribeMessagePayload(
-                query='subscription { echo(message: "Hi", delay: 5) }'
-            ),
-        ).as_dict()
+            {
+                "id": "sub1",
+                "type": "subscribe",
+                "payload": {"query": 'subscription { echo(message: "Hi", delay: 5) }'},
+            }
+        )
     )
 
-    data = await ws.receive(timeout=2)
+    await ws.receive(timeout=2)
     assert ws.closed
     assert ws.close_code == 4409
     assert ws.close_reason == "Subscriber for sub1 already exists"
@@ -355,58 +362,64 @@ async def test_reused_operation_ids(ws: WebSocketClient):
     # Use sub1 as an id for an operation
     await ws.send_json(
         SubscribeMessage(
-            id="sub1",
-            payload=SubscribeMessagePayload(
-                query='subscription { echo(message: "Hi") }'
-            ),
-        ).as_dict()
+            {
+                "id": "sub1",
+                "type": "subscribe",
+                "payload": {"query": 'subscription { echo(message: "Hi") }'},
+            }
+        )
     )
 
-    response = await ws.receive_json()
-    assert_next(response, "sub1", {"echo": "Hi"})
+    next_message1: NextMessage = await ws.receive_json()
+    assert_next(next_message1, "sub1", {"echo": "Hi"})
 
-    response = await ws.receive_json()
-    assert response == CompleteMessage(id="sub1").as_dict()
+    complete_message: CompleteMessage = await ws.receive_json()
+    assert complete_message == {"id": "sub1", "type": "complete"}
 
     # operation is now complete.  Create a new operation using
     # the same ID
     await ws.send_json(
         SubscribeMessage(
-            id="sub1",
-            payload=SubscribeMessagePayload(
-                query='subscription { echo(message: "Hi") }'
-            ),
-        ).as_dict()
+            {
+                "id": "sub1",
+                "type": "subscribe",
+                "payload": {"query": 'subscription { echo(message: "Hi") }'},
+            }
+        )
     )
 
-    response = await ws.receive_json()
-    assert_next(response, "sub1", {"echo": "Hi"})
+    next_message2: NextMessage = await ws.receive_json()
+    assert_next(next_message2, "sub1", {"echo": "Hi"})
 
 
 async def test_simple_subscription(ws: WebSocketClient):
     await ws.send_json(
         SubscribeMessage(
-            id="sub1",
-            payload=SubscribeMessagePayload(
-                query='subscription { echo(message: "Hi") }'
-            ),
-        ).as_dict()
+            {
+                "id": "sub1",
+                "type": "subscribe",
+                "payload": {"query": 'subscription { echo(message: "Hi") }'},
+            }
+        )
     )
 
-    response = await ws.receive_json()
-    assert_next(response, "sub1", {"echo": "Hi"})
-    await ws.send_json(CompleteMessage(id="sub1").as_dict())
+    next_message: NextMessage = await ws.receive_json()
+    assert_next(next_message, "sub1", {"echo": "Hi"})
+    await ws.send_json(CompleteMessage({"id": "sub1", "type": "complete"}))
 
 
 async def test_subscription_syntax_error(ws: WebSocketClient):
     await ws.send_json(
         SubscribeMessage(
-            id="sub1",
-            payload=SubscribeMessagePayload(query="subscription { INVALID_SYNTAX "),
-        ).as_dict()
+            {
+                "id": "sub1",
+                "type": "subscribe",
+                "payload": {"query": "subscription { INVALID_SYNTAX "},
+            }
+        )
     )
 
-    data = await ws.receive(timeout=2)
+    await ws.receive(timeout=2)
     assert ws.closed
     assert ws.close_code == 4400
     assert ws.close_reason == "Syntax Error: Expected Name, found <EOF>."
@@ -417,84 +430,110 @@ async def test_subscription_field_errors(ws: WebSocketClient):
     with patch.object(Schema, "process_errors", process_errors):
         await ws.send_json(
             SubscribeMessage(
-                id="sub1",
-                payload=SubscribeMessagePayload(
-                    query="subscription { notASubscriptionField }",
-                ),
-            ).as_dict()
+                {
+                    "id": "sub1",
+                    "type": "subscribe",
+                    "payload": {
+                        "query": "subscription { notASubscriptionField }",
+                    },
+                }
+            )
         )
 
-        response = await ws.receive_json()
-        assert response["type"] == ErrorMessage.type
-        assert response["id"] == "sub1"
-        assert len(response["payload"]) == 1
-        assert response["payload"][0].get("path") is None
-        assert response["payload"][0]["locations"] == [{"line": 1, "column": 16}]
+        error_message: ErrorMessage = await ws.receive_json()
+        assert error_message["type"] == "error"
+        assert error_message["id"] == "sub1"
+        assert len(error_message["payload"]) == 1
+
+        assert "locations" in error_message["payload"][0]
+        assert error_message["payload"][0]["locations"] == [{"line": 1, "column": 16}]
+
+        assert "message" in error_message["payload"][0]
         assert (
-            response["payload"][0]["message"]
+            error_message["payload"][0]["message"]
             == "Cannot query field 'notASubscriptionField' on type 'Subscription'."
         )
+
         process_errors.assert_called_once()
 
 
 async def test_subscription_cancellation(ws: WebSocketClient):
     await ws.send_json(
         SubscribeMessage(
-            id="sub1",
-            payload=SubscribeMessagePayload(
-                query='subscription { echo(message: "Hi", delay: 99) }'
-            ),
-        ).as_dict()
+            {
+                "id": "sub1",
+                "type": "subscribe",
+                "payload": {"query": 'subscription { echo(message: "Hi", delay: 99) }'},
+            }
+        )
     )
 
     await ws.send_json(
         SubscribeMessage(
-            id="sub2",
-            payload=SubscribeMessagePayload(
-                query="subscription { debug { numActiveResultHandlers } }",
-            ),
-        ).as_dict()
+            {
+                "id": "sub2",
+                "type": "subscribe",
+                "payload": {
+                    "query": "subscription { debug { numActiveResultHandlers } }",
+                },
+            }
+        )
     )
 
-    response = await ws.receive_json()
-    assert_next(response, "sub2", {"debug": {"numActiveResultHandlers": 2}})
-    response = await ws.receive_json()
-    assert response == CompleteMessage(id="sub2").as_dict()
+    next_message: NextMessage = await ws.receive_json()
+    assert_next(next_message, "sub2", {"debug": {"numActiveResultHandlers": 2}})
 
-    await ws.send_json(CompleteMessage(id="sub1").as_dict())
+    complete_message: CompleteMessage = await ws.receive_json()
+    assert complete_message == {"id": "sub2", "type": "complete"}
+
+    await ws.send_json(CompleteMessage({"id": "sub1", "type": "complete"}))
 
     await ws.send_json(
         SubscribeMessage(
-            id="sub3",
-            payload=SubscribeMessagePayload(
-                query="subscription { debug { numActiveResultHandlers } }",
-            ),
-        ).as_dict()
+            {
+                "id": "sub3",
+                "type": "subscribe",
+                "payload": {
+                    "query": "subscription { debug { numActiveResultHandlers } }",
+                },
+            }
+        )
     )
 
-    response = await ws.receive_json()
-    assert_next(response, "sub3", {"debug": {"numActiveResultHandlers": 1}})
+    next_message: NextMessage = await ws.receive_json()
+    assert_next(next_message, "sub3", {"debug": {"numActiveResultHandlers": 1}})
 
-    response = await ws.receive_json()
-    assert response == CompleteMessage(id="sub3").as_dict()
+    complete_message: CompleteMessage = await ws.receive_json()
+    assert complete_message == {"id": "sub3", "type": "complete"}
 
 
 async def test_subscription_errors(ws: WebSocketClient):
     await ws.send_json(
         SubscribeMessage(
-            id="sub1",
-            payload=SubscribeMessagePayload(
-                query='subscription { error(message: "TEST ERR") }',
-            ),
-        ).as_dict()
+            {
+                "id": "sub1",
+                "type": "subscribe",
+                "payload": {
+                    "query": 'subscription { error(message: "TEST ERR") }',
+                },
+            }
+        )
     )
 
-    response = await ws.receive_json()
-    assert response["type"] == NextMessage.type
-    assert response["id"] == "sub1"
-    assert len(response["payload"]["errors"]) == 1
-    assert response["payload"]["errors"][0]["path"] == ["error"]
-    assert response["payload"]["errors"][0]["message"] == "TEST ERR"
+    next_message: NextMessage = await ws.receive_json()
+    assert next_message["type"] == "next"
+    assert next_message["id"] == "sub1"
+
+    assert "errors" in next_message["payload"]
+    payload_errors = next_message["payload"]["errors"]
+    assert payload_errors is not None
+    assert len(payload_errors) == 1
+
+    assert "path" in payload_errors[0]
+    assert payload_errors[0]["path"] == ["error"]
+
+    assert "message" in payload_errors[0]
+    assert payload_errors[0]["message"] == "TEST ERR"
 
 
 async def test_operation_error_no_complete(ws: WebSocketClient):
@@ -504,22 +543,26 @@ async def test_operation_error_no_complete(ws: WebSocketClient):
     # see https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md#error
     await ws.send_json(
         SubscribeMessage(
-            id="sub1",
-            payload=SubscribeMessagePayload(
-                query="subscription Foo($bar: String!){ exception(message: $bar) }",
-            ),
-        ).as_dict()
+            {
+                "id": "sub1",
+                "type": "subscribe",
+                "payload": {
+                    "query": "subscription Foo($bar: String!){ exception(message: $bar) }",
+                },
+            }
+        )
     )
 
-    response = await ws.receive_json()
-    assert response["type"] == ErrorMessage.type
-    assert response["id"] == "sub1"
+    error_message: ErrorMessage = await ws.receive_json()
+    assert error_message["type"] == "error"
+    assert error_message["id"] == "sub1"
 
     # after an "error" message, there should be nothing more
     # sent regarding "sub1", not even a "complete".
-    await ws.send_json(PingMessage().as_dict())
-    data = await ws.receive_json(timeout=1)
-    assert data == PongMessage().as_dict()
+    await ws.send_json(PingMessage({"type": "ping"}))
+
+    pong_message: PongMessage = await ws.receive_json(timeout=1)
+    assert pong_message == {"type": "pong"}
 
 
 async def test_subscription_exceptions(ws: WebSocketClient):
@@ -527,32 +570,40 @@ async def test_subscription_exceptions(ws: WebSocketClient):
     with patch.object(Schema, "process_errors", process_errors):
         await ws.send_json(
             SubscribeMessage(
-                id="sub1",
-                payload=SubscribeMessagePayload(
-                    query='subscription { exception(message: "TEST EXC") }',
-                ),
-            ).as_dict()
+                {
+                    "id": "sub1",
+                    "type": "subscribe",
+                    "payload": {
+                        "query": 'subscription { exception(message: "TEST EXC") }',
+                    },
+                }
+            )
         )
 
-        response = await ws.receive_json()
-        assert response["type"] == NextMessage.type
-        assert response["id"] == "sub1"
-        assert response["payload"]["errors"] == [{"message": "TEST EXC"}]
+        next_message: NextMessage = await ws.receive_json()
+        assert next_message["type"] == "next"
+        assert next_message["id"] == "sub1"
+        assert "errors" in next_message["payload"]
+        assert next_message["payload"]["errors"] == [{"message": "TEST EXC"}]
         process_errors.assert_called_once()
 
 
 async def test_single_result_query_operation(ws: WebSocketClient):
     await ws.send_json(
         SubscribeMessage(
-            id="sub1",
-            payload=SubscribeMessagePayload(query="query { hello }"),
-        ).as_dict()
+            {
+                "id": "sub1",
+                "type": "subscribe",
+                "payload": {"query": "query { hello }"},
+            }
+        )
     )
 
-    response = await ws.receive_json()
-    assert_next(response, "sub1", {"hello": "Hello world"})
-    response = await ws.receive_json()
-    assert response == CompleteMessage(id="sub1").as_dict()
+    next_message: NextMessage = await ws.receive_json()
+    assert_next(next_message, "sub1", {"hello": "Hello world"})
+
+    complete_message: CompleteMessage = await ws.receive_json()
+    assert complete_message == {"id": "sub1", "type": "complete"}
 
 
 async def test_single_result_query_operation_async(ws: WebSocketClient):
@@ -562,65 +613,72 @@ async def test_single_result_query_operation_async(ws: WebSocketClient):
     """
     await ws.send_json(
         SubscribeMessage(
-            id="sub1",
-            payload=SubscribeMessagePayload(
-                query='query { asyncHello(name: "Dolly", delay:0.01)}'
-            ),
-        ).as_dict()
+            {
+                "id": "sub1",
+                "type": "subscribe",
+                "payload": {"query": 'query { asyncHello(name: "Dolly", delay:0.01)}'},
+            }
+        )
     )
 
-    response = await ws.receive_json()
-    assert_next(response, "sub1", {"asyncHello": "Hello Dolly"})
+    next_message: NextMessage = await ws.receive_json()
+    assert_next(next_message, "sub1", {"asyncHello": "Hello Dolly"})
 
-    response = await ws.receive_json()
-    assert response == CompleteMessage(id="sub1").as_dict()
+    complete_message: CompleteMessage = await ws.receive_json()
+    assert complete_message == {"id": "sub1", "type": "complete"}
 
 
 async def test_single_result_query_operation_overlapped(ws: WebSocketClient):
     """Test that two single result queries can be in flight at the same time,
     just like regular queries.  Start two queries with separate ids. The
-    first query has a delay, so we expect the response to the second
+    first query has a delay, so we expect the message to the second
     query to be delivered first.
     """
     # first query
     await ws.send_json(
         SubscribeMessage(
-            id="sub1",
-            payload=SubscribeMessagePayload(
-                query='query { asyncHello(name: "Dolly", delay:1)}'
-            ),
-        ).as_dict()
+            {
+                "id": "sub1",
+                "type": "subscribe",
+                "payload": {"query": 'query { asyncHello(name: "Dolly", delay:1)}'},
+            }
+        )
     )
     # second query
     await ws.send_json(
         SubscribeMessage(
-            id="sub2",
-            payload=SubscribeMessagePayload(
-                query='query { asyncHello(name: "Dolly", delay:0)}'
-            ),
-        ).as_dict()
+            {
+                "id": "sub2",
+                "type": "subscribe",
+                "payload": {"query": 'query { asyncHello(name: "Dolly", delay:0)}'},
+            }
+        )
     )
 
-    # we expect the response to the second query to arrive first
-    response = await ws.receive_json()
-    assert_next(response, "sub2", {"asyncHello": "Hello Dolly"})
-    response = await ws.receive_json()
-    assert response == CompleteMessage(id="sub2").as_dict()
+    # we expect the message to the second query to arrive first
+    next_message: NextMessage = await ws.receive_json()
+    assert_next(next_message, "sub2", {"asyncHello": "Hello Dolly"})
+
+    complete_message: CompleteMessage = await ws.receive_json()
+    assert complete_message == {"id": "sub2", "type": "complete"}
 
 
 async def test_single_result_mutation_operation(ws: WebSocketClient):
     await ws.send_json(
         SubscribeMessage(
-            id="sub1",
-            payload=SubscribeMessagePayload(query="mutation { hello }"),
-        ).as_dict()
+            {
+                "id": "sub1",
+                "type": "subscribe",
+                "payload": {"query": "mutation { hello }"},
+            }
+        )
     )
 
-    response = await ws.receive_json()
-    assert_next(response, "sub1", {"hello": "strawberry"})
+    next_message: NextMessage = await ws.receive_json()
+    assert_next(next_message, "sub1", {"hello": "strawberry"})
 
-    response = await ws.receive_json()
-    assert response == CompleteMessage(id="sub1").as_dict()
+    complete_message: CompleteMessage = await ws.receive_json()
+    assert complete_message == {"id": "sub1", "type": "complete"}
 
 
 async def test_single_result_operation_selection(ws: WebSocketClient):
@@ -635,15 +693,19 @@ async def test_single_result_operation_selection(ws: WebSocketClient):
 
     await ws.send_json(
         SubscribeMessage(
-            id="sub1",
-            payload=SubscribeMessagePayload(query=query, operationName="Query2"),
-        ).as_dict()
+            {
+                "id": "sub1",
+                "type": "subscribe",
+                "payload": {"query": query, "operationName": "Query2"},
+            }
+        )
     )
 
-    response = await ws.receive_json()
-    assert_next(response, "sub1", {"hello": "Hello Strawberry"})
-    response = await ws.receive_json()
-    assert response == CompleteMessage(id="sub1").as_dict()
+    next_message: NextMessage = await ws.receive_json()
+    assert_next(next_message, "sub1", {"hello": "Hello Strawberry"})
+
+    complete_message: CompleteMessage = await ws.receive_json()
+    assert complete_message == {"id": "sub1", "type": "complete"}
 
 
 async def test_single_result_invalid_operation_selection(ws: WebSocketClient):
@@ -655,12 +717,15 @@ async def test_single_result_invalid_operation_selection(ws: WebSocketClient):
 
     await ws.send_json(
         SubscribeMessage(
-            id="sub1",
-            payload=SubscribeMessagePayload(query=query, operationName="Query2"),
-        ).as_dict()
+            {
+                "id": "sub1",
+                "type": "subscribe",
+                "payload": {"query": query, "operationName": "Query2"},
+            }
+        )
     )
 
-    data = await ws.receive(timeout=2)
+    await ws.receive(timeout=2)
     assert ws.closed
     assert ws.close_code == 4400
     assert ws.close_reason == "Can't get GraphQL operation type"
@@ -671,20 +736,30 @@ async def test_single_result_execution_error(ws: WebSocketClient):
     with patch.object(Schema, "process_errors", process_errors):
         await ws.send_json(
             SubscribeMessage(
-                id="sub1",
-                payload=SubscribeMessagePayload(
-                    query="query { alwaysFail }",
-                ),
-            ).as_dict()
+                {
+                    "id": "sub1",
+                    "type": "subscribe",
+                    "payload": {
+                        "query": "query { alwaysFail }",
+                    },
+                }
+            )
         )
 
-        response = await ws.receive_json()
-        assert response["type"] == NextMessage.type
-        assert response["id"] == "sub1"
-        errs = response["payload"]["errors"]
-        assert len(errs) == 1
-        assert errs[0]["path"] == ["alwaysFail"]
-        assert errs[0]["message"] == "You are not authorized"
+        next_message: NextMessage = await ws.receive_json()
+        assert next_message["type"] == "next"
+        assert next_message["id"] == "sub1"
+
+        assert "errors" in next_message["payload"]
+        payload_errors = next_message["payload"]["errors"]
+        assert payload_errors is not None
+        assert len(payload_errors) == 1
+
+        assert "path" in payload_errors[0]
+        assert payload_errors[0]["path"] == ["alwaysFail"]
+
+        assert "message" in payload_errors[0]
+        assert payload_errors[0]["message"] == "You are not authorized"
 
         process_errors.assert_called_once()
 
@@ -697,19 +772,23 @@ async def test_single_result_pre_execution_error(ws: WebSocketClient):
     with patch.object(Schema, "process_errors", process_errors):
         await ws.send_json(
             SubscribeMessage(
-                id="sub1",
-                payload=SubscribeMessagePayload(
-                    query="query { IDontExist }",
-                ),
-            ).as_dict()
+                {
+                    "id": "sub1",
+                    "type": "subscribe",
+                    "payload": {
+                        "query": "query { IDontExist }",
+                    },
+                }
+            )
         )
 
-        response = await ws.receive_json()
-        assert response["type"] == ErrorMessage.type
-        assert response["id"] == "sub1"
-        assert len(response["payload"]) == 1
+        error_message: ErrorMessage = await ws.receive_json()
+        assert error_message["type"] == "error"
+        assert error_message["id"] == "sub1"
+        assert len(error_message["payload"]) == 1
+        assert "message" in error_message["payload"][0]
         assert (
-            response["payload"][0]["message"]
+            error_message["payload"][0]["message"]
             == "Cannot query field 'IDontExist' on type 'Query'."
         )
         process_errors.assert_called_once()
@@ -724,23 +803,27 @@ async def test_single_result_duplicate_ids_sub(ws: WebSocketClient):
     # regular subscription
     await ws.send_json(
         SubscribeMessage(
-            id="sub1",
-            payload=SubscribeMessagePayload(
-                query='subscription { echo(message: "Hi", delay: 5) }'
-            ),
-        ).as_dict()
+            {
+                "id": "sub1",
+                "type": "subscribe",
+                "payload": {"query": 'subscription { echo(message: "Hi", delay: 5) }'},
+            }
+        )
     )
     # single result subscription with duplicate id
     await ws.send_json(
         SubscribeMessage(
-            id="sub1",
-            payload=SubscribeMessagePayload(
-                query="query { hello }",
-            ),
-        ).as_dict()
+            {
+                "id": "sub1",
+                "type": "subscribe",
+                "payload": {
+                    "query": "query { hello }",
+                },
+            }
+        )
     )
 
-    data = await ws.receive(timeout=2)
+    await ws.receive(timeout=2)
     assert ws.closed
     assert ws.close_code == 4409
     assert ws.close_reason == "Subscriber for sub1 already exists"
@@ -754,24 +837,28 @@ async def test_single_result_duplicate_ids_query(ws: WebSocketClient):
     # single result subscription 1
     await ws.send_json(
         SubscribeMessage(
-            id="sub1",
-            payload=SubscribeMessagePayload(
-                query='query { asyncHello(name: "Hi", delay: 5) }'
-            ),
-        ).as_dict()
+            {
+                "id": "sub1",
+                "type": "subscribe",
+                "payload": {"query": 'query { asyncHello(name: "Hi", delay: 5) }'},
+            }
+        )
     )
     # single result subscription with duplicate id
     await ws.send_json(
         SubscribeMessage(
-            id="sub1",
-            payload=SubscribeMessagePayload(
-                query="query { hello }",
-            ),
-        ).as_dict()
+            {
+                "id": "sub1",
+                "type": "subscribe",
+                "payload": {
+                    "query": "query { hello }",
+                },
+            }
+        )
     )
 
     # We expect the remote to close the socket due to duplicate ID in use
-    data = await ws.receive(timeout=2)
+    await ws.receive(timeout=2)
     assert ws.closed
     assert ws.close_code == 4409
     assert ws.close_reason == "Subscriber for sub1 already exists"
@@ -779,29 +866,36 @@ async def test_single_result_duplicate_ids_query(ws: WebSocketClient):
 
 async def test_injects_connection_params(ws_raw: WebSocketClient):
     ws = ws_raw
-    await ws.send_json(ConnectionInitMessage(payload={"strawberry": "rocks"}).as_dict())
+    await ws.send_json(
+        ConnectionInitMessage(
+            {"type": "connection_init", "payload": {"strawberry": "rocks"}}
+        )
+    )
 
-    response = await ws.receive_json()
-    assert response == ConnectionAckMessage().as_dict()
+    connection_ack_message: ConnectionAckMessage = await ws.receive_json()
+    assert connection_ack_message == {"type": "connection_ack"}
 
     await ws.send_json(
         SubscribeMessage(
-            id="sub1",
-            payload=SubscribeMessagePayload(query="subscription { connectionParams }"),
-        ).as_dict()
+            {
+                "id": "sub1",
+                "type": "subscribe",
+                "payload": {"query": "subscription { connectionParams }"},
+            }
+        )
     )
 
-    response = await ws.receive_json()
-    assert_next(response, "sub1", {"connectionParams": "rocks"})
+    next_message: NextMessage = await ws.receive_json()
+    assert_next(next_message, "sub1", {"connectionParams": "rocks"})
 
-    await ws.send_json(CompleteMessage(id="sub1").as_dict())
+    await ws.send_json(CompleteMessage({"id": "sub1", "type": "complete"}))
 
 
 async def test_rejects_connection_params_not_dict(ws_raw: WebSocketClient):
     ws = ws_raw
-    await ws.send_json(ConnectionInitMessage(payload="gonna fail").as_dict())
+    await ws.send_json({"type": "connection_init", "payload": "gonna fail"})
 
-    data = await ws.receive(timeout=2)
+    await ws.receive(timeout=2)
     assert ws.closed
     assert ws.close_code == 4400
     assert ws.close_reason == "Invalid connection init payload"
@@ -812,12 +906,12 @@ async def test_rejects_connection_params_not_dict(ws_raw: WebSocketClient):
     [[], "invalid value", 1],
 )
 async def test_rejects_connection_params_with_wrong_type(
-    payload: Any, ws_raw: WebSocketClient
+    payload: object, ws_raw: WebSocketClient
 ):
     ws = ws_raw
-    await ws.send_json(ConnectionInitMessage(payload=payload).as_dict())
+    await ws.send_json({"type": "connection_init", "payload": payload})
 
-    data = await ws.receive(timeout=2)
+    await ws.receive(timeout=2)
     assert ws.closed
     assert ws.close_code == 4400
     assert ws.close_reason == "Invalid connection init payload"
@@ -833,31 +927,43 @@ async def test_subsciption_cancel_finalization_delay(ws: WebSocketClient):
 
     await ws.send_json(
         SubscribeMessage(
-            id="sub1",
-            payload=SubscribeMessagePayload(
-                query=f"subscription {{ longFinalizer(delay: {delay}) }}"
-            ),
-        ).as_dict()
+            {
+                "id": "sub1",
+                "type": "subscribe",
+                "payload": {
+                    "query": f"subscription {{ longFinalizer(delay: {delay}) }}"
+                },
+            }
+        )
     )
 
-    response = await ws.receive_json()
-    assert_next(response, "sub1", {"longFinalizer": "hello"})
+    next_message: NextMessage = await ws.receive_json()
+    assert_next(next_message, "sub1", {"longFinalizer": "hello"})
 
-    # now cancel the stubscription and send a new query.  We expect the response
+    # now cancel the stubscription and send a new query. We expect the message
     # to the new query to arrive immediately, without waiting for the finalizer
     start = time.time()
-    await ws.send_json(CompleteMessage(id="sub1").as_dict())
+    await ws.send_json(CompleteMessage({"id": "sub1", "type": "complete"}))
     await ws.send_json(
         SubscribeMessage(
-            id="sub2",
-            payload=SubscribeMessagePayload(query="query { hello }"),
-        ).as_dict()
+            {
+                "id": "sub2",
+                "type": "subscribe",
+                "payload": {"query": "query { hello }"},
+            }
+        )
     )
+
     while True:
-        response = await ws.receive_json()
-        assert response["type"] in ("next", "complete")
-        if response["id"] == "sub2":
+        next_or_complete_message: Union[
+            NextMessage, CompleteMessage
+        ] = await ws.receive_json()
+
+        assert next_or_complete_message["type"] in ("next", "complete")
+
+        if next_or_complete_message["id"] == "sub2":
             break
+
     end = time.time()
     elapsed = end - start
     assert elapsed < delay
@@ -895,9 +1001,9 @@ async def test_error_handler_for_timeout(http_client: HttpClient):
             "/graphql", protocols=[GRAPHQL_TRANSPORT_WS_PROTOCOL]
         ) as ws:
             await asyncio.sleep(0.01)  # wait for the timeout task to start
-            await ws.send_json(ConnectionInitMessage().as_dict())
-            response = await ws.receive_json()
-            assert response == ConnectionAckMessage().as_dict()
+            await ws.send_json(ConnectionInitMessage({"type": "connection_init"}))
+            connection_ack_message: ConnectionAckMessage = await ws.receive_json()
+            assert connection_ack_message == {"type": "connection_ack"}
             await ws.close()
 
     # the error hander should have been called
@@ -916,34 +1022,40 @@ async def test_subscription_errors_continue(ws: WebSocketClient):
     with patch.object(Schema, "process_errors", process_errors):
         await ws.send_json(
             SubscribeMessage(
-                id="sub1",
-                payload=SubscribeMessagePayload(
-                    query="subscription { flavorsInvalid }",
-                ),
-            ).as_dict()
+                {
+                    "id": "sub1",
+                    "type": "subscribe",
+                    "payload": {
+                        "query": "subscription { flavorsInvalid }",
+                    },
+                }
+            )
         )
 
-        response = await ws.receive_json()
-        assert response["type"] == NextMessage.type
-        assert response["id"] == "sub1"
-        assert response["payload"]["data"] == {"flavorsInvalid": "VANILLA"}
+        next_message1: NextMessage = await ws.receive_json()
+        assert next_message1["type"] == "next"
+        assert next_message1["id"] == "sub1"
+        assert "data" in next_message1["payload"]
+        assert next_message1["payload"]["data"] == {"flavorsInvalid": "VANILLA"}
 
-        response = await ws.receive_json()
-        assert response["type"] == NextMessage.type
-        assert response["id"] == "sub1"
-        assert response["payload"]["data"] is None
-        errors = response["payload"]["errors"]
-        assert "cannot represent value" in str(errors)
+        next_message2: NextMessage = await ws.receive_json()
+        assert next_message2["type"] == "next"
+        assert next_message2["id"] == "sub1"
+        assert "data" in next_message2["payload"]
+        assert next_message2["payload"]["data"] is None
+        assert "errors" in next_message2["payload"]
+        assert "cannot represent value" in str(next_message2["payload"]["errors"])
         process_errors.assert_called_once()
 
-        response = await ws.receive_json()
-        assert response["type"] == NextMessage.type
-        assert response["id"] == "sub1"
-        assert response["payload"]["data"] == {"flavorsInvalid": "CHOCOLATE"}
+        next_message3: NextMessage = await ws.receive_json()
+        assert next_message3["type"] == "next"
+        assert next_message3["id"] == "sub1"
+        assert "data" in next_message3["payload"]
+        assert next_message3["payload"]["data"] == {"flavorsInvalid": "CHOCOLATE"}
 
-        response = await ws.receive_json()
-        assert response["type"] == CompleteMessage.type
-        assert response["id"] == "sub1"
+        complete_message: CompleteMessage = await ws.receive_json()
+        assert complete_message["type"] == "complete"
+        assert complete_message["id"] == "sub1"
 
 
 @patch.object(MyExtension, MyExtension.get_results.__name__, return_value={})
@@ -952,17 +1064,18 @@ async def test_no_extensions_results_wont_send_extensions_in_payload(
 ):
     await ws.send_json(
         SubscribeMessage(
-            id="sub1",
-            payload=SubscribeMessagePayload(
-                query='subscription { echo(message: "Hi") }'
-            ),
-        ).as_dict()
+            {
+                "id": "sub1",
+                "type": "subscribe",
+                "payload": {"query": 'subscription { echo(message: "Hi") }'},
+            }
+        )
     )
 
-    response = await ws.receive_json()
+    next_message: NextMessage = await ws.receive_json()
     mock.assert_called_once()
-    assert_next(response, "sub1", {"echo": "Hi"})
-    assert "extensions" not in response["payload"]
+    assert_next(next_message, "sub1", {"echo": "Hi"})
+    assert "extensions" not in next_message["payload"]
 
 
 async def test_unexpected_client_disconnects_are_gracefully_handled(
@@ -973,11 +1086,14 @@ async def test_unexpected_client_disconnects_are_gracefully_handled(
     with patch.object(Schema, "process_errors", process_errors):
         await ws.send_json(
             SubscribeMessage(
-                id="sub1",
-                payload=SubscribeMessagePayload(
-                    query='subscription { echo(message: "Hi", delay: 0.5) }'
-                ),
-            ).as_dict()
+                {
+                    "id": "sub1",
+                    "type": "subscribe",
+                    "payload": {
+                        "query": 'subscription { echo(message: "Hi", delay: 0.5) }'
+                    },
+                }
+            )
         )
 
         await ws.close()


### PR DESCRIPTION
## Description

I recently migrated the legacy ws protocols types to typed dicts (#3689), in this PR the modern ws protocols types are migrated to typed dicts. This, again, comes with some nice benefits such as:

- precise modeling of `null` vs `undefined` values
- no more need for custom `.to_dict()` methods on dataclasses to avoid performance penalties
- no more need for `UNSET` conversions
- more precise test assertions (that's were all the extra code comes from)
- (the protocol implementation now also no longer uses `Any`)

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Summary by Sourcery

Enhancements:
- Migrate graphql-transport-ws types from data classes to TypedDicts for better type precision and code simplification.