### PR TITLE
Fix inconsistent naming of aiohttp adapters

### DIFF
--- a/strawberry/aiohttp/views.py
+++ b/strawberry/aiohttp/views.py
@@ -43,7 +43,7 @@ if TYPE_CHECKING:
     from strawberry.schema import BaseSchema
 
 
-class AioHTTPRequestAdapter(AsyncHTTPRequestAdapter):
+class AiohttpHTTPRequestAdapter(AsyncHTTPRequestAdapter):
     def __init__(self, request: web.Request) -> None:
         self.request = request
 
@@ -84,7 +84,7 @@ class AioHTTPRequestAdapter(AsyncHTTPRequestAdapter):
         return self.headers.get("content-type")
 
 
-class AioHTTPWebSocketAdapter(AsyncWebSocketAdapter):
+class AiohttpWebSocketAdapter(AsyncWebSocketAdapter):
     def __init__(
         self, view: AsyncBaseHTTPView, request: web.Request, ws: web.WebSocketResponse
     ) -> None:
@@ -132,8 +132,8 @@ class GraphQLView(
     _is_coroutine = asyncio.coroutines._is_coroutine  # type: ignore[attr-defined]
 
     allow_queries_via_get = True
-    request_adapter_class = AioHTTPRequestAdapter
-    websocket_adapter_class = AioHTTPWebSocketAdapter
+    request_adapter_class = AiohttpHTTPRequestAdapter
+    websocket_adapter_class = AiohttpWebSocketAdapter
 
     def __init__(
         self,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
This mini-PR fixes the inconsistency in the names of the aiohttp HTTP request and WebSocket adapters, which were previously inconsistent with other integrations.

(i.e., correctly stylized framework name + `HTTPRequestAdapter` or `WebSocketAdapter`).

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation
