### PR TITLE
Fix root value and context getter types

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+Release type: minor
+
+In this release, the return types of the `get_root_value` and `get_context`
+methods were updated to be consistent across all view integrations. Before this
+release, the return types used by the ASGI and Django views were too generic.

--- a/strawberry/asgi/__init__.py
+++ b/strawberry/asgi/__init__.py
@@ -5,7 +5,6 @@ from datetime import timedelta
 from json import JSONDecodeError
 from typing import (
     TYPE_CHECKING,
-    Any,
     AsyncGenerator,
     AsyncIterator,
     Callable,
@@ -185,7 +184,9 @@ class GraphQL(
         else:  # pragma: no cover
             raise ValueError("Unknown scope type: {!r}".format(scope["type"]))
 
-    async def get_root_value(self, request: Union[Request, WebSocket]) -> Optional[Any]:
+    async def get_root_value(
+        self, request: Union[Request, WebSocket]
+    ) -> Optional[RootValue]:
         return None
 
     async def get_context(

--- a/strawberry/django/views.py
+++ b/strawberry/django/views.py
@@ -221,8 +221,8 @@ class GraphQLView(
     def get_root_value(self, request: HttpRequest) -> Optional[RootValue]:
         return None
 
-    def get_context(self, request: HttpRequest, response: HttpResponse) -> Any:
-        return StrawberryDjangoContext(request=request, response=response)
+    def get_context(self, request: HttpRequest, response: HttpResponse) -> Context:
+        return StrawberryDjangoContext(request=request, response=response)  # type: ignore
 
     def get_sub_response(self, request: HttpRequest) -> TemporalHttpResponse:
         return TemporalHttpResponse()
@@ -276,11 +276,13 @@ class AsyncGraphQLView(
 
         return view
 
-    async def get_root_value(self, request: HttpRequest) -> Any:
+    async def get_root_value(self, request: HttpRequest) -> Optional[RootValue]:
         return None
 
-    async def get_context(self, request: HttpRequest, response: HttpResponse) -> Any:
-        return StrawberryDjangoContext(request=request, response=response)
+    async def get_context(
+        self, request: HttpRequest, response: HttpResponse
+    ) -> Context:
+        return StrawberryDjangoContext(request=request, response=response)  # type: ignore
 
     async def get_sub_response(self, request: HttpRequest) -> TemporalHttpResponse:
         return TemporalHttpResponse()


### PR DESCRIPTION
## Description

This PR updates the ASGI and Django view to use the same return types as all other integrations (instead of just `Any`).
Unfortunately, as with the other integrations, we have to use `# type: ignore` for the default context we provide.
This will stay like that until we dictate a base class for contexts (or use PEP 696?).

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Summary by Sourcery

Update the return types of get_root_value and get_context methods in ASGI and Django views to align with other integrations, enhancing type consistency. Add a release note documenting these changes.

Enhancements:
- Update ASGI and Django view return types for get_root_value and get_context methods to be consistent with other integrations.

Documentation:
- Add a RELEASE.md file documenting the changes in return types for get_root_value and get_context methods.