### PR TITLE
Add `strawberry.cast` 

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,21 @@
+Release type: minor
+
+The common `node: Node` used to resolve relay nodes means we will be relying on
+is_type_of to check if the returned object is in fact a subclass of the Node
+interface.
+
+However, integrations such as Django, SQLAlchemy and Pydantic will not return
+the type itself, but instead an alike object that is later resolved to the
+expected type.
+
+In case there are more than one possible type defined for that model that is
+being returned, the first one that replies True to `is_type_of` check would be
+used in the resolution, meaning that when asking for `"PublicUser:123"`,
+strawberry could end up returning `"User:123"`, which can lead to security
+issues (such as data leakage).
+
+In here we are introducing a new `strawberry.cast`, which will be used to mark
+an object with the already known type by us, and when asking for is_type_of that
+mark will be used to check instead, ensuring we will return the correct type.
+
+That `cast` is already in place for the relay node resolution and pydantic.

--- a/strawberry/__init__.py
+++ b/strawberry/__init__.py
@@ -13,6 +13,7 @@ from .schema import Schema
 from .schema_directive import schema_directive
 from .types.arguments import argument
 from .types.auto import auto
+from .types.cast import cast
 from .types.enum import enum, enum_value
 from .types.field import field
 from .types.info import Info
@@ -36,6 +37,7 @@ __all__ = [
     "argument",
     "asdict",
     "auto",
+    "cast",
     "directive",
     "directive_field",
     "enum",

--- a/strawberry/experimental/pydantic/object_type.py
+++ b/strawberry/experimental/pydantic/object_type.py
@@ -29,6 +29,7 @@ from strawberry.experimental.pydantic.utils import (
     get_private_fields,
 )
 from strawberry.types.auto import StrawberryAuto
+from strawberry.types.cast import get_strawberry_type_cast
 from strawberry.types.field import StrawberryField
 from strawberry.types.object_type import _process_type, _wrap_dataclass
 from strawberry.types.type_resolver import _get_fields
@@ -207,6 +208,9 @@ def type(  # noqa: PLR0915
         # pydantic objects (not the corresponding strawberry type)
         @classmethod  # type: ignore
         def is_type_of(cls: builtins.type, obj: Any, _info: GraphQLResolveInfo) -> bool:
+            if (type_cast := get_strawberry_type_cast(obj)) is not None:
+                return type_cast is cls
+
             return isinstance(obj, (cls, model))
 
         namespace = {"is_type_of": is_type_of}

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -58,6 +58,7 @@ from strawberry.types.base import (
     get_object_definition,
     has_object_definition,
 )
+from strawberry.types.cast import get_strawberry_type_cast
 from strawberry.types.enum import EnumDefinition
 from strawberry.types.field import UNRESOLVED
 from strawberry.types.lazy_type import LazyType
@@ -619,6 +620,9 @@ class GraphQLCoreConverter:
             )
 
             def is_type_of(obj: Any, _info: GraphQLResolveInfo) -> bool:
+                if (type_cast := get_strawberry_type_cast(obj)) is not None:
+                    return type_cast in possible_types
+
                 if object_type.concrete_of and (
                     has_object_definition(obj)
                     and obj.__strawberry_definition__.origin
@@ -898,6 +902,9 @@ class GraphQLCoreConverter:
         if object_type.interfaces:
 
             def is_type_of(obj: Any, _info: GraphQLResolveInfo) -> bool:
+                if (type_cast := get_strawberry_type_cast(obj)) is not None:
+                    return type_cast is object_type.origin
+
                 if object_type.concrete_of and (
                     has_object_definition(obj)
                     and obj.__strawberry_definition__.origin

--- a/strawberry/types/cast.py
+++ b/strawberry/types/cast.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import Any, TypeVar, overload
+
+_T = TypeVar("_T", bound=object)
+
+TYPE_CAST_ATTRIBUTE = "__as_strawberry_type__"
+
+
+@overload
+def cast(type_: type, obj: None) -> None: ...
+
+
+@overload
+def cast(type_: type, obj: _T) -> _T: ...
+
+
+def cast(type_: type, obj: _T | None) -> _T | None:
+    """Cast an object to given type.
+
+    This is used to mark an object as a cast object, so that the type can be
+    picked up when resolving unions/interfaces in case of ambiguity, which can
+    happen when returning an alike object instead of an instance of the type
+    (e.g. returning a Django, Pydantic or SQLAlchemy object)
+    """
+    if obj is None:
+        return None
+
+    setattr(obj, TYPE_CAST_ATTRIBUTE, type_)
+    return obj
+
+
+def get_strawberry_type_cast(obj: Any) -> type | None:
+    """Get the type of a cast object."""
+    return getattr(obj, TYPE_CAST_ATTRIBUTE, None)

--- a/tests/types/test_cast.py
+++ b/tests/types/test_cast.py
@@ -1,0 +1,28 @@
+import strawberry
+from strawberry.types.cast import get_strawberry_type_cast
+
+
+def test_cast():
+    @strawberry.type
+    class SomeType: ...
+
+    class OtherType: ...
+
+    obj = OtherType
+    assert get_strawberry_type_cast(obj) is None
+
+    cast_obj = strawberry.cast(SomeType, obj)
+    assert cast_obj is obj
+    assert get_strawberry_type_cast(cast_obj) is SomeType
+
+
+def test_cast_none_obj():
+    @strawberry.type
+    class SomeType: ...
+
+    obj = None
+    assert get_strawberry_type_cast(obj) is None
+
+    cast_obj = strawberry.cast(SomeType, obj)
+    assert cast_obj is None
+    assert get_strawberry_type_cast(obj) is None


### PR DESCRIPTION
The common `node: Node` used to resolve relay nodes means we will be relying on `is_type_of` to check if the returned object is in fact a subclass of the `Node` interface.

However, integrations such as Django, SQLAlchemy and Pydantic will not return the type itself, but instead an alike object that is later resolved to the expected type.

In case there are more than one possible type defined for that model that is being returned, the first one that replies `True` to `is_type_of` check would be used in the resolution, meaning that when asking for `PublicUser:123`, strawberry could end up returning `User:123`, which can lead to security issues (such as data leakage).

In here we are introducing a new `strawberry.cast`, which will be used to mark an object with the already known type by us, and when asking for `is_type_of` that mark will be used to check instead, ensuring we will return the correct type.

## Summary by Sourcery

Bug Fixes:
- Fix a security issue where resolving a relay node with multiple possibilities could return the wrong type, leading to potential data leakage.