### PR TITLE
Sync subscription protocols arg types

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+Release type: patch
+
+In this release, we updated the type hints for `subscription_protocols` across
+all HTTP view integrations. It's now consistently defined as `Sequence[str]`,
+the minimum type required by Strawberry.

--- a/strawberry/aiohttp/views.py
+++ b/strawberry/aiohttp/views.py
@@ -36,7 +36,7 @@ from strawberry.http.typevars import (
 from strawberry.subscriptions import GRAPHQL_TRANSPORT_WS_PROTOCOL, GRAPHQL_WS_PROTOCOL
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator, Iterable, Mapping
+    from collections.abc import AsyncGenerator, Mapping, Sequence
 
     from strawberry.http import GraphQLHTTPResponse
     from strawberry.http.ides import GraphQL_IDE
@@ -144,7 +144,7 @@ class GraphQLView(
         keep_alive: bool = True,
         keep_alive_interval: float = 1,
         debug: bool = False,
-        subscription_protocols: Iterable[str] = (
+        subscription_protocols: Sequence[str] = (
             GRAPHQL_TRANSPORT_WS_PROTOCOL,
             GRAPHQL_WS_PROTOCOL,
         ),

--- a/strawberry/channels/handlers/ws_handler.py
+++ b/strawberry/channels/handlers/ws_handler.py
@@ -19,7 +19,7 @@ from strawberry.subscriptions import GRAPHQL_TRANSPORT_WS_PROTOCOL, GRAPHQL_WS_P
 from .base import ChannelsWSConsumer
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator, Mapping
+    from collections.abc import AsyncGenerator, Mapping, Sequence
 
     from strawberry.http import GraphQLHTTPResponse
     from strawberry.schema import BaseSchema
@@ -110,7 +110,7 @@ class GraphQLWSConsumer(
         keep_alive: bool = False,
         keep_alive_interval: float = 1,
         debug: bool = False,
-        subscription_protocols: tuple[str, str] = (
+        subscription_protocols: Sequence[str] = (
             GRAPHQL_TRANSPORT_WS_PROTOCOL,
             GRAPHQL_WS_PROTOCOL,
         ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
For completeness, this PR updates the `subscription_protocols` parameter type hints of the two remaining HTTP view integrations that did not use `Sequence[str]` yet.

(In the near future, I would like to rename that parameter to something like `ws_protocols`, because it's no longer just for subscriptions. We might also want to deprecate the constants in favor of a regular literal, similar to the `graphql_ide` parameter).

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Summary by Sourcery

Update subscription_protocols type hints to Sequence[str] across Strawberry HTTP view integrations for consistency

Enhancements:
- Change subscription_protocols parameter type from Iterable[str]/tuple[str, str] to Sequence[str] in AioHTTP views and Channels WS handler
- Add Sequence import in TYPE_CHECKING blocks to support the new type hints

Documentation:
- Add RELEASE.md with patch release notes for updated type hints