### PR TITLE
Add an example query to the DisableIntrospection docs

### DIFF
--- a/docs/extensions/disable-introspection.md
+++ b/docs/extensions/disable-introspection.md
@@ -35,3 +35,37 @@ schema = strawberry.Schema(
 ## API reference:
 
 _No arguments_
+
+## Example query:
+
+Running any query including the introspection field `__schema` will result in an
+error. Consider the following query, for example:
+
+```graphql
+query {
+  __schema {
+    __typename
+  }
+}
+```
+
+Running it against the schema with the `DisableIntrospection` extension enabled
+will result in an error response indicating that introspection has been
+disabled:
+
+```json
+{
+  "data": null,
+  "errors": [
+    {
+      "message": "GraphQL introspection has been disabled, but the requested query contained the field '__schema'.",
+      "locations": [
+        {
+          "line": 2,
+          "column": 3
+        }
+      ]
+    }
+  ]
+}
+```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
This PR is a small follow-up to #3895, adding an example query to the documentation that showcases what happens when clients run introspection queries against a schema with introspection disabled.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Summary by Sourcery

Documentation:
- Add an example GraphQL introspection query and its error response to the DisableIntrospection documentation.