### PR TITLE
add `locate-definition` command to cli

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,15 @@
+Release type: patch
+
+Adds a new CLI command `strawberry locate-definition` that allows you to find the source location of a definition in the schema.
+
+```
+strawberry locate-definition path.to.schema:schema ObjectName
+```
+
+```
+strawberry locate-definition path.to.schema:schema ObjectName.fieldName
+```
+
+Results take the form of `path/to/file.py:line:column`.
+
+This can be used, for example, with the go to definition feature of VS Code's Relay extension (configured via the `relay.pathToLocateCommand` setting).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,4 @@
-Release type: patch
+Release type: minor
 
 Adds a new CLI command `strawberry locate-definition` that allows you to find the source location of a definition in the schema.
 
@@ -10,6 +10,6 @@ strawberry locate-definition path.to.schema:schema ObjectName
 strawberry locate-definition path.to.schema:schema ObjectName.fieldName
 ```
 
-Results take the form of `path/to/file.py:line:column`.
+Results take the form of `path/to/file.py:line:column`, for example: `src/models/user.py:45:12`.
 
 This can be used, for example, with the go to definition feature of VS Code's Relay extension (configured via the `relay.pathToLocateCommand` setting).

--- a/TWEET.md
+++ b/TWEET.md
@@ -1,0 +1,6 @@
+🆕 Release $version is out! Thanks to $contributor for the PR 👏
+
+✨ New CLI command: `strawberry locate-definition` - find source locations of
+schema definitions! Perfect for @code's Relay extension 🎯 /cc @RelayFramework
+
+Get it here 👉 $release_url

--- a/docs/cli/locate-definition.md
+++ b/docs/cli/locate-definition.md
@@ -18,4 +18,23 @@ strawberry locate-definition path.to.schema:schema ObjectName.fieldName
 ```
 
 If found, the result will be printed to the console in the form of
-`path/to/file.py:line:column`.
+`path/to/file.py:line:column`, for example: `src/models/user.py:45:12`.
+
+## Using with VS Code's Relay extension
+
+You can use this command with the go to definition feature of VS Code's Relay extension (configured via the `relay.pathToLocateCommand` setting).
+
+You can create a script to do this, for example:
+
+```sh
+# ./locate-definition.sh
+strawberry locate-definition "$2"
+```
+
+Then, you can set the `relay.pathToLocateCommand` setting to the path of the script, e.g.:
+
+```json
+"relay.pathToLocateCommand": "./locate-definition.sh"
+```
+
+You can then use the go to definition feature to navigate to the definition of a model or field.

--- a/docs/cli/locate-definition.md
+++ b/docs/cli/locate-definition.md
@@ -29,7 +29,7 @@ You can create a script to do this, for example:
 
 ```sh
 # ./locate-definition.sh
-strawberry locate-definition "$2"
+strawberry locate-definition path.to.schema:schema "$2"
 ```
 
 Then, you can set the `relay.pathToLocateCommand` setting to the path of the

--- a/docs/cli/locate-definition.md
+++ b/docs/cli/locate-definition.md
@@ -1,0 +1,19 @@
+---
+title: Locate definition
+---
+
+# Locate definition
+
+Strawberry provides a CLI command `strawberry locate-definition` that allows you to find the source location of a definition within the schema.
+
+You can provide either a model name or a model name and field name, e.g.:
+
+```
+strawberry locate-definition path.to.schema:schema ObjectName
+```
+
+```
+strawberry locate-definition path.to.schema:schema ObjectName.fieldName
+```
+
+If found, the result will be printed to the console in the form of `path/to/file.py:line:column`.

--- a/docs/cli/locate-definition.md
+++ b/docs/cli/locate-definition.md
@@ -22,7 +22,8 @@ If found, the result will be printed to the console in the form of
 
 ## Using with VS Code's Relay extension
 
-You can use this command with the go to definition feature of VS Code's Relay extension (configured via the `relay.pathToLocateCommand` setting).
+You can use this command with the go to definition feature of VS Code's Relay
+extension (configured via the `relay.pathToLocateCommand` setting).
 
 You can create a script to do this, for example:
 
@@ -31,10 +32,12 @@ You can create a script to do this, for example:
 strawberry locate-definition "$2"
 ```
 
-Then, you can set the `relay.pathToLocateCommand` setting to the path of the script, e.g.:
+Then, you can set the `relay.pathToLocateCommand` setting to the path of the
+script, e.g.:
 
 ```json
 "relay.pathToLocateCommand": "./locate-definition.sh"
 ```
 
-You can then use the go to definition feature to navigate to the definition of a model or field.
+You can then use the go to definition feature to navigate to the definition of a
+model or field.

--- a/strawberry/cli/__init__.py
+++ b/strawberry/cli/__init__.py
@@ -2,6 +2,7 @@ try:
     from .app import app
     from .commands.codegen import codegen as codegen  # noqa: PLC0414
     from .commands.export_schema import export_schema as export_schema  # noqa: PLC0414
+    from .commands.locate_definition import locate_definition as locate_definition  # noqa: PLC0414
     from .commands.schema_codegen import (
         schema_codegen as schema_codegen,  # noqa: PLC0414
     )

--- a/strawberry/cli/commands/locate_definition.py
+++ b/strawberry/cli/commands/locate_definition.py
@@ -1,3 +1,4 @@
+import sys
 import typer
 
 from rich.console import Console
@@ -37,7 +38,7 @@ def locate_definition(
 
     if not schema_type:
         err_console.print(f"Definition not found: {symbol}")
-        return
+        sys.exit(1)
 
     location = (
         finder.find_class_attribute_from_object(schema_type.origin, field)
@@ -47,6 +48,6 @@ def locate_definition(
 
     if not location:
         err_console.print(f"Definition not found: {symbol}")
-        return
+        sys.exit(1)
 
     typer.echo(f"{location.path}:{location.error_line}:{location.error_column + 1}")

--- a/strawberry/cli/commands/locate_definition.py
+++ b/strawberry/cli/commands/locate_definition.py
@@ -1,0 +1,52 @@
+import typer
+
+from rich.console import Console
+
+from strawberry.cli.app import app
+from strawberry.cli.utils import load_schema
+from strawberry.exceptions.utils.source_finder import SourceFinder
+
+err_console = Console(stderr=True)
+
+
+@app.command(help="Locate a definition in the schema")
+def locate_definition(
+    schema: str,
+    symbol: str,
+    app_dir: str = typer.Option(
+        ".",
+        "--app-dir",
+        show_default=True,
+        help=(
+            "Look for the module in the specified directory, by adding this to the "
+            "PYTHONPATH. Defaults to the current working directory. "
+            "Works the same as `--app-dir` in uvicorn."
+        ),
+    ),
+) -> None:
+    schema_symbol = load_schema(schema, app_dir)
+
+    finder = SourceFinder()
+
+    if "." in symbol:
+        model, field = symbol.split(".")
+    else:
+        model, field = symbol, None
+
+    schema_type = schema_symbol.get_type_by_name(model)
+
+    if not schema_type:
+        err_console.print(f"Definition not found: {symbol}")
+        return
+
+    location = (
+        finder.find_class_attribute_from_object(schema_type.origin, field)
+        if field
+        else finder.find_class_from_object(schema_type.origin)
+    )
+
+    if not location:
+        err_console.print(f"Definition not found: {symbol}")
+        return
+
+    typer.echo(f"{location.path}:{location.error_line}:{location.error_column + 1}")

--- a/strawberry/cli/commands/locate_definition.py
+++ b/strawberry/cli/commands/locate_definition.py
@@ -12,7 +12,7 @@ from strawberry.utils.locate_definition import (
 err_console = Console(stderr=True)
 
 
-@app.command(help="Locate a definition in the schema")
+@app.command(help="Locate a definition in the schema (output: path:line:column)")
 def locate_definition(
     schema: str,
     symbol: str,
@@ -29,9 +29,7 @@ def locate_definition(
 ) -> None:
     schema_symbol = load_schema(schema, app_dir)
 
-    location = locate_definition_util(schema_symbol, symbol)
-
-    if location:
+    if location := locate_definition_util(schema_symbol, symbol):
         typer.echo(location)
     else:
         err_console.print(f"Definition not found: {symbol}")

--- a/strawberry/cli/commands/locate_definition.py
+++ b/strawberry/cli/commands/locate_definition.py
@@ -5,7 +5,6 @@ from rich.console import Console
 
 from strawberry.cli.app import app
 from strawberry.cli.utils import load_schema
-from strawberry.exceptions.utils.source_finder import SourceFinder
 from strawberry.utils.locate_definition import (
     locate_definition as locate_definition_util,
 )

--- a/strawberry/exceptions/utils/source_finder.py
+++ b/strawberry/exceptions/utils/source_finder.py
@@ -512,7 +512,8 @@ class LibCSTSourceFinder:
         path = Path(scalar_definition._source_file)
         source = path.read_text()
 
-        matcher = m.Call(
+        # Try to find direct strawberry.scalar() calls with name parameter
+        direct_matcher = m.Call(
             func=m.Attribute(value=m.Name(value="strawberry"), attr=m.Name("scalar"))
             | m.Name("scalar"),
             args=[
@@ -526,31 +527,89 @@ class LibCSTSourceFinder:
             ],
         )
 
-        scalar_calls = self._find(source, matcher)
+        direct_calls = self._find(source, direct_matcher)
+        if direct_calls:
+            return self._create_scalar_exception_source(
+                path, source, direct_calls[0], scalar_definition, is_newtype=False
+            )
 
-        if not scalar_calls:
-            return None  # pragma: no cover
-
-        scalar_call_node = scalar_calls[0]
-
-        argument_node = m.findall(
-            scalar_call_node,
-            m.Arg(
-                keyword=m.Name(value="name"),
-            ),
+        # Try to find strawberry.scalar() calls with NewType pattern
+        newtype_matcher = m.Call(
+            func=m.Attribute(value=m.Name(value="strawberry"), attr=m.Name("scalar"))
+            | m.Name("scalar"),
+            args=[
+                m.Arg(
+                    value=m.Call(
+                        func=m.Name(value="NewType"),
+                        args=[
+                            m.Arg(
+                                value=m.SimpleString(
+                                    value=f"'{scalar_definition.name}'"
+                                )
+                                | m.SimpleString(value=f'"{scalar_definition.name}"'),
+                            ),
+                            m.ZeroOrMore(),
+                        ],
+                    )
+                ),
+                m.ZeroOrMore(),
+            ],
         )
 
-        position = self._position_metadata[scalar_call_node]
-        argument_node_position = self._position_metadata[argument_node[0]]
+        newtype_calls = self._find(source, newtype_matcher)
+        if newtype_calls:
+            return self._create_scalar_exception_source(
+                path, source, newtype_calls[0], scalar_definition, is_newtype=True
+            )
+
+        return None  # pragma: no cover
+
+    def _create_scalar_exception_source(
+        self,
+        path: Path,
+        source: str,
+        call_node: Any,
+        scalar_definition: ScalarDefinition,
+        is_newtype: bool,
+    ) -> ExceptionSource:
+        """Helper method to create ExceptionSource for scalar calls."""
+        import libcst.matchers as m
+
+        if is_newtype:
+            # For NewType pattern, find the string argument within the NewType call
+            newtype_nodes = m.findall(call_node, m.Call(func=m.Name(value="NewType")))
+            if not newtype_nodes:
+                return None  # pragma: no cover
+
+            target_node = newtype_nodes[0]
+            string_nodes = m.findall(
+                target_node,
+                m.SimpleString(value=f"'{scalar_definition.name}'")
+                | m.SimpleString(value=f'"{scalar_definition.name}"'),
+            )
+            if not string_nodes:
+                return None  # pragma: no cover
+
+            target_node = string_nodes[0]
+        else:
+            # For direct calls, find the name argument
+            target_nodes = m.findall(call_node, m.Arg(keyword=m.Name(value="name")))
+            if not target_nodes:
+                return None  # pragma: no cover
+
+            target_node = target_nodes[0]
+
+        position = self._position_metadata[call_node]
+        target_position = self._position_metadata[target_node]
 
         return ExceptionSource(
             path=path,
             code=source,
             start_line=position.start.line,
             end_line=position.end.line,
-            error_line=argument_node_position.start.line,
-            error_column=argument_node_position.start.column,
-            error_column_end=argument_node_position.end.column,
+            error_line=target_position.start.line,
+            error_column=target_position.start.column,
+            error_column_end=target_position.end.column,
         )
 
 

--- a/strawberry/exceptions/utils/source_finder.py
+++ b/strawberry/exceptions/utils/source_finder.py
@@ -166,7 +166,8 @@ class LibCSTSourceFinder:
         attribute_definitions = m.findall(
             class_def,
             m.AssignTarget(target=m.Name(value=attribute_name))
-            | m.AnnAssign(target=m.Name(value=attribute_name)),
+            | m.AnnAssign(target=m.Name(value=attribute_name))
+            | m.FunctionDef(name=m.Name(value=attribute_name)),
         )
 
         if not attribute_definitions:

--- a/strawberry/exceptions/utils/source_finder.py
+++ b/strawberry/exceptions/utils/source_finder.py
@@ -571,7 +571,7 @@ class LibCSTSourceFinder:
         call_node: Any,
         scalar_definition: ScalarDefinition,
         is_newtype: bool,
-    ) -> ExceptionSource:
+    ) -> Optional[ExceptionSource]:
         """Helper method to create ExceptionSource for scalar calls."""
         import libcst.matchers as m
 

--- a/strawberry/types/enum.py
+++ b/strawberry/types/enum.py
@@ -45,6 +45,10 @@ class EnumDefinition(StrawberryType):
     def is_graphql_generic(self) -> bool:
         return False
 
+    @property
+    def origin(self) -> type:
+        return self.wrapped_cls
+
 
 # TODO: remove duplication of EnumValueDefinition and EnumValue
 @dataclasses.dataclass

--- a/strawberry/types/union.py
+++ b/strawberry/types/union.py
@@ -283,6 +283,10 @@ def union(
             union._source_file = frame.f_code.co_filename
             union._source_line = frame.f_lineno
 
+            # TODO: here union._source_file could be "<string>"
+            # (when using future annotations)
+            # we should find a better way to handle this
+
         return union
 
     warnings.warn(

--- a/strawberry/utils/locate_definition.py
+++ b/strawberry/utils/locate_definition.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
-from strawberry.exceptions.utils.source_finder import SourceFinder
 
+from strawberry.exceptions.utils.source_finder import SourceFinder
 from strawberry.schema.schema import Schema
 
 

--- a/strawberry/utils/locate_definition.py
+++ b/strawberry/utils/locate_definition.py
@@ -13,7 +13,7 @@ def locate_definition(schema_symbol: Schema, symbol: str) -> str | None:
     finder = SourceFinder()
 
     if "." in symbol:
-        model, field = symbol.split(".")
+        model, field = symbol.split(".", 1)
     else:
         model, field = symbol, None
 

--- a/strawberry/utils/locate_definition.py
+++ b/strawberry/utils/locate_definition.py
@@ -25,8 +25,10 @@ def locate_definition(schema_symbol: Schema, symbol: str) -> str | None:
         return None
 
     if field:
+        assert not isinstance(schema_type, StrawberryUnion)
+
         location = finder.find_class_attribute_from_object(
-            schema_type.origin,
+            schema_type.origin,  # type: ignore
             to_snake_case(field)
             if schema_symbol.config.name_converter.auto_camel_case
             else field,

--- a/strawberry/utils/locate_definition.py
+++ b/strawberry/utils/locate_definition.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
+from typing import TYPE_CHECKING
 
 from strawberry.exceptions.utils.source_finder import SourceFinder
-from strawberry.schema.schema import Schema
+
+if TYPE_CHECKING:
+    from strawberry.schema.schema import Schema
 
 
 def locate_definition(schema_symbol: Schema, symbol: str) -> str | None:

--- a/strawberry/utils/locate_definition.py
+++ b/strawberry/utils/locate_definition.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING
 
 from strawberry.exceptions.utils.source_finder import SourceFinder
 
+from strawberry.utils.str_converters import to_snake_case
+
 if TYPE_CHECKING:
     from strawberry.schema.schema import Schema
 
@@ -22,7 +24,9 @@ def locate_definition(schema_symbol: Schema, symbol: str) -> str | None:
         return None
 
     location = (
-        finder.find_class_attribute_from_object(schema_type.origin, field)
+        finder.find_class_attribute_from_object(
+            schema_type.origin, to_snake_case(field)
+        )
         if field
         else finder.find_class_from_object(schema_type.origin)
     )

--- a/strawberry/utils/locate_definition.py
+++ b/strawberry/utils/locate_definition.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from strawberry.exceptions.utils.source_finder import SourceFinder
-
 from strawberry.utils.str_converters import to_snake_case
 
 if TYPE_CHECKING:

--- a/strawberry/utils/locate_definition.py
+++ b/strawberry/utils/locate_definition.py
@@ -24,7 +24,10 @@ def locate_definition(schema_symbol: Schema, symbol: str) -> str | None:
 
     location = (
         finder.find_class_attribute_from_object(
-            schema_type.origin, to_snake_case(field)
+            schema_type.origin,
+            to_snake_case(field)
+            if schema_symbol.config.name_converter.auto_camel_case
+            else field,
         )
         if field
         else finder.find_class_from_object(schema_type.origin)

--- a/strawberry/utils/locate_definition.py
+++ b/strawberry/utils/locate_definition.py
@@ -23,6 +23,8 @@ def locate_definition(schema_symbol: Schema, symbol: str) -> str | None:
         return None
 
     location = (
+        # TODO: store the GraphQL name on the schema once we generate the schema
+        # so we don't have to convert names
         finder.find_class_attribute_from_object(
             schema_type.origin,
             to_snake_case(field)

--- a/strawberry/utils/locate_definition.py
+++ b/strawberry/utils/locate_definition.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+from strawberry.exceptions.utils.source_finder import SourceFinder
+
+from strawberry.schema.schema import Schema
+
+
+def locate_definition(schema_symbol: Schema, symbol: str) -> str | None:
+    finder = SourceFinder()
+
+    if "." in symbol:
+        model, field = symbol.split(".")
+    else:
+        model, field = symbol, None
+
+    schema_type = schema_symbol.get_type_by_name(model)
+
+    if not schema_type:
+        return None
+
+    location = (
+        finder.find_class_attribute_from_object(schema_type.origin, field)
+        if field
+        else finder.find_class_from_object(schema_type.origin)
+    )
+
+    if not location:
+        return None
+
+    return f"{location.path}:{location.error_line}:{location.error_column + 1}"

--- a/tests/cli/test_export_schema.py
+++ b/tests/cli/test_export_schema.py
@@ -1,3 +1,4 @@
+from inline_snapshot import snapshot
 from typer import Typer
 from typer.testing import CliRunner
 
@@ -7,15 +8,40 @@ def test_schema_export(cli_app: Typer, cli_runner: CliRunner):
     result = cli_runner.invoke(cli_app, ["export-schema", selector])
 
     assert result.exit_code == 0
-    assert result.stdout == (
-        "type Query {\n"
-        "  user: User!\n"
-        "}\n"
-        "\n"
-        "type User {\n"
-        "  name: String!\n"
-        "  age: Int!\n"
-        "}\n"
+    assert result.stdout == snapshot(
+        """\
+type A {
+  name: String!
+}
+
+type B {
+  a: A!
+}
+
+scalar ExampleScalar
+
+union InlineUnion = A | B
+
+type Query {
+  user: User!
+}
+
+enum Role {
+  ADMIN
+  USER
+}
+
+union UnionExample = A | B
+
+type User {
+  name: String!
+  age: Int!
+  role: Role!
+  exampleScalar: ExampleScalar!
+  unionExample: UnionExample!
+  inlineUnion: InlineUnion!
+}
+"""
     )
 
 
@@ -86,13 +112,38 @@ def test_output_option(cli_app: Typer, cli_runner: CliRunner, tmp_path):
         )
 
         assert result.exit_code == 0
-        assert output.read_text() == (
-            "type Query {\n"
-            "  user: User!\n"
-            "}\n"
-            "\n"
-            "type User {\n"
-            "  name: String!\n"
-            "  age: Int!\n"
-            "}\n"
+        assert output.read_text() == snapshot(
+            """\
+type A {
+  name: String!
+}
+
+type B {
+  a: A!
+}
+
+scalar ExampleScalar
+
+union InlineUnion = A | B
+
+type Query {
+  user: User!
+}
+
+enum Role {
+  ADMIN
+  USER
+}
+
+union UnionExample = A | B
+
+type User {
+  name: String!
+  age: Int!
+  role: Role!
+  exampleScalar: ExampleScalar!
+  unionExample: UnionExample!
+  inlineUnion: InlineUnion!
+}
+"""
         )

--- a/tests/cli/test_locate_definition.py
+++ b/tests/cli/test_locate_definition.py
@@ -1,5 +1,16 @@
+from pathlib import Path
+
+from inline_snapshot import snapshot
 from typer import Typer
 from typer.testing import CliRunner
+
+
+def _simplify_path(path: str) -> str:
+    path = Path(path)
+
+    root = Path(__file__).parents[1]
+
+    return str(path.relative_to(root))
 
 
 def test_find_model_name(cli_app: Typer, cli_runner: CliRunner):
@@ -7,8 +18,8 @@ def test_find_model_name(cli_app: Typer, cli_runner: CliRunner):
     result = cli_runner.invoke(cli_app, ["locate-definition", selector, "User"])
 
     assert result.exit_code == 0
-    assert result.stdout.strip().endswith(
-        "tests/fixtures/sample_package/sample_module.py:10:7"
+    assert _simplify_path(result.stdout.strip()) == snapshot(
+        "fixtures/sample_package/sample_module.py:38:7"
     )
 
 
@@ -17,8 +28,8 @@ def test_find_model_field(cli_app: Typer, cli_runner: CliRunner):
     result = cli_runner.invoke(cli_app, ["locate-definition", selector, "User.name"])
 
     assert result.exit_code == 0
-    assert result.stdout.strip().endswith(
-        "tests/fixtures/sample_package/sample_module.py:11:5"
+    assert _simplify_path(result.stdout.strip()) == snapshot(
+        "fixtures/sample_package/sample_module.py:39:5"
     )
 
 
@@ -27,7 +38,7 @@ def test_find_missing_model(cli_app: Typer, cli_runner: CliRunner):
     result = cli_runner.invoke(cli_app, ["locate-definition", selector, "Missing"])
 
     assert result.exit_code == 1
-    assert result.stdout.strip() == "Definition not found: Missing"
+    assert result.stdout.strip() == snapshot("Definition not found: Missing")
 
 
 def test_find_missing_model_field(cli_app: Typer, cli_runner: CliRunner):
@@ -37,7 +48,7 @@ def test_find_missing_model_field(cli_app: Typer, cli_runner: CliRunner):
     )
 
     assert result.exit_code == 1
-    assert result.stdout.strip() == "Definition not found: Missing.field"
+    assert result.stdout.strip() == snapshot("Definition not found: Missing.field")
 
 
 def test_find_missing_schema(cli_app: Typer, cli_runner: CliRunner):

--- a/tests/cli/test_locate_definition.py
+++ b/tests/cli/test_locate_definition.py
@@ -2,7 +2,7 @@ from typer import Typer
 from typer.testing import CliRunner
 
 
-def test_find_model_name(mocker, cli_app: Typer, cli_runner: CliRunner):
+def test_find_model_name(cli_app: Typer, cli_runner: CliRunner):
     selector = "tests.fixtures.sample_package.sample_module:schema"
     result = cli_runner.invoke(cli_app, ["locate-definition", selector, "User"])
 
@@ -12,7 +12,7 @@ def test_find_model_name(mocker, cli_app: Typer, cli_runner: CliRunner):
     )
 
 
-def test_find_model_field(mocker, cli_app: Typer, cli_runner: CliRunner):
+def test_find_model_field(cli_app: Typer, cli_runner: CliRunner):
     selector = "tests.fixtures.sample_package.sample_module:schema"
     result = cli_runner.invoke(cli_app, ["locate-definition", selector, "User.name"])
 
@@ -22,7 +22,7 @@ def test_find_model_field(mocker, cli_app: Typer, cli_runner: CliRunner):
     )
 
 
-def test_find_missing_model(mocker, cli_app: Typer, cli_runner: CliRunner):
+def test_find_missing_model(cli_app: Typer, cli_runner: CliRunner):
     selector = "tests.fixtures.sample_package.sample_module:schema"
     result = cli_runner.invoke(cli_app, ["locate-definition", selector, "Missing"])
 
@@ -30,7 +30,7 @@ def test_find_missing_model(mocker, cli_app: Typer, cli_runner: CliRunner):
     assert result.stdout.strip() == "Definition not found: Missing"
 
 
-def test_find_missing_model_field(mocker, cli_app: Typer, cli_runner: CliRunner):
+def test_find_missing_model_field(cli_app: Typer, cli_runner: CliRunner):
     selector = "tests.fixtures.sample_package.sample_module:schema"
     result = cli_runner.invoke(
         cli_app, ["locate-definition", selector, "Missing.field"]
@@ -38,3 +38,10 @@ def test_find_missing_model_field(mocker, cli_app: Typer, cli_runner: CliRunner)
 
     assert result.exit_code == 1
     assert result.stdout.strip() == "Definition not found: Missing.field"
+
+
+def test_find_missing_schema(cli_app: Typer, cli_runner: CliRunner):
+    selector = "tests.fixtures.sample_package.sample_module:missing"
+    result = cli_runner.invoke(cli_app, ["locate-definition", selector, "User"])
+
+    assert result.exit_code == 2

--- a/tests/cli/test_locate_definition.py
+++ b/tests/cli/test_locate_definition.py
@@ -1,0 +1,22 @@
+from typer import Typer
+from typer.testing import CliRunner
+
+
+def test_find_model_name(mocker, cli_app: Typer, cli_runner: CliRunner):
+    selector = "tests.fixtures.sample_package.sample_module:schema"
+    result = cli_runner.invoke(cli_app, ["locate-definition", selector, "User"])
+
+    assert result.exit_code == 0
+    assert result.stdout.strip().endswith(
+        "tests/fixtures/sample_package/sample_module.py:10:7"
+    )
+
+
+def test_find_model_field(mocker, cli_app: Typer, cli_runner: CliRunner):
+    selector = "tests.fixtures.sample_package.sample_module:schema"
+    result = cli_runner.invoke(cli_app, ["locate-definition", selector, "User.name"])
+
+    assert result.exit_code == 0
+    assert result.stdout.strip().endswith(
+        "tests/fixtures/sample_package/sample_module.py:11:5"
+    )

--- a/tests/cli/test_locate_definition.py
+++ b/tests/cli/test_locate_definition.py
@@ -4,6 +4,10 @@ from inline_snapshot import snapshot
 from typer import Typer
 from typer.testing import CliRunner
 
+from tests.typecheckers.utils.marks import skip_on_windows
+
+pytestmark = skip_on_windows
+
 
 def _simplify_path(path: str) -> str:
     path = Path(path)

--- a/tests/cli/test_locate_definition.py
+++ b/tests/cli/test_locate_definition.py
@@ -20,3 +20,21 @@ def test_find_model_field(mocker, cli_app: Typer, cli_runner: CliRunner):
     assert result.stdout.strip().endswith(
         "tests/fixtures/sample_package/sample_module.py:11:5"
     )
+
+
+def test_find_missing_model(mocker, cli_app: Typer, cli_runner: CliRunner):
+    selector = "tests.fixtures.sample_package.sample_module:schema"
+    result = cli_runner.invoke(cli_app, ["locate-definition", selector, "Missing"])
+
+    assert result.exit_code == 1
+    assert result.stdout.strip() == "Definition not found: Missing"
+
+
+def test_find_missing_model_field(mocker, cli_app: Typer, cli_runner: CliRunner):
+    selector = "tests.fixtures.sample_package.sample_module:schema"
+    result = cli_runner.invoke(
+        cli_app, ["locate-definition", selector, "Missing.field"]
+    )
+
+    assert result.exit_code == 1
+    assert result.stdout.strip() == "Definition not found: Missing.field"

--- a/tests/fixtures/sample_package/sample_module.py
+++ b/tests/fixtures/sample_package/sample_module.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Annotated, NewType
+from typing import Annotated, NewType, Union
 
 import strawberry
 
@@ -20,7 +20,7 @@ class B:
     a: A
 
 
-UnionExample = Annotated[A | B, strawberry.union("UnionExample")]
+UnionExample = Annotated[Union[A, B], strawberry.union("UnionExample")]
 
 
 class SampleClass:
@@ -41,7 +41,7 @@ class User:
     role: Role
     example_scalar: ExampleScalar
     union_example: UnionExample
-    inline_union: Annotated[A | B, strawberry.union("InlineUnion")]
+    inline_union: Annotated[Union[A, B], strawberry.union("InlineUnion")]
 
 
 @strawberry.type

--- a/tests/fixtures/sample_package/sample_module.py
+++ b/tests/fixtures/sample_package/sample_module.py
@@ -1,6 +1,26 @@
 from enum import Enum
+from typing import Annotated, NewType
 
 import strawberry
+
+ExampleScalar = strawberry.scalar(
+    NewType("ExampleScalar", object),
+    serialize=lambda v: v,
+    parse_value=lambda v: v,
+)
+
+
+@strawberry.type
+class A:
+    name: str
+
+
+@strawberry.type
+class B:
+    a: A
+
+
+UnionExample = Annotated[A | B, strawberry.union("UnionExample")]
 
 
 class SampleClass:
@@ -19,6 +39,9 @@ class User:
     name: str
     age: int
     role: Role
+    example_scalar: ExampleScalar
+    union_example: UnionExample
+    inline_union: Annotated[A | B, strawberry.union("InlineUnion")]
 
 
 @strawberry.type

--- a/tests/fixtures/sample_package/sample_module.py
+++ b/tests/fixtures/sample_package/sample_module.py
@@ -1,3 +1,5 @@
+from enum import Enum
+
 import strawberry
 
 
@@ -6,10 +8,17 @@ class SampleClass:
         self.schema = schema
 
 
+@strawberry.enum
+class Role(Enum):
+    ADMIN = "ADMIN"
+    USER = "USER"
+
+
 @strawberry.type
 class User:
     name: str
     age: int
+    role: Role
 
 
 @strawberry.type

--- a/tests/utils/test_locate_definition.py
+++ b/tests/utils/test_locate_definition.py
@@ -8,7 +8,16 @@ def test_find_model_name(mocker):
     )
     result = locate_definition(schema, "User")
 
-    assert result.endswith("tests/fixtures/sample_package/sample_module.py:10:7")
+    assert result.endswith("tests/fixtures/sample_package/sample_module.py:18:7")
+
+
+def test_find_model_name_enum(mocker):
+    schema = import_module_symbol(
+        "tests.fixtures.sample_package.sample_module", default_symbol_name="schema"
+    )
+    result = locate_definition(schema, "Role")
+
+    assert result.endswith("tests/fixtures/sample_package/sample_module.py:12:7")
 
 
 def test_find_model_field(mocker):
@@ -17,7 +26,16 @@ def test_find_model_field(mocker):
     )
     result = locate_definition(schema, "User.name")
 
-    assert result.endswith("tests/fixtures/sample_package/sample_module.py:11:5")
+    assert result.endswith("tests/fixtures/sample_package/sample_module.py:19:5")
+
+
+def test_find_model_field_with_resolver(mocker):
+    schema = import_module_symbol(
+        "tests.fixtures.sample_package.sample_module", default_symbol_name="schema"
+    )
+    result = locate_definition(schema, "Query.user")
+
+    assert result.endswith("tests/fixtures/sample_package/sample_module.py:27:5")
 
 
 def test_find_missing_model(mocker):

--- a/tests/utils/test_locate_definition.py
+++ b/tests/utils/test_locate_definition.py
@@ -4,6 +4,9 @@ from inline_snapshot import snapshot
 
 from strawberry.utils.importer import import_module_symbol
 from strawberry.utils.locate_definition import locate_definition
+from tests.typecheckers.utils.marks import skip_on_windows
+
+pytestmark = skip_on_windows
 
 
 def _simplify_path(path: str) -> str:

--- a/tests/utils/test_locate_definition.py
+++ b/tests/utils/test_locate_definition.py
@@ -1,44 +1,86 @@
+from pathlib import Path
+
+from inline_snapshot import snapshot
+
 from strawberry.utils.importer import import_module_symbol
 from strawberry.utils.locate_definition import locate_definition
 
 
-def test_find_model_name(mocker):
+def _simplify_path(path: str) -> str:
+    path = Path(path)
+
+    root = Path(__file__).parents[1]
+
+    return str(path.relative_to(root))
+
+
+def test_find_model_name() -> None:
     schema = import_module_symbol(
         "tests.fixtures.sample_package.sample_module", default_symbol_name="schema"
     )
     result = locate_definition(schema, "User")
 
-    assert result.endswith("tests/fixtures/sample_package/sample_module.py:18:7")
+    assert _simplify_path(result) == snapshot(
+        "fixtures/sample_package/sample_module.py:38:7"
+    )
 
 
-def test_find_model_name_enum(mocker):
+def test_find_model_name_enum() -> None:
     schema = import_module_symbol(
         "tests.fixtures.sample_package.sample_module", default_symbol_name="schema"
     )
     result = locate_definition(schema, "Role")
 
-    assert result.endswith("tests/fixtures/sample_package/sample_module.py:12:7")
+    assert _simplify_path(result) == snapshot(
+        "fixtures/sample_package/sample_module.py:32:7"
+    )
 
 
-def test_find_model_field(mocker):
+def test_find_model_name_scalar() -> None:
+    schema = import_module_symbol(
+        "tests.fixtures.sample_package.sample_module", default_symbol_name="schema"
+    )
+    result = locate_definition(schema, "ExampleScalar")
+
+    assert _simplify_path(result) == snapshot(
+        "fixtures/sample_package/sample_module.py:7:13"
+    )
+
+
+def test_find_model_field() -> None:
     schema = import_module_symbol(
         "tests.fixtures.sample_package.sample_module", default_symbol_name="schema"
     )
     result = locate_definition(schema, "User.name")
 
-    assert result.endswith("tests/fixtures/sample_package/sample_module.py:19:5")
+    assert _simplify_path(result) == snapshot(
+        "fixtures/sample_package/sample_module.py:39:5"
+    )
 
 
-def test_find_model_field_with_resolver(mocker):
+def test_find_model_field_scalar() -> None:
+    schema = import_module_symbol(
+        "tests.fixtures.sample_package.sample_module", default_symbol_name="schema"
+    )
+    result = locate_definition(schema, "User.example_scalar")
+
+    assert _simplify_path(result) == snapshot(
+        "fixtures/sample_package/sample_module.py:42:5"
+    )
+
+
+def test_find_model_field_with_resolver() -> None:
     schema = import_module_symbol(
         "tests.fixtures.sample_package.sample_module", default_symbol_name="schema"
     )
     result = locate_definition(schema, "Query.user")
 
-    assert result.endswith("tests/fixtures/sample_package/sample_module.py:27:5")
+    assert _simplify_path(result) == snapshot(
+        "fixtures/sample_package/sample_module.py:50:5"
+    )
 
 
-def test_find_missing_model(mocker):
+def test_find_missing_model() -> None:
     schema = import_module_symbol(
         "tests.fixtures.sample_package.sample_module", default_symbol_name="schema"
     )
@@ -47,10 +89,32 @@ def test_find_missing_model(mocker):
     assert result is None
 
 
-def test_find_missing_model_field(mocker):
+def test_find_missing_model_field() -> None:
     schema = import_module_symbol(
         "tests.fixtures.sample_package.sample_module", default_symbol_name="schema"
     )
     result = locate_definition(schema, "Missing.field")
 
     assert result is None
+
+
+def test_find_union() -> None:
+    schema = import_module_symbol(
+        "tests.fixtures.sample_package.sample_module", default_symbol_name="schema"
+    )
+    result = locate_definition(schema, "UnionExample")
+
+    assert _simplify_path(result) == snapshot(
+        "fixtures/sample_package/sample_module.py:23:16"
+    )
+
+
+def test_find_inline_union() -> None:
+    schema = import_module_symbol(
+        "tests.fixtures.sample_package.sample_module", default_symbol_name="schema"
+    )
+    result = locate_definition(schema, "InlineUnion")
+
+    assert _simplify_path(result) == snapshot(
+        "fixtures/sample_package/sample_module.py:44:19"
+    )

--- a/tests/utils/test_locate_definition.py
+++ b/tests/utils/test_locate_definition.py
@@ -1,0 +1,38 @@
+from strawberry.utils.importer import import_module_symbol
+from strawberry.utils.locate_definition import locate_definition
+
+
+def test_find_model_name(mocker):
+    schema = import_module_symbol(
+        "tests.fixtures.sample_package.sample_module", default_symbol_name="schema"
+    )
+    result = locate_definition(schema, "User")
+
+    assert result.endswith("tests/fixtures/sample_package/sample_module.py:10:7")
+
+
+def test_find_model_field(mocker):
+    schema = import_module_symbol(
+        "tests.fixtures.sample_package.sample_module", default_symbol_name="schema"
+    )
+    result = locate_definition(schema, "User.name")
+
+    assert result.endswith("tests/fixtures/sample_package/sample_module.py:11:5")
+
+
+def test_find_missing_model(mocker):
+    schema = import_module_symbol(
+        "tests.fixtures.sample_package.sample_module", default_symbol_name="schema"
+    )
+    result = locate_definition(schema, "Missing")
+
+    assert result is None
+
+
+def test_find_missing_model_field(mocker):
+    schema = import_module_symbol(
+        "tests.fixtures.sample_package.sample_module", default_symbol_name="schema"
+    )
+    result = locate_definition(schema, "Missing.field")
+
+    assert result is None


### PR DESCRIPTION
## Description

Adds a command to locate the definition of an entity within the source code.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [X] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
- [X] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Add a new `strawberry locate-definition` command backed by a `locate_definition` utility to locate schema class and field definitions in source code, extend the source finder to detect methods, and include tests and documentation.

New Features:
- Introduce `locate-definition` CLI command to find source locations of schema types and fields
- Add `locate_definition` utility in `strawberry.utils` to locate class and attribute definitions

Enhancements:
- Extend `SourceFinder` to recognize method definitions when locating class attributes

Documentation:
- Add CLI user guide for `locate-definition` and update release notes

Tests:
- Add CLI and utility tests for successful and missing definition lookups