### PR TITLE
Add Query batching support

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,53 @@
+Release type: minor
+
+## Add GraphQL Query batching support
+
+GraphQL query batching is now supported across all frameworks (sync and async)
+To enable query batching, set the `batch` parameter to True at the view level.
+
+This makes your GraphQL API compatible with batching features supported by various
+client side libraries, such as [Apollo GraphQL](https://www.apollographql.com/docs/react/api/link/apollo-link-batch-http) and [Relay](https://github.com/relay-tools/react-relay-network-modern?tab=readme-ov-file#batching-several-requests-into-one).
+
+Example (FastAPI):
+
+```py
+import strawberry
+
+from fastapi import FastAPI
+from strawberry.fastapi import GraphQLRouter
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def hello(self) -> str:
+        return "Hello World"
+
+
+schema = strawberry.Schema(Query)
+
+graphql_app = GraphQLRouter(schema, batch=True)
+
+app = FastAPI()
+app.include_router(graphql_app, prefix="/graphql/batch")
+```
+
+Example (Flask):
+```py
+from flask import Flask
+from strawberry.flask.views import GraphQLView
+
+from api.schema import schema
+
+app = Flask(__name__)
+
+app.add_url_rule(
+    "/graphql/batch",
+    view_func=GraphQLView.as_view("graphql_view", schema=schema, batch=True),
+)
+
+if __name__ == "__main__":
+    app.run()
+```
+
+Note: Query Batching is not supported for multipart subscriptions

--- a/strawberry/aiohttp/views.py
+++ b/strawberry/aiohttp/views.py
@@ -210,7 +210,9 @@ class GraphQLView(
         return {"request": request, "response": response}  # type: ignore
 
     def create_response(
-        self, response_data: GraphQLHTTPResponse, sub_response: web.Response
+        self,
+        response_data: Union[GraphQLHTTPResponse, list[GraphQLHTTPResponse]],
+        sub_response: web.Response,
     ) -> web.Response:
         sub_response.text = self.encode_json(response_data)
         sub_response.content_type = "application/json"

--- a/strawberry/aiohttp/views.py
+++ b/strawberry/aiohttp/views.py
@@ -150,6 +150,7 @@ class GraphQLView(
         ),
         connection_init_wait_timeout: timedelta = timedelta(minutes=1),
         multipart_uploads_enabled: bool = False,
+        batch: bool = False,
     ) -> None:
         self.schema = schema
         self.allow_queries_via_get = allow_queries_via_get
@@ -159,6 +160,7 @@ class GraphQLView(
         self.subscription_protocols = subscription_protocols
         self.connection_init_wait_timeout = connection_init_wait_timeout
         self.multipart_uploads_enabled = multipart_uploads_enabled
+        self.batch = batch
 
         if graphiql is not None:
             warnings.warn(

--- a/strawberry/asgi/__init__.py
+++ b/strawberry/asgi/__init__.py
@@ -205,7 +205,9 @@ class GraphQL(
         return HTMLResponse(self.graphql_ide_html)
 
     def create_response(
-        self, response_data: GraphQLHTTPResponse, sub_response: Response
+        self,
+        response_data: Union[GraphQLHTTPResponse, list[GraphQLHTTPResponse]],
+        sub_response: Response,
     ) -> Response:
         response = Response(
             self.encode_json(response_data),

--- a/strawberry/asgi/__init__.py
+++ b/strawberry/asgi/__init__.py
@@ -145,6 +145,7 @@ class GraphQL(
         ),
         connection_init_wait_timeout: timedelta = timedelta(minutes=1),
         multipart_uploads_enabled: bool = False,
+        batch: bool = False,
     ) -> None:
         self.schema = schema
         self.allow_queries_via_get = allow_queries_via_get
@@ -154,6 +155,7 @@ class GraphQL(
         self.protocols = subscription_protocols
         self.connection_init_wait_timeout = connection_init_wait_timeout
         self.multipart_uploads_enabled = multipart_uploads_enabled
+        self.batch = batch
 
         if graphiql is not None:
             warnings.warn(

--- a/strawberry/asgi/__init__.py
+++ b/strawberry/asgi/__init__.py
@@ -129,6 +129,7 @@ class GraphQL(
     allow_queries_via_get = True
     request_adapter_class = ASGIRequestAdapter
     websocket_adapter_class = ASGIWebSocketAdapter
+    batch: bool = False
 
     def __init__(
         self,

--- a/strawberry/chalice/views.py
+++ b/strawberry/chalice/views.py
@@ -114,7 +114,9 @@ class GraphQLView(
         return {"request": request, "response": response}  # type: ignore
 
     def create_response(
-        self, response_data: GraphQLHTTPResponse, sub_response: TemporalResponse
+        self,
+        response_data: Union[GraphQLHTTPResponse, list[GraphQLHTTPResponse]],
+        sub_response: TemporalResponse,
     ) -> Response:
         status_code = 200
 

--- a/strawberry/chalice/views.py
+++ b/strawberry/chalice/views.py
@@ -63,9 +63,11 @@ class GraphQLView(
         graphiql: Optional[bool] = None,
         graphql_ide: Optional[GraphQL_IDE] = "graphiql",
         allow_queries_via_get: bool = True,
+        batch: bool = False,
     ) -> None:
         self.allow_queries_via_get = allow_queries_via_get
         self.schema = schema
+        self.batch = batch
         if graphiql is not None:
             warnings.warn(
                 "The `graphiql` argument is deprecated in favor of `graphql_ide`",

--- a/strawberry/channels/handlers/http_handler.py
+++ b/strawberry/channels/handlers/http_handler.py
@@ -5,13 +5,7 @@ import json
 import warnings
 from functools import cached_property
 from io import BytesIO
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Optional,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 from typing_extensions import TypeGuard, assert_never
 from urllib.parse import parse_qs
 
@@ -186,7 +180,9 @@ class BaseGraphQLHTTPConsumer(ChannelsConsumer, AsyncHttpConsumer):
         super().__init__(**kwargs)
 
     def create_response(
-        self, response_data: GraphQLHTTPResponse, sub_response: TemporalResponse
+        self,
+        response_data: Union[GraphQLHTTPResponse, list[GraphQLHTTPResponse]],
+        sub_response: TemporalResponse,
     ) -> ChannelsResponse:
         return ChannelsResponse(
             content=json.dumps(response_data).encode(),

--- a/strawberry/channels/handlers/http_handler.py
+++ b/strawberry/channels/handlers/http_handler.py
@@ -161,11 +161,13 @@ class BaseGraphQLHTTPConsumer(ChannelsConsumer, AsyncHttpConsumer):
         graphql_ide: Optional[GraphQL_IDE] = "graphiql",
         allow_queries_via_get: bool = True,
         multipart_uploads_enabled: bool = False,
+        batch: bool = False,
         **kwargs: Any,
     ) -> None:
         self.schema = schema
         self.allow_queries_via_get = allow_queries_via_get
         self.multipart_uploads_enabled = multipart_uploads_enabled
+        self.batch = batch
 
         if graphiql is not None:
             warnings.warn(
@@ -252,6 +254,7 @@ class GraphQLHTTPConsumer(
     ```
     """
 
+    batch: bool = False
     allow_queries_via_get: bool = True
     request_adapter_class = ChannelsRequestAdapter
 
@@ -325,6 +328,7 @@ class SyncGraphQLHTTPConsumer(
     synchronous and not asynchronous).
     """
 
+    batch: bool = False
     allow_queries_via_get: bool = True
     request_adapter_class = SyncChannelsRequestAdapter
 

--- a/strawberry/django/views.py
+++ b/strawberry/django/views.py
@@ -163,7 +163,9 @@ class BaseView:
         super().__init__(**kwargs)
 
     def create_response(
-        self, response_data: GraphQLHTTPResponse, sub_response: HttpResponse
+        self,
+        response_data: Union[GraphQLHTTPResponse, list[GraphQLHTTPResponse]],
+        sub_response: HttpResponse,
     ) -> HttpResponseBase:
         data = self.encode_json(response_data)
 

--- a/strawberry/django/views.py
+++ b/strawberry/django/views.py
@@ -217,6 +217,7 @@ class GraphQLView(
     allow_queries_via_get = True
     schema: BaseSchema = None  # type: ignore
     request_adapter_class = DjangoHTTPRequestAdapter
+    batch: bool = False
 
     def get_root_value(self, request: HttpRequest) -> Optional[RootValue]:
         return None
@@ -265,6 +266,7 @@ class AsyncGraphQLView(
     allow_queries_via_get = True
     schema: BaseSchema = None  # type: ignore
     request_adapter_class = AsyncDjangoHTTPRequestAdapter
+    batch: bool = False
 
     @classonlymethod  # pyright: ignore[reportIncompatibleMethodOverride]
     def as_view(cls, **initkwargs: Any) -> Callable[..., HttpResponse]:  # noqa: N805

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -59,6 +59,7 @@ class GraphQLRouter(
     allow_queries_via_get = True
     request_adapter_class = ASGIRequestAdapter
     websocket_adapter_class = ASGIWebSocketAdapter
+    batch: bool = False
 
     @staticmethod
     async def __get_root_value() -> None:

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -152,6 +152,7 @@ class GraphQLRouter(
             generate_unique_id
         ),
         multipart_uploads_enabled: bool = False,
+        batch: bool = False,
         **kwargs: Any,
     ) -> None:
         super().__init__(
@@ -187,6 +188,7 @@ class GraphQLRouter(
         self.protocols = subscription_protocols
         self.connection_init_wait_timeout = connection_init_wait_timeout
         self.multipart_uploads_enabled = multipart_uploads_enabled
+        self.batch = batch
 
         if graphiql is not None:
             warnings.warn(

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -274,7 +274,9 @@ class GraphQLRouter(
         return self.temporal_response
 
     def create_response(
-        self, response_data: GraphQLHTTPResponse, sub_response: Response
+        self,
+        response_data: Union[GraphQLHTTPResponse, list[GraphQLHTTPResponse]],
+        sub_response: Response,
     ) -> Response:
         response = Response(
             self.encode_json(response_data),

--- a/strawberry/flask/views.py
+++ b/strawberry/flask/views.py
@@ -91,7 +91,9 @@ class BaseGraphQLView:
             self.graphql_ide = graphql_ide
 
     def create_response(
-        self, response_data: GraphQLHTTPResponse, sub_response: Response
+        self,
+        response_data: Union[GraphQLHTTPResponse, list[GraphQLHTTPResponse]],
+        sub_response: Response,
     ) -> Response:
         sub_response.set_data(self.encode_json(response_data))  # type: ignore
 

--- a/strawberry/flask/views.py
+++ b/strawberry/flask/views.py
@@ -74,11 +74,13 @@ class BaseGraphQLView:
         graphql_ide: Optional[GraphQL_IDE] = "graphiql",
         allow_queries_via_get: bool = True,
         multipart_uploads_enabled: bool = False,
+        batch: bool = False,
     ) -> None:
         self.schema = schema
         self.graphiql = graphiql
         self.allow_queries_via_get = allow_queries_via_get
         self.multipart_uploads_enabled = multipart_uploads_enabled
+        self.batch = batch
 
         if graphiql is not None:
             warnings.warn(

--- a/strawberry/flask/views.py
+++ b/strawberry/flask/views.py
@@ -108,6 +108,7 @@ class GraphQLView(
     methods: ClassVar[list[str]] = ["GET", "POST"]
     allow_queries_via_get: bool = True
     request_adapter_class = FlaskHTTPRequestAdapter
+    batch: bool = False
 
     def get_context(self, request: Request, response: Response) -> Context:
         return {"request": request, "response": response}  # type: ignore
@@ -171,6 +172,7 @@ class AsyncGraphQLView(
     methods: ClassVar[list[str]] = ["GET", "POST"]
     allow_queries_via_get: bool = True
     request_adapter_class = AsyncFlaskHTTPRequestAdapter
+    batch: bool = False
 
     async def get_context(self, request: Request, response: Response) -> Context:
         return {"request": request, "response": response}  # type: ignore

--- a/strawberry/http/async_base_view.py
+++ b/strawberry/http/async_base_view.py
@@ -533,9 +533,13 @@ class AsyncBaseHTTPView(
             raise HTTPException(400, "Unsupported content type")
 
         if isinstance(data, list):
-            if protocol == "multipart-subscription" or not self.batch:
+            if protocol == "multipart-subscription":
                 # note: multipart-subscriptions are not supported in batch requests
-                raise HTTPException(400, "Batch requests are not supported")
+                raise HTTPException(
+                    400, "Batching is not supported for multipart subscriptions"
+                )
+            if not self.batch:
+                raise HTTPException(400, "Batching is not enabled")
             return [
                 GraphQLRequestData(
                     query=item.get("query"),

--- a/strawberry/http/sync_base_view.py
+++ b/strawberry/http/sync_base_view.py
@@ -210,8 +210,7 @@ class SyncBaseHTTPView(
 
         if isinstance(data, list):
             if not self.batch:
-                # note: multipart-subscriptions are not supported in batch requests
-                raise HTTPException(400, "Batch requests are not supported")
+                raise HTTPException(400, "Batching is not enabled")
             return [
                 GraphQLRequestData(
                     query=item.get("query"),

--- a/strawberry/litestar/controller.py
+++ b/strawberry/litestar/controller.py
@@ -259,6 +259,7 @@ class GraphQLController(
     )
     keep_alive: bool = False
     keep_alive_interval: float = 1
+    batch: bool = False
 
     def is_websocket_request(
         self, request: Union[Request, WebSocket]
@@ -302,7 +303,9 @@ class GraphQLController(
         return Response(self.graphql_ide_html, media_type=MediaType.HTML)
 
     def create_response(
-        self, response_data: GraphQLHTTPResponse, sub_response: Response[bytes]
+        self,
+        response_data: Union[GraphQLHTTPResponse, list[GraphQLHTTPResponse]],
+        sub_response: Response[bytes],
     ) -> Response[bytes]:
         response = Response(
             self.encode_json(response_data).encode(),
@@ -417,6 +420,7 @@ def make_graphql_controller(
     ),
     connection_init_wait_timeout: timedelta = timedelta(minutes=1),
     multipart_uploads_enabled: bool = False,
+    batch: bool = False,
 ) -> type[GraphQLController]:  # sourcery skip: move-assign
     if context_getter is None:
         custom_context_getter_ = _none_custom_context_getter
@@ -464,6 +468,7 @@ def make_graphql_controller(
     _GraphQLController.allow_queries_via_get = allow_queries_via_get_
     _GraphQLController.graphql_ide = graphql_ide_
     _GraphQLController.multipart_uploads_enabled = multipart_uploads_enabled
+    _GraphQLController.batch = batch
 
     return _GraphQLController
 

--- a/strawberry/quart/views.py
+++ b/strawberry/quart/views.py
@@ -1,6 +1,6 @@
 import warnings
 from collections.abc import AsyncGenerator, Mapping
-from typing import TYPE_CHECKING, Callable, ClassVar, Optional, cast
+from typing import TYPE_CHECKING, Callable, ClassVar, Optional, Union, cast
 from typing_extensions import TypeGuard
 
 from quart import Request, Response, request
@@ -82,7 +82,9 @@ class GraphQLView(
         return Response(self.graphql_ide_html)
 
     def create_response(
-        self, response_data: "GraphQLHTTPResponse", sub_response: Response
+        self,
+        response_data: Union["GraphQLHTTPResponse", list["GraphQLHTTPResponse"]],
+        sub_response: Response,
     ) -> Response:
         sub_response.set_data(self.encode_json(response_data))
 

--- a/strawberry/quart/views.py
+++ b/strawberry/quart/views.py
@@ -64,10 +64,12 @@ class GraphQLView(
         graphql_ide: Optional[GraphQL_IDE] = "graphiql",
         allow_queries_via_get: bool = True,
         multipart_uploads_enabled: bool = False,
+        batch: bool = False,
     ) -> None:
         self.schema = schema
         self.allow_queries_via_get = allow_queries_via_get
         self.multipart_uploads_enabled = multipart_uploads_enabled
+        self.batch = batch
 
         if graphiql is not None:
             warnings.warn(

--- a/strawberry/quart/views.py
+++ b/strawberry/quart/views.py
@@ -55,6 +55,7 @@ class GraphQLView(
     methods: ClassVar[list[str]] = ["GET", "POST"]
     allow_queries_via_get: bool = True
     request_adapter_class = QuartHTTPRequestAdapter
+    batch: bool = False
 
     def __init__(
         self,

--- a/strawberry/sanic/views.py
+++ b/strawberry/sanic/views.py
@@ -7,6 +7,7 @@ from typing import (
     Any,
     Callable,
     Optional,
+    Union,
     cast,
 )
 from typing_extensions import TypeGuard
@@ -158,7 +159,9 @@ class GraphQLView(
         return TemporalResponse()
 
     def create_response(
-        self, response_data: GraphQLHTTPResponse, sub_response: TemporalResponse
+        self,
+        response_data: Union[GraphQLHTTPResponse, list[GraphQLHTTPResponse]],
+        sub_response: TemporalResponse,
     ) -> HTTPResponse:
         status_code = sub_response.status_code
 

--- a/strawberry/sanic/views.py
+++ b/strawberry/sanic/views.py
@@ -101,6 +101,7 @@ class GraphQLView(
 
     allow_queries_via_get = True
     request_adapter_class = SanicHTTPRequestAdapter
+    batch: bool = False
 
     def __init__(
         self,
@@ -111,12 +112,14 @@ class GraphQLView(
         json_encoder: Optional[type[json.JSONEncoder]] = None,
         json_dumps_params: Optional[dict[str, Any]] = None,
         multipart_uploads_enabled: bool = False,
+        batch: bool = False,
     ) -> None:
         self.schema = schema
         self.allow_queries_via_get = allow_queries_via_get
         self.json_encoder = json_encoder
         self.json_dumps_params = json_dumps_params
         self.multipart_uploads_enabled = multipart_uploads_enabled
+        self.batch = batch
 
         if self.json_encoder is not None:  # pragma: no cover
             warnings.warn(

--- a/tests/http/clients/aiohttp.py
+++ b/tests/http/clients/aiohttp.py
@@ -64,6 +64,7 @@ class AioHttpClient(HttpClient):
         allow_queries_via_get: bool = True,
         result_override: ResultOverrideFunction = None,
         multipart_uploads_enabled: bool = False,
+        batch: bool = False,
     ):
         view = GraphQLView(
             schema=schema,
@@ -72,6 +73,7 @@ class AioHttpClient(HttpClient):
             allow_queries_via_get=allow_queries_via_get,
             keep_alive=False,
             multipart_uploads_enabled=multipart_uploads_enabled,
+            batch=batch,
         )
         view.result_override = result_override
 

--- a/tests/http/clients/asgi.py
+++ b/tests/http/clients/asgi.py
@@ -66,6 +66,7 @@ class AsgiHttpClient(HttpClient):
         allow_queries_via_get: bool = True,
         result_override: ResultOverrideFunction = None,
         multipart_uploads_enabled: bool = False,
+        batch: bool = False,
     ):
         view = GraphQLView(
             schema,
@@ -74,6 +75,7 @@ class AsgiHttpClient(HttpClient):
             allow_queries_via_get=allow_queries_via_get,
             keep_alive=False,
             multipart_uploads_enabled=multipart_uploads_enabled,
+            batch=batch,
         )
         view.result_override = result_override
 

--- a/tests/http/clients/async_django.py
+++ b/tests/http/clients/async_django.py
@@ -47,6 +47,7 @@ class AsyncDjangoHttpClient(DjangoHttpClient):
             allow_queries_via_get=self.allow_queries_via_get,
             result_override=self.result_override,
             multipart_uploads_enabled=self.multipart_uploads_enabled,
+            batch=self.batch,
         )
 
         try:

--- a/tests/http/clients/async_flask.py
+++ b/tests/http/clients/async_flask.py
@@ -53,6 +53,7 @@ class AsyncFlaskHttpClient(FlaskHttpClient):
         allow_queries_via_get: bool = True,
         result_override: ResultOverrideFunction = None,
         multipart_uploads_enabled: bool = False,
+        batch: bool = False,
     ):
         self.app = Flask(__name__)
         self.app.debug = True
@@ -65,6 +66,7 @@ class AsyncFlaskHttpClient(FlaskHttpClient):
             allow_queries_via_get=allow_queries_via_get,
             result_override=result_override,
             multipart_uploads_enabled=multipart_uploads_enabled,
+            batch=batch,
         )
 
         self.app.add_url_rule(

--- a/tests/http/clients/base.py
+++ b/tests/http/clients/base.py
@@ -102,6 +102,7 @@ class HttpClient(abc.ABC):
         allow_queries_via_get: bool = True,
         result_override: ResultOverrideFunction = None,
         multipart_uploads_enabled: bool = False,
+        batch: bool = False,
     ): ...
 
     @abc.abstractmethod
@@ -135,7 +136,7 @@ class HttpClient(abc.ABC):
         self,
         url: str,
         data: Optional[bytes] = None,
-        json: Optional[JSON] = None,
+        json: Optional[Union[JSON, list[JSON]]] = None,
         headers: Optional[dict[str, str]] = None,
     ) -> Response: ...
 

--- a/tests/http/clients/chalice.py
+++ b/tests/http/clients/chalice.py
@@ -51,6 +51,7 @@ class ChaliceHttpClient(HttpClient):
         allow_queries_via_get: bool = True,
         result_override: ResultOverrideFunction = None,
         multipart_uploads_enabled: bool = False,
+        batch: bool = False,
     ):
         self.app = Chalice(app_name="TheStackBadger")
 
@@ -59,6 +60,7 @@ class ChaliceHttpClient(HttpClient):
             graphiql=graphiql,
             graphql_ide=graphql_ide,
             allow_queries_via_get=allow_queries_via_get,
+            batch=batch,
         )
         view.result_override = result_override
 

--- a/tests/http/clients/channels.py
+++ b/tests/http/clients/channels.py
@@ -142,6 +142,7 @@ class ChannelsHttpClient(HttpClient):
         allow_queries_via_get: bool = True,
         result_override: ResultOverrideFunction = None,
         multipart_uploads_enabled: bool = False,
+        batch: bool = False,
     ):
         self.ws_app = DebuggableGraphQLWSConsumer.as_asgi(
             schema=schema,
@@ -155,6 +156,7 @@ class ChannelsHttpClient(HttpClient):
             allow_queries_via_get=allow_queries_via_get,
             result_override=result_override,
             multipart_uploads_enabled=multipart_uploads_enabled,
+            batch=batch,
         )
 
     def create_app(self, **kwargs: Any) -> None:
@@ -266,6 +268,7 @@ class SyncChannelsHttpClient(ChannelsHttpClient):
         allow_queries_via_get: bool = True,
         result_override: ResultOverrideFunction = None,
         multipart_uploads_enabled: bool = False,
+        batch: bool = False,
     ):
         self.http_app = DebuggableSyncGraphQLHTTPConsumer.as_asgi(
             schema=schema,
@@ -274,6 +277,7 @@ class SyncChannelsHttpClient(ChannelsHttpClient):
             allow_queries_via_get=allow_queries_via_get,
             result_override=result_override,
             multipart_uploads_enabled=multipart_uploads_enabled,
+            batch=batch,
         )
 
 

--- a/tests/http/clients/django.py
+++ b/tests/http/clients/django.py
@@ -51,12 +51,14 @@ class DjangoHttpClient(HttpClient):
         allow_queries_via_get: bool = True,
         result_override: ResultOverrideFunction = None,
         multipart_uploads_enabled: bool = False,
+        batch: bool = False,
     ):
         self.graphiql = graphiql
         self.graphql_ide = graphql_ide
         self.allow_queries_via_get = allow_queries_via_get
         self.result_override = result_override
         self.multipart_uploads_enabled = multipart_uploads_enabled
+        self.batch = batch
 
     def _get_header_name(self, key: str) -> str:
         return f"HTTP_{key.upper().replace('-', '_')}"
@@ -80,6 +82,7 @@ class DjangoHttpClient(HttpClient):
             allow_queries_via_get=self.allow_queries_via_get,
             result_override=self.result_override,
             multipart_uploads_enabled=self.multipart_uploads_enabled,
+            batch=self.batch,
         )
 
         try:

--- a/tests/http/clients/fastapi.py
+++ b/tests/http/clients/fastapi.py
@@ -76,6 +76,7 @@ class FastAPIHttpClient(HttpClient):
         allow_queries_via_get: bool = True,
         result_override: ResultOverrideFunction = None,
         multipart_uploads_enabled: bool = False,
+        batch: bool = False,
     ):
         self.app = FastAPI()
 
@@ -88,6 +89,7 @@ class FastAPIHttpClient(HttpClient):
             allow_queries_via_get=allow_queries_via_get,
             keep_alive=False,
             multipart_uploads_enabled=multipart_uploads_enabled,
+            batch=batch,
         )
         graphql_app.result_override = result_override
         self.app.include_router(graphql_app, prefix="/graphql")

--- a/tests/http/clients/flask.py
+++ b/tests/http/clients/flask.py
@@ -62,6 +62,7 @@ class FlaskHttpClient(HttpClient):
         allow_queries_via_get: bool = True,
         result_override: ResultOverrideFunction = None,
         multipart_uploads_enabled: bool = False,
+        batch: bool = False,
     ):
         self.app = Flask(__name__)
         self.app.debug = True
@@ -74,6 +75,7 @@ class FlaskHttpClient(HttpClient):
             allow_queries_via_get=allow_queries_via_get,
             result_override=result_override,
             multipart_uploads_enabled=multipart_uploads_enabled,
+            batch=batch,
         )
 
         self.app.add_url_rule(

--- a/tests/http/clients/litestar.py
+++ b/tests/http/clients/litestar.py
@@ -51,6 +51,7 @@ class LitestarHttpClient(HttpClient):
         allow_queries_via_get: bool = True,
         result_override: ResultOverrideFunction = None,
         multipart_uploads_enabled: bool = False,
+        batch: bool = False,
     ):
         self.create_app(
             graphiql=graphiql,
@@ -58,6 +59,7 @@ class LitestarHttpClient(HttpClient):
             allow_queries_via_get=allow_queries_via_get,
             result_override=result_override,
             multipart_uploads_enabled=multipart_uploads_enabled,
+            batch=batch,
         )
 
     def create_app(self, result_override: ResultOverrideFunction = None, **kwargs: Any):

--- a/tests/http/clients/quart.py
+++ b/tests/http/clients/quart.py
@@ -55,6 +55,7 @@ class QuartHttpClient(HttpClient):
         allow_queries_via_get: bool = True,
         result_override: ResultOverrideFunction = None,
         multipart_uploads_enabled: bool = False,
+        batch: bool = False,
     ):
         self.app = Quart(__name__)
         self.app.debug = True
@@ -67,6 +68,7 @@ class QuartHttpClient(HttpClient):
             allow_queries_via_get=allow_queries_via_get,
             result_override=result_override,
             multipart_uploads_enabled=multipart_uploads_enabled,
+            batch=batch,
         )
 
         self.app.add_url_rule(

--- a/tests/http/clients/sanic.py
+++ b/tests/http/clients/sanic.py
@@ -54,6 +54,7 @@ class SanicHttpClient(HttpClient):
         allow_queries_via_get: bool = True,
         result_override: ResultOverrideFunction = None,
         multipart_uploads_enabled: bool = False,
+        batch: bool = False,
     ):
         self.app = Sanic(
             f"test_{int(randint(0, 1000))}",  # noqa: S311
@@ -65,6 +66,7 @@ class SanicHttpClient(HttpClient):
             allow_queries_via_get=allow_queries_via_get,
             result_override=result_override,
             multipart_uploads_enabled=multipart_uploads_enabled,
+            batch=batch,
         )
         self.app.add_route(
             view,

--- a/tests/http/test_query_batching.py
+++ b/tests/http/test_query_batching.py
@@ -1,4 +1,59 @@
+import contextlib
+
+import pytest
+
 from .clients.base import HttpClient
+
+
+@pytest.fixture
+def multipart_subscriptions_batch_http_client(
+    http_client_class: type[HttpClient],
+) -> HttpClient:
+    with contextlib.suppress(ImportError):
+        import django
+
+        if django.VERSION < (4, 2):
+            pytest.skip(reason="Django < 4.2 doesn't async streaming responses")
+
+        from .clients.django import DjangoHttpClient
+
+        if http_client_class is DjangoHttpClient:
+            pytest.skip(
+                reason="(sync) DjangoHttpClient doesn't support multipart subscriptions"
+            )
+
+    with contextlib.suppress(ImportError):
+        from .clients.channels import SyncChannelsHttpClient
+
+        # TODO: why do we have a sync channels client?
+        if http_client_class is SyncChannelsHttpClient:
+            pytest.skip(
+                reason="SyncChannelsHttpClient doesn't support multipart subscriptions"
+            )
+
+    with contextlib.suppress(ImportError):
+        from .clients.async_flask import AsyncFlaskHttpClient
+        from .clients.flask import FlaskHttpClient
+
+        if http_client_class is FlaskHttpClient:
+            pytest.skip(
+                reason="FlaskHttpClient doesn't support multipart subscriptions"
+            )
+
+        if http_client_class is AsyncFlaskHttpClient:
+            pytest.xfail(
+                reason="AsyncFlaskHttpClient doesn't support multipart subscriptions"
+            )
+
+    with contextlib.suppress(ImportError):
+        from .clients.chalice import ChaliceHttpClient
+
+        if http_client_class is ChaliceHttpClient:
+            pytest.skip(
+                reason="ChaliceHttpClient doesn't support multipart subscriptions"
+            )
+
+    return http_client_class(batch=True)
 
 
 async def test_batch_graphql_query(http_client_class: type[HttpClient]):
@@ -37,3 +92,23 @@ async def test_returns_error_when_batching_is_disabled(
     assert response.status_code == 400
 
     assert "Batching is not enabled" in response.text
+
+
+async def test_returns_error_for_multipart_subscriptions(
+    multipart_subscriptions_batch_http_client: HttpClient,
+):
+    response = await multipart_subscriptions_batch_http_client.post(
+        url="/graphql",
+        json=[
+            {"query": 'subscription { echo(message: "Hello world", delay: 0.2) }'},
+            {"query": 'subscription { echo(message: "Hello world", delay: 0.2) }'},
+        ],
+        headers={
+            "content-type": "application/json",
+            "accept": "multipart/mixed;boundary=graphql;subscriptionSpec=1.0,application/json",
+        },
+    )
+
+    assert response.status_code == 400
+
+    assert "Batching is not supported for multipart subscriptions" in response.text

--- a/tests/http/test_query_batching.py
+++ b/tests/http/test_query_batching.py
@@ -1,0 +1,39 @@
+from .clients.base import HttpClient
+
+
+async def test_batch_graphql_query(http_client_class: type[HttpClient]):
+    http_client = http_client_class(batch=True)
+
+    response = await http_client.post(
+        url="/graphql",
+        json=[
+            {"query": "{ hello }"},
+            {"query": "{ hello }"},
+        ],
+        headers={"content-type": "application/json"},
+    )
+
+    assert response.status_code == 200
+    assert response.json == [
+        {"data": {"hello": "Hello world"}, "extensions": {"example": "example"}},
+        {"data": {"hello": "Hello world"}, "extensions": {"example": "example"}},
+    ]
+
+
+async def test_returns_error_when_batching_is_disabled(
+    http_client_class: type[HttpClient],
+):
+    http_client = http_client_class(batch=False)
+
+    response = await http_client.post(
+        url="/graphql",
+        json=[
+            {"query": "{ hello }"},
+            {"query": "{ hello }"},
+        ],
+        headers={"content-type": "application/json"},
+    )
+
+    assert response.status_code == 400
+
+    assert "Batching is not enabled" in response.text


### PR DESCRIPTION
# Add Query Batching Support

## Description

This PR adds Query batching support for GraphQL APIs using Strawberry GraphQL.

This makes Strawberry GraphQL compatible with batching features supported by various
client side libraries, such as [Apollo GraphQL](https://www.apollographql.com/docs/react/api/link/apollo-link-batch-http) and [Relay](https://github.com/relay-tools/react-relay-network-modern?tab=readme-ov-file#batching-several-requests-into-one).


Example (FastAPI):

```py
import strawberry

from fastapi import FastAPI
from strawberry.fastapi import GraphQLRouter


@strawberry.type
class Query:
    @strawberry.field
    def hello(self) -> str:
        return "Hello World"


schema = strawberry.Schema(Query)

graphql_app = GraphQLRouter(schema, batch=True)

app = FastAPI()
app.include_router(graphql_app, prefix="/graphql/batch")
```

Example (Flask):
```py
from flask import Flask
from strawberry.flask.views import GraphQLView

from api.schema import schema

app = Flask(__name__)

app.add_url_rule(
    "/graphql/batch",
    view_func=GraphQLView.as_view("graphql_view", schema=schema, batch=True),
)

if __name__ == "__main__":
    app.run()
```

Note: Query Batching is not supported for multipart subscriptions


## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/strawberry-graphql/strawberry/issues/1383

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
