### PR TITLE
Quart subscription support

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: minor
+
+This release adds support for GraphQL over WebSocket transport protocols to the Quart integration.

--- a/docs/general/subscriptions.md
+++ b/docs/general/subscriptions.md
@@ -328,7 +328,7 @@ Strawberry allows you to choose which protocols you want to accept. All
 integrations supporting subscriptions can be configured with a list of
 `subscription_protocols` to accept. By default, all protocols are accepted.
 
-##### AIOHTTP
+### AIOHTTP
 
 ```python
 from strawberry.aiohttp.views import GraphQLView
@@ -341,7 +341,7 @@ view = GraphQLView(
 )
 ```
 
-##### ASGI
+### ASGI
 
 ```python
 from strawberry.asgi import GraphQL
@@ -358,7 +358,7 @@ app = GraphQL(
 )
 ```
 
-##### Django + Channels
+### Django + Channels
 
 ```python
 import os
@@ -384,7 +384,7 @@ application = GraphQLProtocolTypeRouter(
 Note: Check the [channels integraton](../integrations/channels.md) page for more
 information regarding it.
 
-#### FastAPI
+### FastAPI
 
 ```python
 from strawberry.fastapi import GraphQLRouter
@@ -399,11 +399,38 @@ graphql_router = GraphQLRouter(
         GRAPHQL_WS_PROTOCOL,
     ],
 )
+
 app = FastAPI()
 app.include_router(graphql_router, prefix="/graphql")
 ```
 
-### Single result operations
+### Quart
+
+```python
+from strawberry.quart.views import GraphQLView
+from strawberry.subscriptions import GRAPHQL_TRANSPORT_WS_PROTOCOL, GRAPHQL_WS_PROTOCOL
+from quart import Quart
+from api.schema import schema
+
+view = GraphQLView.as_view(
+    "graphql_view",
+    schema=schema,
+    subscription_protocols=[
+        GRAPHQL_TRANSPORT_WS_PROTOCOL,
+        GRAPHQL_WS_PROTOCOL,
+    ],
+)
+
+app = Quart(__name__)
+app.app.add_url_rule(
+    "/graphql",
+    view_func=view,
+    methods=["GET"],
+    websocket=True,
+)
+```
+
+## Single result operations
 
 In addition to _streaming operations_ (i.e. subscriptions), the
 `graphql-transport-ws` protocol supports so called _single result operations_
@@ -411,7 +438,7 @@ In addition to _streaming operations_ (i.e. subscriptions), the
 
 This enables clients to use one protocol and one connection for queries,
 mutations and subscriptions. Take a look at the
-[protocols repository](https://github.com/enisdenjo/graphql-ws) to learn how to
+[protocol's repository](https://github.com/enisdenjo/graphql-ws) to learn how to
 correctly set up the graphql client of your choice.
 
 Strawberry supports single result operations out of the box when the

--- a/docs/general/subscriptions.md
+++ b/docs/general/subscriptions.md
@@ -422,7 +422,7 @@ view = GraphQLView.as_view(
 )
 
 app = Quart(__name__)
-app.app.add_url_rule(
+app.add_url_rule(
     "/graphql",
     view_func=view,
     methods=["GET"],

--- a/docs/integrations/quart.md
+++ b/docs/integrations/quart.md
@@ -10,15 +10,13 @@ use to serve your GraphQL schema:
 ```python
 from quart import Quart
 from strawberry.quart.views import GraphQLView
-
 from api.schema import schema
 
-app = Quart(__name__)
+view = GraphQLView.as_view("graphql_view", schema=schema)
 
-app.add_url_rule(
-    "/graphql",
-    view_func=GraphQLView.as_view("graphql_view", schema=schema),
-)
+app = Quart(__name__)
+app.add_url_rule("/graphql", view_func=view)
+app.add_url_rule("/graphql", view_func=view, methods=["GET"], websocket=True)
 
 if __name__ == "__main__":
     app.run()
@@ -50,6 +48,7 @@ methods:
 - `def decode_json(self, data: Union[str, bytes]) -> object`
 - `def encode_json(self, data: object) -> str`
 - `async def render_graphql_ide(self, request: Request) -> Response`
+- `async def on_ws_connect(self, context: Context) -> Union[UnsetType, None, Dict[str, object]]`
 
 ### get_context
 
@@ -190,4 +189,48 @@ class MyGraphQLView(GraphQLView):
         custom_html = """<html><body><h1>Custom GraphQL IDE</h1></body></html>"""
 
         return Response(self.graphql_ide_html)
+```
+
+### on_ws_connect
+
+By overriding `on_ws_connect` you can customize the behavior when a `graphql-ws`
+or `graphql-transport-ws` connection is established. This is particularly useful
+for authentication and authorization. By default, all connections are accepted.
+
+To manually accept a connection, return `strawberry.UNSET` or a connection
+acknowledgment payload. The acknowledgment payload will be sent to the client.
+
+Note that the legacy protocol does not support `None`/`null` acknowledgment
+payloads, while the new protocol does. Our implementation will treat
+`None`/`null` payloads the same as `strawberry.UNSET` in the context of the
+legacy protocol.
+
+To reject a connection, raise a `ConnectionRejectionError`. You can optionally
+provide a custom error payload that will be sent to the client when the legacy
+GraphQL over WebSocket protocol is used.
+
+```python
+from typing import Dict
+from strawberry.exceptions import ConnectionRejectionError
+from strawberry.quart.views import GraphQLView
+
+
+class MyGraphQLView(GraphQLView):
+    async def on_ws_connect(self, context: Dict[str, object]):
+        connection_params = context["connection_params"]
+
+        if not isinstance(connection_params, dict):
+            # Reject without a custom graphql-ws error payload
+            raise ConnectionRejectionError()
+
+        if connection_params.get("password") != "secret":
+            # Reject with a custom graphql-ws error payload
+            raise ConnectionRejectionError({"reason": "Invalid password"})
+
+        if username := connection_params.get("username"):
+            # Accept with a custom acknowledgment payload
+            return {"message": f"Hello, {username}!"}
+
+        # Accept without a acknowledgment payload
+        return await super().on_ws_connect(context)
 ```

--- a/docs/integrations/quart.md
+++ b/docs/integrations/quart.md
@@ -188,7 +188,7 @@ class MyGraphQLView(GraphQLView):
     async def render_graphql_ide(self, request: Request) -> Response:
         custom_html = """<html><body><h1>Custom GraphQL IDE</h1></body></html>"""
 
-        return Response(self.graphql_ide_html)
+        return Response(custom_html)
 ```
 
 ### on_ws_connect

--- a/docs/integrations/quart.md
+++ b/docs/integrations/quart.md
@@ -231,6 +231,6 @@ class MyGraphQLView(GraphQLView):
             # Accept with a custom acknowledgment payload
             return {"message": f"Hello, {username}!"}
 
-        # Accept without a acknowledgment payload
+        # Accept without an acknowledgment payload
         return await super().on_ws_connect(context)
 ```

--- a/strawberry/quart/views.py
+++ b/strawberry/quart/views.py
@@ -198,14 +198,7 @@ class GraphQLView(
     def is_websocket_request(
         self, request: Union[Request, Websocket]
     ) -> TypeGuard[Websocket]:
-        if has_websocket_context():
-            return True
-
-        # Check if the request is a WebSocket upgrade request
-        connection = request.headers.get("Connection", "").lower()
-        upgrade = request.headers.get("Upgrade", "").lower()
-
-        return "upgrade" in connection and "websocket" in upgrade
+        return has_websocket_context()
 
     async def pick_websocket_subprotocol(self, request: Websocket) -> Optional[str]:
         protocols = request.requested_subprotocols

--- a/strawberry/quart/views.py
+++ b/strawberry/quart/views.py
@@ -60,7 +60,7 @@ class QuartHTTPRequestAdapter(AsyncHTTPRequestAdapter):
 
 
 class QuartWebSocketAdapter(AsyncWebSocketAdapter):
-    def __init__(self, view: AsyncBaseHTTPView, request, ws) -> None:
+    def __init__(self, view: AsyncBaseHTTPView, request: Request, ws: Response) -> None:
         super().__init__(view)
         self.ws = websocket
 

--- a/strawberry/quart/views.py
+++ b/strawberry/quart/views.py
@@ -17,6 +17,7 @@ from strawberry.http.async_base_view import (
 from strawberry.http.exceptions import (
     HTTPException,
     NonJsonMessageReceived,
+    NonTextMessageReceived,
     WebSocketDisconnected,
 )
 from strawberry.http.ides import GraphQL_IDE
@@ -72,6 +73,9 @@ class QuartWebSocketAdapter(AsyncWebSocketAdapter):
                 # Raises asyncio.CancelledError when the connection is closed.
                 # https://quart.palletsprojects.com/en/latest/how_to_guides/websockets.html#detecting-disconnection
                 message = await self.ws.receive()
+
+                if not isinstance(message, str):
+                    raise NonTextMessageReceived
 
                 try:
                     yield self.view.decode_json(message)

--- a/strawberry/quart/views.py
+++ b/strawberry/quart/views.py
@@ -1,15 +1,27 @@
 import warnings
 from collections.abc import AsyncGenerator, Mapping
+from datetime import timedelta
 from typing import TYPE_CHECKING, Callable, ClassVar, Optional, cast
 from typing_extensions import TypeGuard
+from json.decoder import JSONDecodeError
 
-from quart import Request, Response, request
+from quart import Quart, Request, Response, websocket, request
+from quart.ctx import has_websocket_context
 from quart.views import View
-from strawberry.http.async_base_view import AsyncBaseHTTPView, AsyncHTTPRequestAdapter
-from strawberry.http.exceptions import HTTPException
+from strawberry.http.async_base_view import (
+    AsyncBaseHTTPView,
+    AsyncHTTPRequestAdapter,
+    AsyncWebSocketAdapter
+)
+from strawberry.http.exceptions import (
+    HTTPException,
+    NonJsonMessageReceived,
+    WebSocketDisconnected
+)
 from strawberry.http.ides import GraphQL_IDE
 from strawberry.http.types import FormData, HTTPMethod, QueryParams
 from strawberry.http.typevars import Context, RootValue
+from strawberry.subscriptions import GRAPHQL_TRANSPORT_WS_PROTOCOL, GRAPHQL_WS_PROTOCOL
 
 if TYPE_CHECKING:
     from quart.typing import ResponseReturnValue
@@ -46,6 +58,35 @@ class QuartHTTPRequestAdapter(AsyncHTTPRequestAdapter):
         return FormData(files=files, form=form)
 
 
+class QuartWebSocketAdapter(AsyncWebSocketAdapter):
+    def __init__(self, view: AsyncBaseHTTPView, request, ws) -> None:
+        super().__init__(view)
+        self.ws = websocket
+
+    async def iter_json(
+        self, *, ignore_parsing_errors: bool = False
+    ) -> AsyncGenerator[object, None]:
+        while True:
+            try:
+                message = await self.ws.receive()
+                try:
+                    yield self.view.decode_json(message)
+                except JSONDecodeError as e:
+                    if not ignore_parsing_errors:
+                        raise NonJsonMessageReceived from e
+            except Exception as exc:
+                raise WebSocketDisconnected from exc
+
+    async def send_json(self, message: Mapping[str, object]) -> None:
+        try:
+            await self.ws.send(self.view.encode_json(message))
+        except Exception as exc:
+            raise WebSocketDisconnected from exc
+
+    async def close(self, code: int, reason: str) -> None:
+        await self.ws.close(code, reason=reason)
+
+
 class GraphQLView(
     AsyncBaseHTTPView[
         Request, Response, Response, Request, Response, Context, RootValue
@@ -55,6 +96,7 @@ class GraphQLView(
     methods: ClassVar[list[str]] = ["GET", "POST"]
     allow_queries_via_get: bool = True
     request_adapter_class = QuartHTTPRequestAdapter
+    websocket_adapter_class = QuartWebSocketAdapter
 
     def __init__(
         self,
@@ -62,10 +104,23 @@ class GraphQLView(
         graphiql: Optional[bool] = None,
         graphql_ide: Optional[GraphQL_IDE] = "graphiql",
         allow_queries_via_get: bool = True,
+        keep_alive: bool = True,
+        keep_alive_interval: float = 1,
+        debug: bool = False,
+        subscription_protocols: list[str] = [
+            GRAPHQL_TRANSPORT_WS_PROTOCOL,
+            GRAPHQL_WS_PROTOCOL,
+        ],
+        connection_init_wait_timeout: timedelta = timedelta(minutes=1),
         multipart_uploads_enabled: bool = False,
     ) -> None:
         self.schema = schema
         self.allow_queries_via_get = allow_queries_via_get
+        self.keep_alive = keep_alive
+        self.keep_alive_interval = keep_alive_interval
+        self.debug = debug
+        self.subscription_protocols = subscription_protocols
+        self.connection_init_wait_timeout = connection_init_wait_timeout
         self.multipart_uploads_enabled = multipart_uploads_enabled
 
         if graphiql is not None:
@@ -123,15 +178,59 @@ class GraphQLView(
         )
 
     def is_websocket_request(self, request: Request) -> TypeGuard[Request]:
-        return False
+        if has_websocket_context():
+            return True
+
+        # Check if the request is a WebSocket upgrade request
+        connection = request.headers.get("Connection", "").lower()
+        upgrade = request.headers.get("Upgrade", "").lower()
+
+        return ("upgrade" in connection and "websocket" in upgrade)
 
     async def pick_websocket_subprotocol(self, request: Request) -> Optional[str]:
-        raise NotImplementedError
+        # Get the requested protocols
+        protocols_header = websocket.headers.get("Sec-WebSocket-Protocol", "")
+        if not protocols_header:
+            return None
+
+        # Find the first matching protocol
+        requested_protocols = [p.strip() for p in protocols_header.split(",")]
+        for protocol in requested_protocols:
+            if protocol in self.subscription_protocols:
+                return protocol
+
+        return None
 
     async def create_websocket_response(
         self, request: Request, subprotocol: Optional[str]
     ) -> Response:
-        raise NotImplementedError
+        if subprotocol:
+            # Set the WebSocket protocol if specified
+            await websocket.accept(subprotocol=subprotocol)
+        else:
+            await websocket.accept()
+
+        # Return the current websocket context as the "response"
+        return None
+
+    @classmethod
+    def register_route(cls, app: Quart, rule_name: str, path: str, **kwargs):
+        """
+        Helper method to register both HTTP and WebSocket handlers for a given path.
+
+        Args:
+            app: The Quart application
+            rule_name: The name of the rule
+            path: The path to register the handlers for
+            **kwargs: Parameters to pass to the GraphQLView constructor
+        """
+        # Register both HTTP and WebSocket handler at the same path
+        view_func = cls.as_view(rule_name, **kwargs)
+        app.add_url_rule(path, view_func=view_func, methods=["GET", "POST"])
+
+        # Register the WebSocket handler using the same view function
+        # Quart will handle routing based on the WebSocket upgrade header
+        app.add_url_rule(path, view_func=view_func, methods=["GET"], websocket=True)
 
 
 __all__ = ["GraphQLView"]

--- a/strawberry/quart/views.py
+++ b/strawberry/quart/views.py
@@ -1,12 +1,12 @@
 import asyncio
 import warnings
-from collections.abc import AsyncGenerator, Mapping
+from collections.abc import AsyncGenerator, Mapping, Sequence
 from datetime import timedelta
 from json.decoder import JSONDecodeError
 from typing import TYPE_CHECKING, Callable, ClassVar, Optional, cast
 from typing_extensions import TypeGuard
 
-from quart import Quart, Request, Response, request, websocket
+from quart import Request, Response, request, websocket
 from quart.ctx import has_websocket_context
 from quart.views import View
 from strawberry.http.async_base_view import (
@@ -113,10 +113,10 @@ class GraphQLView(
         keep_alive: bool = True,
         keep_alive_interval: float = 1,
         debug: bool = False,
-        subscription_protocols: list[str] = [
+        subscription_protocols: Sequence[str] = (
             GRAPHQL_TRANSPORT_WS_PROTOCOL,
             GRAPHQL_WS_PROTOCOL,
-        ],
+        ),
         connection_init_wait_timeout: timedelta = timedelta(minutes=1),
         multipart_uploads_enabled: bool = False,
     ) -> None:

--- a/strawberry/quart/views.py
+++ b/strawberry/quart/views.py
@@ -219,23 +219,5 @@ class GraphQLView(
         # Return the current websocket context as the "response"
         return None
 
-    @classmethod
-    def register_route(cls, app: Quart, rule_name: str, path: str, **kwargs):
-        """Helper method to register both HTTP and WebSocket handlers for a given path.
-
-        Args:
-            app: The Quart application
-            rule_name: The name of the rule
-            path: The path to register the handlers for
-            **kwargs: Parameters to pass to the GraphQLView constructor
-        """
-        # Register both HTTP and WebSocket handler at the same path
-        view_func = cls.as_view(rule_name, **kwargs)
-        app.add_url_rule(path, view_func=view_func, methods=["GET", "POST"])
-
-        # Register the WebSocket handler using the same view function
-        # Quart will handle routing based on the WebSocket upgrade header
-        app.add_url_rule(path, view_func=view_func, methods=["GET"], websocket=True)
-
 
 __all__ = ["GraphQLView"]

--- a/strawberry/quart/views.py
+++ b/strawberry/quart/views.py
@@ -210,11 +210,7 @@ class GraphQLView(
     async def create_websocket_response(
         self, request: Request, subprotocol: Optional[str]
     ) -> Response:
-        if subprotocol:
-            # Set the WebSocket protocol if specified
-            await websocket.accept(subprotocol=subprotocol)
-        else:
-            await websocket.accept()
+        await websocket.accept(subprotocol=subprotocol)
 
         # Return the current websocket context as the "response"
         return None

--- a/strawberry/quart/views.py
+++ b/strawberry/quart/views.py
@@ -1,22 +1,22 @@
 import warnings
 from collections.abc import AsyncGenerator, Mapping
 from datetime import timedelta
+from json.decoder import JSONDecodeError
 from typing import TYPE_CHECKING, Callable, ClassVar, Optional, cast
 from typing_extensions import TypeGuard
-from json.decoder import JSONDecodeError
 
-from quart import Quart, Request, Response, websocket, request
+from quart import Quart, Request, Response, request, websocket
 from quart.ctx import has_websocket_context
 from quart.views import View
 from strawberry.http.async_base_view import (
     AsyncBaseHTTPView,
     AsyncHTTPRequestAdapter,
-    AsyncWebSocketAdapter
+    AsyncWebSocketAdapter,
 )
 from strawberry.http.exceptions import (
     HTTPException,
     NonJsonMessageReceived,
-    WebSocketDisconnected
+    WebSocketDisconnected,
 )
 from strawberry.http.ides import GraphQL_IDE
 from strawberry.http.types import FormData, HTTPMethod, QueryParams
@@ -185,7 +185,7 @@ class GraphQLView(
         connection = request.headers.get("Connection", "").lower()
         upgrade = request.headers.get("Upgrade", "").lower()
 
-        return ("upgrade" in connection and "websocket" in upgrade)
+        return "upgrade" in connection and "websocket" in upgrade
 
     async def pick_websocket_subprotocol(self, request: Request) -> Optional[str]:
         # Get the requested protocols
@@ -215,8 +215,7 @@ class GraphQLView(
 
     @classmethod
     def register_route(cls, app: Quart, rule_name: str, path: str, **kwargs):
-        """
-        Helper method to register both HTTP and WebSocket handlers for a given path.
+        """Helper method to register both HTTP and WebSocket handlers for a given path.
 
         Args:
             app: The Quart application

--- a/strawberry/quart/views.py
+++ b/strawberry/quart/views.py
@@ -156,7 +156,7 @@ class GraphQLView(
         return sub_response
 
     async def get_context(
-        self, request: Union[Request, Websocket], response: Union[Response, Websocket]
+        self, request: Union[Request, Websocket], response: Response
     ) -> Context:
         return {"request": request, "response": response}  # type: ignore
 

--- a/tests/http/clients/quart.py
+++ b/tests/http/clients/quart.py
@@ -19,6 +19,7 @@ from strawberry.quart.views import GraphQLView as BaseGraphQLView
 from strawberry.types import ExecutionResult
 from tests.http.context import get_context
 from tests.views.schema import Query, schema
+from tests.websockets.views import OnWSConnectMixin
 
 from .asgi import AsgiWebSocketClient
 from .base import (
@@ -32,7 +33,7 @@ from .base import (
 )
 
 
-class GraphQLView(BaseGraphQLView[dict[str, object], object]):
+class GraphQLView(OnWSConnectMixin, BaseGraphQLView[dict[str, object], object]):
     methods = ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"]
     result_override: ResultOverrideFunction = None
     graphql_transport_ws_handler_class = DebuggableGraphQLTransportWSHandler

--- a/tests/http/clients/quart.py
+++ b/tests/http/clients/quart.py
@@ -35,7 +35,7 @@ class GraphQLView(BaseGraphQLView[dict[str, object], object]):
     result_override: ResultOverrideFunction = None
 
     def __init__(self, *args: Any, **kwargs: Any):
-        self.result_override = kwargs.pop("result_override")
+        self.result_override = kwargs.pop("result_override", None)
         super().__init__(*args, **kwargs)
 
     async def get_root_value(self, request: QuartRequest) -> Query:

--- a/tests/http/clients/quart.py
+++ b/tests/http/clients/quart.py
@@ -105,8 +105,12 @@ class QuartHttpClient(HttpClient):
             "/graphql",
             view_func=view,
         )
+
         self.app.add_url_rule(
-            "/graphql", view_func=view, methods=["GET"], websocket=True
+            "/graphql",
+            view_func=view,
+            methods=["GET"],
+            websocket=True,
         )
 
         self.client = TestClient(QuartAsgiAppAdapter(self.app))

--- a/tests/http/clients/quart.py
+++ b/tests/http/clients/quart.py
@@ -1,8 +1,14 @@
+import asyncio
+import contextlib
 import json
 import urllib.parse
 from io import BytesIO
-from typing import Any, Optional
+from typing import Any, Optional, AsyncGenerator, Mapping
+
+from quart.typing import TestWebsocketConnectionProtocol
 from typing_extensions import Literal
+
+from starlette.testclient import TestClient, WebSocketTestSession
 
 from quart import Quart
 from quart import Request as QuartRequest
@@ -15,7 +21,8 @@ from strawberry.types import ExecutionResult
 from tests.http.context import get_context
 from tests.views.schema import Query, schema
 
-from .base import JSON, HttpClient, Response, ResultOverrideFunction
+from .base import JSON, HttpClient, Response, ResultOverrideFunction, WebSocketClient, \
+    Message
 
 
 class GraphQLView(BaseGraphQLView[dict[str, object], object]):
@@ -73,6 +80,34 @@ class QuartHttpClient(HttpClient):
             "/graphql",
             view_func=view,
         )
+        self.app.add_url_rule(
+            '/graphql',
+            view_func=view,
+            methods=["GET"],
+            websocket=True
+        )
+
+        self.client = TestClient(self.app)
+
+    def create_app(self, **kwargs: Any) -> None:
+        self.app = Quart(__name__)
+        self.app.debug = True
+
+        view = GraphQLView.as_view("graphql_view", schema=schema, **kwargs)
+
+        self.app.add_url_rule(
+            "/graphql",
+            view_func=view,
+        )
+        self.app.add_url_rule(
+            '/graphql',
+            view_func=view,
+            methods=["GET"],
+            websocket=True
+        )
+
+        self.client = TestClient(self.app)
+
 
     async def _graphql_request(
         self,
@@ -140,3 +175,74 @@ class QuartHttpClient(HttpClient):
         return await self.request(
             url, "post", **{k: v for k, v in kwargs.items() if v is not None}
         )
+
+    @contextlib.asynccontextmanager
+    async def ws_connect(
+        self,
+        url: str,
+        *,
+        protocols: list[str],
+    ) -> AsyncGenerator[WebSocketClient, None]:
+        with self.client.websocket_connect(url, protocols) as ws:
+            yield QuartWebSocketClient(ws)
+
+
+
+class QuartWebSocketClient(WebSocketClient):
+    def __init__(self, ws: WebSocketTestSession):
+        self.ws = ws
+        self._closed: bool = False
+        self._close_code: Optional[int] = None
+        self._close_reason: Optional[str] = None
+
+    async def send_text(self, payload: str) -> None:
+        self.ws.send_text(payload)
+
+    async def send_json(self, payload: Mapping[str, object]) -> None:
+        self.ws.send_json(payload)
+
+    async def send_bytes(self, payload: bytes) -> None:
+        self.ws.send_bytes(payload)
+
+    async def receive(self, timeout: Optional[float] = None) -> Message:
+        if self._closed:
+            # if close was received via exception, fake it so that recv works
+            return Message(
+                type="websocket.close", data=self._close_code, extra=self._close_reason
+            )
+        m = self.ws.receive()
+        if m["type"] == "websocket.close":
+            self._closed = True
+            self._close_code = m["code"]
+            self._close_reason =  m.get("reason", None)
+            return Message(type=m["type"], data=m["code"], extra=m.get("reason", None))
+        if m["type"] == "websocket.send":
+            return Message(type=m["type"], data=m["text"])
+        return Message(type=m["type"], data=m["data"], extra=m["extra"])
+
+    async def receive_json(self, timeout: Optional[float] = None) -> Any:
+        m = self.ws.receive()
+        assert m["type"] == "websocket.send"
+        assert "text" in m
+        return json.loads(m["text"])
+
+    async def close(self) -> None:
+        self.ws.close()
+        self._closed = True
+
+    @property
+    def accepted_subprotocol(self) -> Optional[str]:
+        return self.ws.accepted_subprotocol
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    @property
+    def close_code(self) -> int:
+        assert self._close_code is not None
+        return self._close_code
+
+    @property
+    def close_reason(self) -> Optional[str]:
+        return self._close_reason

--- a/tests/http/clients/quart.py
+++ b/tests/http/clients/quart.py
@@ -3,7 +3,7 @@ import json
 import urllib.parse
 from collections.abc import AsyncGenerator
 from io import BytesIO
-from typing import Any, Optional
+from typing import Any, Optional, Union
 from typing_extensions import Literal
 
 from starlette.testclient import TestClient
@@ -12,6 +12,7 @@ from starlette.types import Receive, Scope, Send
 from quart import Quart
 from quart import Request as QuartRequest
 from quart import Response as QuartResponse
+from quart import Websocket as QuartWebsocket
 from quart.datastructures import FileStorage
 from strawberry.http import GraphQLHTTPResponse
 from strawberry.http.ides import GraphQL_IDE
@@ -43,12 +44,14 @@ class GraphQLView(OnWSConnectMixin, BaseGraphQLView[dict[str, object], object]):
         self.result_override = kwargs.pop("result_override", None)
         super().__init__(*args, **kwargs)
 
-    async def get_root_value(self, request: QuartRequest) -> Query:
+    async def get_root_value(
+        self, request: Union[QuartRequest, QuartWebsocket]
+    ) -> Query:
         await super().get_root_value(request)  # for coverage
         return Query()
 
     async def get_context(
-        self, request: QuartRequest, response: QuartResponse
+        self, request: Union[QuartRequest, QuartWebsocket], response: QuartResponse
     ) -> dict[str, object]:
         context = await super().get_context(request, response)
 

--- a/tests/http/clients/quart.py
+++ b/tests/http/clients/quart.py
@@ -77,6 +77,7 @@ class QuartHttpClient(HttpClient):
             graphql_ide=graphql_ide,
             allow_queries_via_get=allow_queries_via_get,
             result_override=result_override,
+            keep_alive=False,
             multipart_uploads_enabled=multipart_uploads_enabled,
         )
 

--- a/tests/http/clients/quart.py
+++ b/tests/http/clients/quart.py
@@ -23,6 +23,8 @@ from tests.views.schema import Query, schema
 from .asgi import AsgiWebSocketClient
 from .base import (
     JSON,
+    DebuggableGraphQLTransportWSHandler,
+    DebuggableGraphQLWSHandler,
     HttpClient,
     Response,
     ResultOverrideFunction,
@@ -32,8 +34,9 @@ from .base import (
 
 class GraphQLView(BaseGraphQLView[dict[str, object], object]):
     methods = ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"]
-
     result_override: ResultOverrideFunction = None
+    graphql_transport_ws_handler_class = DebuggableGraphQLTransportWSHandler
+    graphql_ws_handler_class = DebuggableGraphQLWSHandler
 
     def __init__(self, *args: Any, **kwargs: Any):
         self.result_override = kwargs.pop("result_override", None)

--- a/tests/http/clients/quart.py
+++ b/tests/http/clients/quart.py
@@ -1,11 +1,9 @@
-import asyncio
 import contextlib
 import json
 import urllib.parse
+from collections.abc import AsyncGenerator, Mapping
 from io import BytesIO
-from typing import Any, Optional, AsyncGenerator, Mapping
-
-from quart.typing import TestWebsocketConnectionProtocol
+from typing import Any, Optional
 from typing_extensions import Literal
 
 from starlette.testclient import TestClient, WebSocketTestSession
@@ -21,8 +19,14 @@ from strawberry.types import ExecutionResult
 from tests.http.context import get_context
 from tests.views.schema import Query, schema
 
-from .base import JSON, HttpClient, Response, ResultOverrideFunction, WebSocketClient, \
-    Message
+from .base import (
+    JSON,
+    HttpClient,
+    Message,
+    Response,
+    ResultOverrideFunction,
+    WebSocketClient,
+)
 
 
 class GraphQLView(BaseGraphQLView[dict[str, object], object]):
@@ -81,10 +85,7 @@ class QuartHttpClient(HttpClient):
             view_func=view,
         )
         self.app.add_url_rule(
-            '/graphql',
-            view_func=view,
-            methods=["GET"],
-            websocket=True
+            "/graphql", view_func=view, methods=["GET"], websocket=True
         )
 
         self.client = TestClient(self.app)
@@ -100,14 +101,10 @@ class QuartHttpClient(HttpClient):
             view_func=view,
         )
         self.app.add_url_rule(
-            '/graphql',
-            view_func=view,
-            methods=["GET"],
-            websocket=True
+            "/graphql", view_func=view, methods=["GET"], websocket=True
         )
 
         self.client = TestClient(self.app)
-
 
     async def _graphql_request(
         self,
@@ -187,7 +184,6 @@ class QuartHttpClient(HttpClient):
             yield QuartWebSocketClient(ws)
 
 
-
 class QuartWebSocketClient(WebSocketClient):
     def __init__(self, ws: WebSocketTestSession):
         self.ws = ws
@@ -214,7 +210,7 @@ class QuartWebSocketClient(WebSocketClient):
         if m["type"] == "websocket.close":
             self._closed = True
             self._close_code = m["code"]
-            self._close_reason =  m.get("reason", None)
+            self._close_reason = m.get("reason", None)
             return Message(type=m["type"], data=m["code"], extra=m.get("reason", None))
         if m["type"] == "websocket.send":
             return Message(type=m["type"], data=m["text"])

--- a/tests/http/clients/quart.py
+++ b/tests/http/clients/quart.py
@@ -126,7 +126,10 @@ class QuartHttpClient(HttpClient):
             view_func=view,
         )
         self.app.add_url_rule(
-            "/graphql", view_func=view, methods=["GET"], websocket=True
+            "/graphql",
+            view_func=view,
+            methods=["GET"],
+            websocket=True,
         )
 
         self.client = TestClient(QuartAsgiAppAdapter(self.app))

--- a/tests/websockets/conftest.py
+++ b/tests/websockets/conftest.py
@@ -14,6 +14,7 @@ def _get_http_client_classes() -> Generator[Any, None, None]:
         ("ChannelsHttpClient", "channels", [pytest.mark.channels]),
         ("FastAPIHttpClient", "fastapi", [pytest.mark.fastapi]),
         ("LitestarHttpClient", "litestar", [pytest.mark.litestar]),
+        ("QuartHttpClient", "quart", [pytest.mark.quart]),
     ]:
         try:
             client_class = getattr(

--- a/tests/websockets/test_graphql_transport_ws.py
+++ b/tests/websockets/test_graphql_transport_ws.py
@@ -72,7 +72,6 @@ def assert_next(
 
 async def test_unknown_message_type(ws_raw: WebSocketClient):
     ws = ws_raw
-
     await ws.send_json({"type": "NOT_A_MESSAGE_TYPE"})
 
     await ws.receive(timeout=2)

--- a/tests/websockets/test_graphql_transport_ws.py
+++ b/tests/websockets/test_graphql_transport_ws.py
@@ -72,6 +72,7 @@ def assert_next(
 
 async def test_unknown_message_type(ws_raw: WebSocketClient):
     ws = ws_raw
+
     await ws.send_json({"type": "NOT_A_MESSAGE_TYPE"})
 
     await ws.receive(timeout=2)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
This PR adds support for both GraphQL over WS protocols to the Quart integration.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Closes #3818

## Summary by Sourcery

Add GraphQL over WebSocket subscription support to the Quart integration.

New Features:
- Add GraphQL over WebSocket subscription support to the Quart integration.
- Introduce configurable subscription options (`subscription_protocols`, `keep_alive`, `keep_alive_interval`, `connection_init_wait_timeout`) in `GraphQLView`. 

Enhancements:
- Implement `QuartWebSocketAdapter` and extend `GraphQLView` with WebSocket routing, protocol negotiation, and streaming response handling.
- Extend the test HTTP client with an ASGI adapter and WebSocket connect helper for Quart.

Documentation:
- Update Quart integration documentation with WebSocket setup and the `on_ws_connect` hook.
- Add a Quart section to the general subscriptions guide.

Tests:
- Add WebSocket tests and custom handlers for GraphQL subscriptions in the Quart client.