### PR TITLE
fix: make payload:null handling in connection_init consistent between protocols

### DIFF
--- a/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
@@ -167,7 +167,8 @@ class BaseGraphQLTransportWSHandler(Generic[Context, RootValue]):
             self.connection_init_timeout_task.cancel()
 
         payload = message.get("payload", {})
-
+        if payload is None:
+            payload = {}
         if not isinstance(payload, dict):
             await self.websocket.close(
                 code=4400, reason="Invalid connection init payload"

--- a/strawberry/subscriptions/protocols/graphql_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_ws/handlers.py
@@ -97,7 +97,9 @@ class BaseGraphQLWSHandler(Generic[Context, RootValue]):
 
     async def handle_connection_init(self, message: ConnectionInitMessage) -> None:
         payload = message.get("payload")
-        if payload is not None and not isinstance(payload, dict):
+        if payload is None:
+            payload = {}
+        if not isinstance(payload, dict):
             await self.send_message({"type": "connection_error"})
             await self.websocket.close(code=1000, reason="")
             return


### PR DESCRIPTION
When client specifies `payload: null` in connection_init message graphql_transport_ws erored with `Invalid connection init payload`, while in `graphql_ws` this case was handled.