### PR TITLE
Update errors.md

### DIFF
--- a/.alexrc
+++ b/.alexrc
@@ -13,6 +13,6 @@
     "special",
     "primitive",
     "invalid",
-    "crash"
+    "failed"
   ]
 }

--- a/docs/guides/errors.md
+++ b/docs/guides/errors.md
@@ -163,13 +163,16 @@ schema = strawberry.Schema(query=Query)
 
 ## Partial responses for failed resolvers
 
-By default, GraphQL allows partial responses when a resolver fails. This means that successfully resolved fields are still returned alongside errors. However, this applies only when the erroneous field is defined as optional.
+By default, GraphQL allows partial responses when a resolver fails. This means
+that successfully resolved fields are still returned alongside errors. However,
+this applies only when the erroneous field is defined as optional.
 
 Consider the following example:
 
 ```python
 from typing import Optional
 import strawberry
+
 
 @strawberry.type
 class Query:
@@ -181,6 +184,7 @@ class Query:
     def error_field(self) -> Optional[str]:
         raise Exception("This field fails")
 
+
 schema = strawberry.Schema(query=Query)
 ```
 
@@ -188,8 +192,8 @@ schema = strawberry.Schema(query=Query)
 
 ```graphql
 {
-    successfulField
-    errorField
+  successfulField
+  errorField
 }
 ```
 
@@ -202,7 +206,7 @@ schema = strawberry.Schema(query=Query)
   "errors": [
     {
       "message": "This field fails",
-      "locations": [{"line": 3, "column": 3}],
+      "locations": [{ "line": 3, "column": 3 }],
       "path": ["errorField"]
     }
   ]
@@ -211,7 +215,8 @@ schema = strawberry.Schema(query=Query)
 
 </CodeGrid>
 
-The response includes both successfully resolved data and error details, demonstrating GraphQL's ability to return partial results.
+The response includes both successfully resolved data and error details,
+demonstrating GraphQL's ability to return partial results.
 
 ## Expected errors
 

--- a/docs/guides/errors.md
+++ b/docs/guides/errors.md
@@ -161,6 +161,58 @@ schema = strawberry.Schema(query=Query)
 
 </CodeGrid>
 
+## Partial responses for failed resolvers
+
+By default, GraphQL allows partial responses when a resolver fails. This means that successfully resolved fields are still returned alongside errors. However, this applies only when the erroneous field is defined as optional.
+
+Consider the following example:
+
+```python
+from typing import Optional
+import strawberry
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def successful_field(self) -> Optional[str]:
+        return "This field works"
+
+    @strawberry.field
+    def error_field(self) -> Optional[str]:
+        raise Exception("This field fails")
+
+schema = strawberry.Schema(query=Query)
+```
+
+<CodeGrid>
+
+```graphql
+{
+    successfulField
+    errorField
+}
+```
+
+```json
+{
+  "data": {
+    "successfulField": "This field works",
+    "errorField": null
+  },
+  "errors": [
+    {
+      "message": "This field fails",
+      "locations": [{"line": 3, "column": 3}],
+      "path": ["errorField"]
+    }
+  ]
+}
+```
+
+</CodeGrid>
+
+The response includes both successfully resolved data and error details, demonstrating GraphQL's ability to return partial results.
+
 ## Expected errors
 
 If an error is expected then it is often best to express it in the schema. This


### PR DESCRIPTION
Added partial error response details in error guides

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This PR enhances the Dealing with Errors documentation by adding details about partial error responses. It addresses an issue where a single resolver failure causes the entire GraphQL response to be null instead of returning partial data. The update explains the expected behavior and highlights the importance of using Optional types in field resolvers to ensure partial responses are correctly handled.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

* Closes #3814

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Document how Strawberry handles partial responses when a resolver fails, and explain how to use Optional types to ensure partial responses are correctly handled.

Enhancements:
- Explain how Strawberry handles partial responses when a resolver fails.
- Recommend the use of Optional types in field resolvers to ensure partial responses are correctly handled.