### PR TITLE
Fix type ignore was hiding support for HEAD

### DIFF
--- a/tests/http/clients/aiohttp.py
+++ b/tests/http/clients/aiohttp.py
@@ -134,7 +134,7 @@ class AioHttpClient(HttpClient):
     async def request(
         self,
         url: str,
-        method: Literal["get", "post", "patch", "put", "delete"],
+        method: Literal["head", "get", "post", "patch", "put", "delete"],
         headers: Optional[dict[str, str]] = None,
     ) -> Response:
         async with TestClient(TestServer(self.app)) as client:

--- a/tests/http/clients/base.py
+++ b/tests/http/clients/base.py
@@ -126,7 +126,7 @@ class HttpClient(abc.ABC):
     async def request(
         self,
         url: str,
-        method: Literal["get", "post", "patch", "put", "delete"],
+        method: Literal["head", "get", "post", "patch", "put", "delete"],
         headers: Optional[dict[str, str]] = None,
     ) -> Response: ...
 

--- a/tests/http/clients/chalice.py
+++ b/tests/http/clients/chalice.py
@@ -118,7 +118,7 @@ class ChaliceHttpClient(HttpClient):
     async def request(
         self,
         url: str,
-        method: Literal["get", "post", "patch", "put", "delete"],
+        method: Literal["head", "get", "post", "patch", "put", "delete"],
         headers: Optional[dict[str, str]] = None,
     ) -> Response:
         with Client(self.app) as client:

--- a/tests/http/clients/channels.py
+++ b/tests/http/clients/channels.py
@@ -217,7 +217,7 @@ class ChannelsHttpClient(HttpClient):
     async def request(
         self,
         url: str,
-        method: Literal["get", "post", "patch", "put", "delete"],
+        method: Literal["head", "get", "post", "patch", "put", "delete"],
         headers: Optional[dict[str, str]] = None,
         body: bytes = b"",
     ) -> Response:

--- a/tests/http/clients/django.py
+++ b/tests/http/clients/django.py
@@ -137,7 +137,7 @@ class DjangoHttpClient(HttpClient):
     async def request(
         self,
         url: str,
-        method: Literal["get", "post", "patch", "put", "delete"],
+        method: Literal["head", "get", "post", "patch", "put", "delete"],
         headers: Optional[dict[str, str]] = None,
     ) -> Response:
         headers = headers or {}

--- a/tests/http/clients/fastapi.py
+++ b/tests/http/clients/fastapi.py
@@ -159,7 +159,7 @@ class FastAPIHttpClient(HttpClient):
     async def request(
         self,
         url: str,
-        method: Literal["get", "post", "patch", "put", "delete"],
+        method: Literal["head", "get", "post", "patch", "put", "delete"],
         headers: Optional[dict[str, str]] = None,
     ) -> Response:
         response = getattr(self.client, method)(url, headers=headers)

--- a/tests/http/clients/flask.py
+++ b/tests/http/clients/flask.py
@@ -137,7 +137,7 @@ class FlaskHttpClient(HttpClient):
     async def request(
         self,
         url: str,
-        method: Literal["get", "post", "patch", "put", "delete"],
+        method: Literal["head", "get", "post", "patch", "put", "delete"],
         headers: Optional[dict[str, str]] = None,
         **kwargs: Any,
     ) -> Response:

--- a/tests/http/clients/litestar.py
+++ b/tests/http/clients/litestar.py
@@ -138,7 +138,7 @@ class LitestarHttpClient(HttpClient):
     async def request(
         self,
         url: str,
-        method: Literal["get", "post", "patch", "put", "delete"],
+        method: Literal["head", "get", "post", "patch", "put", "delete"],
         headers: Optional[dict[str, str]] = None,
     ) -> Response:
         response = getattr(self.client, method)(url, headers=headers)

--- a/tests/http/clients/quart.py
+++ b/tests/http/clients/quart.py
@@ -174,7 +174,7 @@ class QuartHttpClient(HttpClient):
     async def request(
         self,
         url: str,
-        method: Literal["get", "post", "patch", "put", "delete"],
+        method: Literal["head", "get", "post", "patch", "put", "delete"],
         headers: Optional[dict[str, str]] = None,
         **kwargs: Any,
     ) -> Response:

--- a/tests/http/clients/sanic.py
+++ b/tests/http/clients/sanic.py
@@ -111,7 +111,7 @@ class SanicHttpClient(HttpClient):
     async def request(
         self,
         url: str,
-        method: Literal["get", "post", "patch", "put", "delete"],
+        method: Literal["head", "get", "post", "patch", "put", "delete"],
         headers: Optional[dict[str, str]] = None,
     ) -> Response:
         request, response = await self.app.asgi_client.request(

--- a/tests/http/test_http.py
+++ b/tests/http/test_http.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 import pytest
 
 from strawberry.http.base import BaseView
@@ -7,10 +9,10 @@ from .clients.base import HttpClient
 
 @pytest.mark.parametrize("method", ["delete", "head", "put", "patch"])
 async def test_does_only_allow_get_and_post(
-    method: str,
+    method: Literal["delete", "head", "put", "patch"],
     http_client: HttpClient,
 ):
-    response = await http_client.request(url="/graphql", method=method)  # type: ignore
+    response = await http_client.request(url="/graphql", method=method)
 
     assert response.status_code == 405
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
This PR adds explicit support for HEAD requests to our test clients.

Previously, HEAD requests were already used in our tests, but a `type: ignore` was used to gloss over the outdated signature of the `request` method.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Summary by Sourcery

Add explicit HEAD request support to HTTP test clients and update tests accordingly.

Enhancements:
- Include "head" in the allowed method literal for all HTTP test client request signatures.

Tests:
- Update test parameters to include "head" in method literal and remove type ignore from request calls.