### PR TITLE
Remove deprecated extra getting started steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,17 +93,6 @@ urlpatterns = [
 ]
 ```
 
-## WebSockets
-
-To support graphql Subscriptions over WebSockets you need to provide a WebSocket
-enabled server. The debug server can be made to support WebSockets with these
-commands:
-
-```shell
-pip install 'strawberry-graphql[debug-server]'
-pip install 'uvicorn[standard]'
-```
-
 ## Examples
 
 * [Various examples on how to use Strawberry](https://github.com/strawberry-graphql/examples)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Turns out we had instructions to work around #3872 in our readme (but not in the docs). These instructions are no longer needed because our debug server now supports websockets out of the box.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Summary by Sourcery

Documentation:
- Remove the deprecated “WebSockets” section and its installation commands from the README