### PR TITLE
Fix aiohttp test server teardown

### DIFF
--- a/tests/http/clients/aiohttp.py
+++ b/tests/http/clients/aiohttp.py
@@ -172,11 +172,9 @@ class AioHttpClient(HttpClient):
         *,
         protocols: List[str],
     ) -> AsyncGenerator[WebSocketClient, None]:
-        server = TestServer(self.app)
-        await server.start_server()
-        client = TestClient(server)
-        async with client.ws_connect(url, protocols=protocols) as ws:
-            yield AioWebSocketClient(ws)
+        async with TestClient(TestServer(self.app)) as client:
+            async with client.ws_connect(url, protocols=protocols) as ws:
+                yield AioWebSocketClient(ws)
 
 
 class AioWebSocketClient(WebSocketClient):


### PR DESCRIPTION
## Description

This PR fixes that the AIOHTTP test server was not torn down in tests using WebSockets. This resulted in a bunch of error messages when running tests looking like this:

<details>

```log
tests/websockets/test_websockets.py::test_generally_unsupported_subprotocols_are_rejected[FastAPIHttpClient]
  /home/john/.cache/pypoetry/virtualenvs/strawberry-graphql-sn8mzJXE-py3.12/lib/python3.12/site-packages/_pytest/unraisableexception.py:78: PytestUnraisableExceptionWarning: Exception ignored in: <coroutine object RequestHandler.start at 0x7c4bd02f4dc0>
  
  Traceback (most recent call last):
    File "/home/john/.cache/pypoetry/virtualenvs/strawberry-graphql-sn8mzJXE-py3.12/lib/python3.12/site-packages/aiohttp/web_protocol.py", line 615, in start
      self.transport.close()
    File "/usr/lib/python3.12/asyncio/selector_events.py", line 1210, in close
      super().close()
    File "/usr/lib/python3.12/asyncio/selector_events.py", line 875, in close
      self._loop.call_soon(self._call_connection_lost, None)
    File "/usr/lib/python3.12/asyncio/base_events.py", line 795, in call_soon
      self._check_closed()
    File "/usr/lib/python3.12/asyncio/base_events.py", line 541, in _check_closed
      raise RuntimeError('Event loop is closed')
  RuntimeError: Event loop is closed
  
    warnings.warn(pytest.PytestUnraisableExceptionWarning(msg))
```

</details>

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Summary by Sourcery

Bug Fixes:
- Fix the issue where the AIOHTTP test server was not properly torn down in tests using WebSockets, preventing error messages related to closed event loops.