### PR TITLE
add support for including pydantic computed fields

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,23 @@
+Release type: minor
+
+Adds the ability to include pydantic computed fields when using pydantic.type decorator.
+
+Example:
+```python
+class UserModel(pydantic.BaseModel):
+    age: int
+
+    @computed_field
+    @property
+    def next_age(self) -> int:
+        return self.age + 1
+
+
+@strawberry.experimental.pydantic.type(
+    UserModel, all_fields=True, include_computed=True
+)
+class User:
+    pass
+```
+
+Will allow `nextAge` to be requested from a user entity.

--- a/docs/integrations/pydantic.md
+++ b/docs/integrations/pydantic.md
@@ -63,6 +63,22 @@ class UserType:
     pass
 ```
 
+By default, computed fields are excluded. To also include all computed fields
+pass `include_computed=True` to the decorator.
+
+```python
+import strawberry
+
+from .models import User
+
+
+@strawberry.experimental.pydantic.type(
+    model=User, all_fields=True, include_computed=True
+)
+class UserType:
+    pass
+```
+
 ## Input types
 
 Input types are similar to types; we can create one by using the

--- a/strawberry/experimental/pydantic/_compat.py
+++ b/strawberry/experimental/pydantic/_compat.py
@@ -199,7 +199,10 @@ class PydanticV1Compat:
     def PYDANTIC_MISSING_TYPE(self) -> Any:  # noqa: N802
         return dataclasses.MISSING
 
-    def get_model_fields(self, model: type[BaseModel]) -> dict[str, CompatModelField]:
+    def get_model_fields(
+        self, model: type[BaseModel], include_computed: bool = False
+    ) -> dict[str, CompatModelField]:
+        """`include_computed` is a noop for PydanticV1Compat."""
         new_fields = {}
         # Convert it into CompatModelField
         for name, field in model.__fields__.items():  # type: ignore[attr-defined]

--- a/strawberry/experimental/pydantic/object_type.py
+++ b/strawberry/experimental/pydantic/object_type.py
@@ -126,11 +126,12 @@ def type(  # noqa: PLR0915
     description: Optional[str] = None,
     directives: Optional[Sequence[object]] = (),
     all_fields: bool = False,
+    include_computed: bool = False,
     use_pydantic_alias: bool = True,
 ) -> Callable[..., builtins.type[StrawberryTypeFromPydantic[PydanticModel]]]:
     def wrap(cls: Any) -> builtins.type[StrawberryTypeFromPydantic[PydanticModel]]:  # noqa: PLR0915
         compat = PydanticCompat.from_model(model)
-        model_fields = compat.get_model_fields(model)
+        model_fields = compat.get_model_fields(model, include_computed=include_computed)
         original_fields_set = set(fields) if fields else set()
 
         if fields:
@@ -171,7 +172,10 @@ def type(  # noqa: PLR0915
             raise MissingFieldsListError(cls)
 
         ensure_all_auto_fields_in_pydantic(
-            model=model, auto_fields=auto_fields_set, cls_name=cls.__name__
+            model=model,
+            auto_fields=auto_fields_set,
+            cls_name=cls.__name__,
+            include_computed=include_computed,
         )
 
         wrapped = _wrap_dataclass(cls)

--- a/strawberry/experimental/pydantic/utils.py
+++ b/strawberry/experimental/pydantic/utils.py
@@ -117,11 +117,17 @@ def get_default_factory_for_field(
 
 
 def ensure_all_auto_fields_in_pydantic(
-    model: type[BaseModel], auto_fields: set[str], cls_name: str
+    model: type[BaseModel],
+    auto_fields: set[str],
+    cls_name: str,
+    include_computed: bool = False,
 ) -> None:
     compat = PydanticCompat.from_model(model)
     # Raise error if user defined a strawberry.auto field not present in the model
-    non_existing_fields = list(auto_fields - compat.get_model_fields(model).keys())
+    non_existing_fields = list(
+        auto_fields
+        - compat.get_model_fields(model, include_computed=include_computed).keys()
+    )
 
     if non_existing_fields:
         raise AutoFieldsNotInBaseModelError(

--- a/tests/experimental/pydantic/schema/test_computed.py
+++ b/tests/experimental/pydantic/schema/test_computed.py
@@ -1,0 +1,63 @@
+import textwrap
+
+import pydantic
+from pydantic import computed_field
+
+import strawberry
+
+
+def test_computed_field():
+    class UserModel(pydantic.BaseModel):
+        age: int
+
+        @computed_field
+        @property
+        def next_age(self) -> int:
+            return self.age + 1
+
+    @strawberry.experimental.pydantic.type(
+        UserModel, all_fields=True, include_computed=True
+    )
+    class User:
+        pass
+
+    @strawberry.experimental.pydantic.type(UserModel, all_fields=True)
+    class UserNoComputed:
+        pass
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def user(self) -> User:
+            return User.from_pydantic(UserModel(age=1))
+
+        @strawberry.field
+        def user_no_computed(self) -> UserNoComputed:
+            return UserNoComputed.from_pydantic(UserModel(age=1))
+
+    schema = strawberry.Schema(query=Query)
+
+    expected_schema = """
+    type Query {
+      user: User!
+      userNoComputed: UserNoComputed!
+    }
+
+    type User {
+      age: Int!
+      nextAge: Int!
+    }
+
+    type UserNoComputed {
+      age: Int!
+    }
+    """
+
+    assert str(schema) == textwrap.dedent(expected_schema).strip()
+
+    query = "{ user { age nextAge } }"
+
+    result = schema.execute_sync(query)
+    assert not result.errors
+    assert result.data["user"]["age"] == 1
+    assert result.data["user"]["nextAge"] == 2

--- a/tests/experimental/pydantic/schema/test_computed.py
+++ b/tests/experimental/pydantic/schema/test_computed.py
@@ -1,11 +1,20 @@
 import textwrap
 
 import pydantic
-from pydantic import computed_field
+import pytest
+from pydantic.version import VERSION as PYDANTIC_VERSION
 
 import strawberry
 
+IS_PYDANTIC_V2: bool = PYDANTIC_VERSION.startswith("2.")
 
+if IS_PYDANTIC_V2:
+    from pydantic import computed_field
+
+
+@pytest.mark.skipif(
+    not IS_PYDANTIC_V2, reason="Requires Pydantic v2 for computed_field"
+)
 def test_computed_field():
     class UserModel(pydantic.BaseModel):
         age: int


### PR DESCRIPTION
Adds the ability to include pydantic computed fields when using `pydantic.type` decorator. 

## Description

Fixes https://github.com/strawberry-graphql/strawberry/issues/3607
Reserves backwards compatibility by only enabling this behavior with a bool flag. 

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/strawberry-graphql/strawberry/issues/3607

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Adds support for including Pydantic computed fields in Strawberry types when using the `strawberry.experimental.pydantic.type` decorator. This feature is enabled via the `include_computed` flag.

New Features:
- Adds the ability to include pydantic computed fields when using `pydantic.type` decorator by introducing a new `include_computed` flag.

Tests:
- Adds a test case to verify that computed fields are correctly included in the generated GraphQL schema when the `include_computed` flag is enabled.