### PR TITLE
opentelementry: allow passing a custom tracer provider

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,3 @@
 Release type: patch
 
-Allow passing in a custom `TracerProvider` to the `OpenTelemetryExtension`.
+This releases add support for passing in a custom `TracerProvider` to the `OpenTelemetryExtension`.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Allow passing in a custom `TracerProvider` to the `OpenTelemetryExtension`.

--- a/docs/extensions/opentelemetry.md
+++ b/docs/extensions/opentelemetry.md
@@ -99,3 +99,29 @@ schema = strawberry.Schema(
 ```
 
 </details>
+
+<details>
+  <summary>Using `tracer_provider`</summary>
+
+```python
+import strawberry
+from opentelemetry.trace import TracerProvider
+from strawberry.extensions.tracing import OpenTelemetryExtension
+
+
+class MyTracerProvider(TracerProvider):
+    def get_tracer(self, name, version=None, schema_url=None):
+        return super().get_tracer(name, version, schema_url)
+
+
+schema = strawberry.Schema(
+    Query,
+    extensions=[
+        OpenTelemetryExtension(
+            tracer_provider=MyTracerProvider(),
+        ),
+    ],
+)
+```
+
+</details>

--- a/strawberry/extensions/tracing/opentelemetry.py
+++ b/strawberry/extensions/tracing/opentelemetry.py
@@ -42,9 +42,10 @@ class OpenTelemetryExtension(SchemaExtension):
         *,
         execution_context: Optional[ExecutionContext] = None,
         arg_filter: Optional[ArgFilter] = None,
+        tracer_provider: Optional[trace.TracerProvider] = None,
     ) -> None:
         self._arg_filter = arg_filter
-        self._tracer = trace.get_tracer("strawberry")
+        self._tracer = trace.get_tracer("strawberry", tracer_provider=tracer_provider)
         self._span_holder = {}
         if execution_context:
             self.execution_context = execution_context

--- a/tests/extensions/tracing/test_opentelemetry.py
+++ b/tests/extensions/tracing/test_opentelemetry.py
@@ -1,6 +1,6 @@
 from unittest.mock import Mock
 
-from opentelemetry.trace import Span
+from opentelemetry.trace import Span, TracerProvider
 
 from strawberry.extensions import LifecycleStep
 from strawberry.extensions.tracing.opentelemetry import (
@@ -15,6 +15,9 @@ def test_span_holder_initialization():
     extension._span_holder[LifecycleStep.OPERATION] = Mock(spec=Span)
     extension = OpenTelemetryExtension()
     assert extension._span_holder == {}
+    tracer_provider = Mock(spec=TracerProvider)
+    extension = OpenTelemetryExtension(tracer_provider=tracer_provider)
+    assert tracer_provider.get_tracer.called
 
 
 def test_span_holder_initialization_sync():
@@ -23,3 +26,6 @@ def test_span_holder_initialization_sync():
     extension._span_holder[LifecycleStep.OPERATION] = Mock(spec=Span)
     extension = OpenTelemetryExtensionSync()
     assert extension._span_holder == {}
+    tracer_provider = Mock(spec=TracerProvider)
+    extension = OpenTelemetryExtension(tracer_provider=tracer_provider)
+    assert tracer_provider.get_tracer.called

--- a/tests/schema/extensions/test_opentelemetry.py
+++ b/tests/schema/extensions/test_opentelemetry.py
@@ -43,7 +43,7 @@ async def test_opentelemetry_uses_global_tracer(global_tracer_mock):
 
     await schema.execute(query)
 
-    global_tracer_mock.assert_called_once_with("strawberry")
+    global_tracer_mock.assert_called_once_with("strawberry", tracer_provider=None)
 
 
 @pytest.mark.asyncio
@@ -60,7 +60,7 @@ async def test_opentelemetry_sync_uses_global_tracer(global_tracer_mock):
 
     await schema.execute(query)
 
-    global_tracer_mock.assert_called_once_with("strawberry")
+    global_tracer_mock.assert_called_once_with("strawberry", tracer_provider=None)
 
 
 def _instrumentation_stages(mocker, query):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Passing a custom TracerProvider is common in OpenTelemetry instrumentation libraries and allows finer control of how traces are created. [See example from SQLAlchemy instrumentation library](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/__init__.py#L155-L178)

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Add support for passing a custom TracerProvider to the OpenTelemetryExtension in Strawberry GraphQL

New Features:
- Add optional `tracer_provider` parameter to OpenTelemetryExtension to enable custom tracing configuration

Enhancements:
- Extend OpenTelemetryExtension to allow custom tracer provider configuration, providing more flexibility for tracing in GraphQL applications

Documentation:
- Update documentation with an example of using a custom TracerProvider with OpenTelemetryExtension

Tests:
- Add test cases to verify the custom TracerProvider initialization and usage