### PR TITLE
Fix create type implicitly required field resolvers

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,14 @@
+Release type: patch
+
+This release fixes that the `create_type` tool asked users to pass a `name` for
+fields without resolvers even when a `name` was already provided.
+
+The following code now works as expected:
+
+```python
+import strawberry
+from strawberry.tools import create_type
+
+first_name = strawberry.field(name="firstName")
+Query = create_type(f"Query", [first_name])
+```

--- a/strawberry/tools/create_type.py
+++ b/strawberry/tools/create_type.py
@@ -50,6 +50,9 @@ def create_type(
         if not isinstance(field, StrawberryField):
             raise TypeError("Field is not an instance of StrawberryField")
 
+        # Fields created using `strawberry.field` without a resolver don't have a
+        # `python_name`. In that case, we fall back to the field's `graphql_name`
+        # set via the `name` argument passed to `strawberry.field`.
         field_name = field.python_name or field.graphql_name
 
         if field_name is None:

--- a/strawberry/tools/create_type.py
+++ b/strawberry/tools/create_type.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 import strawberry
 from strawberry.types.field import StrawberryField
+from strawberry.utils.str_converters import to_snake_case
 
 
 def create_type(
@@ -50,15 +51,19 @@ def create_type(
         if not isinstance(field, StrawberryField):
             raise TypeError("Field is not an instance of StrawberryField")
 
-        if field.python_name is None:
+        field_name = field.python_name or (
+            to_snake_case(field.graphql_name) if field.graphql_name else None
+        )
+
+        if field_name is None:
             raise ValueError(
                 "Field doesn't have a name. Fields passed to "
                 "`create_type` must define a name by passing the "
                 "`name` argument to `strawberry.field`."
             )
 
-        namespace[field.python_name] = field
-        annotations[field.python_name] = field.type
+        namespace[field_name] = field
+        annotations[field_name] = field.type
 
     namespace["__annotations__"] = annotations  # type: ignore
 

--- a/strawberry/tools/create_type.py
+++ b/strawberry/tools/create_type.py
@@ -4,7 +4,6 @@ from typing import Optional
 
 import strawberry
 from strawberry.types.field import StrawberryField
-from strawberry.utils.str_converters import to_snake_case
 
 
 def create_type(
@@ -51,9 +50,7 @@ def create_type(
         if not isinstance(field, StrawberryField):
             raise TypeError("Field is not an instance of StrawberryField")
 
-        field_name = field.python_name or (
-            to_snake_case(field.graphql_name) if field.graphql_name else None
-        )
+        field_name = field.python_name or field.graphql_name
 
         if field_name is None:
             raise ValueError(

--- a/tests/tools/test_create_type.py
+++ b/tests/tools/test_create_type.py
@@ -128,7 +128,7 @@ def test_requires_resolver_or_name_to_create_type_field():
 
 def test_can_create_type_field_from_resolver_only():
     def get_name() -> str:
-        return "foo"
+        return "foo"  # pragma: no cover
 
     name = strawberry.field(resolver=get_name)
 
@@ -153,7 +153,7 @@ def test_can_create_type_field_from_name_only():
 
 def test_can_create_type_field_from_resolver_and_name():
     def get_first_name() -> str:
-        return "foo"
+        return "foo"  # pragma: no cover
 
     first_name = strawberry.field(name="firstName", resolver=get_first_name)
 

--- a/tests/tools/test_create_type.py
+++ b/tests/tools/test_create_type.py
@@ -147,7 +147,7 @@ def test_can_create_type_field_from_name_only():
 
     definition = get_object_definition(MyType, strict=True)
     assert len(definition.fields) == 1
-    assert definition.fields[0].python_name == "first_name"
+    assert definition.fields[0].python_name == "firstName"
     assert definition.fields[0].graphql_name == "firstName"
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

This PR addresses the issue summarized in https://github.com/strawberry-graphql/strawberry/issues/3421#issuecomment-2940066583 by restoring the ability of `create_type` to create types from fields without resolvers, which was lost when https://github.com/strawberry-graphql/strawberry/pull/798 was merged.

This is useful when creating types from fields that rely on the schema's default resolver as in the following example:

```python
import strawberry
from strawberry.tools import create_type
from strawberry.schema.config import StrawberryConfig

first_name = strawberry.field(name="firstName", graphql_type=str)
Query = create_type(f"Query", [first_name])  # This threw a ValueError because the field had no python_name (which would normally be derived from its resolver unless explicitly provided to the StrawberryField constructor)

def default_resolver(obj, field):
    return "Hi"

schema = strawberry.Schema(
    query=Query,
    config=StrawberryConfig(default_resolver=default_resolver)
)
```

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #3421

## Summary by Sourcery

Restore create_type’s flexibility by inferring missing python_name and allowing fields with only GraphQL names or only resolvers.

Bug Fixes:
- Restore create_type to accept fields with only a GraphQL name and fields with only a resolver

Enhancements:
- Infer a field’s python_name from its GraphQL name using snake_case conversion when missing

Documentation:
- Add RELEASE.md entry describing the create_type name requirement fix

Tests:
- Add tests for create_type with resolver-only, name-only, and resolver+name scenarios
- Update error message test when a field lacks both name and resolver