### PR TITLE
Fix the package name in the file upload doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5666,10 +5666,10 @@ Contributed by [Patrick Arminio](https://github.com/patrick91) via [PR #2128](ht
 
 Reduce the number of required dependencies, by marking Pygments and python-multipart as optional. These dependencies are still necessary for some functionality, and so users of that functionality need to ensure they're installed, either explicitly or via an extra:
 
-- Pygments is still necessary when using Strawberry in debug mode, and is included in the `strawberry[debug-server]` extra.
-- python-multipart is still necessary when using `strawberry.file_uploads.Upload` with FastAPI or Starlette, and is included in the `strawberry[fastapi]` and `strawberry[asgi]` extras, respectively.
+- Pygments is still necessary when using Strawberry in debug mode, and is included in the `strawberry-graphql[debug-server]` extra.
+- python-multipart is still necessary when using `strawberry.file_uploads.Upload` with FastAPI or Starlette, and is included in the `strawberry-graphql[fastapi]` and `strawberry-graphql[asgi]` extras, respectively.
 
-There is now also the `strawberry[cli]` extra to support commands like `strawberry codegen` and `strawberry export-schema`.
+There is now also the `strawberry-graphql[cli]` extra to support commands like `strawberry codegen` and `strawberry export-schema`.
 
 Contributed by [Huon Wilson](https://github.com/huonw) via [PR #2205](https://github.com/strawberry-graphql/strawberry/pull/2205/)
 
@@ -9235,7 +9235,7 @@ you can install the required dependencies needed to use Strawberry with
 ASGI by running:
 
 ```
-pip install 'strawberry[asgi]'
+pip install 'strawberry-graphql[asgi]'
 ```
 
 Contributed by [A. Coady](https://github.com/coady) [PR #1036](https://github.com/strawberry-graphql/strawberry/pull/1036/)

--- a/docs/guides/file-upload.md
+++ b/docs/guides/file-upload.md
@@ -60,11 +60,11 @@ async.
 
 Additionally, these servers rely on the `python-multipart` package, which is not
 included by Strawberry by default. It can be installed directly, or, for
-convenience, it is included in extras: `strawberry[asgi]` (for ASGI/Starlette)
-or `strawberry[fastapi]` (for FastAPI). For example:
+convenience, it is included in extras: `strawberry-graphql[asgi]` (for ASGI/Starlette)
+or `strawberry-graphql[fastapi]` (for FastAPI). For example:
 
-- if using Pip, `pip install 'strawberry[fastapi]'`
-- if using Poetry, `strawberry = { version = "...", extras = ["fastapi"] }` in
+- if using Pip, `pip install 'strawberry-graphql[fastapi]'`
+- if using Poetry, `strawberry-graphql = { version = "...", extras = ["fastapi"] }` in
   `pyproject.toml`.
 
 Example:

--- a/docs/guides/file-upload.md
+++ b/docs/guides/file-upload.md
@@ -60,11 +60,12 @@ async.
 
 Additionally, these servers rely on the `python-multipart` package, which is not
 included by Strawberry by default. It can be installed directly, or, for
-convenience, it is included in extras: `strawberry-graphql[asgi]` (for ASGI/Starlette)
-or `strawberry-graphql[fastapi]` (for FastAPI). For example:
+convenience, it is included in extras: `strawberry-graphql[asgi]` (for
+ASGI/Starlette) or `strawberry-graphql[fastapi]` (for FastAPI). For example:
 
 - if using Pip, `pip install 'strawberry-graphql[fastapi]'`
-- if using Poetry, `strawberry-graphql = { version = "...", extras = ["fastapi"] }` in
+- if using Poetry,
+  `strawberry-graphql = { version = "...", extras = ["fastapi"] }` in
   `pyproject.toml`.
 
 Example:


### PR DESCRIPTION
## Description

The package `strawberry` was referenced, but that's another project, this one is `strawberry-graphql`.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Summary by Sourcery

Documentation:
- Fix the file upload documentation to reference the correct package name (`strawberry-graphql`) instead of `strawberry`.