### PR TITLE
fix(printer): Do not print UNSET inputs as "" in directive arguments

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,60 @@
+Release type: patch
+
+This release adjusts the schema printer to avoid printing a schema directive
+value set to `UNSET` as `""` (empty string).
+
+For example, the following:
+
+```python
+@strawberry.input
+class FooInput:
+    a: str | None = strawberry.UNSET
+    b: str | None = strawberry.UNSET
+
+
+@strawberry.schema_directive(locations=[Location.FIELD_DEFINITION])
+class FooDirective:
+    input: FooInput
+
+
+@strawberry.type
+class Query:
+    @strawberry.field(directives=[FooDirective(input=FooInput(a="aaa"))])
+    def foo(self, info) -> str: ...
+```
+
+Would previously print as:
+
+```graphql
+directive @fooDirective(
+  input: FooInput!
+  optionalInput: FooInput
+) on FIELD_DEFINITION
+
+type Query {
+  foo: String! @fooDirective(input: { a: "aaa", b: "" })
+}
+
+input FooInput {
+  a: String
+  b: String
+}
+```
+
+Now it will be correctly printed as:
+
+```graphql
+directive @fooDirective(
+  input: FooInput!
+  optionalInput: FooInput
+) on FIELD_DEFINITION
+
+type Query {
+  foo: String! @fooDirective(input: { a: "aaa" })
+}
+
+input FooInput {
+  a: String
+  b: String
+}
+```

--- a/strawberry/printer/printer.py
+++ b/strawberry/printer/printer.py
@@ -83,7 +83,7 @@ def _serialize_dataclasses(value: object) -> object: ...
 
 def _serialize_dataclasses(value):
     if dataclasses.is_dataclass(value):
-        return dataclasses.asdict(value)  # type: ignore
+        return {k: v for k, v in dataclasses.asdict(value).items() if v is not UNSET}  # type: ignore
     if isinstance(value, (list, tuple)):
         return [_serialize_dataclasses(v) for v in value]
     if isinstance(value, dict):

--- a/tests/test_printer/test_schema_directives.py
+++ b/tests/test_printer/test_schema_directives.py
@@ -712,3 +712,39 @@ def test_print_directive_on_argument_with_description():
     schema = strawberry.Schema(query=Query)
 
     assert print_schema(schema) == textwrap.dedent(expected_output).strip()
+
+
+def test_print_directive_with_unset_value():
+    @strawberry.input
+    class FooInput:
+        a: Optional[str] = strawberry.UNSET
+        b: Optional[str] = strawberry.UNSET
+
+    @strawberry.schema_directive(locations=[Location.FIELD_DEFINITION])
+    class FooDirective:
+        input: FooInput
+        optional_input: Optional[FooInput] = strawberry.UNSET
+
+    @strawberry.type
+    class Query:
+        @strawberry.field(directives=[FooDirective(input=FooInput(a="something"))])
+        def foo(self, info) -> str: ...
+
+    schema = strawberry.Schema(query=Query)
+
+    expected_output = """
+    directive @fooDirective(input: FooInput!, optionalInput: FooInput) on FIELD_DEFINITION
+
+    type Query {
+      foo: String! @fooDirective(input: {a: "something"})
+    }
+
+    input FooInput {
+      a: String
+      b: String
+    }
+    """
+
+    schema = strawberry.Schema(query=Query)
+
+    assert print_schema(schema) == textwrap.dedent(expected_output).strip()

--- a/tests/test_printer/test_schema_directives.py
+++ b/tests/test_printer/test_schema_directives.py
@@ -714,6 +714,7 @@ def test_print_directive_on_argument_with_description():
     assert print_schema(schema) == textwrap.dedent(expected_output).strip()
 
 
+@skip_if_gql_32("formatting is different in gql 3.2")
 def test_print_directive_with_unset_value():
     @strawberry.input
     class FooInput:

--- a/tests/test_printer/test_schema_directives.py
+++ b/tests/test_printer/test_schema_directives.py
@@ -736,7 +736,7 @@ def test_print_directive_with_unset_value():
     directive @fooDirective(input: FooInput!, optionalInput: FooInput) on FIELD_DEFINITION
 
     type Query {
-      foo: String! @fooDirective(input: {a: "something"})
+      foo: String! @fooDirective(input: { a: "something" })
     }
 
     input FooInput {


### PR DESCRIPTION
Fix #3761

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where UNSET values in directive arguments were printed as empty strings.