### PR TITLE
Fix test case unnecessarily skipped aiohttp

### DIFF
--- a/tests/websockets/test_graphql_transport_ws.py
+++ b/tests/websockets/test_graphql_transport_ws.py
@@ -154,15 +154,6 @@ async def test_ws_message_frame_types_cannot_be_mixed(ws_raw: WebSocketClient):
 
 
 async def test_connection_init_timeout(http_client_class: type[HttpClient]):
-    with contextlib.suppress(ImportError):
-        from tests.http.clients.aiohttp import AioHttpClient
-
-        if http_client_class == AioHttpClient:
-            pytest.skip(
-                "Closing a AIOHTTP WebSocket from a "
-                "task currently doesn't work as expected"
-            )
-
     test_client = http_client_class()
     test_client.create_app(connection_init_wait_timeout=timedelta(seconds=0))
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
This PR updates a test case to no longer skip aiohttp.

The test case consistently passes for me with aiohttp. The skip was added before we refactored the WebSocket protocol handlers and integrated them better with the async base view.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Summary by Sourcery

Tests:
- Remove the `contextlib.suppress` import and `pytest.skip` call for `AioHttpClient` in `test_graphql_transport_ws.py`, re-enabling the WebSocket timeout test for aiohttp.