### PR TITLE
Add _unsafe_disable_same_type_validation config option

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,25 @@
+Release type: minor
+
+Added a new configuration option `_unsafe_disable_same_type_validation` that allows disabling the same type validation check in the schema converter. This is useful in cases where you need to have multiple type definitions with the same name in your schema.
+
+Example:
+
+```python
+@strawberry.type(name="DuplicatedType")
+class A:
+    a: int
+
+
+@strawberry.type(name="DuplicatedType")
+class B:
+    b: int
+
+
+schema = strawberry.Schema(
+    query=Query,
+    types=[A, B],
+    config=strawberry.StrawberryConfig(_unsafe_disable_same_type_validation=True),
+)
+```
+
+Note: This is an unsafe option and should be used with caution as it bypasses a safety check in the schema converter.

--- a/strawberry/schema/config.py
+++ b/strawberry/schema/config.py
@@ -17,6 +17,7 @@ class StrawberryConfig:
     relay_use_legacy_global_id: bool = False
     disable_field_suggestions: bool = False
     info_class: type[Info] = Info
+    _unsafe_disable_same_type_validation: bool = False
 
     def __post_init__(
         self,

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -968,8 +968,11 @@ class GraphQLCoreConverter:
     def validate_same_type_definition(
         self, name: str, type_definition: StrawberryType, cached_type: ConcreteType
     ) -> None:
-        # if the type definitions are the same we can return
-        if cached_type.definition == type_definition:
+        # Skip validation if _unsafe_disable_same_type_validation is True
+        if (
+            self.config._unsafe_disable_same_type_validation
+            or cached_type.definition == type_definition
+        ):
             return
 
         # otherwise we need to check if we are dealing with different instances

--- a/tests/schema/test_duplicated_types.py
+++ b/tests/schema/test_duplicated_types.py
@@ -6,6 +6,7 @@ import pytest
 
 import strawberry
 from strawberry.exceptions import DuplicatedTypeName
+from strawberry.schema.config import StrawberryConfig
 
 
 @pytest.mark.raises_strawberry_exception(
@@ -151,6 +152,40 @@ def test_allows_multiple_instance_of_same_generic():
         type Query {
           first: IntA!
           second: IntA!
+        }
+        """
+    ).strip()
+
+    assert str(schema) == expected_schema
+
+
+def test_allows_duplicated_types_when_validation_disabled():
+    @strawberry.type(name="DuplicatedType")
+    class A:
+        a: int
+
+    @strawberry.type(name="DuplicatedType")
+    class B:
+        b: int
+
+    @strawberry.type
+    class Query:
+        field: int
+
+    schema = strawberry.Schema(
+        query=Query,
+        types=[A, B],
+        config=StrawberryConfig(_unsafe_disable_same_type_validation=True),
+    )
+
+    expected_schema = textwrap.dedent(
+        """
+        type DuplicatedType {
+          a: Int!
+        }
+
+        type Query {
+          field: Int!
         }
         """
     ).strip()


### PR DESCRIPTION
- Add new configuration option to StrawberryConfig to disable same type validation
- Update schema converter to respect the new option
- Add test case to verify the functionality
- Add RELEASE.md for minor version bump

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This PR adds a new configuration option `_unsafe_disable_same_type_validation` to `StrawberryConfig` that allows disabling the same type validation check in the schema converter. This is useful in cases where you need to have multiple type definitions with the same name in your schema.

## Example Usage

```python
@strawberry.type(name="DuplicatedType")
class A:
    a: int

@strawberry.type(name="DuplicatedType")
class B:
    b: int

schema = strawberry.Schema(
    query=Query,
    types=[A, B],
    config=StrawberryConfig(_unsafe_disable_same_type_validation=True)
)
```

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x]  I have tested the changes and verified that they work and don't break anything (as well as I can manage).
