### PR TITLE
fix(fastapi): context_getter signature to allow Awaitable

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+This release adjusts the `context_getter` attribute from the fastapi `GraphQLRouter`
+to accept an async callables.

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -125,7 +125,9 @@ class GraphQLRouter(
         keep_alive_interval: float = 1,
         debug: bool = False,
         root_value_getter: Optional[Callable[[], RootValue]] = None,
-        context_getter: Optional[Callable[..., Optional[Context]]] = None,
+        context_getter: Optional[
+            Callable[..., Union[Optional[Context], Awaitable[Optional[Context]]]]
+        ] = None,
         subscription_protocols: Sequence[str] = (
             GRAPHQL_TRANSPORT_WS_PROTOCOL,
             GRAPHQL_WS_PROTOCOL,


### PR DESCRIPTION
## Description

The `context_getter` is further passed to https://github.com/strawberry-graphql/strawberry/blob/7ba5928a418ca790cf8b663f52b8174b6de12b2a/strawberry/fastapi/router.py#L69-L71 so https://github.com/strawberry-graphql/strawberry/blob/7ba5928a418ca790cf8b663f52b8174b6de12b2a/strawberry/fastapi/router.py#L128 should likely have the same signature

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #3762

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Bug Fixes:
- Fix an issue where context getters were not awaited properly.