### PR TITLE
Fix some test clients set unwanted body data

### DIFF
--- a/tests/http/clients/chalice.py
+++ b/tests/http/clients/chalice.py
@@ -144,7 +144,7 @@ class ChaliceHttpClient(HttpClient):
         json: Optional[JSON] = None,
         headers: Optional[dict[str, str]] = None,
     ) -> Response:
-        body = data or dumps(json)
+        body = dumps(json) if json is not None else data
 
         with Client(self.app) as client:
             response = client.http.post(url, headers=headers, body=body)

--- a/tests/http/clients/django.py
+++ b/tests/http/clients/django.py
@@ -171,7 +171,7 @@ class DjangoHttpClient(HttpClient):
 
         additional_arguments = {**headers}
 
-        body = data or dumps(json)
+        body = dumps(json) if json is not None else data
 
         if headers.get("HTTP_CONTENT_TYPE"):
             additional_arguments["content_type"] = headers["HTTP_CONTENT_TYPE"]

--- a/tests/http/clients/sanic.py
+++ b/tests/http/clients/sanic.py
@@ -140,7 +140,8 @@ class SanicHttpClient(HttpClient):
         json: Optional[JSON] = None,
         headers: Optional[dict[str, str]] = None,
     ) -> Response:
-        body = data or dumps(json)
+        body = dumps(json) if json is not None else data
+
         request, response = await self.app.asgi_client.request(
             "post", url, content=body, headers=headers
         )

--- a/tests/http/test_graphql_over_http_spec.py
+++ b/tests/http/test_graphql_over_http_spec.py
@@ -195,11 +195,6 @@ async def test_a5bf(http_client):
     """
     MAY use 400 status code when request body is missing on POST
     """
-    if isinstance(http_client, (DjangoHttpClient, ChaliceHttpClient, SanicHttpClient)):
-        pytest.xfail(
-            "Our Django, Chalice, and Sanic test clients currently require a body"
-        )
-
     response = await http_client.post(
         url="/graphql",
         headers={"Content-Type": "application/json"},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
This PR fixes that the Django, Chalice, and Sanic test clients always set a body, even if no body/json data was passed to them.

This made it impossible to implement a GraphQL over HTTP test case that checks how servers react to missing POST bodies.

(Note that our test clients currently define JSON as `dict[str, object]`, while `None` indicates that no `json` argument was provided. Technically, `None` would be valid JSON too (`null`), but we currently neither reflect that in our types nor do we make use of it in tests. So, no need to replace `None` with `UNSET` in our test clients (yet)). 

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Summary by Sourcery

Fix HTTP test clients to omit the request body when no data or JSON is provided and re-enable missing-body behavior tests for Django, Chalice, and Sanic.

Bug Fixes:
- Prevent Django, Chalice, and Sanic test clients from always sending a JSON body when no body is provided
- Remove forced xfail for missing POST body tests in GraphQL over HTTP spec

Enhancements:
- Adjust body assignment logic to use dumps(json) only if json is not None

Tests:
- Re-enable and run test for missing request body on POST without client-specific skips