### PR TITLE
Fix error message for operation selection edge-case

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+Release type: patch
+
+In this release, we improved some GraphQL over WS error messages. More precise
+error messages are now returned if Strawberry fails to find an operation in the
+query document.

--- a/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
@@ -216,13 +216,18 @@ class BaseGraphQLTransportWSHandler(Generic[Context, RootValue]):
             await self.websocket.close(code=4400, reason=exc.message)
             return
 
+        operation_name = message["payload"].get("operationName")
+
         try:
-            operation_type = get_operation_type(
-                graphql_document, message["payload"].get("operationName")
-            )
+            operation_type = get_operation_type(graphql_document, operation_name)
         except RuntimeError:
             await self.websocket.close(
-                code=4400, reason="Can't get GraphQL operation type"
+                code=4400,
+                reason=(
+                    f'Unknown operation named "{operation_name}".'
+                    if operation_name
+                    else "Can't get GraphQL operation type"
+                ),
             )
             return
 

--- a/strawberry/subscriptions/protocols/graphql_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_ws/handlers.py
@@ -199,7 +199,13 @@ class BaseGraphQLWSHandler(Generic[Context, RootValue]):
                 ErrorMessage(
                     type="error",
                     id=operation_id,
-                    payload={"message": f'Unknown operation named "{operation_name}".'},
+                    payload={
+                        "message": (
+                            f'Unknown operation named "{operation_name}".'
+                            if operation_name
+                            else "Can't get GraphQL operation type"
+                        )
+                    },
                 )
             )
         except asyncio.CancelledError:

--- a/tests/websockets/test_graphql_transport_ws.py
+++ b/tests/websockets/test_graphql_transport_ws.py
@@ -480,6 +480,37 @@ async def test_simple_subscription(ws: WebSocketClient):
     await ws.send_message({"id": "sub1", "type": "complete"})
 
 
+@pytest.mark.parametrize(
+    ("extra_payload", "expected_message"),
+    [
+        ({}, "Hi1"),
+        ({"operationName": None}, "Hi1"),
+        ({"operationName": "Subscription1"}, "Hi1"),
+        ({"operationName": "Subscription2"}, "Hi2"),
+    ],
+)
+async def test_operation_selection(
+    ws: WebSocketClient, extra_payload, expected_message
+):
+    await ws.send_json(
+        {
+            "type": "subscribe",
+            "id": "sub1",
+            "payload": {
+                "query": """
+                    subscription Subscription1 { echo(message: "Hi1") }
+                    subscription Subscription2 { echo(message: "Hi2") }
+                """,
+                **extra_payload,
+            },
+        }
+    )
+
+    next_message: NextMessage = await ws.receive_json()
+    assert_next(next_message, "sub1", {"echo": expected_message})
+    await ws.send_message({"id": "sub1", "type": "complete"})
+
+
 async def test_subscription_syntax_error(ws: WebSocketClient):
     await ws.send_message(
         {
@@ -727,26 +758,37 @@ async def test_single_result_mutation_operation(ws: WebSocketClient):
     assert complete_message == {"id": "sub1", "type": "complete"}
 
 
-async def test_single_result_operation_selection(ws: WebSocketClient):
+@pytest.mark.parametrize(
+    ("extra_payload", "expected_message"),
+    [
+        ({}, "Hello Strawberry1"),
+        ({"operationName": None}, "Hello Strawberry1"),
+        ({"operationName": "Query1"}, "Hello Strawberry1"),
+        ({"operationName": "Query2"}, "Hello Strawberry2"),
+    ],
+)
+async def test_single_result_operation_selection(
+    ws: WebSocketClient, extra_payload, expected_message
+):
     query = """
         query Query1 {
-            hello
+            hello(name: "Strawberry1")
         }
         query Query2 {
-            hello(name: "Strawberry")
+            hello(name: "Strawberry2")
         }
     """
 
-    await ws.send_message(
+    await ws.send_json(
         {
             "id": "sub1",
             "type": "subscribe",
-            "payload": {"query": query, "operationName": "Query2"},
+            "payload": {"query": query, **extra_payload},
         }
     )
 
     next_message: NextMessage = await ws.receive_json()
-    assert_next(next_message, "sub1", {"hello": "Hello Strawberry"})
+    assert_next(next_message, "sub1", {"hello": expected_message})
 
     complete_message: CompleteMessage = await ws.receive_json()
     assert complete_message == {"id": "sub1", "type": "complete"}

--- a/tests/websockets/test_graphql_transport_ws.py
+++ b/tests/websockets/test_graphql_transport_ws.py
@@ -529,6 +529,25 @@ async def test_invalid_operation_selection(ws: WebSocketClient):
     await ws.receive(timeout=2)
     assert ws.closed
     assert ws.close_code == 4400
+    assert ws.close_reason == 'Unknown operation named "Subscription2".'
+
+
+async def test_operation_selection_without_operations(ws: WebSocketClient):
+    await ws.send_message(
+        {
+            "type": "subscribe",
+            "id": "sub1",
+            "payload": {
+                "query": """
+                    fragment Fragment1 on Query { __typename }
+                """,
+            },
+        }
+    )
+
+    await ws.receive(timeout=2)
+    assert ws.closed
+    assert ws.close_code == 4400
     assert ws.close_reason == "Can't get GraphQL operation type"
 
 
@@ -828,6 +847,27 @@ async def test_single_result_invalid_operation_selection(ws: WebSocketClient):
             "id": "sub1",
             "type": "subscribe",
             "payload": {"query": query, "operationName": "Query2"},
+        }
+    )
+
+    await ws.receive(timeout=2)
+    assert ws.closed
+    assert ws.close_code == 4400
+    assert ws.close_reason == 'Unknown operation named "Query2".'
+
+
+async def test_single_result_operation_selection_without_operations(
+    ws: WebSocketClient,
+):
+    await ws.send_message(
+        {
+            "id": "sub1",
+            "type": "subscribe",
+            "payload": {
+                "query": """
+                    fragment Fragment1 on Query { __typename }
+                """,
+            },
         }
     )
 

--- a/tests/websockets/test_graphql_transport_ws.py
+++ b/tests/websockets/test_graphql_transport_ws.py
@@ -485,6 +485,7 @@ async def test_simple_subscription(ws: WebSocketClient):
     [
         ({}, "Hi1"),
         ({"operationName": None}, "Hi1"),
+        ({"operationName": ""}, "Hi1"),
         ({"operationName": "Subscription1"}, "Hi1"),
         ({"operationName": "Subscription2"}, "Hi2"),
     ],
@@ -763,6 +764,7 @@ async def test_single_result_mutation_operation(ws: WebSocketClient):
     [
         ({}, "Hello Strawberry1"),
         ({"operationName": None}, "Hello Strawberry1"),
+        ({"operationName": ""}, "Hello Strawberry1"),
         ({"operationName": "Query1"}, "Hello Strawberry1"),
         ({"operationName": "Query2"}, "Hello Strawberry2"),
     ],

--- a/tests/websockets/test_graphql_transport_ws.py
+++ b/tests/websockets/test_graphql_transport_ws.py
@@ -512,6 +512,26 @@ async def test_operation_selection(
     await ws.send_message({"id": "sub1", "type": "complete"})
 
 
+async def test_invalid_operation_selection(ws: WebSocketClient):
+    await ws.send_message(
+        {
+            "type": "subscribe",
+            "id": "sub1",
+            "payload": {
+                "query": """
+                    subscription Subscription1 { echo(message: "Hi1") }
+                """,
+                "operationName": "Subscription2",
+            },
+        }
+    )
+
+    await ws.receive(timeout=2)
+    assert ws.closed
+    assert ws.close_code == 4400
+    assert ws.close_reason == "Can't get GraphQL operation type"
+
+
 async def test_subscription_syntax_error(ws: WebSocketClient):
     await ws.send_message(
         {

--- a/tests/websockets/test_graphql_ws.py
+++ b/tests/websockets/test_graphql_ws.py
@@ -81,8 +81,19 @@ async def test_simple_subscription(ws: WebSocketClient):
     assert complete_message["id"] == "demo"
 
 
-async def test_operation_selection(ws: WebSocketClient):
-    await ws.send_legacy_message(
+@pytest.mark.parametrize(
+    ("extra_payload", "expected_message"),
+    [
+        ({}, "Hi1"),
+        ({"operationName": None}, "Hi1"),
+        ({"operationName": "Subscription1"}, "Hi1"),
+        ({"operationName": "Subscription2"}, "Hi2"),
+    ],
+)
+async def test_operation_selection(
+    ws: WebSocketClient, extra_payload, expected_message
+):
+    await ws.send_json(
         {
             "type": "start",
             "id": "demo",
@@ -91,7 +102,7 @@ async def test_operation_selection(ws: WebSocketClient):
                     subscription Subscription1 { echo(message: "Hi1") }
                     subscription Subscription2 { echo(message: "Hi2") }
                 """,
-                "operationName": "Subscription2",
+                **extra_payload,
             },
         }
     )
@@ -99,7 +110,7 @@ async def test_operation_selection(ws: WebSocketClient):
     data_message: DataMessage = await ws.receive_json()
     assert data_message["type"] == "data"
     assert data_message["id"] == "demo"
-    assert data_message["payload"]["data"] == {"echo": "Hi2"}
+    assert data_message["payload"]["data"] == {"echo": expected_message}
 
     await ws.send_legacy_message({"type": "stop", "id": "demo"})
 

--- a/tests/websockets/test_graphql_ws.py
+++ b/tests/websockets/test_graphql_ws.py
@@ -86,6 +86,7 @@ async def test_simple_subscription(ws: WebSocketClient):
     [
         ({}, "Hi1"),
         ({"operationName": None}, "Hi1"),
+        ({"operationName": ""}, "Hi1"),
         ({"operationName": "Subscription1"}, "Hi1"),
         ({"operationName": "Subscription2"}, "Hi2"),
     ],

--- a/tests/websockets/test_graphql_ws.py
+++ b/tests/websockets/test_graphql_ws.py
@@ -142,6 +142,25 @@ async def test_invalid_operation_selection(ws: WebSocketClient):
     }
 
 
+async def test_operation_selection_without_operations(ws: WebSocketClient):
+    await ws.send_legacy_message(
+        {
+            "type": "start",
+            "id": "demo",
+            "payload": {
+                "query": """
+                    fragment Fragment1 on Query { __typename }
+                """,
+            },
+        }
+    )
+
+    error_message: ErrorMessage = await ws.receive_json()
+    assert error_message["type"] == "error"
+    assert error_message["id"] == "demo"
+    assert error_message["payload"] == {"message": "Can't get GraphQL operation type"}
+
+
 async def test_connections_are_accepted_by_default(ws_raw: WebSocketClient):
     await ws_raw.send_legacy_message({"type": "connection_init"})
     connection_ack_message: ConnectionAckMessage = await ws_raw.receive_json()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Note: This PR is based on #3868 (<- let's review and merge that one first).

This PR updates both GraphQL over WS implementations to return more precise error messages when an operation cannot be found in the request's query document.

There are two cases to consider:
1. An operation name was specified in the request, but it cannot be found in the query document
2. No operation name was specified in the request, in which case we would fall back to the first operation in the query document, but the query document does not contain any operations at all

Starting with this PR, we'll send distinct error messages for both cases to clients. In case 1, we inform the client that an operation with the requested name cannot be found. In case 2, we inform the client that no operation could be found.

Previously, both cases were handled the same way which resulted in an confusing error message when the legacy GraphQL over WS protocol was used.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation
