### PR TITLE
Allow using both `ID` and `GlobalID` at the same time

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,25 @@
+Release type: patch
+
+This releases fixed an issue that prevented from using `ID` and `GlobalID` at the same
+time, like in this example:
+
+```python
+import strawberry
+from strawberry.relay.types import GlobalID
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def hello(self, id: GlobalID) -> str:
+        return "Hello World"
+
+    @strawberry.field
+    def hello2(self, id: strawberry.ID) -> str:
+        return "Hello World"
+
+
+schema = strawberry.Schema(
+    Query,
+)
+```

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -817,9 +817,9 @@ class GraphQLCoreConverter:
 
         scalar_name = self.config.name_converter.from_type(scalar_definition)
 
-        if scalar_name not in self.type_map:
-            from strawberry.relay import GlobalID
+        from strawberry.relay import GlobalID
 
+        if scalar_name not in self.type_map:
             if scalar is GlobalID and hasattr(GraphQLNamedType, "reserved_types"):
                 GraphQLNamedType.reserved_types.pop("ID")
 
@@ -838,12 +838,19 @@ class GraphQLCoreConverter:
         else:
             other_definition = self.type_map[scalar_name].definition
 
-            if scalar_name == "ID" and other_definition.name == "ID":
-                pass
-
             # TODO: the other definition might not be a scalar, we should
             # handle this case better, since right now we assume it is a scalar
 
+            # special case to allow GlobalID to be used as an ID scalar
+            # TODO: we need to find a better way to handle this, might be
+            # worth reworking our scalar implementation.
+            if (
+                hasattr(other_definition, "origin")
+                and hasattr(scalar_definition, "origin")
+                and other_definition.origin == GlobalID
+                and scalar_definition.origin == GraphQLID
+            ):
+                pass
             elif other_definition != scalar_definition:
                 other_definition = cast("ScalarDefinition", other_definition)
 

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -838,10 +838,13 @@ class GraphQLCoreConverter:
         else:
             other_definition = self.type_map[scalar_name].definition
 
+            if scalar_name == "ID" and other_definition.name == "ID":
+                pass
+
             # TODO: the other definition might not be a scalar, we should
             # handle this case better, since right now we assume it is a scalar
 
-            if other_definition != scalar_definition:
+            elif other_definition != scalar_definition:
                 other_definition = cast("ScalarDefinition", other_definition)
 
                 raise ScalarAlreadyRegisteredError(scalar_definition, other_definition)

--- a/strawberry/schema/types/scalar.py
+++ b/strawberry/schema/types/scalar.py
@@ -40,6 +40,7 @@ def _make_scalar_definition(scalar_type: GraphQLScalarType) -> ScalarDefinition:
         parse_literal=scalar_type.parse_literal,
         parse_value=scalar_type.parse_value,
         implementation=scalar_type,
+        origin=scalar_type,
     )
 
 

--- a/strawberry/types/scalar.py
+++ b/strawberry/types/scalar.py
@@ -43,6 +43,7 @@ class ScalarDefinition(StrawberryType):
     parse_value: Optional[Callable]
     parse_literal: Optional[Callable]
     directives: Iterable[object] = ()
+    origin: Optional[GraphQLScalarType | type] = None
 
     # Optionally store the GraphQLScalarType instance so that we don't get
     # duplicates
@@ -115,6 +116,7 @@ def _process_scalar(
         parse_literal=parse_literal,
         parse_value=parse_value,
         directives=directives,
+        origin=cls,  # type: ignore[arg-type]
         _source_file=_source_file,
         _source_line=_source_line,
     )

--- a/tests/relay/test_id.py
+++ b/tests/relay/test_id.py
@@ -88,3 +88,52 @@ type Query {
             }
         }
     )
+
+
+def test_can_use_both_global_id_and_id() -> None:
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def hello(self, id: GlobalID) -> str:
+            return "Hello World"
+
+        @strawberry.field
+        def hello2(self, id: strawberry.ID) -> str:
+            return "Hello World"
+
+    schema = strawberry.Schema(Query)
+
+    assert str(schema) == snapshot("""\
+type Query {
+  hello(id: ID!): String!
+  hello2(id: ID!): String!
+}\
+""")
+
+
+def test_can_use_both_global_id_and_id_legacy() -> None:
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def hello(self, id: GlobalID) -> str:
+            return "Hello World"
+
+        @strawberry.field
+        def hello2(self, id: strawberry.ID) -> str:
+            return "Hello World"
+
+    schema = strawberry.Schema(
+        query=Query, config=StrawberryConfig(relay_use_legacy_global_id=True)
+    )
+
+    assert str(schema) == snapshot('''\
+"""
+The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `"4"`) or integer (such as `4`) input value will be accepted as an ID.
+"""
+scalar GlobalID @specifiedBy(url: "https://relay.dev/graphql/objectidentification.htm")
+
+type Query {
+  hello(id: GlobalID!): String!
+  hello2(id: ID!): String!
+}\
+''')


### PR DESCRIPTION
The implementation is meh, I need to find a better way :D

Closes #3854

## Summary by Sourcery

Allow simultaneous use of `ID` and `GlobalID` scalars in a single schema by exempting `GlobalID` from the reserved `ID` type and adding special-case handling in scalar registration.

Bug Fixes:
- Enable using both `strawberry.ID` and `strawberry.relay.GlobalID` fields in the same schema instance.

Enhancements:
- Introduce an `origin` attribute on `ScalarDefinition` to distinguish between scalar implementations during registration.

Documentation:
- Add a `RELEASE.md` entry documenting the patch for concurrent use of `ID` and `GlobalID`.

Tests:
- Add tests verifying schema snapshots for both default and legacy modes when using `GlobalID` and `ID` together.