### PR TITLE
Update imports for future pydantic release

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+
+This release adds support for the upcoming version of Pydantic (2.11)

--- a/noxfile.py
+++ b/noxfile.py
@@ -130,7 +130,7 @@ def tests_integrations(session: Session, integration: str, gql_core: str) -> Non
 
 
 @session(python=PYTHON_VERSIONS, name="Pydantic tests", tags=["tests", "pydantic"])
-@with_gql_core_parametrize("pydantic", ["1.10", "2.8.0", "2.9.0"])
+@with_gql_core_parametrize("pydantic", ["1.10", "2.9.0", "2.10.0", "2.11.0b1"])
 def test_pydantic(session: Session, pydantic: str, gql_core: str) -> None:
     session.run_always("poetry", "install", external=True)
 

--- a/strawberry/experimental/pydantic/_compat.py
+++ b/strawberry/experimental/pydantic/_compat.py
@@ -263,8 +263,8 @@ class PydanticCompat:
 if IS_PYDANTIC_V2:
     from typing_extensions import get_args, get_origin
 
-    from pydantic._internal._typing_extra import is_new_type
-    from pydantic._internal._utils import lenient_issubclass, smart_deepcopy
+    from pydantic.v1.typing import is_new_type
+    from pydantic.v1.utils import lenient_issubclass, smart_deepcopy
 
     def new_type_supertype(type_: Any) -> Any:
         return type_.__supertype__

--- a/strawberry/experimental/pydantic/_compat.py
+++ b/strawberry/experimental/pydantic/_compat.py
@@ -91,6 +91,10 @@ ATTR_TO_TYPE_MAP_Pydantic_V2 = {
     "SecretStr": str,
     "SecretBytes": bytes,
     "AnyUrl": str,
+    "AnyHttpUrl": str,
+    "HttpUrl": str,
+    "PostgresDsn": str,
+    "RedisDsn": str,
 }
 
 ATTR_TO_TYPE_MAP_Pydantic_Core_V2 = {


### PR DESCRIPTION
Closes #3807

## Summary by Sourcery

Tests:
- Adds Pydantic 2.11.0b1 to the test matrix.