### PR TITLE
Let WS and HTTP use the same JSON encoder

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,7 @@
+Release type: minor
+
+Starting with this release, the same JSON encoder is used to encode HTTP
+responses and WebSocket messages.
+
+This enables developers to override the `encode_json` method on their views to
+customize the JSON encoder used by all web protocols.

--- a/docs/breaking-changes/0.251.0.md
+++ b/docs/breaking-changes/0.251.0.md
@@ -1,0 +1,25 @@
+---
+title: 0.251.0 Breaking Changes
+slug: breaking-changes/0.251.0
+---
+
+# v0.251.0 Breaking Changes
+
+We slightly changed the signature of the `encode_json` method used to customize
+the JSON encoder used by our HTTP views.
+
+Originally, the method was only meant to encode HTTP response data. Starting
+with this release, it's also used to encode WebSocket messages.
+
+Previously, the method signature was:
+
+```python
+def encode_json(self, response_data: GraphQLHTTPResponse) -> str: ...
+```
+
+To upgrade your code, change the method signature to the following and make sure
+your method can handle the same inputs as the built-in `json.dumps` method:
+
+```python
+def encode_json(self, data: object) -> str: ...
+```

--- a/docs/integrations/aiohttp.md
+++ b/docs/integrations/aiohttp.md
@@ -50,7 +50,7 @@ methods:
 - `async get_context(self, request: aiohttp.web.Request, response: aiohttp.web.StreamResponse) -> object`
 - `async get_root_value(self, request: aiohttp.web.Request) -> object`
 - `async process_result(self, request: aiohttp.web.Request, result: ExecutionResult) -> GraphQLHTTPResponse`
-- `def encode_json(self, data: GraphQLHTTPResponse) -> str`
+- `def encode_json(self, data: object) -> str`
 - `async def render_graphql_ide(self, request: aiohttp.web.Request) -> aiohttp.web.Response`
 
 ### get_context
@@ -144,12 +144,13 @@ tweaked based on your needs.
 
 ### encode_json
 
-`encode_json` allows to customize the encoding of the JSON response. By default
-we use `json.dumps` but you can override this method to use a different encoder.
+`encode_json` allows to customize the encoding of HTTP and WebSocket JSON
+responses. By default we use `json.dumps` but you can override this method to
+use a different encoder.
 
 ```python
 class MyGraphQLView(GraphQLView):
-    def encode_json(self, data: GraphQLHTTPResponse) -> str:
+    def encode_json(self, data: object) -> str:
         return json.dumps(data, indent=2)
 ```
 

--- a/docs/integrations/asgi.md
+++ b/docs/integrations/asgi.md
@@ -49,7 +49,7 @@ We allow to extend the base `GraphQL` app, by overriding the following methods:
 - `async get_context(self, request: Union[Request, WebSocket], response: Optional[Response] = None) -> Any`
 - `async get_root_value(self, request: Request) -> Any`
 - `async process_result(self, request: Request, result: ExecutionResult) -> GraphQLHTTPResponse`
-- `def encode_json(self, response_data: GraphQLHTTPResponse) -> str`
+- `def encode_json(self, response_data: object) -> str`
 - `async def render_graphql_ide(self, request: Request) -> Response`
 
 ### get_context
@@ -169,12 +169,13 @@ tweaked based on your needs.
 
 ### encode_json
 
-`encode_json` allows to customize the encoding of the JSON response. By default
-we use `json.dumps` but you can override this method to use a different encoder.
+`encode_json` allows to customize the encoding of HTTP and WebSocket JSON
+responses. By default we use `json.dumps` but you can override this method to
+use a different encoder.
 
 ```python
 class MyGraphQLView(GraphQL):
-    def encode_json(self, data: GraphQLHTTPResponse) -> str:
+    def encode_json(self, data: object) -> str:
         return json.dumps(data, indent=2)
 ```
 

--- a/docs/integrations/chalice.md
+++ b/docs/integrations/chalice.md
@@ -75,7 +75,7 @@ We allow to extend the base `GraphQLView`, by overriding the following methods:
 - `get_context(self, request: Request, response: TemporalResponse) -> Any`
 - `get_root_value(self, request: Request) -> Any`
 - `process_result(self, request: Request, result: ExecutionResult) -> GraphQLHTTPResponse`
-- `encode_json(self, response_data: GraphQLHTTPResponse) -> str`
+- `encode_json(self, response_data: object) -> str`
 - `def render_graphql_ide(self, request: Request) -> Response`
 
 ### get_context
@@ -154,12 +154,13 @@ tweaked based on your needs.
 
 ### encode_json
 
-`encode_json` allows to customize the encoding of the JSON response. By default
-we use `json.dumps` but you can override this method to use a different encoder.
+`encode_json` allows to customize the encoding of HTTP and WebSocket JSON
+responses. By default we use `json.dumps` but you can override this method to
+use a different encoder.
 
 ```python
 class MyGraphQLView(GraphQLView):
-    def encode_json(self, data: GraphQLHTTPResponse) -> str:
+    def encode_json(self, data: object) -> str:
         return json.dumps(data, indent=2)
 ```
 

--- a/docs/integrations/django.md
+++ b/docs/integrations/django.md
@@ -208,7 +208,7 @@ methods:
 - `async get_context(self, request: HttpRequest) -> Any`
 - `async get_root_value(self, request: HttpRequest) -> Any`
 - `async process_result(self, request: HttpRequest, result: ExecutionResult) -> GraphQLHTTPResponse`
-- `def encode_json(self, data: GraphQLHTTPResponse) -> str`
+- `def encode_json(self, data: object) -> str`
 - `async def render_graphql_ide(self, request: HttpRequest) -> HttpResponse`
 
 ### get_context
@@ -288,12 +288,13 @@ tweaked based on your needs.
 
 ### encode_json
 
-`encode_json` allows to customize the encoding of the JSON response. By default
-we use `json.dumps` but you can override this method to use a different encoder.
+`encode_json` allows to customize the encoding of HTTP and WebSocket JSON
+responses. By default we use `json.dumps` but you can override this method to
+use a different encoder.
 
 ```python
 class MyGraphQLView(AsyncGraphQLView):
-    def encode_json(self, data: GraphQLHTTPResponse) -> str:
+    def encode_json(self, data: object) -> str:
         return json.dumps(data, indent=2)
 ```
 

--- a/docs/integrations/fastapi.md
+++ b/docs/integrations/fastapi.md
@@ -292,14 +292,14 @@ tweaked based on your needs.
 
 ### encode_json
 
-`encode_json` allows to customize the encoding of the JSON response. By default
-we use `json.dumps` but you can override this method to use a different encoder.
-For example, the `orjson` library from pypi has blazing fast speeds.
+`encode_json` allows to customize the encoding of HTTP and WebSocket JSON
+responses. By default we use `json.dumps` but you can override this method to
+use a different encoder.
 
 ```python
 class MyGraphQLRouter(GraphQLRouter):
-    def encode_json(self, data: GraphQLHTTPResponse) -> bytes:
-        return orjson.dumps(data)
+    def encode_json(self, data: object) -> bytes:
+        return json.dumps(data, indent=2)
 ```
 
 ### render_graphql_ide

--- a/docs/integrations/flask.md
+++ b/docs/integrations/flask.md
@@ -54,7 +54,7 @@ We allow to extend the base `GraphQLView`, by overriding the following methods:
 - `def get_context(self, request: Request, response: Response) -> Any`
 - `def get_root_value(self, request: Request) -> Any`
 - `def process_result(self, result: ExecutionResult) -> GraphQLHTTPResponse`
-- `def encode_json(self, response_data: GraphQLHTTPResponse) -> str`
+- `def encode_json(self, response_data: object) -> str`
 - `def render_graphql_ide(self, request: Request) -> Response`
 
 <Note>
@@ -141,12 +141,13 @@ tweaked based on your needs.
 
 ### encode_json
 
-`encode_json` allows to customize the encoding of the JSON response. By default
-we use `json.dumps` but you can override this method to use a different encoder.
+`encode_json` allows to customize the encoding of HTTP and WebSocket JSON
+responses. By default we use `json.dumps` but you can override this method to
+use a different encoder.
 
 ```python
 class MyGraphQLView(GraphQLView):
-    def encode_json(self, data: GraphQLHTTPResponse) -> str:
+    def encode_json(self, data: object) -> str:
         return json.dumps(data, indent=2)
 ```
 

--- a/docs/integrations/quart.md
+++ b/docs/integrations/quart.md
@@ -46,7 +46,7 @@ We allow to extend the base `GraphQLView`, by overriding the following methods:
 - `async def get_context(self, request: Request, response: Response) -> Any`
 - `async def get_root_value(self, request: Request) -> Any`
 - `async def process_result(self, result: ExecutionResult) -> GraphQLHTTPResponse`
-- `def encode_json(self, response_data: GraphQLHTTPResponse) -> str`
+- `def encode_json(self, response_data: object) -> str`
 - `async def render_graphql_ide(self, request: Request) -> Response`
 
 ### get_context
@@ -125,12 +125,13 @@ tweaked based on your needs.
 
 ### encode_json
 
-`encode_json` allows to customize the encoding of the JSON response. By default
-we use `json.dumps` but you can override this method to use a different encoder.
+`encode_json` allows to customize the encoding of HTTP and WebSocket JSON
+responses. By default we use `json.dumps` but you can override this method to
+use a different encoder.
 
 ```python
 class MyGraphQLView(GraphQLView):
-    def encode_json(self, data: GraphQLHTTPResponse) -> str:
+    def encode_json(self, data: object) -> str:
         return json.dumps(data, indent=2)
 ```
 

--- a/docs/integrations/sanic.md
+++ b/docs/integrations/sanic.md
@@ -123,12 +123,13 @@ tweaked based on your needs.
 
 ### encode_json
 
-`encode_json` allows to customize the encoding of the JSON response. By default
-we use `json.dumps` but you can override this method to use a different encoder.
+`encode_json` allows to customize the encoding of HTTP and WebSocket JSON
+responses. By default we use `json.dumps` but you can override this method to
+use a different encoder.
 
 ```python
 class MyGraphQLView(GraphQLView):
-    def encode_json(self, data: GraphQLHTTPResponse) -> str:
+    def encode_json(self, data: object) -> str:
         return json.dumps(data, indent=2)
 ```
 

--- a/strawberry/aiohttp/views.py
+++ b/strawberry/aiohttp/views.py
@@ -87,7 +87,10 @@ class AioHTTPRequestAdapter(AsyncHTTPRequestAdapter):
 
 
 class AioHTTPWebSocketAdapter(AsyncWebSocketAdapter):
-    def __init__(self, request: web.Request, ws: web.WebSocketResponse) -> None:
+    def __init__(
+        self, view: AsyncBaseHTTPView, request: web.Request, ws: web.WebSocketResponse
+    ) -> None:
+        super().__init__(view)
         self.request = request
         self.ws = ws
 
@@ -107,7 +110,7 @@ class AioHTTPWebSocketAdapter(AsyncWebSocketAdapter):
 
     async def send_json(self, message: Mapping[str, object]) -> None:
         try:
-            await self.ws.send_json(message)
+            await self.ws.send_str(self.view.encode_json(message))
         except RuntimeError as exc:
             raise WebSocketDisconnected from exc
 

--- a/strawberry/asgi/__init__.py
+++ b/strawberry/asgi/__init__.py
@@ -87,7 +87,10 @@ class ASGIRequestAdapter(AsyncHTTPRequestAdapter):
 
 
 class ASGIWebSocketAdapter(AsyncWebSocketAdapter):
-    def __init__(self, request: WebSocket, response: WebSocket) -> None:
+    def __init__(
+        self, view: AsyncBaseHTTPView, request: WebSocket, response: WebSocket
+    ) -> None:
+        super().__init__(view)
         self.ws = response
 
     async def iter_json(
@@ -107,7 +110,7 @@ class ASGIWebSocketAdapter(AsyncWebSocketAdapter):
 
     async def send_json(self, message: Mapping[str, object]) -> None:
         try:
-            await self.ws.send_json(message)
+            await self.ws.send_text(self.view.encode_json(message))
         except WebSocketDisconnect as exc:
             raise WebSocketDisconnected from exc
 

--- a/strawberry/channels/handlers/ws_handler.py
+++ b/strawberry/channels/handlers/ws_handler.py
@@ -28,7 +28,13 @@ if TYPE_CHECKING:
 
 
 class ChannelsWebSocketAdapter(AsyncWebSocketAdapter):
-    def __init__(self, request: GraphQLWSConsumer, response: GraphQLWSConsumer) -> None:
+    def __init__(
+        self,
+        view: AsyncBaseHTTPView,
+        request: GraphQLWSConsumer,
+        response: GraphQLWSConsumer,
+    ) -> None:
+        super().__init__(view)
         self.ws_consumer = response
 
     async def iter_json(
@@ -50,7 +56,7 @@ class ChannelsWebSocketAdapter(AsyncWebSocketAdapter):
                     raise NonJsonMessageReceived()
 
     async def send_json(self, message: Mapping[str, object]) -> None:
-        serialized_message = json.dumps(message)
+        serialized_message = self.view.encode_json(message)
         await self.ws_consumer.send(serialized_message)
 
     async def close(self, code: int, reason: str) -> None:

--- a/strawberry/django/views.py
+++ b/strawberry/django/views.py
@@ -201,8 +201,8 @@ class BaseView:
             },
         )
 
-    def encode_json(self, response_data: GraphQLHTTPResponse) -> str:
-        return json.dumps(response_data, cls=DjangoJSONEncoder)
+    def encode_json(self, data: object) -> str:
+        return json.dumps(data, cls=DjangoJSONEncoder)
 
 
 class GraphQLView(

--- a/strawberry/http/base.py
+++ b/strawberry/http/base.py
@@ -2,7 +2,6 @@ import json
 from typing import Any, Dict, Generic, List, Mapping, Optional, Union
 from typing_extensions import Protocol
 
-from strawberry.http import GraphQLHTTPResponse
 from strawberry.http.ides import GraphQL_IDE, get_graphql_ide_html
 from strawberry.http.types import HTTPMethod, QueryParams
 
@@ -44,8 +43,8 @@ class BaseView(Generic[Request]):
         except json.JSONDecodeError as e:
             raise HTTPException(400, "Unable to parse request body as JSON") from e
 
-    def encode_json(self, response_data: GraphQLHTTPResponse) -> str:
-        return json.dumps(response_data)
+    def encode_json(self, data: object) -> str:
+        return json.dumps(data)
 
     def parse_query_params(self, params: QueryParams) -> Dict[str, Any]:
         params = dict(params)

--- a/strawberry/litestar/controller.py
+++ b/strawberry/litestar/controller.py
@@ -194,7 +194,10 @@ class LitestarRequestAdapter(AsyncHTTPRequestAdapter):
 
 
 class LitestarWebSocketAdapter(AsyncWebSocketAdapter):
-    def __init__(self, request: WebSocket, response: WebSocket) -> None:
+    def __init__(
+        self, view: AsyncBaseHTTPView, request: WebSocket, response: WebSocket
+    ) -> None:
+        super().__init__(view)
         self.ws = response
 
     async def iter_json(
@@ -218,7 +221,7 @@ class LitestarWebSocketAdapter(AsyncWebSocketAdapter):
 
     async def send_json(self, message: Mapping[str, object]) -> None:
         try:
-            await self.ws.send_json(message)
+            await self.ws.send_data(data=self.view.encode_json(message))
         except WebSocketDisconnect as exc:
             raise WebSocketDisconnected from exc
 


### PR DESCRIPTION
## Description

It was already possible and documented to override `encode_json` on views to customize the JSON encoder used for responses sent via HTTP. The same `encode_json` method is now also used to encode WebSocket messages.

This was proposed a few weeks ago by @bellini666 and it's super handy if someone wants to use `orjson` or otherwise customize JSON responses and messages.

Note that this change is kinda breaking since the `encode_json` methode previously only expected `GraphQLHTTPResponse` dicts, whereas now it must be able to handle any kind of json data.
In reality anyone overriding this method can probably already handle any json data.

(Will do the same for decoding in a separate PR).

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Summary by Sourcery

Unify the JSON encoding process for HTTP and WebSocket by using the same encode_json method, allowing for consistent customization across both protocols. Update documentation and add tests to support this change.

New Features:
- Enable the use of a single JSON encoder for both HTTP responses and WebSocket messages by allowing the override of the encode_json method.

Documentation:
- Update documentation to reflect the change in the encode_json method, which now applies to both HTTP and WebSocket JSON responses.
- Add a breaking changes document for version 0.251.0, detailing the changes to the encode_json method signature.

Tests:
- Add a test to verify that WebSocket handlers use the view's encode_json method for encoding JSON messages.