### PR TITLE
Bring the view extensions docs on par

### DIFF
--- a/docs/integrations/asgi.md
+++ b/docs/integrations/asgi.md
@@ -44,11 +44,12 @@ The `GraphQL` app accepts the following options at the moment:
 
 ## Extending the view
 
-We allow to extend the base `GraphQL` app, by overriding the following methods:
+The base `GraphQL` class can be extended by overriding any of the following
+methods:
 
-- `async get_context(self, request: Union[Request, WebSocket], response: Optional[Response] = None) -> Any`
-- `async get_root_value(self, request: Request) -> Any`
-- `async process_result(self, request: Request, result: ExecutionResult) -> GraphQLHTTPResponse`
+- `async def get_context(self, request: Union[Request, WebSocket], response: Union[Response, WebSocket]) -> Context`
+- `async def get_root_value(self, request: Union[Request, WebSocket]) -> Optional[RootValue]`
+- `async def process_result(self, request: Request, result: ExecutionResult) -> GraphQLHTTPResponse`
 - `def decode_json(self, data: Union[str, bytes]) -> object`
 - `def encode_json(self, data: object) -> str`
 - `async def render_graphql_ide(self, request: Request) -> Response`
@@ -60,10 +61,17 @@ resolver. You can return anything here, by default we return a dictionary with
 the request and the response.
 
 ```python
+import strawberry
+from typing import Union
+from strawberry.asgi import GraphQL
+from starlette.requests import Request
+from starlette.responses import Response
+
+
 class MyGraphQL(GraphQL):
     async def get_context(
         self, request: Union[Request, WebSocket], response: Optional[Response] = None
-    ) -> Any:
+    ):
         return {"example": 1}
 
 
@@ -90,6 +98,9 @@ This is possible by updating the response object contained inside the context of
 the `Info` object.
 
 ```python
+import strawberry
+
+
 @strawberry.type
 class Mutation:
     @strawberry.mutation
@@ -105,6 +116,7 @@ Similarly, [background tasks](https://www.starlette.io/background/) can be set
 on the response via the context:
 
 ```python
+import strawberry
 from starlette.background import BackgroundTask
 
 
@@ -126,8 +138,15 @@ probably not used a lot but it might be useful in certain situations.
 Here's an example:
 
 ```python
+import strawberry
+from typing import Union
+from strawberry.asgi import GraphQL
+from starlette.requests import Request
+from starlette.websockets import WebSocket
+
+
 class MyGraphQL(GraphQL):
-    async def get_root_value(self, request: Request) -> Any:
+    async def get_root_value(self, request: Union[Request, WebSocket]):
         return Query(name="Patrick")
 
 
@@ -149,8 +168,10 @@ It needs to return an object of `GraphQLHTTPResponse` and accepts the request
 and the execution results.
 
 ```python
+from strawberry.asgi import GraphQL
 from strawberry.http import GraphQLHTTPResponse
 from strawberry.types import ExecutionResult
+from starlette.requests import Request
 
 
 class MyGraphQL(GraphQL):
@@ -195,6 +216,10 @@ responses. By default we use `json.dumps` but you can override this method to
 use a different encoder.
 
 ```python
+import json
+from strawberry.asgi import GraphQL
+
+
 class MyGraphQLView(GraphQL):
     def encode_json(self, data: object) -> str:
         return json.dumps(data, indent=2)

--- a/docs/integrations/chalice.md
+++ b/docs/integrations/chalice.md
@@ -70,12 +70,14 @@ The `GraphQLView` accepts two options at the moment:
 
 ## Extending the view
 
-We allow to extend the base `GraphQLView`, by overriding the following methods:
+The base `GraphQLView` class can be extended by overriding any of the following
+methods:
 
-- `get_context(self, request: Request, response: TemporalResponse) -> Any`
-- `get_root_value(self, request: Request) -> Any`
-- `process_result(self, request: Request, result: ExecutionResult) -> GraphQLHTTPResponse`
-- `encode_json(self, response_data: object) -> str`
+- `def get_context(self, request: Request, response: TemporalResponse) -> Context`
+- `def get_root_value(self, request: Request) -> Optional[RootValue]`
+- `def process_result(self, request: Request, result: ExecutionResult) -> GraphQLHTTPResponse`
+- `def decode_json(self, data: Union[str, bytes]) -> object`
+- `def encode_json(self, data: object) -> str`
 - `def render_graphql_ide(self, request: Request) -> Response`
 
 ### get_context
@@ -86,8 +88,14 @@ the request. By default; the `Response` object from `flask` is injected via the
 parameters.
 
 ```python
+import strawberry
+from strawberry.chalice.views import GraphQLView
+from strawberry.http.temporal import TemporalResponse
+from chalice.app import Request
+
+
 class MyGraphQLView(GraphQLView):
-    def get_context(self, response: Response) -> Any:
+    def get_context(self, request: Request, response: TemporalResponse):
         return {"example": 1}
 
 
@@ -112,8 +120,12 @@ probably not used a lot but it might be useful in certain situations.
 Here's an example:
 
 ```python
+import strawberry
+from strawberry.chalice.views import GraphQLView
+
+
 class MyGraphQLView(GraphQLView):
-    def get_root_value(self) -> Any:
+    def get_root_value(self):
         return Query(name="Patrick")
 
 
@@ -137,6 +149,7 @@ result.
 ```python
 from strawberry.http import GraphQLHTTPResponse
 from strawberry.types import ExecutionResult
+from strawberry.chalice.views import GraphQLView
 
 
 class MyGraphQLView(GraphQLView):
@@ -179,6 +192,10 @@ responses. By default we use `json.dumps` but you can override this method to
 use a different encoder.
 
 ```python
+import json
+from strawberry.chalice.views import GraphQLView
+
+
 class MyGraphQLView(GraphQLView):
     def encode_json(self, data: object) -> str:
         return json.dumps(data, indent=2)

--- a/docs/integrations/channels.md
+++ b/docs/integrations/channels.md
@@ -529,11 +529,14 @@ GraphQLWebsocketCommunicator(
 
 ### Extending the consumer
 
-We allow to extend `GraphQLHTTPConsumer`, by overriding the following methods:
+The base `GraphQLHTTPConsumer` class can be extended by overriding any of the
+following methods:
 
 - `async def get_context(self, request: ChannelsRequest, response: TemporalResponse) -> Context`
 - `async def get_root_value(self, request: ChannelsRequest) -> Optional[RootValue]`
-- `async def process_result(self, request: Request, result: ExecutionResult) -> GraphQLHTTPResponse`.
+- `async def process_result(self, request: Request, result: ExecutionResult) -> GraphQLHTTPResponse`
+- `def decode_json(self, data: Union[str, bytes]) -> object`
+- `def encode_json(self, data: object) -> str`
 - `async def render_graphql_ide(self, request: ChannelsRequest) -> ChannelsResponse`
 
 #### Context
@@ -582,10 +585,13 @@ class MyGraphQLHTTPConsumer(GraphQLHTTPConsumer):
 
 ### Extending the consumer
 
-We allow to extend `GraphQLWSConsumer`, by overriding the following methods:
+The base `GraphQLWSConsumer` class can be extended by overriding any of the
+following methods:
 
-- `async def get_context(self, request: ChannelsConsumer, connection_params: Any) -> Context`
-- `async def get_root_value(self, request: ChannelsConsumer) -> Optional[RootValue]`
+- `async def get_context(self, request: GraphQLWSConsumer, response: GraphQLWSConsumer) -> Context`
+- `async def get_root_value(self, request: GraphQLWSConsumer) -> Optional[RootValue]`
+- `def decode_json(self, data: Union[str, bytes]) -> object`
+- `def encode_json(self, data: object) -> str`
 
 ### Context
 

--- a/docs/integrations/fastapi.md
+++ b/docs/integrations/fastapi.md
@@ -259,6 +259,16 @@ app.include_router(graphql_app, prefix="/graphql")
 Here we are returning a Query where the name is "Patrick", so when we request
 the field name we'll return "Patrick".
 
+## Extending the router
+
+The base `GraphQLRouter` class can be extended by overriding any of the
+following methods:
+
+- `async def process_result(self, request: Request, result: ExecutionResult) -> GraphQLHTTPResponse`
+- `def decode_json(self, data: Union[str, bytes]) -> object`
+- `def encode_json(self, data: object) -> str`
+- `async def render_graphql_ide(self, request: Request) -> HTMLResponse`
+
 ### process_result
 
 The `process_result` option allows you to customize and/or process results
@@ -269,7 +279,7 @@ It needs to return a `GraphQLHTTPResponse` object and accepts the request and
 execution results.
 
 ```python
-from fastapi import Request
+from starlette.requests import Request
 from strawberry.fastapi import GraphQLRouter
 from strawberry.http import GraphQLHTTPResponse
 from strawberry.types import ExecutionResult
@@ -318,6 +328,10 @@ responses. By default we use `json.dumps` but you can override this method to
 use a different encoder.
 
 ```python
+from strawberry.fastapi import GraphQLRouter
+import json
+
+
 class MyGraphQLRouter(GraphQLRouter):
     def encode_json(self, data: object) -> bytes:
         return json.dumps(data, indent=2)
@@ -331,6 +345,7 @@ In case you need more control over the rendering of the GraphQL IDE than the
 ```python
 from strawberry.fastapi import GraphQLRouter
 from starlette.responses import HTMLResponse, Response
+from starlette.requests import Request
 
 
 class MyGraphQLRouter(GraphQLRouter):

--- a/docs/integrations/flask.md
+++ b/docs/integrations/flask.md
@@ -49,19 +49,21 @@ The `GraphQLView` accepts the following options at the moment:
 
 ## Extending the view
 
-We allow to extend the base `GraphQLView`, by overriding the following methods:
+The base `GraphQLView` class can be extended by overriding any of the following
+methods:
 
-- `def get_context(self, request: Request, response: Response) -> Any`
-- `def get_root_value(self, request: Request) -> Any`
-- `def process_result(self, result: ExecutionResult) -> GraphQLHTTPResponse`
-- `def encode_json(self, response_data: object) -> str`
+- `def get_context(self, request: Request, response: Response) -> Context`
+- `def get_root_value(self, request: Request) -> Optional[RootValue]`
+- `def process_result(self, request: Request, result: ExecutionResult) -> GraphQLHTTPResponse`
+- `def decode_json(self, data: Union[str, bytes]) -> object`
+- `def encode_json(self, data: object) -> str`
 - `def render_graphql_ide(self, request: Request) -> Response`
 
 <Note>
 
-Note that the `AsyncGraphQLView` can also be extended by overriding the same
-methods above, but `get_context`, `get_root_value` and `process_result` are
-async functions.
+Note that the `AsyncGraphQLView` can also be extended in the same way, but the
+`get_context`, `get_root_value`, `process_result`, and `render_graphql_ide`
+methods are asynchronous.
 
 </Note>
 
@@ -73,8 +75,13 @@ the request. By default; the `Response` object from `flask` is injected via the
 parameters.
 
 ```python
+import strawberry
+from strawberry.flask.views import GraphQLView
+from flask import Request, Response
+
+
 class MyGraphQLView(GraphQLView):
-    def get_context(self, request: Request, response: Response) -> Any:
+    def get_context(self, request: Request, response: Response):
         return {"example": 1}
 
 
@@ -99,8 +106,13 @@ probably not used a lot but it might be useful in certain situations.
 Here's an example:
 
 ```python
+import strawberry
+from strawberry.flask.views import GraphQLView
+from flask import Request
+
+
 class MyGraphQLView(GraphQLView):
-    def get_root_value(self, request: Request) -> Any:
+    def get_root_value(self, request: Request):
         return Query(name="Patrick")
 
 
@@ -122,6 +134,7 @@ It needs to return an object of `GraphQLHTTPResponse` and accepts the execution
 result.
 
 ```python
+from strawberry.flask.views import GraphQLView
 from strawberry.http import GraphQLHTTPResponse
 from strawberry.types import ExecutionResult
 
@@ -166,6 +179,10 @@ responses. By default we use `json.dumps` but you can override this method to
 use a different encoder.
 
 ```python
+import json
+from strawberry.flask.views import GraphQLView
+
+
 class MyGraphQLView(GraphQLView):
     def encode_json(self, data: object) -> str:
         return json.dumps(data, indent=2)

--- a/docs/integrations/quart.md
+++ b/docs/integrations/quart.md
@@ -41,12 +41,14 @@ The `GraphQLView` accepts the following options at the moment:
 
 ## Extending the view
 
-We allow to extend the base `GraphQLView`, by overriding the following methods:
+The base `GraphQLView` class can be extended by overriding any of the following
+methods:
 
-- `async def get_context(self, request: Request, response: Response) -> Any`
-- `async def get_root_value(self, request: Request) -> Any`
-- `async def process_result(self, result: ExecutionResult) -> GraphQLHTTPResponse`
-- `def encode_json(self, response_data: object) -> str`
+- `async def get_context(self, request: Request, response: Response) -> Context`
+- `async def get_root_value(self, request: Request) -> Optional[RootValue]`
+- `async def process_result(self, request: Request, result: ExecutionResult) -> GraphQLHTTPResponse`
+- `def decode_json(self, data: Union[str, bytes]) -> object`
+- `def encode_json(self, data: object) -> str`
 - `async def render_graphql_ide(self, request: Request) -> Response`
 
 ### get_context
@@ -57,8 +59,13 @@ the request. By default; the `Response` object from Quart is injected via the
 parameters.
 
 ```python
+import strawberry
+from strawberry.quart.views import GraphQLView
+from quart import Request, Response
+
+
 class MyGraphQLView(GraphQLView):
-    async def get_context(self, request: Request, response: Response) -> Any:
+    async def get_context(self, request: Request, response: Response):
         return {"example": 1}
 
 
@@ -83,8 +90,13 @@ probably not used a lot but it might be useful in certain situations.
 Here's an example:
 
 ```python
+import strawberry
+from strawberry.quart.views import GraphQLView
+from quart import Request
+
+
 class MyGraphQLView(GraphQLView):
-    async def get_root_value(self, request: Request) -> Any:
+    async def get_root_value(self, request: Request):
         return Query(name="Patrick")
 
 
@@ -106,12 +118,16 @@ It needs to return an object of `GraphQLHTTPResponse` and accepts the execution
 result.
 
 ```python
+from strawberry.quart.views import GraphQLView
 from strawberry.http import GraphQLHTTPResponse
 from strawberry.types import ExecutionResult
+from quart import Request
 
 
 class MyGraphQLView(GraphQLView):
-    async def process_result(self, result: ExecutionResult) -> GraphQLHTTPResponse:
+    async def process_result(
+        self, request: Request, result: ExecutionResult
+    ) -> GraphQLHTTPResponse:
         data: GraphQLHTTPResponse = {"data": result.data}
 
         if result.errors:
@@ -150,6 +166,10 @@ responses. By default we use `json.dumps` but you can override this method to
 use a different encoder.
 
 ```python
+import json
+from strawberry.quart.views import GraphQLView
+
+
 class MyGraphQLView(GraphQLView):
     def encode_json(self, data: object) -> str:
         return json.dumps(data, indent=2)

--- a/docs/integrations/sanic.md
+++ b/docs/integrations/sanic.md
@@ -37,12 +37,14 @@ The `GraphQLView` accepts the following options at the moment:
 
 ## Extending the view
 
-The base `GraphQLView` class can be extended by overriding the following
+The base `GraphQLView` class can be extended by overriding any of the following
 methods:
 
-- `async get_context(self, request: Request, response: Response) -> Any`
-- `async get_root_value(self, request: Request) -> Any`
-- `async process_result(self, result: ExecutionResult) -> GraphQLHTTPResponse`
+- `async def get_context(self, request: Request, response: TemporalResponse) -> Context`
+- `async def get_root_value(self, request: Request) -> Optional[RootValue]`
+- `async def process_result(self, request: Request, result: ExecutionResult) -> GraphQLHTTPResponse`
+- `def decode_json(self, data: Union[str, bytes]) -> object`
+- `def encode_json(self, data: object) -> str`
 - `async def render_graphql_ide(self, request: Request) -> HTTPResponse`
 
 ### get_context
@@ -52,8 +54,14 @@ for your resolvers. You can return anything here; by default GraphQLView returns
 a dictionary with the request.
 
 ```python
+import strawberry
+from strawberry.sanic.views import GraphQLView
+from strawberry.http.temporal_response import TemporalResponse
+from sanic.request import Request
+
+
 class MyGraphQLView(GraphQLView):
-    async def get_context(self, request: Request, response: Response) -> Any:
+    async def get_context(self, request: Request, response: TemporalResponse):
         return {"example": 1}
 
 
@@ -79,8 +87,13 @@ certain situations.
 Here's an example:
 
 ```python
+import strawberry
+from strawberry.sanic.views import GraphQLView
+from sanic.request import Request
+
+
 class MyGraphQLView(GraphQLView):
-    async def get_root_value(self, request: Request) -> Any:
+    async def get_root_value(self, request: Request):
         return Query(name="Patrick")
 
 
@@ -148,6 +161,10 @@ responses. By default we use `json.dumps` but you can override this method to
 use a different encoder.
 
 ```python
+import json
+from strawberry.sanic.views import GraphQLView
+
+
 class MyGraphQLView(GraphQLView):
     def encode_json(self, data: object) -> str:
         return json.dumps(data, indent=2)


### PR DESCRIPTION
## Description

This PR updates the "Extending the view" sections of all integrations.

I made sure all overrideable methods of the base view are documented with the correct types and that all the examples include all required imports to run them.

(The only exception are the Channels docs which I only updated partially. I want to combine the HTTP and WS consumers there first, otherwise the docs will include everything twice).

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Summary by Sourcery

Documentation:
- Update the 'Extending the view' sections across various integration documentation to ensure all overrideable methods of the base view are documented with correct types and examples are copyable.