### PR TITLE
Make clear the requirement of the [cli] dependency group for the schema exporter

### DIFF
--- a/docs/guides/schema-export.md
+++ b/docs/guides/schema-export.md
@@ -10,6 +10,8 @@ schema definition.
 Strawberry provides a command to export your schema definition. The exported
 schema will be described in the GraphQL schema definition language (SDL).
 
+To use the command line tools, you have to ensure Strawberry was installed with `strawberry-graphql[cli]`.
+
 You can export your schema using the following command:
 
 ```bash

--- a/docs/guides/schema-export.md
+++ b/docs/guides/schema-export.md
@@ -10,7 +10,8 @@ schema definition.
 Strawberry provides a command to export your schema definition. The exported
 schema will be described in the GraphQL schema definition language (SDL).
 
-To use the command line tools, you have to ensure Strawberry was installed with `strawberry-graphql[cli]`.
+To use the command line tools, you have to ensure Strawberry was installed with
+`strawberry-graphql[cli]`.
 
 You can export your schema using the following command:
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Make clear the requirement of the [cli] dependency group when running the schema exporter to avoid import module errors.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [X] Documentation

## Issues Fixed or Closed by This PR

Not closed, but related to: https://github.com/strawberry-graphql/strawberry/issues/3056

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Documentation:
- Clarify the requirement of installing the [cli] dependency group for using the schema exporter command line tools.