### PR TITLE
Initial Quart Subscription Support

### DIFF
--- a/strawberry/quart/views.py
+++ b/strawberry/quart/views.py
@@ -16,8 +16,8 @@ from strawberry.http.async_base_view import (
 from strawberry.http.exceptions import (
     HTTPException,
     NonJsonMessageReceived,
+    NonTextMessageReceived,
     WebSocketDisconnected,
-    NonTextMessageReceived
 )
 from strawberry.http.ides import GraphQL_IDE
 from strawberry.http.types import FormData, HTTPMethod, QueryParams

--- a/strawberry/quart/views.py
+++ b/strawberry/quart/views.py
@@ -1,15 +1,27 @@
 import warnings
 from collections.abc import AsyncGenerator, Mapping
+from datetime import timedelta
 from typing import TYPE_CHECKING, Callable, ClassVar, Optional, cast
 from typing_extensions import TypeGuard
+from json.decoder import JSONDecodeError
 
-from quart import Request, Response, request
+from quart import Quart, Request, Response, websocket, request
+from quart.ctx import has_websocket_context
 from quart.views import View
-from strawberry.http.async_base_view import AsyncBaseHTTPView, AsyncHTTPRequestAdapter
-from strawberry.http.exceptions import HTTPException
+from strawberry.http.async_base_view import (
+    AsyncBaseHTTPView,
+    AsyncHTTPRequestAdapter,
+    AsyncWebSocketAdapter
+)
+from strawberry.http.exceptions import (
+    HTTPException,
+    NonJsonMessageReceived,
+    WebSocketDisconnected
+)
 from strawberry.http.ides import GraphQL_IDE
 from strawberry.http.types import FormData, HTTPMethod, QueryParams
 from strawberry.http.typevars import Context, RootValue
+from strawberry.subscriptions import GRAPHQL_TRANSPORT_WS_PROTOCOL, GRAPHQL_WS_PROTOCOL
 
 if TYPE_CHECKING:
     from quart.typing import ResponseReturnValue
@@ -46,6 +58,35 @@ class QuartHTTPRequestAdapter(AsyncHTTPRequestAdapter):
         return FormData(files=files, form=form)
 
 
+class QuartWebSocketAdapter(AsyncWebSocketAdapter):
+    def __init__(self, view: AsyncBaseHTTPView, request, ws) -> None:
+        super().__init__(view)
+        self.ws = websocket
+
+    async def iter_json(
+        self, *, ignore_parsing_errors: bool = False
+    ) -> AsyncGenerator[object, None]:
+        while True:
+            try:
+                message = await self.ws.receive()
+                try:
+                    yield self.view.decode_json(message)
+                except JSONDecodeError as e:
+                    if not ignore_parsing_errors:
+                        raise NonJsonMessageReceived from e
+            except Exception as exc:
+                raise WebSocketDisconnected from exc
+
+    async def send_json(self, message: Mapping[str, object]) -> None:
+        try:
+            await self.ws.send(self.view.encode_json(message))
+        except Exception as exc:
+            raise WebSocketDisconnected from exc
+
+    async def close(self, code: int, reason: str) -> None:
+        await self.ws.close(code, reason=reason)
+
+
 class GraphQLView(
     AsyncBaseHTTPView[
         Request, Response, Response, Request, Response, Context, RootValue
@@ -55,6 +96,7 @@ class GraphQLView(
     methods: ClassVar[list[str]] = ["GET", "POST"]
     allow_queries_via_get: bool = True
     request_adapter_class = QuartHTTPRequestAdapter
+    websocket_adapter_class = QuartWebSocketAdapter
 
     def __init__(
         self,
@@ -62,10 +104,23 @@ class GraphQLView(
         graphiql: Optional[bool] = None,
         graphql_ide: Optional[GraphQL_IDE] = "graphiql",
         allow_queries_via_get: bool = True,
+        keep_alive: bool = True,
+        keep_alive_interval: float = 1,
+        debug: bool = False,
+        subscription_protocols: list[str] = [
+            GRAPHQL_TRANSPORT_WS_PROTOCOL,
+            GRAPHQL_WS_PROTOCOL,
+        ],
+        connection_init_wait_timeout: timedelta = timedelta(minutes=1),
         multipart_uploads_enabled: bool = False,
     ) -> None:
         self.schema = schema
         self.allow_queries_via_get = allow_queries_via_get
+        self.keep_alive = keep_alive
+        self.keep_alive_interval = keep_alive_interval
+        self.debug = debug
+        self.subscription_protocols = subscription_protocols
+        self.connection_init_wait_timeout = connection_init_wait_timeout
         self.multipart_uploads_enabled = multipart_uploads_enabled
 
         if graphiql is not None:
@@ -123,15 +178,59 @@ class GraphQLView(
         )
 
     def is_websocket_request(self, request: Request) -> TypeGuard[Request]:
-        return False
+        if has_websocket_context():
+            return True
+
+        # Check if the request is a WebSocket upgrade request
+        connection = request.headers.get("Connection", "").lower()
+        upgrade = request.headers.get("Upgrade", "").lower()
+
+        return ("upgrade" in connection and "websocket" in upgrade)
 
     async def pick_websocket_subprotocol(self, request: Request) -> Optional[str]:
-        raise NotImplementedError
+        # Get the requested protocols
+        protocols_header = websocket.headers.get("Sec-WebSocket-Protocol", "")
+        if not protocols_header:
+            return None
+
+        # Find the first matching protocol
+        requested_protocols = [p.strip() for p in protocols_header.split(",")]
+        for protocol in requested_protocols:
+            if protocol in self.subscription_protocols:
+                return protocol
+
+        return None
 
     async def create_websocket_response(
         self, request: Request, subprotocol: Optional[str]
     ) -> Response:
-        raise NotImplementedError
+        if subprotocol:
+            # Set the WebSocket protocol if specified
+            await websocket.accept(subprotocol=subprotocol)
+        else:
+            await websocket.accept()
+
+        # Return the current websocket context as the "response"
+        return None
+
+    @classmethod
+    def register_route(cls, app: Quart, rule_name: str, path: str, **kwargs):
+        """
+        Helper method to register both HTTP and WebSocket handlers for a given path.
+
+        Args:
+            app: The Quart application
+            rule_name: The name of the rule
+            path: The path to register the handlers for
+            **kwargs: Parameters to pass to the GraphQLView constructor
+        """
+        # Register both HTTP and WebSocket handler at the same path
+        view_func = cls.as_view(rule_name, **kwargs)
+        app.add_url_rule(path, view_func=view_func, methods=["GET", "POST"])
+
+        # Register the WebSocket handler using the same view function
+        # Quart will handle routing based on the WebSocket upgrade header
+        app.add_url_rule(path, view_func=view_func, methods=["GET"], websocket=True)
 
 
 __all__ = ["GraphQLView"]

--- a/strawberry/quart/views.py
+++ b/strawberry/quart/views.py
@@ -1,9 +1,9 @@
 import asyncio
 import warnings
-from collections.abc import AsyncGenerator, Mapping
+from collections.abc import AsyncGenerator, Mapping, Sequence
 from datetime import timedelta
 from json.decoder import JSONDecodeError
-from typing import TYPE_CHECKING, Callable, ClassVar, Optional, cast, Sequence
+from typing import TYPE_CHECKING, Callable, ClassVar, Optional, cast
 from typing_extensions import TypeGuard
 
 from quart import Quart, Request, Response, request, websocket

--- a/strawberry/quart/views.py
+++ b/strawberry/quart/views.py
@@ -1,22 +1,22 @@
 import warnings
 from collections.abc import AsyncGenerator, Mapping
 from datetime import timedelta
+from json.decoder import JSONDecodeError
 from typing import TYPE_CHECKING, Callable, ClassVar, Optional, cast
 from typing_extensions import TypeGuard
-from json.decoder import JSONDecodeError
 
-from quart import Quart, Request, Response, websocket, request
+from quart import Quart, Request, Response, request, websocket
 from quart.ctx import has_websocket_context
 from quart.views import View
 from strawberry.http.async_base_view import (
     AsyncBaseHTTPView,
     AsyncHTTPRequestAdapter,
-    AsyncWebSocketAdapter
+    AsyncWebSocketAdapter,
 )
 from strawberry.http.exceptions import (
     HTTPException,
     NonJsonMessageReceived,
-    WebSocketDisconnected
+    WebSocketDisconnected,
 )
 from strawberry.http.ides import GraphQL_IDE
 from strawberry.http.types import FormData, HTTPMethod, QueryParams
@@ -185,7 +185,7 @@ class GraphQLView(
         connection = request.headers.get("Connection", "").lower()
         upgrade = request.headers.get("Upgrade", "").lower()
 
-        return ("upgrade" in connection and "websocket" in upgrade)
+        return "upgrade" in connection and "websocket" in upgrade
 
     async def pick_websocket_subprotocol(self, request: Request) -> Optional[str]:
         # Get the requested protocols
@@ -215,8 +215,7 @@ class GraphQLView(
 
     @classmethod
     def register_route(cls, app: Quart, rule_name: str, path: str, **kwargs):
-        """
-        Helper method to register both HTTP and WebSocket handlers for a given path.
+        """Helper method to register both HTTP and WebSocket handlers for a given path.
 
         Args:
             app: The Quart application

--- a/tests/http/clients/quart.py
+++ b/tests/http/clients/quart.py
@@ -1,8 +1,14 @@
+import asyncio
+import contextlib
 import json
 import urllib.parse
 from io import BytesIO
-from typing import Any, Optional
+from typing import Any, Optional, AsyncGenerator, Mapping
+
+from quart.typing import TestWebsocketConnectionProtocol
 from typing_extensions import Literal
+
+from starlette.testclient import TestClient, WebSocketTestSession
 
 from quart import Quart
 from quart import Request as QuartRequest
@@ -15,7 +21,8 @@ from strawberry.types import ExecutionResult
 from tests.http.context import get_context
 from tests.views.schema import Query, schema
 
-from .base import JSON, HttpClient, Response, ResultOverrideFunction
+from .base import JSON, HttpClient, Response, ResultOverrideFunction, WebSocketClient, \
+    Message
 
 
 class GraphQLView(BaseGraphQLView[dict[str, object], object]):
@@ -73,6 +80,34 @@ class QuartHttpClient(HttpClient):
             "/graphql",
             view_func=view,
         )
+        self.app.add_url_rule(
+            '/graphql',
+            view_func=view,
+            methods=["GET"],
+            websocket=True
+        )
+
+        self.client = TestClient(self.app)
+
+    def create_app(self, **kwargs: Any) -> None:
+        self.app = Quart(__name__)
+        self.app.debug = True
+
+        view = GraphQLView.as_view("graphql_view", schema=schema, **kwargs)
+
+        self.app.add_url_rule(
+            "/graphql",
+            view_func=view,
+        )
+        self.app.add_url_rule(
+            '/graphql',
+            view_func=view,
+            methods=["GET"],
+            websocket=True
+        )
+
+        self.client = TestClient(self.app)
+
 
     async def _graphql_request(
         self,
@@ -140,3 +175,74 @@ class QuartHttpClient(HttpClient):
         return await self.request(
             url, "post", **{k: v for k, v in kwargs.items() if v is not None}
         )
+
+    @contextlib.asynccontextmanager
+    async def ws_connect(
+        self,
+        url: str,
+        *,
+        protocols: list[str],
+    ) -> AsyncGenerator[WebSocketClient, None]:
+        with self.client.websocket_connect(url, protocols) as ws:
+            yield QuartWebSocketClient(ws)
+
+
+
+class QuartWebSocketClient(WebSocketClient):
+    def __init__(self, ws: WebSocketTestSession):
+        self.ws = ws
+        self._closed: bool = False
+        self._close_code: Optional[int] = None
+        self._close_reason: Optional[str] = None
+
+    async def send_text(self, payload: str) -> None:
+        self.ws.send_text(payload)
+
+    async def send_json(self, payload: Mapping[str, object]) -> None:
+        self.ws.send_json(payload)
+
+    async def send_bytes(self, payload: bytes) -> None:
+        self.ws.send_bytes(payload)
+
+    async def receive(self, timeout: Optional[float] = None) -> Message:
+        if self._closed:
+            # if close was received via exception, fake it so that recv works
+            return Message(
+                type="websocket.close", data=self._close_code, extra=self._close_reason
+            )
+        m = self.ws.receive()
+        if m["type"] == "websocket.close":
+            self._closed = True
+            self._close_code = m["code"]
+            self._close_reason =  m.get("reason", None)
+            return Message(type=m["type"], data=m["code"], extra=m.get("reason", None))
+        if m["type"] == "websocket.send":
+            return Message(type=m["type"], data=m["text"])
+        return Message(type=m["type"], data=m["data"], extra=m["extra"])
+
+    async def receive_json(self, timeout: Optional[float] = None) -> Any:
+        m = self.ws.receive()
+        assert m["type"] == "websocket.send"
+        assert "text" in m
+        return json.loads(m["text"])
+
+    async def close(self) -> None:
+        self.ws.close()
+        self._closed = True
+
+    @property
+    def accepted_subprotocol(self) -> Optional[str]:
+        return self.ws.accepted_subprotocol
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    @property
+    def close_code(self) -> int:
+        assert self._close_code is not None
+        return self._close_code
+
+    @property
+    def close_reason(self) -> Optional[str]:
+        return self._close_reason

--- a/tests/http/clients/quart.py
+++ b/tests/http/clients/quart.py
@@ -1,11 +1,9 @@
-import asyncio
 import contextlib
 import json
 import urllib.parse
+from collections.abc import AsyncGenerator, Mapping
 from io import BytesIO
-from typing import Any, Optional, AsyncGenerator, Mapping
-
-from quart.typing import TestWebsocketConnectionProtocol
+from typing import Any, Optional
 from typing_extensions import Literal
 
 from starlette.testclient import TestClient, WebSocketTestSession
@@ -21,8 +19,14 @@ from strawberry.types import ExecutionResult
 from tests.http.context import get_context
 from tests.views.schema import Query, schema
 
-from .base import JSON, HttpClient, Response, ResultOverrideFunction, WebSocketClient, \
-    Message
+from .base import (
+    JSON,
+    HttpClient,
+    Message,
+    Response,
+    ResultOverrideFunction,
+    WebSocketClient,
+)
 
 
 class GraphQLView(BaseGraphQLView[dict[str, object], object]):
@@ -81,10 +85,7 @@ class QuartHttpClient(HttpClient):
             view_func=view,
         )
         self.app.add_url_rule(
-            '/graphql',
-            view_func=view,
-            methods=["GET"],
-            websocket=True
+            "/graphql", view_func=view, methods=["GET"], websocket=True
         )
 
         self.client = TestClient(self.app)
@@ -100,14 +101,10 @@ class QuartHttpClient(HttpClient):
             view_func=view,
         )
         self.app.add_url_rule(
-            '/graphql',
-            view_func=view,
-            methods=["GET"],
-            websocket=True
+            "/graphql", view_func=view, methods=["GET"], websocket=True
         )
 
         self.client = TestClient(self.app)
-
 
     async def _graphql_request(
         self,
@@ -187,7 +184,6 @@ class QuartHttpClient(HttpClient):
             yield QuartWebSocketClient(ws)
 
 
-
 class QuartWebSocketClient(WebSocketClient):
     def __init__(self, ws: WebSocketTestSession):
         self.ws = ws
@@ -214,7 +210,7 @@ class QuartWebSocketClient(WebSocketClient):
         if m["type"] == "websocket.close":
             self._closed = True
             self._close_code = m["code"]
-            self._close_reason =  m.get("reason", None)
+            self._close_reason = m.get("reason", None)
             return Message(type=m["type"], data=m["code"], extra=m.get("reason", None))
         if m["type"] == "websocket.send":
             return Message(type=m["type"], data=m["text"])

--- a/tests/websockets/conftest.py
+++ b/tests/websockets/conftest.py
@@ -14,6 +14,7 @@ def _get_http_client_classes() -> Generator[Any, None, None]:
         ("ChannelsHttpClient", "channels", [pytest.mark.channels]),
         ("FastAPIHttpClient", "fastapi", [pytest.mark.fastapi]),
         ("LitestarHttpClient", "litestar", [pytest.mark.litestar]),
+        ("QuartHttpClient", "quart", [pytest.mark.quart]),
     ]:
         try:
             client_class = getattr(

--- a/tests/websockets/test_graphql_transport_ws.py
+++ b/tests/websockets/test_graphql_transport_ws.py
@@ -72,7 +72,6 @@ def assert_next(
 
 async def test_unknown_message_type(ws_raw: WebSocketClient):
     ws = ws_raw
-
     await ws.send_json({"type": "NOT_A_MESSAGE_TYPE"})
 
     await ws.receive(timeout=2)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Strawberry currently doesn't support subscriptions on Quart. This PR aims to rectify that.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Adds initial support for GraphQL subscriptions using Quart, including WebSocket handling and integration with the strawberry library. It also includes necessary updates to the test suite to ensure the new functionality works as expected.

New Features:
- Adds support for GraphQL subscriptions on Quart using WebSockets.
- Introduces a QuartWebSocketAdapter for handling WebSocket connections.
- Adds a register_route class method to GraphQLView to register both HTTP and WebSocket handlers for a given path.

Tests:
- Adds tests for the new Quart WebSocket functionality.