### PR TITLE
[WIP] Add websockets support to Sanic

### DIFF
--- a/strawberry/http/async_base_view.py
+++ b/strawberry/http/async_base_view.py
@@ -13,7 +13,7 @@ from typing import (
     cast,
     overload,
 )
-from typing_extensions import Literal, TypeGuard
+from typing_extensions import Literal, Self, TypeGuard
 
 from graphql import GraphQLError
 
@@ -113,7 +113,7 @@ class AsyncBaseHTTPView(
     request_adapter_class: Callable[[Request], AsyncHTTPRequestAdapter]
     websocket_adapter_class: Callable[
         [
-            "AsyncBaseHTTPView[Any, Any, Any, Any, Any, Context, RootValue]",
+            Self,
             WebSocketRequest,
             WebSocketResponse,
         ],
@@ -361,7 +361,7 @@ class AsyncBaseHTTPView(
             response_data=response_data, sub_response=sub_response
         )
 
-    def encode_multipart_data(self, data: Any, separator: str) -> str:
+    def encode_multipart_data(self, data: object, separator: str) -> str:
         return "".join(
             [
                 f"\r\n--{separator}\r\n",

--- a/tests/websockets/conftest.py
+++ b/tests/websockets/conftest.py
@@ -15,6 +15,7 @@ def _get_http_client_classes() -> Generator[Any, None, None]:
         ("FastAPIHttpClient", "fastapi", [pytest.mark.fastapi]),
         ("LitestarHttpClient", "litestar", [pytest.mark.litestar]),
         ("QuartHttpClient", "quart", [pytest.mark.quart]),
+        ("SanicHttpClient", "sanic", [pytest.mark.sanic]),
     ]:
         try:
             client_class = getattr(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

TODO:
- [ ] fix the test client
    - The Sanic test client can only send requests to websocket endpoints, but cannot work with the actually websocket at all
    - Sanic claims it can be run as an ASGI application, but doing that and using the resulting ASGI app with our ASGI test client doesn't work either: websocket route handlers suddenly receive an object that does not conform with a Sanic `WebSocket` at all, breaking everything
- [ ] make the view easier to use: Sanic's `HTTPMethodView` cannot handle websockets. We could look at Blueprints or ask users to register route handlers individually.
- [ ] resolve route conflicts: looks like Sanic does not allow GET and WebSocket route handlers on the same path (i.e., `/graphql`)

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #2927

## Summary by Sourcery

Add support for GraphQL subscriptions over WebSockets in Sanic by implementing a dedicated WebSocket adapter and extending the GraphQLView to handle WS connections, along with updated test client infrastructure.

New Features:
- Introduce SanicWebSocketAdapter to enable GraphQL WebSocket transports.
- Extend GraphQLView with a websocket() handler for subscription workflows and protocol negotiation.
- Add keep-alive, debug, and protocol configuration options to GraphQLView initialization.
- Integrate WebSocket routes into the Sanic test client and provide a ws_connect helper for testing.

Enhancements:
- Unify HTTP and WebSocket request and context handling in GraphQLView methods.
- Provide default implementations for subprotocol selection and WebSocket response creation.

Tests:
- Update Sanic test client to register WebSocket routes and handle GraphQL WS transports.
- Add an async ws_connect context manager for WebSocket integration tests.
- Include SanicHttpClient in test suite configuration for WebSocket support.