### PR TITLE
Fix missing markers and opening rule violation

### DIFF
--- a/tests/channels/test_layers.py
+++ b/tests/channels/test_layers.py
@@ -58,6 +58,7 @@ async def test_no_layers():
             pass
 
 
+@pytest.mark.django_db
 async def test_channel_listen(ws: WebsocketCommunicator):
     from channels.layers import get_channel_layer
 
@@ -107,6 +108,7 @@ async def test_channel_listen(ws: WebsocketCommunicator):
     await ws.send_json_to(CompleteMessage({"id": "sub1", "type": "complete"}))
 
 
+@pytest.mark.django_db
 async def test_channel_listen_with_confirmation(ws: WebsocketCommunicator):
     from channels.layers import get_channel_layer
 
@@ -162,6 +164,7 @@ async def test_channel_listen_with_confirmation(ws: WebsocketCommunicator):
     await ws.send_json_to(CompleteMessage({"id": "sub1", "type": "complete"}))
 
 
+@pytest.mark.django_db
 async def test_channel_listen_timeout(ws: WebsocketCommunicator):
     from channels.layers import get_channel_layer
 
@@ -195,6 +198,7 @@ async def test_channel_listen_timeout(ws: WebsocketCommunicator):
     assert complete_message == {"id": "sub1", "type": "complete"}
 
 
+@pytest.mark.django_db
 async def test_channel_listen_timeout_cm(ws: WebsocketCommunicator):
     from channels.layers import get_channel_layer
 
@@ -234,6 +238,7 @@ async def test_channel_listen_timeout_cm(ws: WebsocketCommunicator):
     assert complete_message == {"id": "sub1", "type": "complete"}
 
 
+@pytest.mark.django_db
 async def test_channel_listen_no_message_on_channel(ws: WebsocketCommunicator):
     from channels.layers import get_channel_layer
 
@@ -275,6 +280,7 @@ async def test_channel_listen_no_message_on_channel(ws: WebsocketCommunicator):
     assert complete_message == {"id": "sub1", "type": "complete"}
 
 
+@pytest.mark.django_db
 async def test_channel_listen_no_message_on_channel_cm(ws: WebsocketCommunicator):
     from channels.layers import get_channel_layer
 
@@ -322,6 +328,7 @@ async def test_channel_listen_no_message_on_channel_cm(ws: WebsocketCommunicator
     assert complete_message == {"id": "sub1", "type": "complete"}
 
 
+@pytest.mark.django_db
 async def test_channel_listen_group(ws: WebsocketCommunicator):
     from channels.layers import get_channel_layer
 
@@ -390,6 +397,7 @@ async def test_channel_listen_group(ws: WebsocketCommunicator):
     await ws.send_json_to(CompleteMessage({"id": "sub1", "type": "complete"}))
 
 
+@pytest.mark.django_db
 async def test_channel_listen_group_cm(ws: WebsocketCommunicator):
     from channels.layers import get_channel_layer
 
@@ -464,6 +472,7 @@ async def test_channel_listen_group_cm(ws: WebsocketCommunicator):
     await ws.send_json_to(CompleteMessage({"id": "sub1", "type": "complete"}))
 
 
+@pytest.mark.django_db
 async def test_channel_listen_group_twice(ws: WebsocketCommunicator):
     from channels.layers import get_channel_layer
 

--- a/tests/extensions/test_pyinstrument.py
+++ b/tests/extensions/test_pyinstrument.py
@@ -22,7 +22,7 @@ def function_called_by_us_c():
 
 
 def test_basic_pyinstrument():
-    with tempfile.NamedTemporaryFile() as report_file:
+    with tempfile.NamedTemporaryFile(delete=False) as report_file:
         report_file_path = Path(report_file.name)
 
         @strawberry.type

--- a/tests/extensions/test_pyinstrument.py
+++ b/tests/extensions/test_pyinstrument.py
@@ -41,6 +41,7 @@ def test_basic_pyinstrument():
         content = report_file_path.read_text("utf-8")
 
     assert not result.errors
+    assert result.data
     assert result.data["theField"] == 4
 
     assert "function_called_by_us_a" in content


### PR DESCRIPTION
## Description

This PR (hopefully) fixes the following errors currently thrown by our Windows CI:

```log
FAILED \U0001f630  tests/extensions/test_pyinstrument.py::test_basic_pyinstrument - PermissionError: [Errno 13] Permission denied: 'C:\\\\Users\\\\RUNNER~1\\\\AppData\\\\Local\\\\Temp\\\\tmprp5tslzd'
ERROR \U0001f621  tests/channels/test_layers.py::test_channel_listen - RuntimeError: Database access not allowed, use the "django_db" mark, or the "db" or "transactional_db" fixtures to enable it.
ERROR \U0001f621  tests/channels/test_layers.py::test_channel_listen_with_confirmation - RuntimeError: Database access not allowed, use the "django_db" mark, or the "db" or "transactional_db" fixtures to enable it.
ERROR \U0001f621  tests/channels/test_layers.py::test_channel_listen_timeout - RuntimeError: Database access not allowed, use the "django_db" mark, or the "db" or "transactional_db" fixtures to enable it.
ERROR \U0001f621  tests/channels/test_layers.py::test_channel_listen_timeout_cm - RuntimeError: Database access not allowed, use the "django_db" mark, or the "db" or "transactional_db" fixtures to enable it.
ERROR \U0001f621  tests/channels/test_layers.py::test_channel_listen_no_message_on_channel - RuntimeError: Database access not allowed, use the "django_db" mark, or the "db" or "transactional_db" fixtures to enable it.
ERROR \U0001f621  tests/channels/test_layers.py::test_channel_listen_no_message_on_channel_cm - RuntimeError: Database access not allowed, use the "django_db" mark, or the "db" or "transactional_db" fixtures to enable it.
ERROR \U0001f621  tests/channels/test_layers.py::test_channel_listen_group - RuntimeError: Database access not allowed, use the "django_db" mark, or the "db" or "transactional_db" fixtures to enable it.
ERROR \U0001f621  tests/channels/test_layers.py::test_channel_listen_group_cm - RuntimeError: Database access not allowed, use the "django_db" mark, or the "db" or "transactional_db" fixtures to enable it.
ERROR \U0001f621  tests/channels/test_layers.py::test_channel_listen_group_twice - RuntimeError: Database access not allowed, use the "django_db" mark, or the "db" or "transactional_db" fixtures to enable it.
```

The `PermissionError` is caused by our incorrect usage of `tempfile.NamedRemporaryFile` on Windows. The corresponding docs outline [some rules](https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile) that must be followed on Windows when a named file is opened. Not deleting the temporary file appears to be the easiest solution (CI is cleaning up afterward anyway).

The other errors are all related to missing markers. I'm not sure why these tests only fail under Windows. We also set these markers for other Channels tests, so let's try the same here.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Summary by Sourcery

Fix test failures on Windows by addressing PermissionError in test_pyinstrument and adding missing django_db markers to channel layer tests.

Bug Fixes:
- Fix PermissionError in test_pyinstrument by setting delete=False for NamedTemporaryFile on Windows.
- Add missing django_db markers to channel layer tests to prevent RuntimeError related to database access.