### PR TITLE
Fix get_operation_type is buggy if the first definition is a fragment

### DIFF
--- a/strawberry/utils/operation.py
+++ b/strawberry/utils/operation.py
@@ -27,7 +27,8 @@ def get_operation_type(
 
     if operation_name:
         for d in graphql_document.definitions:
-            d = cast("OperationDefinitionNode", d)
+            if not isinstance(d, OperationDefinitionNode):
+                continue
             if d.name and d.name.value == operation_name:
                 definition = d
                 break

--- a/tests/types/test_get_operation_type.py
+++ b/tests/types/test_get_operation_type.py
@@ -1,0 +1,107 @@
+from strawberry.types.graphql import OperationType
+from strawberry.utils.operation import get_operation_type
+from graphql import parse
+
+mutation_collision = parse("""
+fragment UserAgent on UserAgentType {
+  id
+}
+
+mutation UserAgent {
+  getUserAgent {
+    ...UserAgent
+  }
+}
+""")
+
+query_collision = parse("""
+fragment UserAgent on UserAgentType {
+  id
+}
+
+query UserAgent {
+  getUserAgent {
+    ...UserAgent
+  }
+}
+""")
+
+subscription_collision = parse("""
+fragment UserAgent on UserAgentType {
+  id
+}
+
+subscription UserAgent {
+  getUserAgent {
+    ...UserAgent
+  }
+}
+""")
+
+mutation_no_collision = parse("""
+fragment UserAgentFragment on UserAgentType {
+  id
+}
+
+mutation UserAgent {
+  getUserAgent {
+    ...UserAgentFragment
+  }
+}
+""")
+
+query_no_collision = parse("""
+fragment UserAgentFragment on UserAgentType {
+  id
+}
+
+query UserAgent {
+  getUserAgent {
+    ...UserAgentFragment
+  }
+}
+""")
+
+subscription_no_collision = parse("""
+fragment UserAgentFragment on UserAgentType {
+  id
+}
+
+subscription UserAgent {
+  getUserAgent {
+    ...UserAgentFragment
+  }
+}
+""")
+
+
+
+def test_get_operation_type_with_fragment_name_collision():
+    assert get_operation_type(
+        query_collision,
+        'UserAgent'
+    ) == OperationType.QUERY
+    assert get_operation_type(
+        query_no_collision,
+        'UserAgent'
+    ) == OperationType.QUERY
+    assert get_operation_type(
+        mutation_collision,
+        'UserAgent'
+    ) == OperationType.MUTATION
+    assert get_operation_type(
+        mutation_no_collision,
+        'UserAgent'
+    ) ==  OperationType.MUTATION
+    assert get_operation_type(
+        subscription_collision,
+        'UserAgent'
+    ) == OperationType.SUBSCRIPTION
+    assert get_operation_type(
+        subscription_no_collision,
+        'UserAgent'
+    ) == OperationType.SUBSCRIPTION
+
+    assert get_operation_type(query_collision) == OperationType.QUERY
+    assert get_operation_type(mutation_collision) == OperationType.MUTATION
+    assert get_operation_type(subscription_collision) == OperationType.SUBSCRIPTION


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/strawberry-graphql/strawberry/issues/3881

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
