### PR TITLE
Fix deprecated passing of keywords args to Path

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+Release type: patch
+
+This release updates Strawberry internally to no longer pass keywords arguments
+to `pathlib.PurePath`. Support for supplying keyword arguments to
+`pathlib.PurePath` is deprecated and scheduled for removal in Python 3.14

--- a/strawberry/extensions/pyinstrument.py
+++ b/strawberry/extensions/pyinstrument.py
@@ -28,7 +28,7 @@ class PyInstrument(SchemaExtension):
 
         profiler.stop()
 
-        Path(self._report_path, encoding="utf-8").write_text(profiler.output_html())
+        self._report_path.write_text(profiler.output_html())
 
 
 __all__ = ["PyInstrument"]


### PR DESCRIPTION
## Description

This PR fixes that we were passing a keyword argument to `pathlib.Path` which is deprecated and in our case unnecessary.

This resolves the following deprecation warning:

```log
DeprecationWarning: support for supplying keyword arguments to pathlib.PurePath is deprecated and scheduled for removal in Python 3.14
    Path(self._report_path, encoding="utf-8").write_text(profiler.output_html())
```

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Summary by Sourcery

Enhancements:
- Remove deprecated keyword arguments passed to `pathlib.PurePath`.