### PR TITLE
Ensure field extensions are only applied once

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+Release type: minor
+
+This release fixes an issue where field extensions were being applied multiple times when a field was used in multiple schemas. This could lead to unexpected behavior or errors if the extension's `apply` method wasn't idempotent.
+
+The issue has been resolved by introducing a caching mechanism that ensures each field extension is applied only once, regardless of how many schemas the field appears in. Test cases have been added to validate this behavior and ensure that extensions are applied correctly.

--- a/strawberry/extensions/field_extension.py
+++ b/strawberry/extensions/field_extension.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import itertools
 from collections.abc import Awaitable
-from functools import cached_property
+from functools import cache, cached_property
 from typing import TYPE_CHECKING, Any, Callable, Union
 
 if TYPE_CHECKING:
@@ -154,6 +154,17 @@ def build_field_extension_resolvers(
         f"If possible try to change the execution order so that all sync-only "
         f"extensions are executed first."
     )
+
+
+@cache
+def apply_field_extensions(field: StrawberryField) -> None:
+    """Applies the field extensions to the field.
+
+    This function is cached to avoid applying the extensions multiple times in the case
+    of multiple schema generation passes.
+    """
+    for extension in field.extensions:
+        extension.apply(field)
 
 
 __all__ = ["FieldExtension"]

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -47,7 +47,10 @@ from strawberry.exceptions import (
     ScalarAlreadyRegisteredError,
     UnresolvedFieldTypeError,
 )
-from strawberry.extensions.field_extension import build_field_extension_resolvers
+from strawberry.extensions.field_extension import (
+    apply_field_extensions,
+    build_field_extension_resolvers,
+)
 from strawberry.schema.types.scalar import _make_scalar_type
 from strawberry.types.arguments import StrawberryArgument, convert_arguments
 from strawberry.types.base import (
@@ -683,8 +686,7 @@ class GraphQLCoreConverter:
 
         def wrap_field_extensions() -> Callable[..., Any]:
             """Wrap the provided field resolver with the middleware."""
-            for extension in field.extensions:
-                extension.apply(field)
+            apply_field_extensions(field)
 
             extension_functions = build_field_extension_resolvers(field)
 


### PR DESCRIPTION
## Description

Adds the `apply_field_extensions` utility function which uses `@cache` to ensure field extensions are only ever applied once, regardless of the number of schemas that use the field.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #3823

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
