### PR TITLE
Fix assertions, typos, and formatting

### DIFF
--- a/tests/utils/test_get_first_operation.py
+++ b/tests/utils/test_get_first_operation.py
@@ -6,10 +6,10 @@ from strawberry.utils.operation import get_first_operation
 def test_document_without_operation_definition_nodes():
     document = parse(
         """
-		fragment Test on Query {
-			hello
-		}
-		"""
+        fragment Test on Query {
+            hello
+        }
+        """
     )
     assert get_first_operation(document) is None
 
@@ -17,10 +17,10 @@ def test_document_without_operation_definition_nodes():
 def test_single_operation_definition_node():
     document = parse(
         """
-		query Operation1 {
-			hello
-		}
-		"""
+        query Operation1 {
+            hello
+        }
+        """
     )
     node = get_first_operation(document)
     assert node is not None
@@ -30,13 +30,13 @@ def test_single_operation_definition_node():
 def test_multiple_operation_definition_nodes():
     document = parse(
         """
-		mutation Operation1 {
-			hello
-		}
-		query Operation2 {
-			hello
-		}
-		"""
+        mutation Operation1 {
+            hello
+        }
+        query Operation2 {
+            hello
+        }
+        """
     )
     node = get_first_operation(document)
     assert node is not None


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
While fixing the test failures in #3882, I noticed some typos, Pyright complaints about the assertions, and strange whitespace formatting throughout one of the files. Enough little issues to prompt me to clean things up :)

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Summary by Sourcery

Clean up the test suite for get_first_operation by correcting test names, refactoring assertions to satisfy the type checker, and normalizing whitespace formatting.

Tests:
- Rename test functions to correct “notes” to “nodes” in their names.
- Refactor tests to assign get_first_operation output to a variable before performing assertions.
- Normalize indentation and whitespace in GraphQL document strings within tests.