### PR TITLE
Fix warnings directly caused by test code

### DIFF
--- a/tests/benchmarks/api.py
+++ b/tests/benchmarks/api.py
@@ -1,7 +1,7 @@
 from collections.abc import AsyncIterator
 
 import strawberry
-from strawberry.directive import DirectiveLocation
+from strawberry.directive import DirectiveLocation, DirectiveValue
 
 
 @strawberry.type
@@ -80,7 +80,7 @@ class Subscription:
 
 
 @strawberry.directive(locations=[DirectiveLocation.FIELD])
-def uppercase(value: str) -> str:
+def uppercase(value: DirectiveValue[str]) -> str:
     return value.upper()
 
 

--- a/tests/federation/printer/test_additional_directives.py
+++ b/tests/federation/printer/test_additional_directives.py
@@ -30,11 +30,21 @@ def test_additional_schema_directives_printed_correctly_object():
     }
 
     type Query {
+      _entities(representations: [_Any!]!): [_Entity]!
+      _service: _Service!
       federatedType: FederatedType!
+    }
+
+    scalar _Any
+
+    union _Entity = FederatedType
+
+    type _Service {
+      sdl: String!
     }
     """
 
-    schema = strawberry.Schema(
+    schema = strawberry.federation.Schema(
         query=Query, config=StrawberryConfig(auto_camel_case=False)
     )
     assert schema.as_str() == textwrap.dedent(expected_type).strip()
@@ -72,11 +82,21 @@ def test_additional_schema_directives_printed_in_order_object():
     }
 
     type Query {
+      _entities(representations: [_Any!]!): [_Entity]!
+      _service: _Service!
       federatedType: FederatedType!
+    }
+
+    scalar _Any
+
+    union _Entity = FederatedType
+
+    type _Service {
+      sdl: String!
     }
     """
 
-    schema = strawberry.Schema(
+    schema = strawberry.federation.Schema(
         query=Query, config=StrawberryConfig(auto_camel_case=False)
     )
     assert schema.as_str() == textwrap.dedent(expected_type).strip()

--- a/tests/federation/printer/test_inaccessible.py
+++ b/tests/federation/printer/test_inaccessible.py
@@ -1,6 +1,6 @@
 import textwrap
 from enum import Enum
-from typing import Annotated
+from typing import Annotated, Union
 
 import strawberry
 
@@ -249,11 +249,13 @@ def test_field_tag_printed_correctly_on_union():
     class B:
         b: str
 
-    Union = strawberry.federation.union("Union", (A, B), inaccessible=True)
+    MyUnion = Annotated[
+        Union[A, B], strawberry.federation.union("Union", inaccessible=True)
+    ]
 
     @strawberry.federation.type
     class Query:
-        hello: Union
+        hello: MyUnion
 
     schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
 

--- a/tests/federation/printer/test_tag.py
+++ b/tests/federation/printer/test_tag.py
@@ -1,6 +1,6 @@
 import textwrap
 from enum import Enum
-from typing import Annotated
+from typing import Annotated, Union
 
 import strawberry
 
@@ -167,11 +167,13 @@ def test_field_tag_printed_correctly_on_union():
     class B:
         b: str
 
-    Union = strawberry.federation.union("Union", (A, B), tags=["myTag", "anotherTag"])
+    MyUnion = Annotated[
+        Union[A, B], strawberry.federation.union("Union", tags=["myTag", "anotherTag"])
+    ]
 
     @strawberry.federation.type
     class Query:
-        hello: Union
+        hello: MyUnion
 
     schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)
 

--- a/tests/schema/test_resolvers.py
+++ b/tests/schema/test_resolvers.py
@@ -614,20 +614,6 @@ def multiple_infos(root, info1: Info, info2: Info) -> str:
         pytest.param(parent_self_and_root),
         pytest.param(multiple_parents),
         pytest.param(multiple_infos),
-        pytest.param(
-            parent_and_self,
-            marks=pytest.mark.xfail(
-                strict=True,
-                reason="`self` should not raise ConflictingArgumentsError",
-            ),
-        ),
-        pytest.param(
-            self_and_root,
-            marks=pytest.mark.xfail(
-                strict=True,
-                reason="`self` should not raise ConflictingArgumentsError",
-            ),
-        ),
     ),
 )
 @pytest.mark.raises_strawberry_exception(
@@ -638,6 +624,15 @@ def multiple_infos(root, info1: Info, info2: Info) -> str:
     ),
 )
 def test_multiple_conflicting_reserved_arguments(resolver):
+    @strawberry.type
+    class Query:
+        name: str = strawberry.field(resolver=resolver)
+
+    strawberry.Schema(query=Query)
+
+
+@pytest.mark.parametrize("resolver", (parent_and_self, self_and_root))
+def test_self_should_not_raise_conflicting_arguments_error(resolver):
     @strawberry.type
     class Query:
         name: str = strawberry.field(resolver=resolver)

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -10,7 +10,10 @@ class A:
 
 
 def test_type_definition_is_aliased():
-    assert A.__strawberry_definition__ is A._type_definition
+    with pytest.warns(
+        match="_type_definition is deprecated, use __strawberry_definition__ instead"
+    ):
+        assert A.__strawberry_definition__ is A._type_definition
 
 
 def test_get_warns():


### PR DESCRIPTION
## Description

This PR resolves all warnings directly caused by test code. These were mostly `UserWarning`s, but also two `DeprecationWarning`'s I missed last time, and a `PluggyTeardownRaisedWarning`.

We're now down to 15 warnings which all appear to be caused by actual Strawberry code.

For reference, these are the resolved warnings:

<details>

```log
DeprecationWarning: Passing types to `strawberry.union` is deprecated. Please use Union = Annotated[Union[A, B], strawberry.union("Union")] instead

UserWarning: Federation directive found in schema. Use `strawberry.federation.Schema` instead of `strawberry.Schema`

UserWarning: _type_definition is deprecated, use __strawberry_definition__ instead
    
PluggyTeardownRaisedWarning: A plugin raised an exception during an old-style hookwrapper teardown.
  Plugin: strawberry_exceptions, Hook: pytest_runtest_call
  Failed: Expected exception <class 'strawberry.exceptions.conflicting_arguments.ConflictingArgumentsError'>, but it did not raise
  For more information see https://pluggy.readthedocs.io/en/stable/api_reference.html#pluggy.PluggyTeardownRaisedWarning
    lambda: ihook(item=item, **kwds), when=when, reraise=reraise
```

</details>

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Summary by Sourcery

Fix warnings emitted by test code, reducing the total number of warnings.

Bug Fixes:
- Resolved `UserWarning`s, `DeprecationWarning`s, and `PluggyTeardownRaisedWarning`s originating from the test suite.

Tests:
- Removed xfail markers from tests that now pass due to the warning fixes.