### PR TITLE
Type internal test clients stricter

### DIFF
--- a/strawberry/subscriptions/protocols/graphql_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_ws/handlers.py
@@ -34,9 +34,6 @@ if TYPE_CHECKING:
 
 
 class BaseGraphQLWSHandler(Generic[Context, RootValue]):
-    context: Context
-    root_value: RootValue
-
     def __init__(
         self,
         view: AsyncBaseHTTPView[Any, Any, Any, Any, Any, Context, RootValue],

--- a/tests/http/clients/aiohttp.py
+++ b/tests/http/clients/aiohttp.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import contextlib
 import json
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Mapping
 from io import BytesIO
-from typing import Any, Optional
+from typing import Any, Optional, Union
 from typing_extensions import Literal
 
 from aiohttp import web
@@ -37,7 +37,7 @@ class GraphQLView(OnWSConnectMixin, BaseGraphQLView[dict[str, object], object]):
     graphql_ws_handler_class = DebuggableGraphQLWSHandler
 
     async def get_context(
-        self, request: web.Request, response: web.StreamResponse
+        self, request: web.Request, response: Union[web.Response, web.WebSocketResponse]
     ) -> dict[str, object]:
         context = await super().get_context(request, response)
 
@@ -95,7 +95,7 @@ class AioHttpClient(HttpClient):
     async def _graphql_request(
         self,
         method: Literal["get", "post"],
-        query: Optional[str] = None,
+        query: str,
         variables: Optional[dict[str, object]] = None,
         files: Optional[dict[str, BytesIO]] = None,
         headers: Optional[dict[str, str]] = None,
@@ -163,7 +163,7 @@ class AioHttpClient(HttpClient):
             return Response(
                 status_code=response.status,
                 data=(await response.text()).encode(),
-                headers=response.headers,
+                headers=dict(response.headers),
             )
 
     @contextlib.asynccontextmanager
@@ -186,7 +186,7 @@ class AioWebSocketClient(WebSocketClient):
     async def send_text(self, payload: str) -> None:
         await self.ws.send_str(payload)
 
-    async def send_json(self, payload: dict[str, Any]) -> None:
+    async def send_json(self, payload: Mapping[str, object]) -> None:
         await self.ws.send_json(payload)
 
     async def send_bytes(self, payload: bytes) -> None:
@@ -197,7 +197,7 @@ class AioWebSocketClient(WebSocketClient):
         self._reason = m.extra
         return Message(type=m.type, data=m.data, extra=m.extra)
 
-    async def receive_json(self, timeout: Optional[float] = None) -> Any:
+    async def receive_json(self, timeout: Optional[float] = None) -> object:
         m = await self.ws.receive(timeout)
         assert m.type == WSMsgType.TEXT
         return json.loads(m.data)

--- a/tests/http/clients/async_flask.py
+++ b/tests/http/clients/async_flask.py
@@ -16,12 +16,12 @@ from .base import ResultOverrideFunction
 from .flask import FlaskHttpClient
 
 
-class GraphQLView(BaseAsyncGraphQLView):
+class GraphQLView(BaseAsyncGraphQLView[dict[str, object], object]):
     methods = ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"]
 
     result_override: ResultOverrideFunction = None
 
-    def __init__(self, *args: str, **kwargs: Any):
+    def __init__(self, *args: Any, **kwargs: Any):
         self.result_override = kwargs.pop("result_override")
         super().__init__(*args, **kwargs)
 

--- a/tests/http/clients/base.py
+++ b/tests/http/clients/base.py
@@ -108,7 +108,7 @@ class HttpClient(abc.ABC):
     async def _graphql_request(
         self,
         method: Literal["get", "post"],
-        query: Optional[str] = None,
+        query: str,
         variables: Optional[dict[str, object]] = None,
         files: Optional[dict[str, BytesIO]] = None,
         headers: Optional[dict[str, str]] = None,
@@ -141,7 +141,7 @@ class HttpClient(abc.ABC):
 
     async def query(
         self,
-        query: Optional[str] = None,
+        query: str,
         method: Literal["get", "post"] = "post",
         variables: Optional[dict[str, object]] = None,
         files: Optional[dict[str, BytesIO]] = None,
@@ -302,7 +302,9 @@ class WebSocketClient(abc.ABC):
         await self.send_json(message)
 
 
-class DebuggableGraphQLTransportWSHandler(BaseGraphQLTransportWSHandler):
+class DebuggableGraphQLTransportWSHandler(
+    BaseGraphQLTransportWSHandler[dict[str, object], object]
+):
     def on_init(self) -> None:
         """This method can be patched by unit tests to get the instance of the
         transport handler when it is initialized.
@@ -330,10 +332,10 @@ class DebuggableGraphQLTransportWSHandler(BaseGraphQLTransportWSHandler):
         self.original_context = value
 
 
-class DebuggableGraphQLWSHandler(BaseGraphQLWSHandler):
+class DebuggableGraphQLWSHandler(BaseGraphQLWSHandler[dict[str, object], object]):
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
-        self.original_context = self.context
+        self.original_context = kwargs.get("context", {})
 
     def get_tasks(self) -> list:
         return list(self.tasks.values())

--- a/tests/http/clients/chalice.py
+++ b/tests/http/clients/chalice.py
@@ -20,7 +20,7 @@ from ..context import get_context
 from .base import JSON, HttpClient, Response, ResultOverrideFunction
 
 
-class GraphQLView(BaseGraphQLView):
+class GraphQLView(BaseGraphQLView[dict[str, object], object]):
     result_override: ResultOverrideFunction = None
 
     def get_root_value(self, request: ChaliceRequest) -> Query:
@@ -29,7 +29,7 @@ class GraphQLView(BaseGraphQLView):
 
     def get_context(
         self, request: ChaliceRequest, response: TemporalResponse
-    ) -> object:
+    ) -> dict[str, object]:
         context = super().get_context(request, response)
 
         return get_context(context)
@@ -66,12 +66,13 @@ class ChaliceHttpClient(HttpClient):
             "/graphql", methods=["GET", "POST"], content_types=["application/json"]
         )
         def handle_graphql():
+            assert self.app.current_request is not None
             return view.execute_request(self.app.current_request)
 
     async def _graphql_request(
         self,
         method: Literal["get", "post"],
-        query: Optional[str] = None,
+        query: str,
         variables: Optional[dict[str, object]] = None,
         files: Optional[dict[str, BytesIO]] = None,
         headers: Optional[dict[str, str]] = None,

--- a/tests/http/clients/django.py
+++ b/tests/http/clients/django.py
@@ -20,14 +20,16 @@ from ..context import get_context
 from .base import JSON, HttpClient, Response, ResultOverrideFunction
 
 
-class GraphQLView(BaseGraphQLView):
+class GraphQLView(BaseGraphQLView[dict[str, object], object]):
     result_override: ResultOverrideFunction = None
 
     def get_root_value(self, request) -> Query:
         super().get_root_value(request)  # for coverage
         return Query()
 
-    def get_context(self, request: HttpRequest, response: HttpResponse) -> object:
+    def get_context(
+        self, request: HttpRequest, response: HttpResponse
+    ) -> dict[str, object]:
         context = {"request": request, "response": response}
 
         return get_context(context)
@@ -70,7 +72,7 @@ class DjangoHttpClient(HttpClient):
 
         return super()._get_headers(method=method, headers=headers, files=files)
 
-    async def _do_request(self, request: RequestFactory) -> Response:
+    async def _do_request(self, request: HttpRequest) -> Response:
         view = GraphQLView.as_view(
             schema=schema,
             graphiql=self.graphiql,
@@ -83,24 +85,20 @@ class DjangoHttpClient(HttpClient):
         try:
             response = view(request)
         except Http404:
-            return Response(
-                status_code=404, data=b"Not found", headers=response.headers
-            )
+            return Response(status_code=404, data=b"Not found")
         except (BadRequest, SuspiciousOperation) as e:
-            return Response(
-                status_code=400, data=e.args[0].encode(), headers=response.headers
-            )
+            return Response(status_code=400, data=e.args[0].encode())
         else:
             return Response(
                 status_code=response.status_code,
                 data=response.content,
-                headers=response.headers,
+                headers=dict(response.headers),
             )
 
     async def _graphql_request(
         self,
         method: Literal["get", "post"],
-        query: Optional[str] = None,
+        query: str,
         variables: Optional[dict[str, object]] = None,
         files: Optional[dict[str, BytesIO]] = None,
         headers: Optional[dict[str, str]] = None,
@@ -116,11 +114,12 @@ class DjangoHttpClient(HttpClient):
         data: Union[dict[str, object], str, None] = None
 
         if body and files:
-            files = {
-                name: SimpleUploadedFile(name, file.read())
-                for name, file in files.items()
-            }
-            body.update(files)
+            body.update(
+                {
+                    name: SimpleUploadedFile(name, file.read())
+                    for name, file in files.items()
+                }
+            )
         else:
             additional_arguments["content_type"] = "application/json"
 
@@ -142,11 +141,7 @@ class DjangoHttpClient(HttpClient):
         method: Literal["get", "post", "patch", "put", "delete"],
         headers: Optional[dict[str, str]] = None,
     ) -> Response:
-        headers = self._get_headers(
-            method=method,  # type: ignore
-            headers=headers,
-            files=None,
-        )
+        headers = headers or {}
 
         factory = RequestFactory()
         request = getattr(factory, method)(url, **headers)
@@ -158,6 +153,12 @@ class DjangoHttpClient(HttpClient):
         url: str,
         headers: Optional[dict[str, str]] = None,
     ) -> Response:
+        headers = self._get_headers(
+            method="get",
+            headers=headers,
+            files=None,
+        )
+
         return await self.request(url, "get", headers=headers)
 
     async def post(

--- a/tests/http/clients/fastapi.py
+++ b/tests/http/clients/fastapi.py
@@ -7,8 +7,6 @@ from io import BytesIO
 from typing import Any, Optional
 from typing_extensions import Literal
 
-from starlette.websockets import WebSocketDisconnect
-
 from fastapi import BackgroundTasks, Depends, FastAPI, Request, WebSocket
 from fastapi.testclient import TestClient
 from strawberry.fastapi import GraphQLRouter as BaseGraphQLRouter
@@ -180,9 +178,4 @@ class FastAPIHttpClient(HttpClient):
         protocols: list[str],
     ) -> AsyncGenerator[WebSocketClient, None]:
         with self.client.websocket_connect(url, protocols) as ws:
-            ws_client = AsgiWebSocketClient(ws)
-
-            try:
-                yield ws_client
-            except WebSocketDisconnect as error:
-                ws_client.handle_disconnect(error)
+            yield AsgiWebSocketClient(ws)

--- a/tests/http/clients/fastapi.py
+++ b/tests/http/clients/fastapi.py
@@ -35,7 +35,7 @@ def custom_context_dependency() -> str:
     return "Hi!"
 
 
-async def fastapi_get_context(
+def fastapi_get_context(
     background_tasks: BackgroundTasks,
     request: Request = None,  # type: ignore
     ws: WebSocket = None,  # type: ignore
@@ -49,14 +49,14 @@ async def fastapi_get_context(
     )
 
 
-async def get_root_value(
+def get_root_value(
     request: Request = None,  # type: ignore - FastAPI
     ws: WebSocket = None,  # type: ignore - FastAPI
 ) -> Query:
     return Query()
 
 
-class GraphQLRouter(OnWSConnectMixin, BaseGraphQLRouter[Any, Any]):
+class GraphQLRouter(OnWSConnectMixin, BaseGraphQLRouter[dict[str, object], object]):
     result_override: ResultOverrideFunction = None
     graphql_transport_ws_handler_class = DebuggableGraphQLTransportWSHandler
     graphql_ws_handler_class = DebuggableGraphQLWSHandler
@@ -114,7 +114,7 @@ class FastAPIHttpClient(HttpClient):
     async def _graphql_request(
         self,
         method: Literal["get", "post"],
-        query: Optional[str] = None,
+        query: str,
         variables: Optional[dict[str, object]] = None,
         files: Optional[dict[str, BytesIO]] = None,
         headers: Optional[dict[str, str]] = None,
@@ -179,10 +179,10 @@ class FastAPIHttpClient(HttpClient):
         *,
         protocols: list[str],
     ) -> AsyncGenerator[WebSocketClient, None]:
-        try:
-            with self.client.websocket_connect(url, protocols) as ws:
-                yield AsgiWebSocketClient(ws)
-        except WebSocketDisconnect as error:
-            ws = AsgiWebSocketClient(None)
-            ws.handle_disconnect(error)
-            yield ws
+        with self.client.websocket_connect(url, protocols) as ws:
+            ws_client = AsgiWebSocketClient(ws)
+
+            try:
+                yield ws_client
+            except WebSocketDisconnect as error:
+                ws_client.handle_disconnect(error)

--- a/tests/http/clients/flask.py
+++ b/tests/http/clients/flask.py
@@ -22,7 +22,7 @@ from ..context import get_context
 from .base import JSON, HttpClient, Response, ResultOverrideFunction
 
 
-class GraphQLView(BaseGraphQLView):
+class GraphQLView(BaseGraphQLView[dict[str, object], object]):
     # this allows to test our code path for checking the request type
     # TODO: we might want to remove our check since it is done by flask
     # already
@@ -30,7 +30,7 @@ class GraphQLView(BaseGraphQLView):
 
     result_override: ResultOverrideFunction = None
 
-    def __init__(self, *args: str, **kwargs: Any):
+    def __init__(self, *args: Any, **kwargs: Any):
         self.result_override = kwargs.pop("result_override")
         super().__init__(*args, **kwargs)
 
@@ -84,7 +84,7 @@ class FlaskHttpClient(HttpClient):
     async def _graphql_request(
         self,
         method: Literal["get", "post"],
-        query: Optional[str] = None,
+        query: str,
         variables: Optional[dict[str, object]] = None,
         files: Optional[dict[str, BytesIO]] = None,
         headers: Optional[dict[str, str]] = None,

--- a/tests/http/clients/litestar.py
+++ b/tests/http/clients/litestar.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import json
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Mapping
 from io import BytesIO
 from typing import Any, Optional
 from typing_extensions import Literal
@@ -87,7 +87,7 @@ class LitestarHttpClient(HttpClient):
     async def _graphql_request(
         self,
         method: Literal["get", "post"],
-        query: Optional[str] = None,
+        query: str,
         variables: Optional[dict[str, object]] = None,
         files: Optional[dict[str, BytesIO]] = None,
         headers: Optional[dict[str, str]] = None,
@@ -151,7 +151,7 @@ class LitestarHttpClient(HttpClient):
         return Response(
             status_code=response.status_code,
             data=response.content,
-            headers=response.headers,
+            headers=dict(response.headers),
         )
 
     @contextlib.asynccontextmanager
@@ -161,13 +161,13 @@ class LitestarHttpClient(HttpClient):
         *,
         protocols: list[str],
     ) -> AsyncGenerator[WebSocketClient, None]:
-        try:
-            with self.client.websocket_connect(url, protocols) as ws:
-                yield LitestarWebSocketClient(ws)
-        except WebSocketDisconnect as error:
-            ws = LitestarWebSocketClient(None)
-            ws.handle_disconnect(error)
-            yield ws
+        with self.client.websocket_connect(url, protocols) as ws:
+            ws_client = LitestarWebSocketClient(ws)
+
+            try:
+                yield ws_client
+            except WebSocketDisconnect as error:
+                ws_client.handle_disconnect(error)
 
 
 class LitestarWebSocketClient(WebSocketClient):
@@ -184,7 +184,7 @@ class LitestarWebSocketClient(WebSocketClient):
     async def send_text(self, payload: str) -> None:
         self.ws.send_text(payload)
 
-    async def send_json(self, payload: dict[str, Any]) -> None:
+    async def send_json(self, payload: Mapping[str, object]) -> None:
         self.ws.send_json(payload)
 
     async def send_bytes(self, payload: bytes) -> None:
@@ -211,12 +211,15 @@ class LitestarWebSocketClient(WebSocketClient):
             return Message(type=m["type"], data=m["code"], extra=m["reason"])
         elif m["type"] == "websocket.send":
             return Message(type=m["type"], data=m["text"])
+
+        assert "data" in m
         return Message(type=m["type"], data=m["data"], extra=m["extra"])
 
     async def receive_json(self, timeout: Optional[float] = None) -> Any:
         m = self.ws.receive()
         assert m["type"] == "websocket.send"
         assert "text" in m
+        assert m["text"] is not None
         return json.loads(m["text"])
 
     async def close(self) -> None:

--- a/tests/http/clients/litestar.py
+++ b/tests/http/clients/litestar.py
@@ -162,12 +162,7 @@ class LitestarHttpClient(HttpClient):
         protocols: list[str],
     ) -> AsyncGenerator[WebSocketClient, None]:
         with self.client.websocket_connect(url, protocols) as ws:
-            ws_client = LitestarWebSocketClient(ws)
-
-            try:
-                yield ws_client
-            except WebSocketDisconnect as error:
-                ws_client.handle_disconnect(error)
+            yield LitestarWebSocketClient(ws)
 
 
 class LitestarWebSocketClient(WebSocketClient):
@@ -176,10 +171,6 @@ class LitestarWebSocketClient(WebSocketClient):
         self._closed: bool = False
         self._close_code: Optional[int] = None
         self._close_reason: Optional[str] = None
-
-    def handle_disconnect(self, exc: WebSocketDisconnect) -> None:
-        self._closed = True
-        self._close_code = exc.code
 
     async def send_text(self, payload: str) -> None:
         self.ws.send_text(payload)

--- a/tests/http/clients/quart.py
+++ b/tests/http/clients/quart.py
@@ -18,7 +18,7 @@ from ..context import get_context
 from .base import JSON, HttpClient, Response, ResultOverrideFunction
 
 
-class GraphQLView(BaseGraphQLView):
+class GraphQLView(BaseGraphQLView[dict[str, object], object]):
     methods = ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"]
 
     result_override: ResultOverrideFunction = None
@@ -77,7 +77,7 @@ class QuartHttpClient(HttpClient):
     async def _graphql_request(
         self,
         method: Literal["get", "post"],
-        query: Optional[str] = None,
+        query: str,
         variables: Optional[dict[str, object]] = None,
         files: Optional[dict[str, BytesIO]] = None,
         headers: Optional[dict[str, str]] = None,

--- a/tests/websockets/views.py
+++ b/tests/websockets/views.py
@@ -3,10 +3,27 @@ from typing import Union
 from strawberry import UNSET
 from strawberry.exceptions import ConnectionRejectionError
 from strawberry.http.async_base_view import AsyncBaseHTTPView
+from strawberry.http.typevars import (
+    Request,
+    Response,
+    SubResponse,
+    WebSocketRequest,
+    WebSocketResponse,
+)
 from strawberry.types.unset import UnsetType
 
 
-class OnWSConnectMixin(AsyncBaseHTTPView):
+class OnWSConnectMixin(
+    AsyncBaseHTTPView[
+        Request,
+        Response,
+        SubResponse,
+        WebSocketRequest,
+        WebSocketResponse,
+        dict[str, object],
+        object,
+    ]
+):
     async def on_ws_connect(
         self, context: dict[str, object]
     ) -> Union[UnsetType, None, dict[str, object]]:


### PR DESCRIPTION
## Description

This PR improves the typing of our internal HTTP test clients.

The motivation behind this is to see what parts of them could be re/used for our public test clients and to make pylance and me much happier when I work in vscode lol

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Summary by Sourcery

Enhancements:
- Add generic type parameters to internal HTTP test clients to improve type checking.