### PR TITLE
Fix graphql-ws got stuck on invalid operation name

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+This release resolves the issue of subscriptions started via the legacy `graphql-ws` WebSocket subprotocol getting stuck if a non-existing `operationName` was specified.

--- a/strawberry/schema/exceptions.py
+++ b/strawberry/schema/exceptions.py
@@ -1,6 +1,10 @@
 from strawberry.types.graphql import OperationType
 
 
+class CannotGetOperationTypeError(Exception):
+    """Internal error raised when we cannot get the operation type from a GraphQL document."""
+
+
 class InvalidOperationTypeError(Exception):
     def __init__(self, operation_type: OperationType) -> None:
         self.operation_type = operation_type
@@ -15,4 +19,7 @@ class InvalidOperationTypeError(Exception):
         return f"{operation_type} are not allowed when using {method}"
 
 
-__all__ = ["InvalidOperationTypeError"]
+__all__ = [
+    "CannotGetOperationTypeError",
+    "InvalidOperationTypeError",
+]

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -65,7 +65,7 @@ from strawberry.utils.await_maybe import await_maybe
 from . import compat
 from .base import BaseSchema
 from .config import StrawberryConfig
-from .exceptions import InvalidOperationTypeError
+from .exceptions import CannotGetOperationTypeError, InvalidOperationTypeError
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
@@ -421,8 +421,13 @@ class Schema(BaseSchema):
                 context.errors = [error]
                 return PreExecutionError(data=None, errors=[error])
 
-        if context.operation_type not in context.allowed_operations:
-            raise InvalidOperationTypeError(context.operation_type)
+        try:
+            operation_type = context.operation_type
+        except RuntimeError as error:
+            raise CannotGetOperationTypeError from error
+
+        if operation_type not in context.allowed_operations:
+            raise InvalidOperationTypeError(operation_type)
 
         async with extensions_runner.validation():
             _run_validation(context)

--- a/strawberry/subscriptions/protocols/graphql_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_ws/handlers.py
@@ -14,6 +14,7 @@ from typing import (
 from strawberry.exceptions import ConnectionRejectionError
 from strawberry.http.exceptions import NonTextMessageReceived, WebSocketDisconnected
 from strawberry.http.typevars import Context, RootValue
+from strawberry.schema.exceptions import CannotGetOperationTypeError
 from strawberry.subscriptions.protocols.graphql_ws.types import (
     CompleteMessage,
     ConnectionInitMessage,
@@ -193,6 +194,14 @@ class BaseGraphQLWSHandler(Generic[Context, RootValue]):
 
             await self.send_message(CompleteMessage(type="complete", id=operation_id))
 
+        except CannotGetOperationTypeError:
+            await self.send_message(
+                ErrorMessage(
+                    type="error",
+                    id=operation_id,
+                    payload={"message": "Can't get GraphQL operation type"},
+                )
+            )
         except asyncio.CancelledError:
             await self.send_message(CompleteMessage(type="complete", id=operation_id))
 

--- a/tests/websockets/test_graphql_ws.py
+++ b/tests/websockets/test_graphql_ws.py
@@ -108,6 +108,26 @@ async def test_operation_selection(ws: WebSocketClient):
     assert complete_message["id"] == "demo"
 
 
+async def test_invalid_operation_selection(ws: WebSocketClient):
+    await ws.send_legacy_message(
+        {
+            "type": "start",
+            "id": "demo",
+            "payload": {
+                "query": """
+                    subscription Subscription1 { echo(message: "Hi1") }
+                """,
+                "operationName": "Subscription2",
+            },
+        }
+    )
+
+    error_message: ErrorMessage = await ws.receive_json()
+    assert error_message["type"] == "error"
+    assert error_message["id"] == "demo"
+    assert error_message["payload"] == {"message": "Can't get GraphQL operation type"}
+
+
 async def test_connections_are_accepted_by_default(ws_raw: WebSocketClient):
     await ws_raw.send_legacy_message({"type": "connection_init"})
     connection_ack_message: ConnectionAckMessage = await ws_raw.receive_json()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

Currently, subscriptions using the legacy protocol get stuck if an `operationName` is selected that does not exist in the GraphQL document.

This started happening with the release that introduced extensions for subscriptions.

## Description

If a `operationName` is requested that does not exist in the GraphQL document, `get_operation_type` in `strawberry.utils.operation` will raise an `RuntimeError`.

This `RuntimeError` is explicitly handled by the newer protocol, because it supports all operation types and calls `get_operation_type` itself to figure out what to do.

The legacy protocol only supports the subscription operation type, it does not call `get_operation_type` by itself, and did not explicitly handle said `RuntimeError`. However, `get_operation_type` eventually always gets called in `Schema._parse_and_validate_(a)sync` and the `RuntimeError` bubbled all the way up without getting handled, causing the subscription handler to get stuck.

Starting with this PR, we catch the `RuntimeError` early and raise a custom exception that is then handled by the legacy protocol handler, which informs the client. 

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation
