### PR TITLE
Fix GraphQL IDE charset error

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,3 @@
 Release type: patch
 
-Fix GraphQL IDE charset error that showed non-printing characters.
+This release updates the Content-Type header from ⁠`"text/html"` to `⁠"text/html; charset=utf-8"` to prevent the GraphQL IDE from displaying unusual or incorrect characters.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Fix GraphQL IDE charset error that showed non-printing characters.

--- a/strawberry/channels/handlers/http_handler.py
+++ b/strawberry/channels/handlers/http_handler.py
@@ -293,7 +293,8 @@ class GraphQLHTTPConsumer(
 
     async def render_graphql_ide(self, request: ChannelsRequest) -> ChannelsResponse:
         return ChannelsResponse(
-            content=self.graphql_ide_html.encode(), content_type="text/html"
+            content=self.graphql_ide_html.encode(),
+            content_type="text/html; charset=utf-8",
         )
 
     def is_websocket_request(

--- a/strawberry/channels/handlers/http_handler.py
+++ b/strawberry/channels/handlers/http_handler.py
@@ -349,7 +349,8 @@ class SyncGraphQLHTTPConsumer(
 
     def render_graphql_ide(self, request: ChannelsRequest) -> ChannelsResponse:
         return ChannelsResponse(
-            content=self.graphql_ide_html.encode(), content_type="text/html"
+            content=self.graphql_ide_html.encode(),
+            content_type="text/html; charset=utf-8",
         )
 
     # Sync channels is actually async, but it uses database_sync_to_async to call


### PR DESCRIPTION
## Description

Why:

- Hide non-printing characters

This change addresses the need by:

- Explicitly setting the content-type charset to utf-8

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #3821 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Bug Fixes:
- Resolve potential character encoding issues by explicitly setting the content type charset to UTF-8 in the GraphQL IDE handler