### PR TITLE
Make the aiohttp example self-contained

### DIFF
--- a/docs/integrations/aiohttp.md
+++ b/docs/integrations/aiohttp.md
@@ -9,8 +9,10 @@ can use to serve your GraphQL schema:
 
 ```python
 import strawberry
+import asyncio
 from aiohttp import web
 from strawberry.aiohttp.views import GraphQLView
+from typing import AsyncGenerator
 
 
 @strawberry.type
@@ -20,11 +22,21 @@ class Query:
         return f"Hello, {name}!"
 
 
-schema = strawberry.Schema(query=Query)
+@strawberry.type
+class Subscription:
+    @strawberry.subscription
+    async def count(self, to: int = 100) -> AsyncGenerator[int, None]:
+        for i in range(to):
+            yield i
+            await asyncio.sleep(1)
+
+
+schema = strawberry.Schema(query=Query, subscription=Subscription)
 
 app = web.Application()
-
 app.router.add_route("*", "/graphql", GraphQLView(schema=schema))
+
+web.run_app(app)
 ```
 
 ## Options


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
This PR updates the AIOHTTP example code in the docs to be self-contained (i.e., can be copied and run as-is) and to also contain a subscription.

I had to type out this example code too many times at this point. I'd rather copy it from the docs in the future :)

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Summary by Sourcery

Update the AIOHTTP integration docs to provide a fully runnable example with subscription support

Documentation:
- Add missing asyncio and AsyncGenerator imports for standalone execution
- Include a Subscription type with a count subscription example
- Update schema to include the Subscription type
- Add web.run_app call to start the server in the example