### PR TITLE
Use non beta version of pydantic in nox

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -130,7 +130,7 @@ def tests_integrations(session: Session, integration: str, gql_core: str) -> Non
 
 
 @session(python=PYTHON_VERSIONS, name="Pydantic tests", tags=["tests", "pydantic"])
-@with_gql_core_parametrize("pydantic", ["1.10", "2.9.0", "2.10.0", "2.11.0b1"])
+@with_gql_core_parametrize("pydantic", ["1.10", "2.9.0", "2.10.0", "2.11.0"])
 def test_pydantic(session: Session, pydantic: str, gql_core: str) -> None:
     session.run_always("poetry", "install", external=True)
 


### PR DESCRIPTION
Saw this: https://github.com/getsentry/sentry-python/pull/4208

I wonder if that's truly the case or they testing with an older version :)

In any case, it's good to bump the pydantic version from beta to stable

## Summary by Sourcery

Enhancements:
- Remove beta version (2.11.0b1) from Pydantic test matrix and replace with stable 2.11.0 release