### PR TITLE
Add disable introspection extension

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,28 @@
+Release type: minor
+
+This release features a dedicated extension to disable introspection queries.
+Disabling introspection queries was already possible using the
+`AddValidationRules` extension. However, using this new extension requires less
+steps and makes the feature more discoverable.
+
+## Usage example:
+
+```python
+import strawberry
+from strawberry.extensions import DisableIntrospection
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def hello(self) -> str:
+        return "Hello, world!"
+
+
+schema = strawberry.Schema(
+    Query,
+    extensions=[
+        DisableIntrospection(),
+    ],
+)
+```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,7 @@ Release type: minor
 
 This release features a dedicated extension to disable introspection queries.
 Disabling introspection queries was already possible using the
-`AddValidationRules` extension. However, using this new extension requires less
+`AddValidationRules` extension. However, using this new extension requires fewer
 steps and makes the feature more discoverable.
 
 ## Usage example:

--- a/docs/extensions/disable-introspection.md
+++ b/docs/extensions/disable-introspection.md
@@ -1,0 +1,37 @@
+---
+title: Disable Introspection
+summary: Disable all introspection queries.
+tags: security,validation
+---
+
+# `DisableIntrospection`
+
+The `DisableIntrospection` extension disables all introspection queries for the
+schema. This can be useful to prevent clients from discovering unreleased or
+internal features of the API.
+
+## Usage example:
+
+```python
+import strawberry
+from strawberry.extensions import DisableIntrospection
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def hello(self) -> str:
+        return "Hello, world!"
+
+
+schema = strawberry.Schema(
+    Query,
+    extensions=[
+        DisableIntrospection(),
+    ],
+)
+```
+
+## API reference:
+
+_No arguments_

--- a/strawberry/extensions/__init__.py
+++ b/strawberry/extensions/__init__.py
@@ -2,6 +2,7 @@ import warnings
 
 from .add_validation_rules import AddValidationRules
 from .base_extension import LifecycleStep, SchemaExtension
+from .disable_introspection import DisableIntrospection
 from .disable_validation import DisableValidation
 from .field_extension import FieldExtension
 from .mask_errors import MaskErrors
@@ -29,6 +30,7 @@ def __getattr__(name: str) -> type[SchemaExtension]:
 
 __all__ = [
     "AddValidationRules",
+    "DisableIntrospection",
     "DisableValidation",
     "FieldExtension",
     "IgnoreContext",

--- a/strawberry/extensions/disable_introspection.py
+++ b/strawberry/extensions/disable_introspection.py
@@ -1,0 +1,36 @@
+from graphql.validation import NoSchemaIntrospectionCustomRule
+
+from strawberry.extensions import AddValidationRules
+
+
+class DisableIntrospection(AddValidationRules):
+    """Disable introspection queries.
+
+    Example:
+
+    ```python
+    import strawberry
+    from strawberry.extensions import DisableIntrospection
+
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def hello(self) -> str:
+            return "Hello, world!"
+
+
+    schema = strawberry.Schema(
+        Query,
+        extensions=[
+            DisableIntrospection(),
+        ],
+    )
+    ```
+    """
+
+    def __init__(self) -> None:
+        super().__init__([NoSchemaIntrospectionCustomRule])
+
+
+__all__ = ["DisableIntrospection"]

--- a/tests/schema/extensions/test_disable_introspection.py
+++ b/tests/schema/extensions/test_disable_introspection.py
@@ -23,3 +23,18 @@ def test_disables_introspection():
             "locations": [{"line": 1, "column": 9}],
         }
     ]
+
+
+def test_does_not_affect_non_introspection_queries():
+    @strawberry.type
+    class Query:
+        hello: str
+
+    schema = strawberry.Schema(
+        query=Query,
+        extensions=[DisableIntrospection()],
+    )
+
+    result = schema.execute_sync("query { __typename }")
+    assert result.data == {"__typename": "Query"}
+    assert result.errors is None

--- a/tests/schema/extensions/test_disable_introspection.py
+++ b/tests/schema/extensions/test_disable_introspection.py
@@ -1,0 +1,25 @@
+import strawberry
+from strawberry.extensions import DisableIntrospection
+
+
+def test_disables_introspection():
+    @strawberry.type
+    class Query:
+        hello: str
+
+    schema = strawberry.Schema(
+        query=Query,
+        extensions=[DisableIntrospection()],
+    )
+
+    result = schema.execute_sync("query { __schema { __typename } }")
+    assert result.data is None
+    assert result.errors is not None
+
+    formatted_errors = [err.formatted for err in result.errors]
+    assert formatted_errors == [
+        {
+            "message": "GraphQL introspection has been disabled, but the requested query contained the field '__schema'.",
+            "locations": [{"line": 1, "column": 9}],
+        }
+    ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
This PR adds a dedicated `DisableIntrospection` extension.

Disabling introspection was already possible using the `AddValidationRules` extension. But as discussed in #1329 this feature is hard to discover. I recently had to dig around myself to find it. This dedicated extension is more discoverable in our documentation and also hides the fact that it uses GraphQL Core underneath (which `AddValidationRules` doesn't).

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

* Fixes #1329

## Summary by Sourcery

Introduce a dedicated DisableIntrospection extension to simplify disabling schema introspection, including API exposure, documentation, tests, and release notes.

New Features:
- Introduce DisableIntrospection extension to disable GraphQL introspection queries via a dedicated API.

Enhancements:
- Register DisableIntrospection in the public extension registry for discoverability.

Documentation:
- Add user-facing documentation for DisableIntrospection in docs/extensions.

Tests:
- Add tests to verify that introspection queries are blocked when using DisableIntrospection.

Chores:
- Add a RELEASE.md entry to document the new minor release and its usage example.