### PR TITLE
Improve support for custom relay.Edge classes

### DIFF
--- a/strawberry/relay/utils.py
+++ b/strawberry/relay/utils.py
@@ -132,9 +132,13 @@ class SliceMetadata:
         first: int | None = None,
         last: int | None = None,
         max_results: int | None = None,
+        prefix: str | None = None,
     ) -> Self:
         """Get the slice metadata to use on ListConnection."""
         from strawberry.relay.types import PREFIX
+
+        if prefix is None:
+            prefix = PREFIX
 
         max_results = (
             max_results
@@ -146,13 +150,13 @@ class SliceMetadata:
 
         if after:
             after_type, after_parsed = from_base64(after)
-            if after_type != PREFIX:
+            if after_type != prefix:
                 raise TypeError("Argument 'after' contains a non-existing value.")
 
             start = int(after_parsed) + 1
         if before:
             before_type, before_parsed = from_base64(before)
-            if before_type != PREFIX:
+            if before_type != prefix:
                 raise TypeError("Argument 'before' contains a non-existing value.")
             end = int(before_parsed)
 

--- a/tests/relay/test_custom_edge.py
+++ b/tests/relay/test_custom_edge.py
@@ -1,0 +1,200 @@
+import textwrap
+from typing import Any, Self
+
+import pytest
+
+import strawberry
+from strawberry import Schema, relay
+from strawberry.relay import NodeType, to_base64
+
+
+@pytest.fixture
+def schema() -> Schema:
+    @strawberry.type
+    class Fruit(relay.Node):
+        code: relay.NodeID[int]
+
+    @strawberry.type(name="Edge", description="An edge in a connection.")
+    class CustomEdge(relay.Edge[NodeType]):
+        CURSOR_PREFIX = "customprefix"
+        index: int
+
+        @classmethod
+        def resolve_edge(
+            cls, node: NodeType, *, cursor: Any = None, **kwargs: Any
+        ) -> Self:
+            assert isinstance(cursor, int)
+            return super().resolve_edge(node, cursor=cursor, index=cursor, **kwargs)
+
+    @strawberry.type(name="Connection", description="A connection to a list of items.")
+    class CustomListConnection(relay.ListConnection[NodeType]):
+        edges: list[CustomEdge[NodeType]] = strawberry.field(
+            description="Contains the nodes in this connection"
+        )
+
+    @strawberry.type
+    class Query:
+        @relay.connection(CustomListConnection[Fruit])
+        def fruits(self) -> list[Fruit]:
+            return [Fruit(code=i) for i in range(10)]
+
+    return strawberry.Schema(query=Query)
+
+
+def test_schema_with_custom_edge_class(schema: Schema):
+    expected = textwrap.dedent(
+        '''
+        type Fruit implements Node {
+          """The Globally Unique ID of this object"""
+          id: GlobalID!
+        }
+
+        """A connection to a list of items."""
+        type FruitConnection {
+          """Pagination data for this connection"""
+          pageInfo: PageInfo!
+
+          """Contains the nodes in this connection"""
+          edges: [FruitEdge!]!
+        }
+
+        """An edge in a connection."""
+        type FruitEdge {
+          """A cursor for use in pagination"""
+          cursor: String!
+
+          """The item at the end of the edge"""
+          node: Fruit!
+          index: Int!
+        }
+
+        """
+        The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `"4"`) or integer (such as `4`) input value will be accepted as an ID.
+        """
+        scalar GlobalID @specifiedBy(url: "https://relay.dev/graphql/objectidentification.htm")
+
+        """An object with a Globally Unique ID"""
+        interface Node {
+          """The Globally Unique ID of this object"""
+          id: GlobalID!
+        }
+
+        """Information to aid in pagination."""
+        type PageInfo {
+          """When paginating forwards, are there more items?"""
+          hasNextPage: Boolean!
+
+          """When paginating backwards, are there more items?"""
+          hasPreviousPage: Boolean!
+
+          """When paginating backwards, the cursor to continue."""
+          startCursor: String
+
+          """When paginating forwards, the cursor to continue."""
+          endCursor: String
+        }
+
+        type Query {
+          fruits(
+            """Returns the items in the list that come before the specified cursor."""
+            before: String = null
+
+            """Returns the items in the list that come after the specified cursor."""
+            after: String = null
+
+            """Returns the first n items from the list."""
+            first: Int = null
+
+            """Returns the items in the list that come after the specified cursor."""
+            last: Int = null
+          ): FruitConnection!
+        }
+        '''
+    ).strip()
+    assert str(schema) == expected
+
+
+def test_custom_cursor_prefix_used(schema: Schema):
+    result = schema.execute_sync(
+        """
+        query {
+          fruits {
+            edges {
+              cursor
+              node {
+                id
+              }
+            }
+          }
+        }
+        """
+    )
+    assert result.errors is None
+    assert result.data == {
+        "fruits": {
+            "edges": [
+                {
+                    "cursor": to_base64("customprefix", i),
+                    "node": {"id": to_base64("Fruit", i)},
+                }
+                for i in range(10)
+            ]
+        }
+    }
+
+
+def test_custom_cursor_prefix_can_be_parsed(schema: Schema):
+    result = schema.execute_sync(
+        """
+        query TestQuery($after: String) {
+          fruits(after: $after) {
+            edges {
+              cursor
+              node {
+                id
+              }
+            }
+          }
+        }
+        """,
+        {"after": to_base64("customprefix", 2)},
+    )
+    assert result.errors is None
+    assert result.data == {
+        "fruits": {
+            "edges": [
+                {
+                    "cursor": to_base64("customprefix", i),
+                    "node": {"id": to_base64("Fruit", i)},
+                }
+                for i in range(3, 10)
+            ]
+        }
+    }
+
+
+def test_custom_edge_class_fields_can_be_resolved(schema: Schema):
+    result = schema.execute_sync(
+        """
+        query TestQuery($after: String) {
+          fruits(after: $after) {
+            edges {
+              index
+              node {
+                id
+              }
+            }
+          }
+        }
+        """,
+        {"after": to_base64("customprefix", 2)},
+    )
+    assert result.errors is None
+    assert result.data == {
+        "fruits": {
+            "edges": [
+                {"index": i, "node": {"id": to_base64("Fruit", i)}}
+                for i in range(3, 10)
+            ]
+        }
+    }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

These changes improve the support for custom `Edge` subclasses when using `ListConnection`.
- The cursor prefix is moved to a `ClassVar` in the `Edge` class to allow a custom prefix
- `ListConnection` will look at the resolved Edge class for the correct cursor prefix
- `SliceMetadata` is updated to allow a custom prefix, which `ListConnection` uses
- `Edge.resolve_edge` is updated to allow arbitrary kwargs to be specified. This allows subclasses to pass additional constructor arguments while still calling `super.resolve_edge`

The changes to `resolve_edge` are especially useful if you want to implement a custom `Connection` that does "actual cursor pagination" instead of hiding limit/offset in the cursor.
I came across this limitation while working on implementing such support for `strawberry-graphql-django` for a future PR. Currently the code has to do this: https://github.com/diesieben07/strawberry-graphql-django/blob/b4f6d8ac217ff3002936197c8268170018923c8e/strawberry_django/relay_cursor.py#L215-L232

`resolve_edge` has to be overwritten wholly with an incompatible signature. 

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

Fixes #3835

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
- [X] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
