### PR TITLE
Fix incorrectly typed param

### DIFF
--- a/strawberry/channels/handlers/http_handler.py
+++ b/strawberry/channels/handlers/http_handler.py
@@ -361,7 +361,7 @@ class SyncGraphQLHTTPConsumer(
         self,
         request: ChannelsRequest,
         context: Union[Context, UnsetType] = UNSET,
-        root_value: Optional[RootValue] = UNSET,
+        root_value: Union[Optional[RootValue], UnsetType] = UNSET,
     ) -> ChannelsResponse | MultipartChannelsResponse:
         return super().run(request, context, root_value)
 

--- a/strawberry/channels/handlers/http_handler.py
+++ b/strawberry/channels/handlers/http_handler.py
@@ -27,7 +27,7 @@ from strawberry.http.sync_base_view import SyncBaseHTTPView, SyncHTTPRequestAdap
 from strawberry.http.temporal_response import TemporalResponse
 from strawberry.http.types import FormData
 from strawberry.http.typevars import Context, RootValue
-from strawberry.types.unset import UNSET
+from strawberry.types.unset import UNSET, UnsetType
 
 from .base import ChannelsConsumer
 
@@ -360,7 +360,7 @@ class SyncGraphQLHTTPConsumer(
     def run(
         self,
         request: ChannelsRequest,
-        context: Optional[Context] = UNSET,
+        context: Union[Context, UnsetType] = UNSET,
         root_value: Optional[RootValue] = UNSET,
     ) -> ChannelsResponse | MultipartChannelsResponse:
         return super().run(request, context, root_value)

--- a/strawberry/http/async_base_view.py
+++ b/strawberry/http/async_base_view.py
@@ -249,7 +249,7 @@ class AsyncBaseHTTPView(
         self,
         request: Request,
         context: Union[Context, UnsetType] = UNSET,
-        root_value: Optional[RootValue] = UNSET,
+        root_value: Union[Optional[RootValue], UnsetType] = UNSET,
     ) -> Response: ...
 
     @overload
@@ -257,14 +257,14 @@ class AsyncBaseHTTPView(
         self,
         request: WebSocketRequest,
         context: Union[Context, UnsetType] = UNSET,
-        root_value: Optional[RootValue] = UNSET,
+        root_value: Union[Optional[RootValue], UnsetType] = UNSET,
     ) -> WebSocketResponse: ...
 
     async def run(
         self,
         request: Union[Request, WebSocketRequest],
         context: Union[Context, UnsetType] = UNSET,
-        root_value: Optional[RootValue] = UNSET,
+        root_value: Union[Optional[RootValue], UnsetType] = UNSET,
     ) -> Union[Response, WebSocketResponse]:
         root_value = (
             await self.get_root_value(request) if root_value is UNSET else root_value

--- a/strawberry/http/async_base_view.py
+++ b/strawberry/http/async_base_view.py
@@ -248,7 +248,7 @@ class AsyncBaseHTTPView(
     async def run(
         self,
         request: Request,
-        context: Optional[Context] = UNSET,
+        context: Union[Context, UnsetType] = UNSET,
         root_value: Optional[RootValue] = UNSET,
     ) -> Response: ...
 
@@ -256,14 +256,14 @@ class AsyncBaseHTTPView(
     async def run(
         self,
         request: WebSocketRequest,
-        context: Optional[Context] = UNSET,
+        context: Union[Context, UnsetType] = UNSET,
         root_value: Optional[RootValue] = UNSET,
     ) -> WebSocketResponse: ...
 
     async def run(
         self,
         request: Union[Request, WebSocketRequest],
-        context: Optional[Context] = UNSET,
+        context: Union[Context, UnsetType] = UNSET,
         root_value: Optional[RootValue] = UNSET,
     ) -> Union[Response, WebSocketResponse]:
         root_value = (
@@ -317,8 +317,6 @@ class AsyncBaseHTTPView(
             if context is UNSET
             else context
         )
-
-        assert context
 
         if not self.is_request_allowed(request_adapter):
             raise HTTPException(405, "GraphQL only supports GET and POST requests.")

--- a/strawberry/http/sync_base_view.py
+++ b/strawberry/http/sync_base_view.py
@@ -167,7 +167,7 @@ class SyncBaseHTTPView(
         self,
         request: Request,
         context: Union[Context, UnsetType] = UNSET,
-        root_value: Optional[RootValue] = UNSET,
+        root_value: Union[Optional[RootValue], UnsetType] = UNSET,
     ) -> Response:
         request_adapter = self.request_adapter_class(request)
 

--- a/strawberry/http/sync_base_view.py
+++ b/strawberry/http/sync_base_view.py
@@ -11,7 +11,6 @@ from typing import (
 
 from graphql import GraphQLError
 
-from strawberry import UNSET
 from strawberry.exceptions import MissingQueryError
 from strawberry.file_uploads.utils import replace_placeholders_with_files
 from strawberry.http import (
@@ -24,6 +23,7 @@ from strawberry.schema import BaseSchema
 from strawberry.schema.exceptions import InvalidOperationTypeError
 from strawberry.types import ExecutionResult
 from strawberry.types.graphql import OperationType
+from strawberry.types.unset import UNSET, UnsetType
 
 from .base import BaseView
 from .exceptions import HTTPException
@@ -166,7 +166,7 @@ class SyncBaseHTTPView(
     def run(
         self,
         request: Request,
-        context: Optional[Context] = UNSET,
+        context: Union[Context, UnsetType] = UNSET,
         root_value: Optional[RootValue] = UNSET,
     ) -> Response:
         request_adapter = self.request_adapter_class(request)
@@ -186,8 +186,6 @@ class SyncBaseHTTPView(
             else context
         )
         root_value = self.get_root_value(request) if root_value is UNSET else root_value
-
-        assert context
 
         try:
             result = self.execute_operation(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
This PR fixes incorrectly typed parameters in our base classes, which required us to use `assert` to narrow types.

This is one of those cases where we have an optional parameter, but we cannot use `None` to indicate that.
However, the type hints were incorrect and indicated that `None` was used to indicate the `context` parameter was unset.
Using `Optional[Context]` is an issue here, because it says `context` could be of type `Optional[Context]` aka `Union[Context, None]` even if set! However, if set, `context` must be of type `Context`.

Note: I also updated the `root_value` parameter's type for correctness.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation
