### PR TITLE
Fix cleanup logic in graphql_ws protocol handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3574,23 +3574,23 @@ the attributes of the `IgnoreContext` class.
 For example, the following query:
 ```python
 """
-    query {
-      matt: user(name: "matt") {
-        email
-      }
-      andy: user(name: "andy") {
-        email
-        address {
-          city
-        }
-        pets {
-          name
-          owner {
-            name
-          }
-        }
+query {
+  matt: user(name: "matt") {
+    email
+  }
+  andy: user(name: "andy") {
+    email
+    address {
+      city
+    }
+    pets {
+      name
+      owner {
+        name
       }
     }
+  }
+}
 """
 ```
 can have its depth limited by the following `should_ignore`:
@@ -3607,17 +3607,17 @@ query_depth_limiter = QueryDepthLimiter(should_ignore=should_ignore)
 so that it *effectively* becomes:
 ```python
 """
-    query {
-      andy: user(name: "andy") {
-        email
-        pets {
-          name
-          owner {
-            name
-          }
-        }
+query {
+  andy: user(name: "andy") {
+    email
+    pets {
+      name
+      owner {
+        name
       }
     }
+  }
+}
 """
 ```
 
@@ -10702,7 +10702,7 @@ from typing import Annotated
 class Query:
     @strawberry.field
     def user_by_id(
-        id: Annotated[str, strawberry.argument(description="The ID of the user")]
+        id: Annotated[str, strawberry.argument(description="The ID of the user")],
     ) -> User: ...
 ```
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+This release fixes the issue that some subscription resolvers were not canceled if a client unexpectedly disconnected.

--- a/docs/types/exceptions.md
+++ b/docs/types/exceptions.md
@@ -64,7 +64,7 @@ def name(
         str,
         strawberry.argument(description="This is a description"),
         strawberry.argument(description="Another description"),
-    ]
+    ],
 ) -> str:
     return "Name"
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -150,7 +150,7 @@ def test_pydantic(session: Session, pydantic: str, gql_core: str) -> None:
 
 @session(python=PYTHON_VERSIONS, name="Type checkers tests", tags=["tests"])
 def tests_typecheckers(session: Session) -> None:
-    session.run_always("poetry", "install", external=True)
+    session.run_always("poetry", "install", "--with", "integrations", external=True)
 
     session.install("pyright")
     session.install("pydantic")

--- a/strawberry/federation/field.py
+++ b/strawberry/federation/field.py
@@ -219,7 +219,7 @@ def field(
         Tag,
     )
 
-    directives = list(directives)
+    directives = list(directives or [])
 
     if authenticated:
         directives.append(Authenticated())

--- a/strawberry/federation/field.py
+++ b/strawberry/federation/field.py
@@ -15,22 +15,30 @@ from strawberry.types.field import field as base_field
 from strawberry.types.unset import UNSET
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Sequence
+    from collections.abc import Iterable, Mapping, Sequence
     from typing_extensions import Literal
 
     from strawberry.extensions.field_extension import FieldExtension
     from strawberry.permission import BasePermission
-    from strawberry.types.field import _RESOLVER_TYPE, StrawberryField
+    from strawberry.types.field import (
+        _RESOLVER_TYPE,
+        _RESOLVER_TYPE_ASYNC,
+        _RESOLVER_TYPE_SYNC,
+        StrawberryField,
+    )
 
     from .schema_directives import Override
 
 T = TypeVar("T")
 
+# NOTE: we are separating the sync and async resolvers because using both
+# in the same function will cause mypy to raise an error. Not sure if it is a bug
+
 
 @overload
 def field(
     *,
-    resolver: _RESOLVER_TYPE[T],
+    resolver: _RESOLVER_TYPE_ASYNC[T],
     name: Optional[str] = None,
     is_subscription: bool = False,
     description: Optional[str] = None,
@@ -47,9 +55,39 @@ def field(
     init: Literal[False] = False,
     permission_classes: Optional[list[type[BasePermission]]] = None,
     deprecation_reason: Optional[str] = None,
-    default: Any = UNSET,
-    default_factory: Union[Callable[..., object], object] = UNSET,
-    directives: Sequence[object] = (),
+    default: Any = dataclasses.MISSING,
+    default_factory: Union[Callable[..., object], object] = dataclasses.MISSING,
+    metadata: Optional[Mapping[Any, Any]] = None,
+    directives: Optional[Sequence[object]] = (),
+    extensions: Optional[list[FieldExtension]] = None,
+    graphql_type: Optional[Any] = None,
+) -> T: ...
+
+
+@overload
+def field(
+    *,
+    resolver: _RESOLVER_TYPE_SYNC[T],
+    name: Optional[str] = None,
+    is_subscription: bool = False,
+    description: Optional[str] = None,
+    authenticated: bool = False,
+    external: bool = False,
+    inaccessible: bool = False,
+    policy: Optional[list[list[str]]] = None,
+    provides: Optional[list[str]] = None,
+    override: Optional[Union[Override, str]] = None,
+    requires: Optional[list[str]] = None,
+    requires_scopes: Optional[list[list[str]]] = None,
+    tags: Optional[Iterable[str]] = (),
+    shareable: bool = False,
+    init: Literal[False] = False,
+    permission_classes: Optional[list[type[BasePermission]]] = None,
+    deprecation_reason: Optional[str] = None,
+    default: Any = dataclasses.MISSING,
+    default_factory: Union[Callable[..., object], object] = dataclasses.MISSING,
+    metadata: Optional[Mapping[Any, Any]] = None,
+    directives: Optional[Sequence[object]] = (),
     extensions: Optional[list[FieldExtension]] = None,
     graphql_type: Optional[Any] = None,
 ) -> T: ...
@@ -74,9 +112,10 @@ def field(
     init: Literal[True] = True,
     permission_classes: Optional[list[type[BasePermission]]] = None,
     deprecation_reason: Optional[str] = None,
-    default: Any = UNSET,
-    default_factory: Union[Callable[..., object], object] = UNSET,
-    directives: Sequence[object] = (),
+    default: Any = dataclasses.MISSING,
+    default_factory: Union[Callable[..., object], object] = dataclasses.MISSING,
+    metadata: Optional[Mapping[Any, Any]] = None,
+    directives: Optional[Sequence[object]] = (),
     extensions: Optional[list[FieldExtension]] = None,
     graphql_type: Optional[Any] = None,
 ) -> Any: ...
@@ -84,7 +123,7 @@ def field(
 
 @overload
 def field(
-    resolver: _RESOLVER_TYPE[T],
+    resolver: _RESOLVER_TYPE_ASYNC[T],
     *,
     name: Optional[str] = None,
     is_subscription: bool = False,
@@ -101,9 +140,38 @@ def field(
     shareable: bool = False,
     permission_classes: Optional[list[type[BasePermission]]] = None,
     deprecation_reason: Optional[str] = None,
-    default: Any = UNSET,
-    default_factory: Union[Callable[..., object], object] = UNSET,
-    directives: Sequence[object] = (),
+    default: Any = dataclasses.MISSING,
+    default_factory: Union[Callable[..., object], object] = dataclasses.MISSING,
+    metadata: Optional[Mapping[Any, Any]] = None,
+    directives: Optional[Sequence[object]] = (),
+    extensions: Optional[list[FieldExtension]] = None,
+    graphql_type: Optional[Any] = None,
+) -> StrawberryField: ...
+
+
+@overload
+def field(
+    resolver: _RESOLVER_TYPE_SYNC[T],
+    *,
+    name: Optional[str] = None,
+    is_subscription: bool = False,
+    description: Optional[str] = None,
+    authenticated: bool = False,
+    external: bool = False,
+    inaccessible: bool = False,
+    policy: Optional[list[list[str]]] = None,
+    provides: Optional[list[str]] = None,
+    override: Optional[Union[Override, str]] = None,
+    requires: Optional[list[str]] = None,
+    requires_scopes: Optional[list[list[str]]] = None,
+    tags: Optional[Iterable[str]] = (),
+    shareable: bool = False,
+    permission_classes: Optional[list[type[BasePermission]]] = None,
+    deprecation_reason: Optional[str] = None,
+    default: Any = dataclasses.MISSING,
+    default_factory: Union[Callable[..., object], object] = dataclasses.MISSING,
+    metadata: Optional[Mapping[Any, Any]] = None,
+    directives: Optional[Sequence[object]] = (),
     extensions: Optional[list[FieldExtension]] = None,
     graphql_type: Optional[Any] = None,
 ) -> StrawberryField: ...
@@ -129,7 +197,8 @@ def field(
     deprecation_reason: Optional[str] = None,
     default: Any = dataclasses.MISSING,
     default_factory: Union[Callable[..., object], object] = dataclasses.MISSING,
-    directives: Sequence[object] = (),
+    metadata: Optional[Mapping[Any, Any]] = None,
+    directives: Optional[Sequence[object]] = (),
     extensions: Optional[list[FieldExtension]] = None,
     graphql_type: Optional[Any] = None,
     # This init parameter is used by PyRight to determine whether this field
@@ -197,6 +266,7 @@ def field(
         default_factory=default_factory,
         init=init,  # type: ignore
         directives=directives,
+        metadata=metadata,
         extensions=extensions,
         graphql_type=graphql_type,
     )

--- a/strawberry/relay/fields.py
+++ b/strawberry/relay/fields.py
@@ -386,7 +386,7 @@ def connection(
     default_factory: Union[Callable[..., object], object] = dataclasses.MISSING,
     metadata: Optional[Mapping[Any, Any]] = None,
     directives: Optional[Sequence[object]] = (),
-    extensions: list[FieldExtension] = (),  # type: ignore
+    extensions: list[FieldExtension] | None = None,
     max_results: Optional[int] = None,
     # This init parameter is used by pyright to determine whether this field
     # is added in the constructor or not. It is not used to change
@@ -473,6 +473,7 @@ def connection(
         https://relay.dev/graphql/connections.htm
 
     """
+    extensions = extensions or []
     f = StrawberryField(
         python_name=None,
         graphql_name=name,

--- a/strawberry/subscriptions/protocols/graphql_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_ws/handlers.py
@@ -76,8 +76,7 @@ class BaseGraphQLWSHandler(Generic[Context, RootValue]):
                 with suppress(BaseException):
                     await self.keep_alive_task
 
-            for operation_id in list(self.subscriptions.keys()):
-                await self.cleanup_operation(operation_id)
+            await self.cleanup()
 
     async def handle_message(
         self,
@@ -201,6 +200,10 @@ class BaseGraphQLWSHandler(Generic[Context, RootValue]):
         with suppress(BaseException):
             await self.tasks[operation_id]
         del self.tasks[operation_id]
+
+    async def cleanup(self) -> None:
+        for operation_id in list(self.tasks.keys()):
+            await self.cleanup_operation(operation_id)
 
     async def send_data_message(
         self, execution_result: ExecutionResult, operation_id: str

--- a/tests/views/schema.py
+++ b/tests/views/schema.py
@@ -151,6 +151,8 @@ class Mutation:
 
 @strawberry.type
 class Subscription:
+    active_infinity_subscriptions = 0
+
     @strawberry.subscription
     async def echo(self, message: str, delay: float = 0) -> AsyncGenerator[str, None]:
         await asyncio.sleep(delay)
@@ -164,9 +166,14 @@ class Subscription:
 
     @strawberry.subscription
     async def infinity(self, message: str) -> AsyncGenerator[str, None]:
-        while True:
-            yield message
-            await asyncio.sleep(1)
+        Subscription.active_infinity_subscriptions += 1
+
+        try:
+            while True:
+                yield message
+                await asyncio.sleep(1)
+        finally:
+            Subscription.active_infinity_subscriptions -= 1
 
     @strawberry.subscription
     async def context(self, info: strawberry.Info) -> AsyncGenerator[str, None]:

--- a/tests/websockets/test_graphql_transport_ws.py
+++ b/tests/websockets/test_graphql_transport_ws.py
@@ -25,7 +25,7 @@ from strawberry.subscriptions.protocols.graphql_transport_ws.types import (
     SubscribeMessage,
 )
 from tests.http.clients.base import DebuggableGraphQLTransportWSHandler
-from tests.views.schema import MyExtension, Schema
+from tests.views.schema import MyExtension, Schema, Subscription
 
 if TYPE_CHECKING:
     from tests.http.clients.base import HttpClient, WebSocketClient
@@ -1105,11 +1105,15 @@ async def test_unexpected_client_disconnects_are_gracefully_handled(
                 "id": "sub1",
                 "type": "subscribe",
                 "payload": {
-                    "query": 'subscription { echo(message: "Hi", delay: 0.5) }'
+                    "query": 'subscription { infinity(message: "Hi") }'
                 },
             }
         )
+        await ws.receive(timeout=2)
+        assert Subscription.active_infinity_subscriptions == 1
 
         await ws.close()
         await asyncio.sleep(1)
+
         assert not process_errors.called
+        assert Subscription.active_infinity_subscriptions == 0

--- a/tests/websockets/test_graphql_transport_ws.py
+++ b/tests/websockets/test_graphql_transport_ws.py
@@ -1104,9 +1104,7 @@ async def test_unexpected_client_disconnects_are_gracefully_handled(
             {
                 "id": "sub1",
                 "type": "subscribe",
-                "payload": {
-                    "query": 'subscription { infinity(message: "Hi") }'
-                },
+                "payload": {"query": 'subscription { infinity(message: "Hi") }'},
             }
         )
         await ws.receive(timeout=2)

--- a/tests/websockets/test_graphql_ws.py
+++ b/tests/websockets/test_graphql_ws.py
@@ -20,7 +20,7 @@ from strawberry.subscriptions.protocols.graphql_ws.types import (
     ErrorMessage,
     StartMessage,
 )
-from tests.views.schema import MyExtension, Schema
+from tests.views.schema import MyExtension, Schema, Subscription
 
 if TYPE_CHECKING:
     from tests.http.clients.aiohttp import HttpClient, WebSocketClient
@@ -806,11 +806,15 @@ async def test_unexpected_client_disconnects_are_gracefully_handled(
                 "type": "start",
                 "id": "sub1",
                 "payload": {
-                    "query": 'subscription { echo(message: "Hi", delay: 0.5) }',
+                    "query": 'subscription { infinity(message: "Hi") }',
                 },
             }
         )
+        await ws.receive_json()
+        assert Subscription.active_infinity_subscriptions == 1
 
         await ws.close()
         await asyncio.sleep(1)
+
         assert not process_errors.called
+        assert Subscription.active_infinity_subscriptions == 0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Ensure all tasks are canceled when performing cleanup in subscription handlers when `graphql_ws` protocol is used.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [X] Bugfix
- [ ] New feature
- [X] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* fixes https://github.com/strawberry-graphql/strawberry/issues/3777

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
- [X] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Fix cleanup logic for GraphQL subscriptions using the `graphql_ws` protocol to ensure all tasks are cancelled during cleanup.

Bug Fixes:
- Fixed a bug where subscription tasks were not cancelled when cleaning up in `graphql_ws` protocol handler.

Tests:
- Added tests to verify that all active subscriptions are cancelled when a client disconnects unexpectedly.