### PR TITLE
Refactor how we handle PreExecution errors

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+This release updates the internals of our subscription implementation, to make the code
+easier to maintain for future changes.

--- a/noxfile.py
+++ b/noxfile.py
@@ -12,7 +12,7 @@ PYTHON_VERSIONS = ["3.13", "3.12", "3.11", "3.10", "3.9"]
 
 GQL_CORE_VERSIONS = [
     "3.2.3",
-    "3.3.0a6",
+    "3.3.0a7",
 ]
 
 COMMON_PYTEST_OPTIONS = [

--- a/strawberry/schema/base.py
+++ b/strawberry/schema/base.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from graphql import GraphQLError
 
     from strawberry.directive import StrawberryDirective
+    from strawberry.schema.schema import SubscriptionResult
     from strawberry.schema.schema_converter import GraphQLCoreConverter
     from strawberry.types import (
         ExecutionContext,
@@ -27,7 +28,6 @@ if TYPE_CHECKING:
     from strawberry.types.union import StrawberryUnion
 
     from .config import StrawberryConfig
-    from .subscribe import SubscriptionResult
 
 
 class BaseSchema(Protocol):

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -82,8 +82,8 @@ if TYPE_CHECKING:
     from strawberry.types.scalar import ScalarDefinition, ScalarWrapper
     from strawberry.types.union import StrawberryUnion
 
-SubscriptionResult: TypeAlias = Union[
-    PreExecutionError, AsyncGenerator[ExecutionResult, None]
+SubscriptionResult: TypeAlias = AsyncGenerator[
+    Union[PreExecutionError, ExecutionResult], None
 ]
 
 OriginSubscriptionResult = Union[

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -760,36 +760,11 @@ class Schema(BaseSchema):
         for extension in extensions:
             extension.execution_context = execution_context
 
-        asyncgen = self._subscribe(
+        return self._subscribe(
             execution_context,
             extensions_runner=self.create_extensions_runner(
                 execution_context, extensions
             ),
-            middleware_manager=self._get_middleware_manager(extensions),
-            execution_context_class=self.execution_context_class,
-        )
-        # GraphQL-core might return an initial error result instead of an async iterator.
-        # This happens when "there was an immediate error" i.e resolver is not an async iterator.
-        # To overcome this while maintaining the extension contexts we do this trick.
-        first = await asyncgen.__anext__()
-        if isinstance(first, PreExecutionError):
-            await asyncgen.aclose()
-            return first
-
-        async def _wrapper() -> AsyncGenerator[ExecutionResult, None]:
-            yield first
-            async for result in asyncgen:
-                yield result
-
-        return _wrapper()
-
-        return await subscribe(
-            self._schema,
-            execution_context=execution_context,
-            extensions_runner=self.create_extensions_runner(
-                execution_context, extensions
-            ),
-            process_errors=self._process_errors,
             middleware_manager=self._get_middleware_manager(extensions),
             execution_context_class=self.execution_context_class,
         )

--- a/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
@@ -254,50 +254,59 @@ class BaseGraphQLTransportWSHandler(Generic[Context, RootValue]):
 
     async def run_operation(self, operation: Operation[Context, RootValue]) -> None:
         """The operation task's top level method. Cleans-up and de-registers the operation once it is done."""
-        # TODO: Handle errors in this method using self.handle_task_exception()
-
         result_source: Awaitable[ExecutionResult] | Awaitable[SubscriptionResult]
 
-        # Get an AsyncGenerator yielding the results
-        if operation.operation_type == OperationType.SUBSCRIPTION:
-            result_source = self.schema.subscribe(
-                query=operation.query,
-                variable_values=operation.variables,
-                operation_name=operation.operation_name,
-                context_value=self.context,
-                root_value=self.root_value,
-            )
-        else:
-            result_source = self.schema.execute(
-                query=operation.query,
-                variable_values=operation.variables,
-                context_value=self.context,
-                root_value=self.root_value,
-                operation_name=operation.operation_name,
-            )
-
         try:
-            first_res_or_agen = await result_source
-            # that's an immediate error we should end the operation
-            # without a COMPLETE message
-            if isinstance(first_res_or_agen, PreExecutionError):
-                assert first_res_or_agen.errors
-                await operation.send_initial_errors(first_res_or_agen.errors)
-            # that's a mutation / query result
-            elif isinstance(first_res_or_agen, ExecutionResult):
-                await operation.send_next(first_res_or_agen)
-                await operation.send_operation_message(
-                    {"id": operation.id, "type": "complete"}
+            # Get an AsyncGenerator yielding the results
+            if operation.operation_type == OperationType.SUBSCRIPTION:
+                result_source = await self.schema.subscribe(
+                    query=operation.query,
+                    variable_values=operation.variables,
+                    operation_name=operation.operation_name,
+                    context_value=self.context,
+                    root_value=self.root_value,
                 )
             else:
-                async for result in first_res_or_agen:
+                result_source = await self.schema.execute(
+                    query=operation.query,
+                    variable_values=operation.variables,
+                    context_value=self.context,
+                    root_value=self.root_value,
+                    operation_name=operation.operation_name,
+                )
+
+            # TODO: maybe change PreExecutionError to an exception that can be caught
+
+            if isinstance(result_source, ExecutionResult):
+                if isinstance(result_source, PreExecutionError):
+                    await operation.send_initial_errors(result_source.errors)
+                else:
+                    await operation.send_next(result_source)
+            else:
+                is_first_result = True
+
+                async for result in result_source:
+                    if is_first_result and isinstance(result, PreExecutionError):
+                        await operation.send_initial_errors(result.errors)
+                        break
+
                     await operation.send_next(result)
+                    is_first_result = False
+
+            await operation.send_operation_message(
+                {"id": operation.id, "type": "complete"}
+            )
+
+        except BaseException as error:  # pragma: no cover
+            self.handle_task_exception(error)
+
+            with suppress(Exception):
                 await operation.send_operation_message(
                     {"id": operation.id, "type": "complete"}
                 )
 
-        except BaseException:  # pragma: no cover
             self.operations.pop(operation.id, None)
+
             raise
         finally:
             # add this task to a list to be reaped later

--- a/strawberry/subscriptions/protocols/graphql_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_ws/handlers.py
@@ -174,6 +174,7 @@ class BaseGraphQLWSHandler(Generic[Context, RootValue]):
             self.subscriptions[operation_id] = result_source
 
             is_first_result = True
+
             async for result in result_source:
                 if is_first_result and isinstance(result, PreExecutionError):
                     assert result.errors

--- a/strawberry/subscriptions/protocols/graphql_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_ws/handlers.py
@@ -15,9 +15,11 @@ from strawberry.exceptions import ConnectionRejectionError
 from strawberry.http.exceptions import NonTextMessageReceived, WebSocketDisconnected
 from strawberry.http.typevars import Context, RootValue
 from strawberry.subscriptions.protocols.graphql_ws.types import (
+    CompleteMessage,
     ConnectionInitMessage,
     ConnectionTerminateMessage,
     DataMessage,
+    ErrorMessage,
     OperationMessage,
     StartMessage,
     StopMessage,
@@ -174,22 +176,24 @@ class BaseGraphQLWSHandler(Generic[Context, RootValue]):
             is_first_result = True
             async for result in result_source:
                 if is_first_result and isinstance(result, PreExecutionError):
+                    assert result.errors
+
                     await self.send_message(
-                        {
-                            "type": "error",
-                            "id": operation_id,
-                            "payload": result.errors[0].formatted,
-                        }
+                        ErrorMessage(
+                            type="error",
+                            id=operation_id,
+                            payload=result.errors[0].formatted,
+                        )
                     )
                     return
 
                 await self.send_data_message(result, operation_id)
                 is_first_result = False
 
-            await self.send_message({"type": "complete", "id": operation_id})
+            await self.send_message(CompleteMessage(type="complete", id=operation_id))
 
         except asyncio.CancelledError:
-            await self.send_message({"type": "complete", "id": operation_id})
+            await self.send_message(CompleteMessage(type="complete", id=operation_id))
 
     async def cleanup_operation(self, operation_id: str) -> None:
         if operation_id in self.subscriptions:

--- a/tests/schema/extensions/schema_extensions/test_subscription.py
+++ b/tests/schema/extensions/schema_extensions/test_subscription.py
@@ -76,7 +76,8 @@ async def test_subscription_extension_handles_immediate_errors(
         "on_execute Entered",
         "on_execute Exited",
         "get_results",
-        "on_operation Exited",
+        # TODO: we might need this
+        # "on_operation Exited",
     ]
 
     result = await schema.subscribe(default_query_types_and_query.subscription)

--- a/tests/schema/extensions/schema_extensions/test_subscription.py
+++ b/tests/schema/extensions/schema_extensions/test_subscription.py
@@ -76,12 +76,15 @@ async def test_subscription_extension_handles_immediate_errors(
         "on_execute Entered",
         "on_execute Exited",
         "get_results",
-        # TODO: we might need this
-        # "on_operation Exited",
+        "on_operation Exited",
     ]
 
     result = await schema.subscribe(default_query_types_and_query.subscription)
-    result = await result.__anext__()
+    results = [result async for result in result]
+
+    assert len(results) == 1
+    result = results[0]
+
     assert isinstance(result, PreExecutionError)
     assert result.errors
 

--- a/tests/schema/extensions/schema_extensions/test_subscription.py
+++ b/tests/schema/extensions/schema_extensions/test_subscription.py
@@ -4,7 +4,7 @@ import pytest
 
 import strawberry
 from strawberry.extensions import SchemaExtension
-from strawberry.types.execution import ExecutionResult
+from strawberry.types.execution import ExecutionResult, PreExecutionError
 from tests.conftest import skip_if_gql_32
 
 from .conftest import ExampleExtension, SchemaHelper
@@ -79,8 +79,10 @@ async def test_subscription_extension_handles_immediate_errors(
         "on_operation Exited",
     ]
 
-    res = await schema.subscribe(default_query_types_and_query.subscription)
-    assert res.errors
+    result = await schema.subscribe(default_query_types_and_query.subscription)
+    result = await result.__anext__()
+    assert isinstance(result, PreExecutionError)
+    assert result.errors
 
     async_extension.assert_expected()
 

--- a/tests/schema/test_permission.py
+++ b/tests/schema/test_permission.py
@@ -79,7 +79,7 @@ async def test_raises_permission_error_for_subscription():
     query = "subscription { user }"
 
     result = await schema.subscribe(query)
-
+    result = await result.__anext__()
     assert result.errors[0].message == "You are not authorized"
 
 

--- a/tests/schema/test_subscription.py
+++ b/tests/schema/test_subscription.py
@@ -1,7 +1,6 @@
 # ruff: noqa: F821
 from __future__ import annotations
 
-import inspect
 from collections import abc  # noqa: F401
 from collections.abc import AsyncGenerator, AsyncIterable, AsyncIterator  # noqa: F401
 from typing import (
@@ -245,14 +244,17 @@ async def test_subscription_immediate_error():
     schema = strawberry.Schema(query=Query, subscription=Subscription)
 
     query = """#graphql
-            subscription { example }
-            """
-    res_or_agen = await schema.subscribe(query)
-    assert isinstance(res_or_agen, PreExecutionError)
-    assert res_or_agen.errors
+        subscription { example }
+    """
+
+    result = await schema.subscribe(query)
+    result = await result.__anext__()
+
+    assert isinstance(result, PreExecutionError)
+    assert result.errors
 
 
-async def test_worng_opeartion_variables():
+async def test_wrong_operation_variables():
     @strawberry.type
     class Query:
         x: str = "Hello"
@@ -266,11 +268,11 @@ async def test_worng_opeartion_variables():
     schema = strawberry.Schema(query=Query, subscription=Subscription)
 
     query = """#graphql
-                subscription subOp($opVar: String!){ example(name: $opVar) }
-            """
+        subscription subOp($opVar: String!){ example(name: $opVar) }
+    """
 
     result = await schema.subscribe(query)
-    assert not inspect.isasyncgen(result)
+    result = await result.__anext__()
 
     assert result.errors
     assert (


### PR DESCRIPTION
## Summary by Sourcery

Refactors how PreExecution errors are handled in subscriptions to ensure errors are properly propagated and handled in both graphql-ws and graphql-transport-ws protocols. This change ensures that extensions are properly handled when an immediate error occurs during subscription.

Enhancements:
- Improves error handling for PreExecutionError in subscriptions.
- Updates the schema subscribe method to return the async generator directly.
- Ensures that extensions are properly handled when an immediate error occurs during subscription.
- Improves error handling in graphql-ws and graphql-transport-ws protocols.