### PR TITLE
Update accessing parent data guide with lazy type declaration

### DIFF
--- a/docs/guides/accessing-parent-data.md
+++ b/docs/guides/accessing-parent-data.md
@@ -57,12 +57,14 @@ pass us the parent of the field, we need to add a new argument with type
 `strawberry.Parent[ParentType]`, like so:
 
 ```python
-def get_full_name(parent: strawberry.Parent[User]) -> str:
+def get_full_name(parent: strawberry.Parent[Annotated["User", strawberry.lazy(".")]]) -> str:
     return f"{parent.first_name} {parent.last_name}"
 ```
 
 `strawberry.Parent` tells Strawberry to pass the parent value of the field, in
-this case it would be the `User`.
+this case it would be the `User`. Because the `User` class has not been defined
+yet at the point that we define the resolver, we need to use a [lazy](
+https://strawberry.rocks/docs/types/lazy) type declaration.
 
 > **Note:** `strawberry.Parent` accepts a type argument, which will then be used
 > by your type checker to check your code!
@@ -73,7 +75,7 @@ Historically Strawberry only supported passing the parent value by adding a
 parameter called `root`:
 
 ```python
-def get_full_name(root: User) -> str:
+def get_full_name(root: Annotated["User", strawberry.lazy(".")]) -> str:
     return f"{root.first_name} {root.last_name}"
 ```
 
@@ -83,7 +85,7 @@ follows Strawberry's philosophy of using type annotations. Also, with
 work:
 
 ```python
-def get_full_name(user: strawberry.Parent[User]) -> str:
+def get_full_name(user: strawberry.Parent[Annotated["User", strawberry.lazy(".")]]) -> str:
     return f"{user.first_name} {user.last_name}"
 ```
 
@@ -102,7 +104,7 @@ class User:
     last_name: str
 
     @strawberry.field
-    def full_name(self, parent: strawberry.Parent[User]) -> str:
+    def full_name(self, parent: strawberry.Parent[Annotated["User", strawberry.lazy(".")]]) -> str:
         return f"{parent.first_name} {parent.last_name}"
 ```
 
@@ -212,7 +214,7 @@ class User:
 
     @strawberry.field
     @staticmethod
-    def full_name(parent: strawberry.Parent[User]) -> str:
+    def full_name(parent: strawberry.Parent[Annotated["User", strawberry.lazy(".")]]) -> str:
         return f"{parent.first_name} {parent.last_name}"
 ```
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The "accessing parent data" guide did not actually work as written because the strawberry.Parents need to use lazy declarations if the class is not yet defined.

This was identified and discussed in https://github.com/strawberry-graphql/strawberry/issues/3481#issuecomment-2503867702

The strawberry lazy incantation is quite verbose, hence why "self" remains useful. 

I'm definitely not a doc writer, so just did my best. Feel free to suggest edits.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/strawberry-graphql/strawberry/issues/3481

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
