### PR TITLE
fix: always get last multipart separator from queue when streaming

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Fix multipart subscriptions by always yielding the closing boundary if it's enqueued.

--- a/strawberry/http/async_base_view.py
+++ b/strawberry/http/async_base_view.py
@@ -406,6 +406,13 @@ class AsyncBaseHTTPView(
            - Guarantees the done signal is queued before drain task completes
 
         Heartbeats are sent every 5 seconds when the drain task isn't sending data.
+
+        Note: Due to the asynchronous nature of the heartbeat task, an extra heartbeat
+        message may be sent after the final stream boundary message. This is safe because
+        both the MIME specification (RFC 2046) and Apollo's GraphQL Multipart HTTP protocol
+        require clients to ignore any content after the final boundary marker. Additionally,
+        Apollo's protocol defines heartbeats as empty JSON objects that clients must
+        silently ignore.
         """
         queue: asyncio.Queue[tuple[bool, bool, Any]] = asyncio.Queue(
             maxsize=1,  # Critical: maxsize=1 for flow control.

--- a/strawberry/http/async_base_view.py
+++ b/strawberry/http/async_base_view.py
@@ -385,7 +385,7 @@ class AsyncBaseHTTPView(
         - raised (bool): True if this contains an exception to be re-raised
         - done (bool): True if this is the final signal indicating stream completion
         - data: The actual message content to yield, or exception if raised=True
-               Note: data is always None when done=True
+               Note: data is always None when done=True and can be ignored
 
         Note: This implementation addresses two critical concerns:
 
@@ -458,6 +458,11 @@ class AsyncBaseHTTPView(
 
                     if done:
                         # Received done signal (data is None), stream is complete.
+                        # Note that we may not get here because of the race between
+                        # task.done() and queue.get(), but that's OK because if
+                        # task.done() is True, the actual final message (including any
+                        # exception) has been consumed. The only intent here is to
+                        # ensure that data=None is not yielded.
                         break
 
                     if raised:

--- a/tests/http/test_async_base_view.py
+++ b/tests/http/test_async_base_view.py
@@ -1,0 +1,41 @@
+import asyncio
+from asyncio import sleep
+from collections.abc import AsyncGenerator
+from secrets import token_hex
+from typing import Any, cast
+
+from strawberry.http.async_base_view import AsyncBaseHTTPView
+
+
+async def test_stream_with_heartbeat_should_always_yield_final_item() -> None:
+    """
+    Tests that AsyncBaseHTTPView._stream_with_heartbeat always yield the final item
+    from a stream.
+
+    This test creates a mock AsyncBaseHTTPView and verifies that when streaming data
+    through the _stream_with_heartbeat method, the final item is always yielded in the
+    output stream. It runs 100 concurrent tests to ensure reliability even with timing
+    variations.
+    """
+
+    class MockAsyncBaseHTTPView:
+        def encode_multipart_data(self, *_: Any, **__: Any) -> str:
+            return ""
+
+    view = MockAsyncBaseHTTPView()
+
+    async def verify() -> None:
+        final_item = token_hex(8)
+
+        async def stream() -> AsyncGenerator[str, None]:
+            yield final_item
+
+        items = []
+        async for item in AsyncBaseHTTPView._stream_with_heartbeat(
+            cast("AsyncBaseHTTPView", view), stream, "graphql"
+        )():
+            items.append(item)
+            await sleep(0.001)
+        assert final_item in items
+
+    await asyncio.gather(*(verify() for _ in range(100)))

--- a/tests/http/test_async_base_view.py
+++ b/tests/http/test_async_base_view.py
@@ -28,6 +28,7 @@ async def test_stream_with_heartbeat_should_always_yield_final_item() -> None:
         final_item = token_hex(8)
 
         async def stream() -> AsyncGenerator[str, None]:
+            yield ""
             yield final_item
 
         items = []

--- a/tests/http/test_async_base_view.py
+++ b/tests/http/test_async_base_view.py
@@ -22,16 +22,17 @@ async def test_stream_with_heartbeat_should_yield_items_correctly(
     expected: list[str],
 ) -> None:
     """
-    Verifies that _stream_with_heartbeat correctly processes all stream items.
+    Verifies _stream_with_heartbeat reliably delivers all items in correct order.
 
-    Ensures three key requirements are met:
-    1. Completeness: All items from the source stream appear in the output
-    2. Uniqueness: Each expected item appears exactly once (no duplicates)
+    Tests three critical stream properties:
+    1. Completeness: All source items appear in output (especially the last item)
+    2. Uniqueness: Each expected item appears exactly once
     3. Order: Original sequence of items is preserved
 
-    Uses parametrization to test various input sizes and runs 100 concurrent
-    streams with randomized delays to detect potential race conditions between the
-    drain task and queue consumer that might affect item delivery or ordering.
+    Uses multiple test cases via parametrization and runs 100 concurrent streams
+    with randomized delays to stress-test the implementation. This specifically
+    targets race conditions between the drain task and queue consumer that could
+    cause missing items, duplicates, or reordering.
     """
 
     assert len(set(expected)) == len(expected), "Test requires unique elements"

--- a/tests/http/test_async_base_view.py
+++ b/tests/http/test_async_base_view.py
@@ -1,22 +1,40 @@
 import asyncio
 from asyncio import sleep
+from collections import Counter
 from collections.abc import AsyncGenerator
-from secrets import token_hex
+from random import random
 from typing import Any, cast
+
+import pytest
 
 from strawberry.http.async_base_view import AsyncBaseHTTPView
 
 
-async def test_stream_with_heartbeat_should_always_yield_final_item() -> None:
+@pytest.mark.parametrize(
+    "expected",
+    [
+        pytest.param(["last"], id="single_item"),
+        pytest.param(["1st", "last"], id="two_items"),
+        pytest.param(["1st", "2nd", "last"], id="three_items"),
+    ],
+)
+async def test_stream_with_heartbeat_should_yield_items_correctly(
+    expected: list[str],
+) -> None:
     """
-    Tests that AsyncBaseHTTPView._stream_with_heartbeat always yield the final item
-    from a stream.
+    Verifies that _stream_with_heartbeat correctly processes all stream items.
 
-    This test creates a mock AsyncBaseHTTPView and verifies that when streaming data
-    through the _stream_with_heartbeat method, the final item is always yielded in the
-    output stream. It runs 100 concurrent tests to ensure reliability even with timing
-    variations.
+    Ensures three key requirements are met:
+    1. Completeness: All items from the source stream appear in the output
+    2. Uniqueness: Each expected item appears exactly once (no duplicates)
+    3. Order: Original sequence of items is preserved
+
+    Uses parametrization to test various input sizes and runs 100 concurrent
+    streams with randomized delays to detect potential race conditions between the
+    drain task and queue consumer that might affect item delivery or ordering.
     """
+
+    assert len(set(expected)) == len(expected), "Test requires unique elements"
 
     class MockAsyncBaseHTTPView:
         def encode_multipart_data(self, *_: Any, **__: Any) -> str:
@@ -24,19 +42,38 @@ async def test_stream_with_heartbeat_should_always_yield_final_item() -> None:
 
     view = MockAsyncBaseHTTPView()
 
-    async def verify() -> None:
-        final_item = token_hex(8)
+    async def stream() -> AsyncGenerator[str, None]:
+        for elem in expected:
+            yield elem
 
-        async def stream() -> AsyncGenerator[str, None]:
-            yield ""
-            yield final_item
-
-        items = []
+    async def collect() -> list[str]:
+        result = []
         async for item in AsyncBaseHTTPView._stream_with_heartbeat(
-            cast("AsyncBaseHTTPView", view), stream, "graphql"
+            cast("AsyncBaseHTTPView", view), stream, ""
         )():
-            items.append(item)
-            await sleep(0.001)
-        assert final_item in items
+            result.append(item)
+            # Random sleep to promote race conditions between concurrent tasks
+            await sleep(random() / 1000)  # noqa: S311
+        return result
 
-    await asyncio.gather(*(verify() for _ in range(100)))
+    for actual in await asyncio.gather(*(collect() for _ in range(100))):
+        # Validation 1: Item completeness
+        count = Counter(actual)
+        if missing_items := set(expected) - set(count):
+            assert not missing_items, f"Missing expected items: {list(missing_items)}"
+
+        # Validation 2: No duplicates
+        for item in expected:
+            item_count = count[item]
+            assert item_count == 1, (
+                f"Expected item '{item}' appears {item_count} times (should appear exactly once)"
+            )
+
+        # Validation 3: Preserved ordering
+        item_indices = {item: actual.index(item) for item in expected}
+        for i in range(len(expected) - 1):
+            curr, next_item = expected[i], expected[i + 1]
+            assert item_indices[curr] < item_indices[next_item], (
+                f"Order incorrect: '{curr}' (at index {item_indices[curr]}) "
+                f"should appear before '{next_item}' (at index {item_indices[next_item]})"
+            )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

This PR fixes an issue with GraphQL multipart subscriptions where the final boundary marker (`--graphql--`) could sometimes be missed due to a race condition between task completion and message handling. See screenshot below.

<img width="1653" alt="Screenshot 2025-05-20 at 10 10 18 PM" src="https://github.com/user-attachments/assets/2a7c8f54-650c-4386-802f-a92922ace269" />


<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #3865 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Fix streaming of multipart GraphQL subscriptions by parameterizing the boundary separator, updating the heartbeat to use it, and draining any remaining queue entries to always emit the final multipart boundary.

Bug Fixes:
- Parameterize and propagate the multipart separator into the `_stream_with_heartbeat` method.
- Use the passed separator in the heartbeat message instead of a hardcoded value.
- Drain leftover queue items and yield the final multipart boundary at the end of the stream.