### PR TITLE
Run tests on latest GraphQL-core alpha

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -12,7 +12,7 @@ PYTHON_VERSIONS = ["3.13", "3.12", "3.11", "3.10", "3.9"]
 
 GQL_CORE_VERSIONS = [
     "3.2.3",
-    "3.3.0a7",
+    "3.3.0a8",
 ]
 
 COMMON_PYTEST_OPTIONS = [


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Bump GraphQL-core version in Nox test matrix from 3.3.0a7 to 3.3.0a8.