### PR TITLE
Let graphql-ws use type inference whenever possible

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+This release refactors part of the legacy `graphql-ws` protocol implementation, making it easier to read, maintain, and extend.

--- a/strawberry/subscriptions/protocols/graphql_ws/types.py
+++ b/strawberry/subscriptions/protocols/graphql_ws/types.py
@@ -78,6 +78,7 @@ OperationMessage = Union[
     DataMessage,
     ErrorMessage,
     CompleteMessage,
+    ConnectionKeepAliveMessage,
 ]
 
 

--- a/tests/http/clients/base.py
+++ b/tests/http/clients/base.py
@@ -28,6 +28,7 @@ from strawberry.subscriptions.protocols.graphql_transport_ws.types import (
     Message as GraphQLTransportWSMessage,
 )
 from strawberry.subscriptions.protocols.graphql_ws.handlers import BaseGraphQLWSHandler
+from strawberry.subscriptions.protocols.graphql_ws.types import OperationMessage
 from strawberry.types import ExecutionResult
 
 logger = logging.getLogger("strawberry.test.http_client")
@@ -305,6 +306,9 @@ class WebSocketClient(abc.ABC):
             yield await self.receive()
 
     async def send_message(self, message: GraphQLTransportWSMessage) -> None:
+        await self.send_json(message)
+
+    async def send_legacy_message(self, message: OperationMessage) -> None:
         await self.send_json(message)
 
 

--- a/tests/websockets/test_graphql_transport_ws.py
+++ b/tests/websockets/test_graphql_transport_ws.py
@@ -72,7 +72,7 @@ def assert_next(
 async def test_unknown_message_type(ws_raw: WebSocketClient):
     ws = ws_raw
 
-    await ws.send_message({"type": "NOT_A_MESSAGE_TYPE"})  # type: ignore
+    await ws.send_json({"type": "NOT_A_MESSAGE_TYPE"})
 
     await ws.receive(timeout=2)
     assert ws.closed
@@ -83,7 +83,7 @@ async def test_unknown_message_type(ws_raw: WebSocketClient):
 async def test_missing_message_type(ws_raw: WebSocketClient):
     ws = ws_raw
 
-    await ws.send_message({"notType": None})  # type: ignore
+    await ws.send_json({"notType": None})
 
     await ws.receive(timeout=2)
     assert ws.closed
@@ -92,7 +92,7 @@ async def test_missing_message_type(ws_raw: WebSocketClient):
 
 
 async def test_parsing_an_invalid_message(ws: WebSocketClient):
-    await ws.send_message({"type": "subscribe", "notPayload": None})  # type: ignore
+    await ws.send_json({"type": "subscribe", "notPayload": None})
 
     await ws.receive(timeout=2)
     assert ws.closed
@@ -218,7 +218,7 @@ async def test_close_twice(
 
         # We set payload is set to "invalid value" to force a invalid payload error
         # which will close the connection
-        await ws.send_message({"type": "connection_init", "payload": "invalid value"})  # type: ignore
+        await ws.send_json({"type": "connection_init", "payload": "invalid value"})
 
         # Yield control so that ._close can be called
         await asyncio.sleep(0)
@@ -830,7 +830,7 @@ async def test_injects_connection_params(ws_raw: WebSocketClient):
 
 async def test_rejects_connection_params_not_dict(ws_raw: WebSocketClient):
     ws = ws_raw
-    await ws.send_message({"type": "connection_init", "payload": "gonna fail"})  # type: ignore
+    await ws.send_json({"type": "connection_init", "payload": "gonna fail"})
 
     await ws.receive(timeout=2)
     assert ws.closed
@@ -846,7 +846,7 @@ async def test_rejects_connection_params_with_wrong_type(
     payload: object, ws_raw: WebSocketClient
 ):
     ws = ws_raw
-    await ws.send_message({"type": "connection_init", "payload": payload})  # type: ignore
+    await ws.send_json({"type": "connection_init", "payload": payload})
 
     await ws.receive(timeout=2)
     assert ws.closed

--- a/tests/websockets/test_graphql_ws.py
+++ b/tests/websockets/test_graphql_ws.py
@@ -15,11 +15,9 @@ from strawberry.subscriptions.protocols.graphql_ws.types import (
     ConnectionErrorMessage,
     ConnectionInitMessage,
     ConnectionKeepAliveMessage,
-    ConnectionTerminateMessage,
     DataMessage,
     ErrorMessage,
     StartMessage,
-    StopMessage,
 )
 from tests.views.schema import MyExtension, Schema
 
@@ -41,13 +39,13 @@ async def ws_raw(http_client: HttpClient) -> AsyncGenerator[WebSocketClient, Non
 async def ws(ws_raw: WebSocketClient) -> AsyncGenerator[WebSocketClient, None]:
     ws = ws_raw
 
-    await ws.send_json(ConnectionInitMessage({"type": "connection_init"}))
+    await ws.send_legacy_message({"type": "connection_init"})
     response: ConnectionAckMessage = await ws.receive_json()
     assert response["type"] == "connection_ack"
 
     yield ws
 
-    await ws.send_json(ConnectionTerminateMessage({"type": "connection_terminate"}))
+    await ws.send_legacy_message({"type": "connection_terminate"})
     # make sure the WebSocket is disconnected now
     await ws.receive(timeout=2)  # receive close
     assert ws.closed
@@ -60,16 +58,14 @@ def aiohttp_app_client(http_client: HttpClient) -> HttpClient:
 
 
 async def test_simple_subscription(ws: WebSocketClient):
-    await ws.send_json(
-        StartMessage(
-            {
-                "type": "start",
-                "id": "demo",
-                "payload": {
-                    "query": 'subscription { echo(message: "Hi") }',
-                },
-            }
-        )
+    await ws.send_legacy_message(
+        {
+            "type": "start",
+            "id": "demo",
+            "payload": {
+                "query": 'subscription { echo(message: "Hi") }',
+            },
+        }
     )
 
     data_message: DataMessage = await ws.receive_json()
@@ -77,7 +73,7 @@ async def test_simple_subscription(ws: WebSocketClient):
     assert data_message["id"] == "demo"
     assert data_message["payload"]["data"] == {"echo": "Hi"}
 
-    await ws.send_json(StopMessage({"type": "stop", "id": "demo"}))
+    await ws.send_legacy_message({"type": "stop", "id": "demo"})
 
     complete_message: CompleteMessage = await ws.receive_json()
     assert complete_message["type"] == "complete"
@@ -85,20 +81,18 @@ async def test_simple_subscription(ws: WebSocketClient):
 
 
 async def test_operation_selection(ws: WebSocketClient):
-    await ws.send_json(
-        StartMessage(
-            {
-                "type": "start",
-                "id": "demo",
-                "payload": {
-                    "query": """
+    await ws.send_legacy_message(
+        {
+            "type": "start",
+            "id": "demo",
+            "payload": {
+                "query": """
                     subscription Subscription1 { echo(message: "Hi1") }
                     subscription Subscription2 { echo(message: "Hi2") }
                 """,
-                    "operationName": "Subscription2",
-                },
-            }
-        )
+                "operationName": "Subscription2",
+            },
+        }
     )
 
     data_message: DataMessage = await ws.receive_json()
@@ -106,7 +100,7 @@ async def test_operation_selection(ws: WebSocketClient):
     assert data_message["id"] == "demo"
     assert data_message["payload"]["data"] == {"echo": "Hi2"}
 
-    await ws.send_json(StopMessage({"type": "stop", "id": "demo"}))
+    await ws.send_legacy_message({"type": "stop", "id": "demo"})
 
     complete_message: CompleteMessage = await ws.receive_json()
     assert complete_message["type"] == "complete"
@@ -118,17 +112,15 @@ async def test_sends_keep_alive(aiohttp_app_client: HttpClient):
     async with aiohttp_app_client.ws_connect(
         "/graphql", protocols=[GRAPHQL_WS_PROTOCOL]
     ) as ws:
-        await ws.send_json(ConnectionInitMessage({"type": "connection_init"}))
-        await ws.send_json(
-            StartMessage(
-                {
-                    "type": "start",
-                    "id": "demo",
-                    "payload": {
-                        "query": 'subscription { echo(message: "Hi", delay: 0.15) }',
-                    },
-                }
-            )
+        await ws.send_legacy_message({"type": "connection_init"})
+        await ws.send_legacy_message(
+            {
+                "type": "start",
+                "id": "demo",
+                "payload": {
+                    "query": 'subscription { echo(message: "Hi", delay: 0.15) }',
+                },
+            }
         )
 
         ack_message: ConnectionAckMessage = await ws.receive_json()
@@ -155,30 +147,26 @@ async def test_sends_keep_alive(aiohttp_app_client: HttpClient):
         assert complete_message["type"] == "complete"
         assert complete_message["id"] == "demo"
 
-        await ws.send_json(ConnectionTerminateMessage({"type": "connection_terminate"}))
+        await ws.send_legacy_message({"type": "connection_terminate"})
 
 
 async def test_subscription_cancellation(ws: WebSocketClient):
-    await ws.send_json(
-        StartMessage(
-            {
-                "type": "start",
-                "id": "demo",
-                "payload": {"query": 'subscription { echo(message: "Hi", delay: 99) }'},
-            }
-        )
+    await ws.send_legacy_message(
+        {
+            "type": "start",
+            "id": "demo",
+            "payload": {"query": 'subscription { echo(message: "Hi", delay: 99) }'},
+        }
     )
 
-    await ws.send_json(
-        StartMessage(
-            {
-                "type": "start",
-                "id": "debug1",
-                "payload": {
-                    "query": "subscription { debug { numActiveResultHandlers } }",
-                },
-            }
-        )
+    await ws.send_legacy_message(
+        {
+            "type": "start",
+            "id": "debug1",
+            "payload": {
+                "query": "subscription { debug { numActiveResultHandlers } }",
+            },
+        }
     )
 
     data_message: DataMessage = await ws.receive_json()
@@ -190,22 +178,20 @@ async def test_subscription_cancellation(ws: WebSocketClient):
     assert complete_message1["type"] == "complete"
     assert complete_message1["id"] == "debug1"
 
-    await ws.send_json(StopMessage({"type": "stop", "id": "demo"}))
+    await ws.send_legacy_message({"type": "stop", "id": "demo"})
 
     complete_message2 = await ws.receive_json()
     assert complete_message2["type"] == "complete"
     assert complete_message2["id"] == "demo"
 
-    await ws.send_json(
-        StartMessage(
-            {
-                "type": "start",
-                "id": "debug2",
-                "payload": {
-                    "query": "subscription { debug { numActiveResultHandlers} }",
-                },
-            }
-        )
+    await ws.send_legacy_message(
+        {
+            "type": "start",
+            "id": "debug2",
+            "payload": {
+                "query": "subscription { debug { numActiveResultHandlers} }",
+            },
+        }
     )
 
     data_message2 = await ws.receive_json()
@@ -219,14 +205,12 @@ async def test_subscription_cancellation(ws: WebSocketClient):
 
 
 async def test_subscription_errors(ws: WebSocketClient):
-    await ws.send_json(
-        StartMessage(
-            {
-                "type": "start",
-                "id": "demo",
-                "payload": {"query": 'subscription { error(message: "TEST ERR") }'},
-            }
-        )
+    await ws.send_legacy_message(
+        {
+            "type": "start",
+            "id": "demo",
+            "payload": {"query": 'subscription { error(message: "TEST ERR") }'},
+        }
     )
 
     data_message: DataMessage = await ws.receive_json()
@@ -246,14 +230,12 @@ async def test_subscription_errors(ws: WebSocketClient):
 
 
 async def test_subscription_exceptions(ws: WebSocketClient):
-    await ws.send_json(
-        StartMessage(
-            {
-                "type": "start",
-                "id": "demo",
-                "payload": {"query": 'subscription { exception(message: "TEST EXC") }'},
-            }
-        )
+    await ws.send_legacy_message(
+        {
+            "type": "start",
+            "id": "demo",
+            "payload": {"query": 'subscription { exception(message: "TEST EXC") }'},
+        }
     )
 
     data_message: DataMessage = await ws.receive_json()
@@ -265,21 +247,19 @@ async def test_subscription_exceptions(ws: WebSocketClient):
     assert payload_errors is not None
     assert payload_errors == [{"message": "TEST EXC"}]
 
-    await ws.send_json(StopMessage({"type": "stop", "id": "demo"}))
+    await ws.send_legacy_message({"type": "stop", "id": "demo"})
     complete_message = await ws.receive_json()
     assert complete_message["type"] == "complete"
     assert complete_message["id"] == "demo"
 
 
 async def test_subscription_field_error(ws: WebSocketClient):
-    await ws.send_json(
-        StartMessage(
-            {
-                "type": "start",
-                "id": "invalid-field",
-                "payload": {"query": "subscription { notASubscriptionField }"},
-            }
-        )
+    await ws.send_legacy_message(
+        {
+            "type": "start",
+            "id": "invalid-field",
+            "payload": {"query": "subscription { notASubscriptionField }"},
+        }
     )
 
     error_message: ErrorMessage = await ws.receive_json()
@@ -294,14 +274,12 @@ async def test_subscription_field_error(ws: WebSocketClient):
 
 
 async def test_subscription_syntax_error(ws: WebSocketClient):
-    await ws.send_json(
-        StartMessage(
-            {
-                "type": "start",
-                "id": "syntax-error",
-                "payload": {"query": "subscription { example "},
-            }
-        )
+    await ws.send_legacy_message(
+        {
+            "type": "start",
+            "id": "syntax-error",
+            "payload": {"query": "subscription { example "},
+        }
     )
 
     error_message: ErrorMessage = await ws.receive_json()
@@ -330,22 +308,20 @@ async def test_non_json_ws_messages_are_ignored(ws_raw: WebSocketClient):
     ws = ws_raw
 
     await ws.send_text("NOT VALID JSON")
-    await ws.send_json(ConnectionInitMessage({"type": "connection_init"}))
+    await ws.send_legacy_message({"type": "connection_init"})
 
     connection_ack_message: ConnectionAckMessage = await ws.receive_json()
     assert connection_ack_message["type"] == "connection_ack"
 
     await ws.send_text("NOT VALID JSON")
-    await ws.send_json(
-        StartMessage(
-            {
-                "type": "start",
-                "id": "demo",
-                "payload": {
-                    "query": 'subscription { echo(message: "Hi") }',
-                },
-            }
-        )
+    await ws.send_legacy_message(
+        {
+            "type": "start",
+            "id": "demo",
+            "payload": {
+                "query": 'subscription { echo(message: "Hi") }',
+            },
+        }
     )
 
     data_message = await ws.receive_json()
@@ -354,14 +330,14 @@ async def test_non_json_ws_messages_are_ignored(ws_raw: WebSocketClient):
     assert data_message["payload"]["data"] == {"echo": "Hi"}
 
     await ws.send_text("NOT VALID JSON")
-    await ws.send_json(StopMessage({"type": "stop", "id": "demo"}))
+    await ws.send_legacy_message({"type": "stop", "id": "demo"})
 
     complete_message: CompleteMessage = await ws.receive_json()
     assert complete_message["type"] == "complete"
     assert complete_message["id"] == "demo"
 
     await ws.send_text("NOT VALID JSON")
-    await ws.send_json(ConnectionTerminateMessage({"type": "connection_terminate"}))
+    await ws.send_legacy_message({"type": "connection_terminate"})
     await ws.receive(timeout=2)  # receive close
     assert ws.closed
 
@@ -369,7 +345,7 @@ async def test_non_json_ws_messages_are_ignored(ws_raw: WebSocketClient):
 async def test_ws_message_frame_types_cannot_be_mixed(ws_raw: WebSocketClient):
     ws = ws_raw
 
-    await ws.send_json(ConnectionInitMessage({"type": "connection_init"}))
+    await ws.send_legacy_message({"type": "connection_init"})
 
     connection_ack_message: ConnectionAckMessage = await ws.receive_json()
     assert connection_ack_message["type"] == "connection_ack"
@@ -397,19 +373,17 @@ async def test_ws_message_frame_types_cannot_be_mixed(ws_raw: WebSocketClient):
 async def test_unknown_protocol_messages_are_ignored(ws_raw: WebSocketClient):
     ws = ws_raw
     await ws.send_json({"type": "NotAProtocolMessage"})
-    await ws.send_json(ConnectionInitMessage({"type": "connection_init"}))
+    await ws.send_legacy_message({"type": "connection_init"})
 
     await ws.send_json({"type": "NotAProtocolMessage"})
-    await ws.send_json(
-        StartMessage(
-            {
-                "type": "start",
-                "id": "demo",
-                "payload": {
-                    "query": 'subscription { echo(message: "Hi") }',
-                },
-            }
-        )
+    await ws.send_legacy_message(
+        {
+            "type": "start",
+            "id": "demo",
+            "payload": {
+                "query": 'subscription { echo(message: "Hi") }',
+            },
+        }
     )
 
     connection_ack_message: ConnectionAckMessage = await ws.receive_json()
@@ -421,14 +395,14 @@ async def test_unknown_protocol_messages_are_ignored(ws_raw: WebSocketClient):
     assert data_message["payload"]["data"] == {"echo": "Hi"}
 
     await ws.send_json({"type": "NotAProtocolMessage"})
-    await ws.send_json(StopMessage({"type": "stop", "id": "demo"}))
+    await ws.send_legacy_message({"type": "stop", "id": "demo"})
 
     complete_message: CompleteMessage = await ws.receive_json()
     assert complete_message["type"] == "complete"
     assert complete_message["id"] == "demo"
 
     await ws.send_json({"type": "NotAProtocolMessage"})
-    await ws.send_json(ConnectionTerminateMessage({"type": "connection_terminate"}))
+    await ws.send_legacy_message({"type": "connection_terminate"})
 
     # make sure the WebSocket is disconnected now
     await ws.receive(timeout=2)  # receive close
@@ -436,16 +410,14 @@ async def test_unknown_protocol_messages_are_ignored(ws_raw: WebSocketClient):
 
 
 async def test_custom_context(ws: WebSocketClient):
-    await ws.send_json(
-        StartMessage(
-            {
-                "type": "start",
-                "id": "demo",
-                "payload": {
-                    "query": "subscription { context }",
-                },
-            }
-        )
+    await ws.send_legacy_message(
+        {
+            "type": "start",
+            "id": "demo",
+            "payload": {
+                "query": "subscription { context }",
+            },
+        }
     )
 
     data_message: DataMessage = await ws.receive_json()
@@ -453,7 +425,7 @@ async def test_custom_context(ws: WebSocketClient):
     assert data_message["id"] == "demo"
     assert data_message["payload"]["data"] == {"context": "a value from context"}
 
-    await ws.send_json(StopMessage({"type": "stop", "id": "demo"}))
+    await ws.send_legacy_message({"type": "stop", "id": "demo"})
 
     complete_message: CompleteMessage = await ws.receive_json()
     assert complete_message["type"] == "complete"
@@ -461,16 +433,14 @@ async def test_custom_context(ws: WebSocketClient):
 
 
 async def test_resolving_enums(ws: WebSocketClient):
-    await ws.send_json(
-        StartMessage(
-            {
-                "type": "start",
-                "id": "demo",
-                "payload": {
-                    "query": "subscription { flavors }",
-                },
-            }
-        )
+    await ws.send_legacy_message(
+        {
+            "type": "start",
+            "id": "demo",
+            "payload": {
+                "query": "subscription { flavors }",
+            },
+        }
     )
 
     data_message1: DataMessage = await ws.receive_json()
@@ -488,7 +458,7 @@ async def test_resolving_enums(ws: WebSocketClient):
     assert data_message3["id"] == "demo"
     assert data_message3["payload"]["data"] == {"flavors": "CHOCOLATE"}
 
-    await ws.send_json(StopMessage({"type": "stop", "id": "demo"}))
+    await ws.send_legacy_message({"type": "stop", "id": "demo"})
 
     complete_message: CompleteMessage = await ws.receive_json()
     assert complete_message["type"] == "complete"
@@ -533,8 +503,8 @@ async def test_task_cancellation_separation(aiohttp_app_client: HttpClient):
         if aio:
             assert len(get_result_handler_tasks()) == 0
 
-        await ws1.send_json(ConnectionInitMessage({"type": "connection_init"}))
-        await ws1.send_json(start_message)
+        await ws1.send_legacy_message({"type": "connection_init"})
+        await ws1.send_legacy_message(start_message)
         await ws1.receive_json()  # ack
         await ws1.receive_json()  # data
 
@@ -542,8 +512,8 @@ async def test_task_cancellation_separation(aiohttp_app_client: HttpClient):
         if aio:
             assert len(get_result_handler_tasks()) == 1
 
-        await ws2.send_json(ConnectionInitMessage({"type": "connection_init"}))
-        await ws2.send_json(start_message)
+        await ws2.send_legacy_message({"type": "connection_init"})
+        await ws2.send_legacy_message(start_message)
         await ws2.receive_json()
         await ws2.receive_json()
 
@@ -551,30 +521,28 @@ async def test_task_cancellation_separation(aiohttp_app_client: HttpClient):
         if aio:
             assert len(get_result_handler_tasks()) == 2
 
-        await ws1.send_json(StopMessage({"type": "stop", "id": "demo"}))
+        await ws1.send_legacy_message({"type": "stop", "id": "demo"})
         await ws1.receive_json()  # complete
 
         # 1 active result handler tasks
         if aio:
             assert len(get_result_handler_tasks()) == 1
 
-        await ws2.send_json(StopMessage({"type": "stop", "id": "demo"}))
+        await ws2.send_legacy_message({"type": "stop", "id": "demo"})
         await ws2.receive_json()  # complete
 
         # 0 active result handler tasks
         if aio:
             assert len(get_result_handler_tasks()) == 0
 
-        await ws1.send_json(
-            StartMessage(
-                {
-                    "type": "start",
-                    "id": "debug1",
-                    "payload": {
-                        "query": "subscription { debug { numActiveResultHandlers } }",
-                    },
-                }
-            )
+        await ws1.send_legacy_message(
+            {
+                "type": "start",
+                "id": "debug1",
+                "payload": {
+                    "query": "subscription { debug { numActiveResultHandlers } }",
+                },
+            }
         )
 
         data_message: DataMessage = await ws1.receive_json()
@@ -595,24 +563,20 @@ async def test_injects_connection_params(aiohttp_app_client: HttpClient):
     async with aiohttp_app_client.ws_connect(
         "/graphql", protocols=[GRAPHQL_WS_PROTOCOL]
     ) as ws:
-        await ws.send_json(
-            ConnectionInitMessage(
-                {
-                    "type": "connection_init",
-                    "payload": {"strawberry": "rocks"},
-                }
-            )
+        await ws.send_legacy_message(
+            {
+                "type": "connection_init",
+                "payload": {"strawberry": "rocks"},
+            }
         )
-        await ws.send_json(
-            StartMessage(
-                {
-                    "type": "start",
-                    "id": "demo",
-                    "payload": {
-                        "query": "subscription { connectionParams }",
-                    },
-                }
-            )
+        await ws.send_legacy_message(
+            {
+                "type": "start",
+                "id": "demo",
+                "payload": {
+                    "query": "subscription { connectionParams }",
+                },
+            }
         )
 
         connection_ack_message: ConnectionAckMessage = await ws.receive_json()
@@ -623,13 +587,13 @@ async def test_injects_connection_params(aiohttp_app_client: HttpClient):
         assert data_message["id"] == "demo"
         assert data_message["payload"]["data"] == {"connectionParams": "rocks"}
 
-        await ws.send_json(StopMessage({"type": "stop", "id": "demo"}))
+        await ws.send_legacy_message({"type": "stop", "id": "demo"})
 
         complete_message: CompleteMessage = await ws.receive_json()
         assert complete_message["type"] == "complete"
         assert complete_message["id"] == "demo"
 
-        await ws.send_json(ConnectionTerminateMessage({"type": "connection_terminate"}))
+        await ws.send_legacy_message({"type": "connection_terminate"})
 
         # make sure the WebSocket is disconnected now
         await ws.receive(timeout=2)  # receive close
@@ -663,17 +627,15 @@ async def test_no_extensions_results_wont_send_extensions_in_payload(
     async with aiohttp_app_client.ws_connect(
         "/graphql", protocols=[GRAPHQL_WS_PROTOCOL]
     ) as ws:
-        await ws.send_json(ConnectionInitMessage({"type": "connection_init"}))
-        await ws.send_json(
-            StartMessage(
-                {
-                    "type": "start",
-                    "id": "demo",
-                    "payload": {
-                        "query": 'subscription { echo(message: "Hi") }',
-                    },
-                }
-            )
+        await ws.send_legacy_message({"type": "connection_init"})
+        await ws.send_legacy_message(
+            {
+                "type": "start",
+                "id": "demo",
+                "payload": {
+                    "query": 'subscription { echo(message: "Hi") }',
+                },
+            }
         )
 
         connection_ack_message = await ws.receive_json()
@@ -685,7 +647,7 @@ async def test_no_extensions_results_wont_send_extensions_in_payload(
         assert data_message["id"] == "demo"
         assert "extensions" not in data_message["payload"]
 
-        await ws.send_json(StopMessage({"type": "stop", "id": "demo"}))
+        await ws.send_legacy_message({"type": "stop", "id": "demo"})
         await ws.receive_json()
 
 
@@ -696,21 +658,19 @@ async def test_unexpected_client_disconnects_are_gracefully_handled(
     process_errors = mock.Mock()
 
     with mock.patch.object(Schema, "process_errors", process_errors):
-        await ws.send_json(ConnectionInitMessage({"type": "connection_init"}))
+        await ws.send_legacy_message({"type": "connection_init"})
 
         connection_ack_message: ConnectionAckMessage = await ws.receive_json()
         assert connection_ack_message["type"] == "connection_ack"
 
-        await ws.send_json(
-            StartMessage(
-                {
-                    "type": "start",
-                    "id": "sub1",
-                    "payload": {
-                        "query": 'subscription { echo(message: "Hi", delay: 0.5) }',
-                    },
-                }
-            )
+        await ws.send_legacy_message(
+            {
+                "type": "start",
+                "id": "sub1",
+                "payload": {
+                    "query": 'subscription { echo(message: "Hi", delay: 0.5) }',
+                },
+            }
         )
 
         await ws.close()

--- a/tests/websockets/test_graphql_ws.py
+++ b/tests/websockets/test_graphql_ws.py
@@ -218,11 +218,15 @@ async def test_subscription_errors(ws: WebSocketClient):
     assert data_message["id"] == "demo"
     assert data_message["payload"]["data"] is None
 
-    data_payload_errors = data_message["payload"].get("errors")
-    assert data_payload_errors is not None
-    assert len(data_payload_errors) == 1
-    assert data_payload_errors[0].get("path") == ["error"]
-    assert data_payload_errors[0].get("message") == "TEST ERR"
+    assert "errors" in data_message["payload"]
+    assert data_message["payload"]["errors"] is not None
+    assert len(data_message["payload"]["errors"]) == 1
+
+    assert "path" in data_message["payload"]["errors"][0]
+    assert data_message["payload"]["errors"][0]["path"] == ["error"]
+
+    assert "message" in data_message["payload"]["errors"][0]
+    assert data_message["payload"]["errors"][0]["message"] == "TEST ERR"
 
     complete_message: CompleteMessage = await ws.receive_json()
     assert complete_message["type"] == "complete"
@@ -243,9 +247,9 @@ async def test_subscription_exceptions(ws: WebSocketClient):
     assert data_message["id"] == "demo"
     assert data_message["payload"]["data"] is None
 
-    payload_errors = data_message["payload"].get("errors")
-    assert payload_errors is not None
-    assert payload_errors == [{"message": "TEST EXC"}]
+    assert "errors" in data_message["payload"]
+    assert data_message["payload"]["errors"] is not None
+    assert data_message["payload"]["errors"] == [{"message": "TEST EXC"}]
 
     await ws.send_legacy_message({"type": "stop", "id": "demo"})
     complete_message = await ws.receive_json()


### PR DESCRIPTION
## Description

This is a followup PR for #3689 briging the changes we discussed in #3701 also to the legacy protocol (i.e., using type inference whenever possible). I also made assertions in two related tests more precise.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation
