### PR TITLE
Fix django test client set unwanted content type

### DIFF
--- a/tests/http/test_graphql_over_http_spec.py
+++ b/tests/http/test_graphql_over_http_spec.py
@@ -161,16 +161,13 @@ async def test_9c48(http_client):
 
 
 @pytest.mark.xfail(
-    reason="OPTIONAL - currently supported by Channels, Chalice, and Sanic",
+    reason="OPTIONAL - currently supported by Channels, Chalice, Django, and Sanic",
     raises=AssertionError,
 )
 async def test_9abe(http_client):
     """
     MAY respond with 4xx status code if content-type is not supplied on POST requests
     """
-    if isinstance(http_client, DjangoHttpClient):
-        pytest.xfail("Our Django test client defaults to multipart/form-data")
-
     response = await http_client.post(
         url="/graphql",
         headers={},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
This PR fixes that our Django test client always sets a content-type header. This made it impossible to implement a GraphQL over HTTP test case that checks how the servers react to the absence of the content-type header.

(Our test clients need a lot more love, I'll keep working on them :) )

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Summary by Sourcery

Fix the Django test client to no longer set a default Content-Type header and adjust the GraphQL HTTP spec tests accordingly

Bug Fixes:
- Prevent the Django test client from automatically injecting a default Content-Type header on requests

Enhancements:
- Introduce _to_django_headers helper to centralize header conversion for Django requests
- Refactor header processing in get and post methods to use the new helper and properly handle Content-Type

Tests:
- Update the GraphQL over HTTP spec tests to include Django in the supported clients list and remove the special-case xfail for missing Content-Type