### PR TITLE
make sure _span_holder is reset

### DIFF
--- a/strawberry/extensions/tracing/opentelemetry.py
+++ b/strawberry/extensions/tracing/opentelemetry.py
@@ -37,7 +37,7 @@ ArgFilter = Callable[[Dict[str, Any], "GraphQLResolveInfo"], Dict[str, Any]]
 
 class OpenTelemetryExtension(SchemaExtension):
     _arg_filter: Optional[ArgFilter]
-    _span_holder: Dict[LifecycleStep, Span] = dict()
+    _span_holder: Dict[LifecycleStep, Span]
     _tracer: Tracer
 
     def __init__(
@@ -48,6 +48,7 @@ class OpenTelemetryExtension(SchemaExtension):
     ) -> None:
         self._arg_filter = arg_filter
         self._tracer = trace.get_tracer("strawberry")
+        self._span_holder = dict()
         if execution_context:
             self.execution_context = execution_context
 

--- a/tests/extensions/tracing/test_opentelemetry.py
+++ b/tests/extensions/tracing/test_opentelemetry.py
@@ -1,0 +1,24 @@
+from unittest.mock import Mock
+
+from opentelemetry.trace import Span
+
+from strawberry.extensions import LifecycleStep
+from strawberry.extensions.tracing.opentelemetry import (
+    OpenTelemetryExtension,
+    OpenTelemetryExtensionSync,
+)
+
+
+def test_span_holder_initialization():
+    extension = OpenTelemetryExtension()
+    assert extension._span_holder == {}
+    extension._span_holder[LifecycleStep.OPERATION] = Mock(spec=Span)
+    extension = OpenTelemetryExtension()
+    assert extension._span_holder == {}
+
+def test_span_holder_initialization_sync():
+    extension = OpenTelemetryExtensionSync()
+    assert extension._span_holder == {}
+    extension._span_holder[LifecycleStep.OPERATION] = Mock(spec=Span)
+    extension = OpenTelemetryExtensionSync()
+    assert extension._span_holder == {}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This PR addresses a bug where the `_span_holder` dictionary in the OpenTelemetryExtension class was shared across all instances due to being defined as a class-level attribute with a mutable default value. The fix is to reset the value of it during init, ensuring that each instance of the class has its own independent dictionary.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

The previous implementation led to unintended consequences:

* Shared State: Modifications to _span_holder in one instance were visible to all other instances, causing data contamination, which messed up the traces.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
