### PR TITLE
fix: Ensure asyncgens gets properly closed in case of errors

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+Release type: patch
+
+This release contains a few improvements to how `AsyncGenerators` are handled by
+strawberry codebase, ensuring they get properly closed in case of unexpected
+errors.

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -60,6 +60,7 @@ from strawberry.types.execution import (
 )
 from strawberry.types.graphql import OperationType
 from strawberry.utils import IS_GQL_32
+from strawberry.utils.aio import aclosing
 from strawberry.utils.await_maybe import await_maybe
 
 from . import compat
@@ -713,12 +714,13 @@ class Schema(BaseSchema):
                     )
                 else:
                     try:
-                        async for result in aiter_or_result:
-                            yield await self._handle_execution_result(
-                                execution_context,
-                                result,
-                                extensions_runner,
-                            )
+                        async with aclosing(aiter_or_result):
+                            async for result in aiter_or_result:
+                                yield await self._handle_execution_result(
+                                    execution_context,
+                                    result,
+                                    extensions_runner,
+                                )
                     # graphql-core doesn't handle exceptions raised while executing.
                     except Exception as exc:  # noqa: BLE001
                         yield await self._handle_execution_result(

--- a/tests/schema/test_permission.py
+++ b/tests/schema/test_permission.py
@@ -12,6 +12,7 @@ from strawberry.exceptions.permission_fail_silently_requires_optional import (
 )
 from strawberry.permission import BasePermission, PermissionExtension
 from strawberry.printer import print_schema
+from strawberry.utils.aio import aclosing
 
 
 def test_raises_graphql_error_when_permission_method_is_missing():
@@ -78,8 +79,9 @@ async def test_raises_permission_error_for_subscription():
 
     query = "subscription { user }"
 
-    result = await schema.subscribe(query)
-    result = await result.__anext__()
+    async with aclosing(await schema.subscribe(query)) as sub_result:
+        result = await sub_result.__anext__()
+
     assert result.errors[0].message == "You are not authorized"
 
 

--- a/tests/schema/test_subscription.py
+++ b/tests/schema/test_subscription.py
@@ -13,6 +13,7 @@ import pytest
 
 import strawberry
 from strawberry.types.execution import PreExecutionError
+from strawberry.utils.aio import aclosing
 
 
 @pytest.mark.asyncio
@@ -31,8 +32,8 @@ async def test_subscription():
 
     query = "subscription { example }"
 
-    sub = await schema.subscribe(query)
-    result = await sub.__anext__()
+    async with aclosing(await schema.subscribe(query)) as sub_result:
+        result = await sub_result.__anext__()
 
     assert not result.errors
     assert result.data["example"] == "Hi"
@@ -64,8 +65,8 @@ async def test_subscription_with_permission():
 
     query = "subscription { example }"
 
-    sub = await schema.subscribe(query)
-    result = await sub.__anext__()
+    async with aclosing(await schema.subscribe(query)) as sub_result:
+        result = await sub_result.__anext__()
 
     assert not result.errors
     assert result.data["example"] == "Hi"
@@ -87,8 +88,8 @@ async def test_subscription_with_arguments():
 
     query = 'subscription { example(name: "Nina") }'
 
-    sub = await schema.subscribe(query)
-    result = await sub.__anext__()
+    async with aclosing(await schema.subscribe(query)) as sub_result:
+        result = await sub_result.__anext__()
 
     assert not result.errors
     assert result.data["example"] == "Hi Nina"
@@ -124,8 +125,8 @@ async def test_subscription_return_annotations(return_annotation: str):
 
     query = "subscription { example }"
 
-    sub = await schema.subscribe(query)
-    result = await sub.__anext__()
+    async with aclosing(await schema.subscribe(query)) as sub_result:
+        result = await sub_result.__anext__()
 
     assert not result.errors
     assert result.data["example"] == "Hi"
@@ -157,8 +158,8 @@ async def test_subscription_with_unions():
 
     query = "subscription { exampleWithUnion { ... on A { a } } }"
 
-    sub = await schema.subscribe(query)
-    result = await sub.__anext__()
+    async with aclosing(await schema.subscribe(query)) as sub_result:
+        result = await sub_result.__anext__()
 
     assert not result.errors
     assert result.data["exampleWithUnion"]["a"] == "Hi"
@@ -196,8 +197,8 @@ async def test_subscription_with_unions_and_annotated():
 
     query = "subscription { exampleWithAnnotatedUnion { ... on C { c } } }"
 
-    sub = await schema.subscribe(query)
-    result = await sub.__anext__()
+    async with aclosing(await schema.subscribe(query)) as sub_result:
+        result = await sub_result.__anext__()
 
     assert not result.errors
     assert result.data["exampleWithAnnotatedUnion"]["c"] == "Hi"
@@ -223,8 +224,8 @@ async def test_subscription_with_annotated():
 
     query = "subscription { example }"
 
-    sub = await schema.subscribe(query)
-    result = await sub.__anext__()
+    async with aclosing(await schema.subscribe(query)) as sub_result:
+        result = await sub_result.__anext__()
 
     assert not result.errors
     assert result.data["example"] == "Hi"
@@ -247,8 +248,8 @@ async def test_subscription_immediate_error():
         subscription { example }
     """
 
-    result = await schema.subscribe(query)
-    result = await result.__anext__()
+    async with aclosing(await schema.subscribe(query)) as sub_result:
+        result = await sub_result.__anext__()
 
     assert isinstance(result, PreExecutionError)
     assert result.errors
@@ -271,8 +272,8 @@ async def test_wrong_operation_variables():
         subscription subOp($opVar: String!){ example(name: $opVar) }
     """
 
-    result = await schema.subscribe(query)
-    result = await result.__anext__()
+    async with aclosing(await schema.subscribe(query)) as sub_result:
+        result = await sub_result.__anext__()
 
     assert result.errors
     assert (


### PR DESCRIPTION
This resolves a lot of warnings we currently have while running pytest, and also should  avoid asyncgens to be kept open in case of unexpected errors in some places (relay connection iteration, subscription handling, etc)

## Summary by Sourcery

Improve handling of AsyncGenerators to ensure proper closure and prevent resource leaks in various scenarios

Bug Fixes:
- Ensure AsyncGenerators are properly closed in case of unexpected errors during subscriptions and relay connections

Enhancements:
- Add an `aclosing` utility to safely close AsyncGenerators
- Modify subscription and schema handling to use context managers for AsyncGenerators

Tests:
- Update test cases to use the new `aclosing` context manager for AsyncGenerator handling