### PR TITLE
Extend graphql over ws operation selection tests

### DIFF
--- a/tests/websockets/test_graphql_transport_ws.py
+++ b/tests/websockets/test_graphql_transport_ws.py
@@ -480,6 +480,37 @@ async def test_simple_subscription(ws: WebSocketClient):
     await ws.send_message({"id": "sub1", "type": "complete"})
 
 
+@pytest.mark.parametrize(
+    ("extra_payload", "expected_message"),
+    [
+        ({}, "Hi1"),
+        ({"operationName": None}, "Hi1"),
+        ({"operationName": "Subscription1"}, "Hi1"),
+        ({"operationName": "Subscription2"}, "Hi2"),
+    ],
+)
+async def test_operation_selection(
+    ws: WebSocketClient, extra_payload, expected_message
+):
+    await ws.send_json(
+        {
+            "type": "subscribe",
+            "id": "sub1",
+            "payload": {
+                "query": """
+                    subscription Subscription1 { echo(message: "Hi1") }
+                    subscription Subscription2 { echo(message: "Hi2") }
+                """,
+                **extra_payload,
+            },
+        }
+    )
+
+    next_message: NextMessage = await ws.receive_json()
+    assert_next(next_message, "sub1", {"echo": expected_message})
+    await ws.send_message({"id": "sub1", "type": "complete"})
+
+
 async def test_subscription_syntax_error(ws: WebSocketClient):
     await ws.send_message(
         {
@@ -727,26 +758,37 @@ async def test_single_result_mutation_operation(ws: WebSocketClient):
     assert complete_message == {"id": "sub1", "type": "complete"}
 
 
-async def test_single_result_operation_selection(ws: WebSocketClient):
+@pytest.mark.parametrize(
+    ("extra_payload", "expected_message"),
+    [
+        ({}, "Hello Strawberry1"),
+        ({"operationName": None}, "Hello Strawberry1"),
+        ({"operationName": "Query1"}, "Hello Strawberry1"),
+        ({"operationName": "Query2"}, "Hello Strawberry2"),
+    ],
+)
+async def test_single_result_operation_selection(
+    ws: WebSocketClient, extra_payload, expected_message
+):
     query = """
         query Query1 {
-            hello
+            hello(name: "Strawberry1")
         }
         query Query2 {
-            hello(name: "Strawberry")
+            hello(name: "Strawberry2")
         }
     """
 
-    await ws.send_message(
+    await ws.send_json(
         {
             "id": "sub1",
             "type": "subscribe",
-            "payload": {"query": query, "operationName": "Query2"},
+            "payload": {"query": query, **extra_payload},
         }
     )
 
     next_message: NextMessage = await ws.receive_json()
-    assert_next(next_message, "sub1", {"hello": "Hello Strawberry"})
+    assert_next(next_message, "sub1", {"hello": expected_message})
 
     complete_message: CompleteMessage = await ws.receive_json()
     assert complete_message == {"id": "sub1", "type": "complete"}

--- a/tests/websockets/test_graphql_transport_ws.py
+++ b/tests/websockets/test_graphql_transport_ws.py
@@ -485,6 +485,7 @@ async def test_simple_subscription(ws: WebSocketClient):
     [
         ({}, "Hi1"),
         ({"operationName": None}, "Hi1"),
+        ({"operationName": ""}, "Hi1"),
         ({"operationName": "Subscription1"}, "Hi1"),
         ({"operationName": "Subscription2"}, "Hi2"),
     ],
@@ -763,6 +764,7 @@ async def test_single_result_mutation_operation(ws: WebSocketClient):
     [
         ({}, "Hello Strawberry1"),
         ({"operationName": None}, "Hello Strawberry1"),
+        ({"operationName": ""}, "Hello Strawberry1"),
         ({"operationName": "Query1"}, "Hello Strawberry1"),
         ({"operationName": "Query2"}, "Hello Strawberry2"),
     ],

--- a/tests/websockets/test_graphql_transport_ws.py
+++ b/tests/websockets/test_graphql_transport_ws.py
@@ -512,6 +512,26 @@ async def test_operation_selection(
     await ws.send_message({"id": "sub1", "type": "complete"})
 
 
+async def test_invalid_operation_selection(ws: WebSocketClient):
+    await ws.send_message(
+        {
+            "type": "subscribe",
+            "id": "sub1",
+            "payload": {
+                "query": """
+                    subscription Subscription1 { echo(message: "Hi1") }
+                """,
+                "operationName": "Subscription2",
+            },
+        }
+    )
+
+    await ws.receive(timeout=2)
+    assert ws.closed
+    assert ws.close_code == 4400
+    assert ws.close_reason == "Can't get GraphQL operation type"
+
+
 async def test_subscription_syntax_error(ws: WebSocketClient):
     await ws.send_message(
         {

--- a/tests/websockets/test_graphql_ws.py
+++ b/tests/websockets/test_graphql_ws.py
@@ -81,8 +81,19 @@ async def test_simple_subscription(ws: WebSocketClient):
     assert complete_message["id"] == "demo"
 
 
-async def test_operation_selection(ws: WebSocketClient):
-    await ws.send_legacy_message(
+@pytest.mark.parametrize(
+    ("extra_payload", "expected_message"),
+    [
+        ({}, "Hi1"),
+        ({"operationName": None}, "Hi1"),
+        ({"operationName": "Subscription1"}, "Hi1"),
+        ({"operationName": "Subscription2"}, "Hi2"),
+    ],
+)
+async def test_operation_selection(
+    ws: WebSocketClient, extra_payload, expected_message
+):
+    await ws.send_json(
         {
             "type": "start",
             "id": "demo",
@@ -91,7 +102,7 @@ async def test_operation_selection(ws: WebSocketClient):
                     subscription Subscription1 { echo(message: "Hi1") }
                     subscription Subscription2 { echo(message: "Hi2") }
                 """,
-                "operationName": "Subscription2",
+                **extra_payload,
             },
         }
     )
@@ -99,7 +110,7 @@ async def test_operation_selection(ws: WebSocketClient):
     data_message: DataMessage = await ws.receive_json()
     assert data_message["type"] == "data"
     assert data_message["id"] == "demo"
-    assert data_message["payload"]["data"] == {"echo": "Hi2"}
+    assert data_message["payload"]["data"] == {"echo": expected_message}
 
     await ws.send_legacy_message({"type": "stop", "id": "demo"})
 

--- a/tests/websockets/test_graphql_ws.py
+++ b/tests/websockets/test_graphql_ws.py
@@ -86,6 +86,7 @@ async def test_simple_subscription(ws: WebSocketClient):
     [
         ({}, "Hi1"),
         ({"operationName": None}, "Hi1"),
+        ({"operationName": ""}, "Hi1"),
         ({"operationName": "Subscription1"}, "Hi1"),
         ({"operationName": "Subscription2"}, "Hi2"),
     ],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
This PR extends the operation selection tests of both GraphQL over WS protocols.

There's still some work left in this area, but I'll do that in a separate PR to keep things reviewable.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Summary by Sourcery

Extend operation selection test coverage for both GraphQL over WS protocols by parametrizing multi‐operation queries to test default, null, and named operationName payloads in subscription and single‐result scenarios.

Tests:
- Parameterize subscription tests in both graphql-transport-ws and graphql-ws to verify selecting default, None, and specific named operations yields expected messages.
- Parameterize single‐result query tests in graphql-transport-ws to cover operationName variations between Query1 and Query2.
- Replace send_message with send_json for consistency when sending JSON payloads in tests.
- Update test queries to emit unique echo/hello messages per operation variant for clearer validation.