### PR TITLE
Change pydantic conversion to not load field data unless requested

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Change pydantic conversion to not load field data unless requested

--- a/strawberry/experimental/pydantic/conversion.py
+++ b/strawberry/experimental/pydantic/conversion.py
@@ -83,14 +83,14 @@ def convert_pydantic_model_to_strawberry_class(
         field = cast("StrawberryField", field_)
         python_name = field.python_name
 
-        data_from_extra = extra.get(python_name, None)
-        data_from_model = (
-            getattr(model_instance, python_name, None) if model_instance else None
-        )
-
         # only convert and add fields to kwargs if they are present in the `__init__`
         # method of the class
         if field.init:
+            data_from_extra = extra.get(python_name, None)
+            data_from_model = (
+                getattr(model_instance, python_name, None) if model_instance else None
+            )
+
             kwargs[python_name] = _convert_from_pydantic_to_strawberry_type(
                 field.type, data_from_model, extra=data_from_extra
             )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

Changes the Pydantic model conversion so that it doesn't retrieve data for fields that aren't going to be used.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

It's been 8 months since I manually patched this in our own codebase, I wanted to create a PR here after some time when I was sure it didn't cause any regressions. 

Without this patch I observed unnecessary requests being made which originated from fields on "Pydantic strawberry types" that weren't requested in the query. Moving these lines inside the `if field.init:` section appeared sufficient to fix this.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
