### PR TITLE
Fix enum value was not working in generic container in lazy union

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+This Release contains fix of enum value was not working in generic container in lazy union.

--- a/strawberry/types/base.py
+++ b/strawberry/types/base.py
@@ -429,8 +429,10 @@ class StrawberryObjectDefinition(StrawberryType):
             if hasattr(real_concrete_type, "_enum_definition"):
                 real_concrete_type = real_concrete_type._enum_definition
 
-            if isinstance(expected_concrete_type, type) and issubclass(
-                real_concrete_type, expected_concrete_type
+            if (
+                isinstance(expected_concrete_type, type)
+                and isinstance(real_concrete_type, type)
+                and issubclass(real_concrete_type, expected_concrete_type)
             ):
                 return True
 

--- a/tests/schema/test_lazy/type_e.py
+++ b/tests/schema/test_lazy/type_e.py
@@ -1,0 +1,26 @@
+from enum import Enum
+import sys
+from typing import Annotated, Generic, TypeVar
+
+import strawberry
+
+T = TypeVar("T")
+
+
+@strawberry.enum
+class MyEnum(Enum):
+    ONE = "ONE"
+
+
+@strawberry.type
+class ValueContainer(Generic[T]):
+    value: T
+
+
+UnionValue = strawberry.union(
+    "UnionValue",
+    types=(
+        ValueContainer[int],
+        ValueContainer[MyEnum],
+    ),
+)

--- a/tests/schema/test_lazy/type_e.py
+++ b/tests/schema/test_lazy/type_e.py
@@ -1,6 +1,5 @@
 from enum import Enum
-import sys
-from typing import Annotated, Generic, TypeVar
+from typing import Generic, TypeVar
 
 import strawberry
 

--- a/tests/schema/test_union.py
+++ b/tests/schema/test_union.py
@@ -649,7 +649,7 @@ def test_lazy_union_with_generic():
     class Query:
         @strawberry.field
         def a(self) -> UnionValue:
-            from tests.schema.test_lazy.type_e import ValueContainer, MyEnum
+            from tests.schema.test_lazy.type_e import MyEnum, ValueContainer
 
             return ValueContainer(value=MyEnum.ONE)
 

--- a/tests/schema/test_union.py
+++ b/tests/schema/test_union.py
@@ -642,6 +642,32 @@ def test_lazy_union():
     assert result.data["b"]["__typename"] == "TypeB"
 
 
+def test_lazy_union_with_generic():
+    UnionValue = Annotated["UnionValue", lazy("tests.schema.test_lazy.type_e")]
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def a(self) -> UnionValue:
+            from tests.schema.test_lazy.type_e import ValueContainer, MyEnum
+
+            return ValueContainer(value=MyEnum.ONE)
+
+    schema = strawberry.Schema(query=Query)
+
+    query = """
+     {
+        a {
+            __typename
+        }
+    }
+    """
+
+    result = schema.execute_sync(query)
+
+    assert result.data["a"]["__typename"] == "MyEnumValueContainer"
+
+
 @pytest.mark.raises_strawberry_exception(
     InvalidUnionTypeError, match="Type `int` cannot be used in a GraphQL Union"
 )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

Lazy Union with Enum value in Generic was causing an error:
```
TypeError: issubclass() arg 1 must be a class
```

Now it's fixed.

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Fix a TypeError when using enum values in generic containers within lazy unions and add corresponding tests

Bug Fixes:
- Guard against non-type values in issubclass check by verifying real_concrete_type is a type before calling issubclass

Tests:
- Add test_lazy_union_with_generic and supporting type definitions to verify enum values in generic containers work in lazy unions