### PR TITLE
Fix graphql-ws links

### DIFF
--- a/docs/general/subscriptions.md
+++ b/docs/general/subscriptions.md
@@ -306,9 +306,9 @@ class Subscription:
 ## GraphQL over WebSocket protocols
 
 Strawberry support both the legacy
-[graphql-ws](https://github.com/apollographql/subscriptions-transport-ws) and
+[graphql-ws](https://github.com/enisdenjo/graphql-ws) and
 the newer recommended
-[graphql-transport-ws](https://github.com/enisdenjo/graphql-ws) WebSocket
+[graphql-transport-ws](https://github.com/apollographql/subscriptions-transport-ws) WebSocket
 sub-protocols.
 
 <Note>

--- a/docs/general/subscriptions.md
+++ b/docs/general/subscriptions.md
@@ -306,10 +306,9 @@ class Subscription:
 ## GraphQL over WebSocket protocols
 
 Strawberry support both the legacy
-[graphql-ws](https://github.com/enisdenjo/graphql-ws) and
-the newer recommended
-[graphql-transport-ws](https://github.com/apollographql/subscriptions-transport-ws) WebSocket
-sub-protocols.
+[graphql-ws](https://github.com/enisdenjo/graphql-ws) and the newer recommended
+[graphql-transport-ws](https://github.com/apollographql/subscriptions-transport-ws)
+WebSocket sub-protocols.
 
 <Note>
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Corrected the links for graphql-ws and graphql-transport-ws protocols in the subscriptions documentation, swapping their repository URLs