### PR TITLE
Fix deprecation warnings caused by tests

### DIFF
--- a/tests/channels/test_layers.py
+++ b/tests/channels/test_layers.py
@@ -50,8 +50,9 @@ async def test_no_layers():
         "Check https://channels.readthedocs.io/en/stable/topics/channel_layers.html "
         "for more information"
     )
-    with pytest.raises(RuntimeError, match=msg):
-        await consumer.channel_listen("foobar").__anext__()
+    with pytest.deprecated_call(match="Use listen_to_channel instead"):
+        with pytest.raises(RuntimeError, match=msg):
+            await consumer.channel_listen("foobar").__anext__()
 
     with pytest.raises(RuntimeError, match=msg):
         async with consumer.listen_to_channel("foobar"):

--- a/tests/fastapi/test_openapi.py
+++ b/tests/fastapi/test_openapi.py
@@ -26,7 +26,7 @@ def test_disable_graphiql_view_and_allow_queries_via_get():
     app = FastAPI()
     schema = strawberry.Schema(query=Query)
     graphql_app = GraphQLRouter[None, None](
-        schema, graphiql=False, allow_queries_via_get=False
+        schema, graphql_ide=None, allow_queries_via_get=False
     )
     app.include_router(graphql_app, prefix="/graphql")
 

--- a/tests/federation/test_entities.py
+++ b/tests/federation/test_entities.py
@@ -375,7 +375,9 @@ def test_propagates_original_error_message_and_graphql_error_metadata():
             exception = Exception("Foo bar")
             exception.extensions = {"baz": "qux"}
             raise located_error(
-                exception, nodes=info.field_nodes[0], path=["_entities_override", 0]
+                exception,
+                nodes=info._raw_info.field_nodes[0],
+                path=["_entities_override", 0],
             )
 
     @strawberry.federation.type(extend=True)

--- a/tests/fields/test_arguments.py
+++ b/tests/fields/test_arguments.py
@@ -1,5 +1,4 @@
 import sys
-import warnings
 from typing import List, Optional, Union
 from typing_extensions import Annotated
 
@@ -488,11 +487,19 @@ def test_unset_deprecation_warning():
 
 
 def test_deprecated_unset():
-    with pytest.deprecated_call():
+    warning = "`is_unset` is deprecated use `value is UNSET` instead"
+
+    with pytest.deprecated_call(match=warning):
         from strawberry.types.unset import is_unset
 
-    with warnings.catch_warnings(record=False):
+    with pytest.deprecated_call(match=warning):
         assert is_unset(UNSET)
+
+    with pytest.deprecated_call(match=warning):
         assert not is_unset(None)
+
+    with pytest.deprecated_call(match=warning):
         assert not is_unset(False)
+
+    with pytest.deprecated_call(match=warning):
         assert not is_unset("hello world")

--- a/tests/litestar/schema.py
+++ b/tests/litestar/schema.py
@@ -99,7 +99,9 @@ class Subscription:
         yield message
 
     @strawberry.subscription
-    async def request_ping(self, info) -> typing.AsyncGenerator[bool, None]:
+    async def request_ping(
+        self, info: strawberry.Info
+    ) -> typing.AsyncGenerator[bool, None]:
         ws = info.context["ws"]
         await ws.send_json(PingMessage().as_dict())
         yield True
@@ -111,7 +113,7 @@ class Subscription:
             await asyncio.sleep(1)
 
     @strawberry.subscription
-    async def context(self, info) -> typing.AsyncGenerator[str, None]:
+    async def context(self, info: strawberry.Info) -> typing.AsyncGenerator[str, None]:
         yield info.context["custom_value"]
 
     @strawberry.subscription
@@ -132,7 +134,9 @@ class Subscription:
         yield Flavor.CHOCOLATE
 
     @strawberry.subscription
-    async def debug(self, info) -> typing.AsyncGenerator[DebugInfo, None]:
+    async def debug(
+        self, info: strawberry.Info
+    ) -> typing.AsyncGenerator[DebugInfo, None]:
         active_result_handlers = [
             task for task in info.context["get_tasks"]() if not task.done()
         ]

--- a/tests/schema/test_arguments.py
+++ b/tests/schema/test_arguments.py
@@ -177,7 +177,7 @@ def test_setting_metadata_on_argument():
         @strawberry.field
         def hello(
             self,
-            info,
+            info: strawberry.Info,
             input: Annotated[str, strawberry.argument(metadata={"test": "foo"})],
         ) -> str:
             nonlocal field_definition

--- a/tests/schema/test_directives.py
+++ b/tests/schema/test_directives.py
@@ -103,7 +103,9 @@ async def test_supports_default_directives_async():
 def test_can_declare_directives():
     @strawberry.type
     class Query:
-        cake: str = "made_in_switzerland"
+        @strawberry.field
+        def cake(self) -> str:
+            return "made_in_switzerland"
 
     @strawberry.directive(
         locations=[DirectiveLocation.FIELD], description="Make string uppercase"
@@ -123,6 +125,10 @@ def test_can_declare_directives():
     '''
 
     assert schema.as_str() == textwrap.dedent(expected_schema).strip()
+
+    result = schema.execute_sync('query { cake @uppercase(example: "foo") }')
+    assert result.errors is None
+    assert result.data == {"cake": "MADE_IN_SWITZERLAND"}
 
 
 def test_directive_arguments_without_value_param():
@@ -199,6 +205,7 @@ def test_runs_directives():
     result = schema.execute_sync(query, variable_values={"identified": False})
 
     assert not result.errors
+    assert result.data
     assert result.data["person"]["name"] == "JESS"
     assert result.data["jess"]["name"] == "Jessica"
     assert result.data["johnDoe"].get("name") is None
@@ -609,7 +616,9 @@ def test_directives_with_custom_types():
 
     @strawberry.type
     class Query:
-        cake: str = "made_in_switzerland"
+        @strawberry.field
+        def cake(self) -> str:
+            return "made_in_switzerland"
 
     @strawberry.directive(
         locations=[DirectiveLocation.FIELD], description="Make string uppercase"
@@ -634,13 +643,19 @@ def test_directives_with_custom_types():
 
     assert schema.as_str() == textwrap.dedent(expected_schema).strip()
 
+    result = schema.execute_sync('query { cake @uppercase(input: { example: "foo" }) }')
+    assert result.errors is None
+    assert result.data == {"cake": "MADE_IN_SWITZERLAND"}
+
 
 def test_directives_with_scalar():
     DirectiveInput = strawberry.scalar(str, name="DirectiveInput")
 
     @strawberry.type
     class Query:
-        cake: str = "made_in_switzerland"
+        @strawberry.field
+        def cake(self) -> str:
+            return "made_in_switzerland"
 
     @strawberry.directive(
         locations=[DirectiveLocation.FIELD], description="Make string uppercase"
@@ -662,6 +677,10 @@ def test_directives_with_scalar():
     '''
 
     assert schema.as_str() == textwrap.dedent(expected_schema).strip()
+
+    result = schema.execute_sync('query { cake @uppercase(input: "foo") }')
+    assert result.errors is None
+    assert result.data == {"cake": "MADE_IN_SWITZERLAND"}
 
 
 @pytest.mark.asyncio

--- a/tests/schema/test_directives.py
+++ b/tests/schema/test_directives.py
@@ -40,6 +40,7 @@ def test_supports_default_directives():
     )
 
     assert not result.errors
+    assert result.data
     assert result.data["person"] == {"name": "Jess"}
 
     query = """query ($skipPoints: Boolean!){
@@ -53,6 +54,7 @@ def test_supports_default_directives():
     result = schema.execute_sync(query, variable_values={"skipPoints": False})
 
     assert not result.errors
+    assert result.data
     assert result.data["person"] == {"name": "Jess", "points": 2000}
 
 
@@ -80,6 +82,7 @@ async def test_supports_default_directives_async():
     result = await schema.execute(query, variable_values={"includePoints": False})
 
     assert not result.errors
+    assert result.data
     assert result.data["person"] == {"name": "Jess"}
 
     query = """query ($skipPoints: Boolean!){
@@ -93,6 +96,7 @@ async def test_supports_default_directives_async():
     result = await schema.execute(query, variable_values={"skipPoints": False})
 
     assert not result.errors
+    assert result.data
     assert result.data["person"] == {"name": "Jess", "points": 2000}
 
 
@@ -104,7 +108,7 @@ def test_can_declare_directives():
     @strawberry.directive(
         locations=[DirectiveLocation.FIELD], description="Make string uppercase"
     )
-    def uppercase(value: str, example: str):
+    def uppercase(value: DirectiveValue[str], example: str):
         return value.upper()
 
     schema = strawberry.Schema(query=Query, directives=[uppercase])
@@ -171,11 +175,11 @@ def test_runs_directives():
     @strawberry.directive(
         locations=[DirectiveLocation.FIELD], description="Make string uppercase"
     )
-    def turn_uppercase(value: str):
+    def turn_uppercase(value: DirectiveValue[str]):
         return value.upper()
 
     @strawberry.directive(locations=[DirectiveLocation.FIELD])
-    def replace(value: str, old: str, new: str):
+    def replace(value: DirectiveValue[str], old: str, new: str):
         return value.replace(old, new)
 
     schema = strawberry.Schema(query=Query, directives=[turn_uppercase, replace])
@@ -214,11 +218,11 @@ def test_runs_directives_camel_case_off():
     @strawberry.directive(
         locations=[DirectiveLocation.FIELD], description="Make string uppercase"
     )
-    def turn_uppercase(value: str):
+    def turn_uppercase(value: DirectiveValue[str]):
         return value.upper()
 
     @strawberry.directive(locations=[DirectiveLocation.FIELD])
-    def replace(value: str, old: str, new: str):
+    def replace(value: DirectiveValue[str], old: str, new: str):
         return value.replace(old, new)
 
     schema = strawberry.Schema(
@@ -242,6 +246,7 @@ def test_runs_directives_camel_case_off():
     result = schema.execute_sync(query, variable_values={"identified": False})
 
     assert not result.errors
+    assert result.data
     assert result.data["person"]["name"] == "JESS"
     assert result.data["jess"]["name"] == "Jessica"
     assert result.data["johnDoe"].get("name") is None
@@ -262,7 +267,7 @@ async def test_runs_directives_async():
     @strawberry.directive(
         locations=[DirectiveLocation.FIELD], description="Make string uppercase"
     )
-    async def uppercase(value: str):
+    async def uppercase(value: DirectiveValue[str]):
         return value.upper()
 
     schema = strawberry.Schema(query=Query, directives=[uppercase])
@@ -293,7 +298,7 @@ def test_runs_directives_with_list_params():
             return Person()
 
     @strawberry.directive(locations=[DirectiveLocation.FIELD])
-    def replace(value: str, old_list: List[str], new: str):
+    def replace(value: DirectiveValue[str], old_list: List[str], new: str):
         for old in old_list:
             value = value.replace(old, new)
 
@@ -310,6 +315,7 @@ def test_runs_directives_with_list_params():
     result = schema.execute_sync(query, variable_values={"identified": False})
 
     assert not result.errors
+    assert result.data
     assert result.data["person"]["name"] == "JESS"
 
 
@@ -327,7 +333,7 @@ def test_runs_directives_with_extensions():
     @strawberry.directive(
         locations=[DirectiveLocation.FIELD], description="Make string uppercase"
     )
-    def uppercase(value: str):
+    def uppercase(value: DirectiveValue[str]):
         return value.upper()
 
     class ExampleExtension(SchemaExtension):
@@ -366,7 +372,7 @@ async def test_runs_directives_with_extensions_async():
     @strawberry.directive(
         locations=[DirectiveLocation.FIELD], description="Make string uppercase"
     )
-    def uppercase(value: str):
+    def uppercase(value: DirectiveValue[str]):
         return value.upper()
 
     class ExampleExtension(SchemaExtension):
@@ -416,7 +422,7 @@ def info_directive_schema() -> strawberry.Schema:
         locations=[DirectiveLocation.FIELD],
         description="Interpolate string on the server from context data",
     )
-    def interpolate(value: str, info: strawberry.Info):
+    def interpolate(value: DirectiveValue[str], info: strawberry.Info):
         try:
             assert isinstance(info, strawberry.Info)
             assert info._field is field
@@ -592,6 +598,7 @@ async def test_directive_list_argument() -> NoReturn:
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["greeting"] == "Hi foo, bar"
 
 
@@ -607,7 +614,7 @@ def test_directives_with_custom_types():
     @strawberry.directive(
         locations=[DirectiveLocation.FIELD], description="Make string uppercase"
     )
-    def uppercase(value: str, input: DirectiveInput):
+    def uppercase(value: DirectiveValue[str], input: DirectiveInput):
         return value.upper()
 
     schema = strawberry.Schema(query=Query, directives=[uppercase])
@@ -638,7 +645,7 @@ def test_directives_with_scalar():
     @strawberry.directive(
         locations=[DirectiveLocation.FIELD], description="Make string uppercase"
     )
-    def uppercase(value: str, input: DirectiveInput):
+    def uppercase(value: DirectiveValue[str], input: DirectiveInput):
         return value.upper()
 
     schema = strawberry.Schema(query=Query, directives=[uppercase])
@@ -687,4 +694,5 @@ async def test_directive_with_custom_info_class() -> NoReturn:
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["greeting"] == "Hi foo, bar"

--- a/tests/schema/test_extensions.py
+++ b/tests/schema/test_extensions.py
@@ -11,6 +11,7 @@ from graphql import (
 )
 
 import strawberry
+from strawberry.directive import DirectiveValue
 from strawberry.scalars import JSON
 from strawberry.schema.schema_converter import GraphQLCoreConverter
 from strawberry.schema_directive import Location
@@ -52,7 +53,7 @@ def test_extensions_schema_directive():
 
 def test_directive():
     @strawberry.directive(locations=[DirectiveLocation.FIELD])
-    def uppercase(value: str, foo: str):
+    def uppercase(value: DirectiveValue[str], foo: str):
         return value.upper()
 
     @strawberry.type()

--- a/tests/schema/test_get_extensions.py
+++ b/tests/schema/test_get_extensions.py
@@ -1,5 +1,5 @@
 import strawberry
-from strawberry.directive import DirectiveLocation
+from strawberry.directive import DirectiveLocation, DirectiveValue
 from strawberry.extensions import SchemaExtension
 from strawberry.extensions.directives import (
     DirectivesExtension,
@@ -13,7 +13,7 @@ class Query:
 
 
 @strawberry.directive(locations=[DirectiveLocation.FIELD])
-def uppercase(value: str) -> str:
+def uppercase(value: DirectiveValue[str]) -> str:
     return value.upper()
 
 

--- a/tests/schema/test_info.py
+++ b/tests/schema/test_info.py
@@ -65,6 +65,7 @@ def test_info_has_the_correct_shape():
     result = schema.execute_sync(query, context_value=my_context, root_value=root_value)
 
     assert not result.errors
+    assert result.data
     info = result.data["helloWorld"]
     assert info.pop("operation").startswith("OperationDefinitionNode at")
     field = json.loads(info.pop("selectedField"))
@@ -315,11 +316,12 @@ def test_return_type_from_resolver(return_type, return_value):
     result = schema.execute_sync("{ field }")
 
     assert not result.errors
+    assert result.data
     assert result.data["field"] == return_value
 
 
 def test_return_type_from_field():
-    def resolver(info):
+    def resolver(info: strawberry.Info):
         assert info.return_type is int
         return 0
 
@@ -332,11 +334,12 @@ def test_return_type_from_field():
     result = schema.execute_sync("{ field }")
 
     assert not result.errors
+    assert result.data
     assert result.data["field"] == 0
 
 
 def test_field_nodes_deprecation():
-    def resolver(info):
+    def resolver(info: strawberry.Info):
         info.field_nodes
         return 0
 
@@ -350,6 +353,7 @@ def test_field_nodes_deprecation():
         result = schema.execute_sync("{ field }")
 
     assert not result.errors
+    assert result.data
     assert result.data["field"] == 0
 
 
@@ -367,7 +371,7 @@ def test_get_argument_defintion_helper():
         @strawberry.field
         def field(
             self,
-            info,
+            info: strawberry.Info,
             arg_1: Annotated[str, strawberry.argument(description="Some description")],
             arg_2: Optional[TestInput] = None,
         ) -> str:

--- a/tests/schema/test_permission.py
+++ b/tests/schema/test_permission.py
@@ -71,9 +71,7 @@ async def test_raises_permission_error_for_subscription():
     @strawberry.type
     class Subscription:
         @strawberry.subscription(permission_classes=[IsAdmin])
-        async def user(
-            self, info
-        ) -> typing.AsyncGenerator[str, None]:  # pragma: no cover
+        async def user(self) -> typing.AsyncGenerator[str, None]:  # pragma: no cover
             yield "Hello"
 
     schema = strawberry.Schema(query=Query, subscription=Subscription)

--- a/tests/schema/test_resolvers.py
+++ b/tests/schema/test_resolvers.py
@@ -1,5 +1,6 @@
 # type: ignore
 import typing
+from contextlib import nullcontext
 from typing import Any, Generic, List, NamedTuple, Optional, Type, TypeVar, Union
 
 import pytest
@@ -512,18 +513,23 @@ def arbitrarily_named_info(icon: str, info_argument: Info) -> str:
 
 
 @pytest.mark.parametrize(
-    "resolver",
+    ("resolver", "deprecation"),
     (
-        pytest.param(name_based_info),
-        pytest.param(type_based_info),
-        pytest.param(generic_type_based_info),
-        pytest.param(arbitrarily_named_info),
+        pytest.param(
+            name_based_info,
+            pytest.deprecated_call(match="Argument name-based matching of"),
+        ),
+        pytest.param(type_based_info, nullcontext()),
+        pytest.param(generic_type_based_info, nullcontext()),
+        pytest.param(arbitrarily_named_info, nullcontext()),
     ),
 )
-def test_info_argument(resolver):
-    @strawberry.type
-    class ResolverGreeting:
-        hello: str = strawberry.field(resolver=resolver)
+def test_info_argument(resolver, deprecation):
+    with deprecation:
+
+        @strawberry.type
+        class ResolverGreeting:
+            hello: str = strawberry.field(resolver=resolver)
 
     schema = strawberry.Schema(query=ResolverGreeting)
     result = schema.execute_sync('{ hello(icon: "🍓") }')

--- a/tests/test/test_client.py
+++ b/tests/test/test_client.py
@@ -9,26 +9,28 @@ from strawberry.utils.await_maybe import await_maybe
 async def test_query_asserts_errors_option_is_deprecated(
     graphql_client, asserts_errors
 ):
-    with pytest.warns(
-        DeprecationWarning,
-        match="The `asserts_errors` argument has been renamed to `assert_no_errors`",
+    with pytest.deprecated_call(
+        match="The `asserts_errors` argument has been renamed to `assert_no_errors`"
     ):
         await await_maybe(
             graphql_client.query("{ hello }", asserts_errors=asserts_errors)
         )
 
 
-@pytest.mark.parametrize("option_name", ["asserts_errors", "assert_no_errors"])
 @pytest.mark.parametrize(
-    ("assert_no_errors", "expectation"),
+    ("option_name", "expectation1"),
+    [("asserts_errors", pytest.deprecated_call()), ("assert_no_errors", nullcontext())],
+)
+@pytest.mark.parametrize(
+    ("assert_no_errors", "expectation2"),
     [(True, pytest.raises(AssertionError)), (False, nullcontext())],
 )
 async def test_query_with_assert_no_errors_option(
-    graphql_client, option_name, assert_no_errors, expectation
+    graphql_client, option_name, assert_no_errors, expectation1, expectation2
 ):
     query = "{ ThisIsNotAValidQuery }"
 
-    with expectation:
+    with expectation1, expectation2:
         await await_maybe(
             graphql_client.query(query, **{option_name: assert_no_errors})
         )

--- a/tests/tools/test_create_type.py
+++ b/tests/tools/test_create_type.py
@@ -137,7 +137,7 @@ def test_create_mutation_type():
         username: str
 
     @strawberry.mutation
-    def make_user(info, username: str) -> User:
+    def make_user(username: str) -> User:
         return User(username=username)
 
     Mutation = create_type("Mutation", [make_user])
@@ -156,7 +156,7 @@ def test_create_mutation_type_with_params():
         username: str
 
     @strawberry.mutation(name="makeNewUser", description="Make a new user")
-    def make_user(info, username: str) -> User:
+    def make_user(username: str) -> User:
         return User(username=username)
 
     Mutation = create_type("Mutation", [make_user])
@@ -176,7 +176,7 @@ def test_create_schema():
         id: strawberry.ID
 
     @strawberry.field
-    def get_user_by_id(info, id: strawberry.ID) -> User:
+    def get_user_by_id(id: strawberry.ID) -> User:
         return User(id=id)
 
     Query = create_type("Query", [get_user_by_id])

--- a/tests/types/test_lazy_types.py
+++ b/tests/types/test_lazy_types.py
@@ -2,7 +2,7 @@
 import enum
 import sys
 import textwrap
-from typing import Generic, TypeVar
+from typing import Generic, TypeVar, Union
 from typing_extensions import Annotated, TypeAlias
 
 import pytest
@@ -173,7 +173,7 @@ def test_lazy_type_in_union():
     ActiveType = LazyType("LaziestType", "test_lazy_types")
     ActiveEnum = LazyType("LazyEnum", "test_lazy_types")
 
-    something = union(name="CoolUnion", types=(ActiveType, ActiveEnum))
+    something = Annotated[Union[ActiveType, ActiveEnum], union(name="CoolUnion")]
     annotation = StrawberryAnnotation(something)
 
     resolved = annotation.resolve()
@@ -190,7 +190,7 @@ def test_lazy_function_in_union():
     ActiveType = Annotated["LaziestType", strawberry.lazy("test_lazy_types")]
     ActiveEnum = Annotated["LazyEnum", strawberry.lazy("test_lazy_types")]
 
-    something = union(name="CoolUnion", types=(ActiveType, ActiveEnum))
+    something = Annotated[Union[ActiveType, ActiveEnum], union(name="CoolUnion")]
     annotation = StrawberryAnnotation(something)
 
     resolved = annotation.resolve()

--- a/tests/views/schema.py
+++ b/tests/views/schema.py
@@ -221,12 +221,13 @@ class Subscription:
     ) -> AsyncGenerator[str, None]:
         yield info.context["request"].channel_name
 
-        async for message in info.context["request"].channel_listen(
+        async with info.context["request"].listen_to_channel(
             type="test.message",
             timeout=timeout,
             groups=[group] if group is not None else [],
-        ):
-            yield message["text"]
+        ) as cm:
+            async for message in cm:
+                yield message["text"]
 
     @strawberry.subscription
     async def listener_with_confirmation(


### PR DESCRIPTION
## Description

This PR fixes all deprecation warnings caused directly by our test code bringing our warning count down from 109 to 53.

Running our tests still results in some deprecation warnings but those are the real ones caused by Strawberry code. I'll look at those in a separate PR so that this PR only changes code in `/tests`.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Summary by Sourcery

Fix deprecation warnings in test code by updating deprecated function calls and argument types, and enhance test assertions to check for result data presence.

Bug Fixes:
- Fix deprecation warnings in test code by updating deprecated function calls and argument types.

Tests:
- Update test assertions to check for result data presence and handle deprecation warnings using pytest.deprecated_call.