### PR TITLE
Fix sanic adapter casting files to io.BytesIO

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+Fix bug where files would be converted into io.BytesIO when using the sanic GraphQLView
+instead of using the sanic File type

--- a/strawberry/sanic/utils.py
+++ b/strawberry/sanic/utils.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from io import BytesIO
 from typing import TYPE_CHECKING, Any, Optional, Union, cast
 
 if TYPE_CHECKING:
@@ -8,7 +7,7 @@ if TYPE_CHECKING:
 
 
 def convert_request_to_files_dict(request: Request) -> dict[str, Any]:
-    """Converts the request.files dictionary to a dictionary of BytesIO objects.
+    """Converts the request.files dictionary to a dictionary of sanic Request objects.
 
     `request.files` has the following format, even if only a single file is uploaded:
 
@@ -27,12 +26,12 @@ def convert_request_to_files_dict(request: Request) -> dict[str, Any]:
     if not request_files:
         return {}
 
-    files_dict: dict[str, Union[BytesIO, list[BytesIO]]] = {}
+    files_dict: dict[str, Union[File, list[File]]] = {}
 
     for field_name, file_list in request_files.items():
         assert len(file_list) == 1
 
-        files_dict[field_name] = BytesIO(file_list[0].body)
+        files_dict[field_name] = file_list[0]
 
     return files_dict
 

--- a/strawberry/schema/name_converter.py
+++ b/strawberry/schema/name_converter.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional, Tuple, Union, cast
+from typing import TYPE_CHECKING, Optional, Union, cast
 from typing_extensions import Protocol
 
 from strawberry.directive import StrawberryDirective
@@ -106,7 +106,7 @@ class NameConverter:
             return union.graphql_name
 
         name = ""
-        types: Tuple[StrawberryType, ...] = union.types
+        types: tuple[StrawberryType, ...] = union.types
 
         if union.concrete_of and union.concrete_of.graphql_name:
             concrete_of_types = set(union.concrete_of.types)

--- a/tests/sanic/test_file_upload.py
+++ b/tests/sanic/test_file_upload.py
@@ -1,14 +1,15 @@
+from io import BytesIO
+from typing import cast
+
 import pytest
+from sanic_testing.testing import SanicTestClient
+
+import strawberry
 from sanic import Sanic
 from sanic.request import File
-from sanic import response
-from sanic_testing.testing import SanicTestClient
-from strawberry.sanic.views import GraphQLView
-import strawberry
 from strawberry.file_uploads import Upload
-from io import BytesIO
 from strawberry.sanic import utils
-from typing import cast
+from strawberry.sanic.views import GraphQLView
 
 
 @strawberry.type

--- a/tests/sanic/test_file_upload.py
+++ b/tests/sanic/test_file_upload.py
@@ -1,0 +1,93 @@
+import pytest
+from sanic import Sanic
+from sanic.request import File
+from sanic import response
+from sanic_testing.testing import SanicTestClient
+from strawberry.sanic.views import GraphQLView
+import strawberry
+from strawberry.file_uploads import Upload
+from io import BytesIO
+from strawberry.sanic import utils
+from typing import cast
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def index(self) -> str:
+        return "Hello there"
+
+
+@strawberry.type
+class Mutation:
+    @strawberry.mutation
+    def file_upload(self, file: Upload) -> str:
+        return cast(File, file).name
+
+
+@pytest.fixture
+def app():
+    sanic_app = Sanic("sanic_testing")
+
+    sanic_app.add_route(
+        GraphQLView.as_view(
+            schema=strawberry.Schema(query=Query, mutation=Mutation),
+            multipart_uploads_enabled=True,
+        ),
+        "/graphql",
+    )
+
+    return sanic_app
+
+
+def test_file_cast(app: Sanic):
+    """Tests that the list of files in a sanic Request gets correctly turned into a dictionary"""
+    file_name = "test.txt"
+
+    file_content = b"Hello, there!."
+    in_memory_file = BytesIO(file_content)
+    in_memory_file.name = file_name
+
+    form_data = {
+        "operations": '{ "query": "mutation($file: Upload!){ fileUpload(file: $file) }", "variables": { "file": null } }',
+        "map": '{ "file": ["variables.file"] }',
+    }
+
+    files = {
+        "file": in_memory_file,
+    }
+
+    request, _ = cast(SanicTestClient, app.test_client).post(
+        "/graphql", data=form_data, files=files
+    )
+
+    files = utils.convert_request_to_files_dict(request)  # type: ignore
+    file = files["file"]
+
+    assert isinstance(file, File)
+    assert file.name == file_name
+    assert file.body == file_content
+
+
+def test_endpoint(app: Sanic):
+    """Tests that the graphql api correctly handles file upload and processing"""
+    file_name = "test.txt"
+
+    file_content = b"Hello, there!"
+    in_memory_file = BytesIO(file_content)
+    in_memory_file.name = file_name
+
+    form_data = {
+        "operations": '{ "query": "mutation($file: Upload!){ fileUpload(file: $file) }", "variables": { "file": null } }',
+        "map": '{ "file": ["variables.file"] }',
+    }
+
+    files = {
+        "file": in_memory_file,
+    }
+
+    _, response = cast(SanicTestClient, app.test_client).post(
+        "/graphql", data=form_data, files=files
+    )
+
+    assert response.json["data"]["fileUpload"] == file_name  # type: ignore

--- a/tests/views/schema.py
+++ b/tests/views/schema.py
@@ -41,6 +41,12 @@ def _read_file(text_file: Upload) -> str:
         if isinstance(text_file, LitestarUploadFile):
             text_file = text_file.file  # type: ignore
 
+    with contextlib.suppress(ModuleNotFoundError):
+        from sanic.request import File as SanicUploadFile
+
+        if isinstance(text_file, SanicUploadFile):
+            return text_file.body.decode()
+
     return text_file.read().decode()
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

The current implementation of `strawberry.sanic.utils.convert_request_to_files_dict` casts uploaded files to `io.BytesIO`, making it return a type that doesn't coincide with the docs. This commit removes this casting and makes the function work in accordance with the [docs](https://strawberry.rocks/docs/guides/file-upload#upload-scalar).

## Description

Changed `files_dict[field_name] = BytesIO(file_list[0].body)` to `files_dict[field_name] = file_list[0]`

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

Fix https://github.com/strawberry-graphql/strawberry/issues/3750

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Bug Fixes:
- Uploaded files are now correctly handled as Sanic `File` objects instead of being cast to `io.BytesIO`.