### PR TITLE
Support aliases in get_specialized_type_var_map

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: minor
+
+Support aliases (TypeVar passthrough) in `get_specialized_type_var_map`.

--- a/tests/python_312/test_inspect.py
+++ b/tests/python_312/test_inspect.py
@@ -91,6 +91,22 @@ def test_get_specialized_type_var_map_double_generic_subclass():
     assert get_specialized_type_var_map(Bin) == {"_T": int}
 
 
+def test_get_specialized_type_var_map_double_generic_passthrough():
+    @strawberry.type
+    class Foo[_T]: ...
+
+    @strawberry.type
+    class Bar[_K](Foo[_K]): ...
+
+    @strawberry.type
+    class Bin(Bar[int]): ...
+
+    assert get_specialized_type_var_map(Bin) == {
+        "_T": int,
+        "_K": int,
+    }
+
+
 def test_get_specialized_type_var_map_multiple_inheritance():
     @strawberry.type
     class Foo[_T]: ...

--- a/tests/utils/test_inspect.py
+++ b/tests/utils/test_inspect.py
@@ -94,6 +94,22 @@ def test_get_specialized_type_var_map_double_generic_subclass():
     assert get_specialized_type_var_map(Bin) == {"_T": int}
 
 
+def test_get_specialized_type_var_map_double_generic_passthrough():
+    @strawberry.type
+    class Foo(Generic[_T]): ...
+
+    @strawberry.type
+    class Bar(Foo[_K], Generic[_K]): ...
+
+    @strawberry.type
+    class Bin(Bar[int]): ...
+
+    assert get_specialized_type_var_map(Bin) == {
+        "_T": int,
+        "_K": int,
+    }
+
+
 def test_get_specialized_type_var_map_multiple_inheritance():
     @strawberry.type
     class Foo(Generic[_T]): ...


### PR DESCRIPTION
## Description

Support aliases (TypeVar passthrough) in `get_specialized_type_var_map`:

```python
def test_get_specialized_type_var_map_double_generic_passthrough():
    @strawberry.type
    class Foo(Generic[_T]): ...

    @strawberry.type
    class Bar(Foo[_K], Generic[_K]): ...

    @strawberry.type
    class Bin(Bar[int]): ...

    assert get_specialized_type_var_map(Bin) == {
        "_T": int,
        "_K": int,
    }
```

Without this change, errors like

```
KeyError: '_T'
```

will appear

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Support TypeVar passthrough in `get_specialized_type_var_map`.

Enhancements:
- Resolve type variables correctly when a generic type inherits from another generic type, passing the type variable through.

Tests:
- Add a test case for TypeVar passthrough with double generics.