### PR TITLE
(feat) cli: export schema from callable

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,14 @@
+Release type: minor
+
+This release adds support for exporting schema created by a callable:
+
+```bash
+strawberry export-schema package.module:create_schema
+```
+
+when
+
+```python
+def create_schema():
+    return strawberry.Schema(query=Query)
+```

--- a/docs/guides/schema-export.md
+++ b/docs/guides/schema-export.md
@@ -19,9 +19,10 @@ You can export your schema using the following command:
 strawberry export-schema package.module:schema
 ```
 
-where `schema` is the name of a Strawberry schema symbol and `package.module` is
-the qualified name of the module containing the symbol. The symbol name defaults
-to `schema` if not specified.
+where `schema` is the name of a Strawberry schema symbol or a callable symbol
+that returns a Strawberry schema and `package.module` is the qualified name of
+the module containing the symbol. The symbol name defaults to `schema` if not
+specified.
 
 In order to store the exported schema in a file, pipes or redirection can be
 utilized:

--- a/strawberry/cli/utils/__init__.py
+++ b/strawberry/cli/utils/__init__.py
@@ -18,6 +18,14 @@ def load_schema(schema: str, app_dir: str) -> Schema:
         rich.print(f"[red]Error: {message}")
         raise typer.Exit(2)  # noqa: B904
 
+    if callable(schema_symbol):
+        try:
+            schema_symbol = schema_symbol()
+        except Exception as exc:  # noqa: BLE001
+            message = f"Error invoking schema_symbol: {exc}"
+            rich.print(f"[red]Error: {message}")
+            raise typer.Exit(2)  # noqa: B904
+
     if not isinstance(schema_symbol, Schema):
         message = "The `schema` must be an instance of strawberry.Schema"
         rich.print(f"[red]Error: {message}")

--- a/tests/cli/test_export_schema.py
+++ b/tests/cli/test_export_schema.py
@@ -19,6 +19,13 @@ def test_schema_export(cli_app: Typer, cli_runner: CliRunner):
     )
 
 
+def test_schema_symbol_is_callable(cli_app: Typer, cli_runner: CliRunner):
+    selector = "tests.fixtures.sample_package.sample_module:create_schema"
+    result = cli_runner.invoke(cli_app, ["export-schema", selector])
+
+    assert result.exit_code == 0
+
+
 def test_default_schema_symbol_name(cli_app: Typer, cli_runner: CliRunner):
     selector = "tests.fixtures.sample_package.sample_module"
     result = cli_runner.invoke(cli_app, ["export-schema", selector])

--- a/tests/fixtures/sample_package/sample_module.py
+++ b/tests/fixtures/sample_package/sample_module.py
@@ -19,6 +19,10 @@ class Query:
         return User(name="Patrick", age=100)
 
 
-schema = strawberry.Schema(query=Query)
+def create_schema():
+    return strawberry.Schema(query=Query)
+
+
+schema = create_schema()
 sample_instance = SampleClass(schema)
 not_a_schema = 42


### PR DESCRIPTION
## Description

Add support for exporting schema created by a callable:

```bash
strawberry export-schema package.module:create_schema
```

when

```python

def create_schema():
    return strawberry.Schema(query=Query)

```

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

None that I'm aware of

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Adds support for exporting a schema created by a callable function using the command line interface.

New Features:
- Adds support for exporting schema created by a callable via the command line interface.

Tests:
- Adds a test case to verify that the CLI can export a schema when the schema symbol is a callable.