### PR TITLE
Remove confusing test client alias

### DIFF
--- a/tests/websockets/test_graphql_transport_ws.py
+++ b/tests/websockets/test_graphql_transport_ws.py
@@ -153,9 +153,7 @@ async def test_ws_message_frame_types_cannot_be_mixed(ws_raw: WebSocketClient):
     assert ws.close_reason == "WebSocket message type must be text"
 
 
-async def test_connection_init_timeout(
-    request: object, http_client_class: type[HttpClient]
-):
+async def test_connection_init_timeout(http_client_class: type[HttpClient]):
     with contextlib.suppress(ImportError):
         from tests.http.clients.aiohttp import AioHttpClient
 
@@ -206,9 +204,7 @@ async def test_connection_init_timeout_cancellation(
 
 
 @pytest.mark.xfail(reason="This test is flaky")
-async def test_close_twice(
-    mocker: MockerFixture, request: object, http_client_class: type[HttpClient]
-):
+async def test_close_twice(mocker: MockerFixture, http_client_class: type[HttpClient]):
     test_client = http_client_class()
     test_client.create_app(connection_init_wait_timeout=timedelta(seconds=0.25))
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
This PR removes a confusing alias and unused fixtures from our WS tests.

For some reason, our test client was aliased as aiohttp test client, which made it look like some tests were only run against the aiohttp integration. This alias is gone now. I also removed a few unused inclusions of pytest's request fixture.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Summary by Sourcery

Simplify WebSocket tests by removing the deprecated aiohttp_app_client alias and unused fixtures, and updating tests to use the http_client fixture directly.

Enhancements:
- Remove the convenience aiohttp_app_client fixture alias from WS tests
- Update all tests to reference http_client instead of the old alias
- Remove unused pytest request fixtures from WS transport tests
- Streamline test function signatures by dropping redundant parameters