### PR TITLE
Pass `request` to custom `graphiql.html`

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+This release updates the handling of the Django `graphql/graphiql.html` template, if provided; it will now receive the current request as context.

--- a/docs/integrations/django.md
+++ b/docs/integrations/django.md
@@ -209,7 +209,10 @@ class MyGraphQLView(GraphQLView):
 ### render_graphql_ide
 
 In case you need more control over the rendering of the GraphQL IDE than the
-`graphql_ide` option provides, you can override the `render_graphql_ide` method.
+`graphql_ide` option provides, you can provide the `graphql/graphiql.html`
+template, which will be used instead of the configured IDE.
+
+Alternatively, you can override the `render_graphql_ide` method:
 
 ```python
 from strawberry.django.views import GraphQLView
@@ -393,7 +396,10 @@ class MyGraphQLView(AsyncGraphQLView):
 ### render_graphql_ide
 
 In case you need more control over the rendering of the GraphQL IDE than the
-`graphql_ide` option provides, you can override the `render_graphql_ide` method.
+`graphql_ide` option provides, you can provide the `graphql/graphiql.html`
+template, which will be used instead of the configured IDE.
+
+Alternatively, you can override the `render_graphql_ide` method:
 
 ```python
 from strawberry.django.views import AsyncGraphQLView

--- a/strawberry/django/views.py
+++ b/strawberry/django/views.py
@@ -238,7 +238,7 @@ class GraphQLView(
 
     def render_graphql_ide(self, request: HttpRequest) -> HttpResponse:
         try:
-            content = render_to_string("graphql/graphiql.html")
+            content = render_to_string("graphql/graphiql.html", request=request)
         except TemplateDoesNotExist:
             content = self.graphql_ide_html
 
@@ -298,7 +298,7 @@ class AsyncGraphQLView(
 
     async def render_graphql_ide(self, request: HttpRequest) -> HttpResponse:
         try:
-            content = render_to_string("graphql/graphiql.html")
+            content = render_to_string("graphql/graphiql.html", request=request)
         except TemplateDoesNotExist:
             content = self.graphql_ide_html
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Strawberry uses the Django template `graphql/graphiql.html` in preference to any other GraphQL IDE setting, if it's available, but it doesn't pass the current request to that template. This change makes it pass the current request to that template. (It also adds a brief mention of that template to the documentation.)

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

* Fixes #3799

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
