### PR TITLE
Modify export_schema cli to include an extra EOF newline when --output option is provided

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+This release modifies export-schema cli to include an EOF newline if --output option is provided. This allows better review in github.com for the generated schema files.

--- a/strawberry/cli/commands/export_schema.py
+++ b/strawberry/cli/commands/export_schema.py
@@ -32,7 +32,7 @@ def export_schema(
     schema_text = print_schema(schema_symbol)
 
     if output:
-        Path(output).write_text(schema_text + "\n")
+        Path(output).write_text(schema_text + "\n", encoding="utf-8")
         typer.echo(f"Schema exported to {output}")
     else:
         print(schema_text)  # noqa: T201

--- a/strawberry/cli/commands/export_schema.py
+++ b/strawberry/cli/commands/export_schema.py
@@ -32,7 +32,7 @@ def export_schema(
     schema_text = print_schema(schema_symbol)
 
     if output:
-        Path(output).write_text(schema_text)
+        Path(output).write_text(schema_text + "\n")
         typer.echo(f"Schema exported to {output}")
     else:
         print(schema_text)  # noqa: T201

--- a/tests/cli/test_export_schema.py
+++ b/tests/cli/test_export_schema.py
@@ -94,5 +94,5 @@ def test_output_option(cli_app: Typer, cli_runner: CliRunner, tmp_path):
             "type User {\n"
             "  name: String!\n"
             "  age: Int!\n"
-            "}"
+            "}\n"
         )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

Modify export_schema cli to include an extra EOF newline when `--output` option is provided. This makes reviewing new schema files in github.com slightly easier.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Ensure that exporting the GraphQL schema to a file always appends a trailing newline when using the --output option to improve diffs in GitHub.

Enhancements:
- Append an extra newline to the schema text when writing to the specified output file

Documentation:
- Add RELEASE.md entry noting the new trailing newline behavior

Tests:
- Update CLI export_schema tests to expect the trailing EOF newline