### PR TITLE
Fix operation selection

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+Release type: minor
+
+In this release, we fixed various edge cases around operation selection in
+GraphQL documents. Now, operation selection works consistently across all
+protocols, both in documents with single and multiple operations.

--- a/strawberry/http/async_base_view.py
+++ b/strawberry/http/async_base_view.py
@@ -26,7 +26,10 @@ from strawberry.http import (
 )
 from strawberry.http.ides import GraphQL_IDE
 from strawberry.schema.base import BaseSchema
-from strawberry.schema.exceptions import InvalidOperationTypeError
+from strawberry.schema.exceptions import (
+    CannotGetOperationTypeError,
+    InvalidOperationTypeError,
+)
 from strawberry.subscriptions import GRAPHQL_TRANSPORT_WS_PROTOCOL, GRAPHQL_WS_PROTOCOL
 from strawberry.subscriptions.protocols.graphql_transport_ws.handlers import (
     BaseGraphQLTransportWSHandler,
@@ -332,6 +335,8 @@ class AsyncBaseHTTPView(
             result = await self.execute_operation(
                 request=request, context=context, root_value=root_value
             )
+        except CannotGetOperationTypeError as e:
+            raise HTTPException(400, e.as_http_error_reason()) from e
         except InvalidOperationTypeError as e:
             raise HTTPException(
                 400, e.as_http_error_reason(request_adapter.method)

--- a/strawberry/http/sync_base_view.py
+++ b/strawberry/http/sync_base_view.py
@@ -21,7 +21,10 @@ from strawberry.http import (
 )
 from strawberry.http.ides import GraphQL_IDE
 from strawberry.schema import BaseSchema
-from strawberry.schema.exceptions import InvalidOperationTypeError
+from strawberry.schema.exceptions import (
+    CannotGetOperationTypeError,
+    InvalidOperationTypeError,
+)
 from strawberry.types import ExecutionResult
 from strawberry.types.graphql import OperationType
 
@@ -195,6 +198,8 @@ class SyncBaseHTTPView(
                 context=context,
                 root_value=root_value,
             )
+        except CannotGetOperationTypeError as e:
+            raise HTTPException(400, e.as_http_error_reason()) from e
         except InvalidOperationTypeError as e:
             raise HTTPException(
                 400, e.as_http_error_reason(request_adapter.method)

--- a/strawberry/schema/exceptions.py
+++ b/strawberry/schema/exceptions.py
@@ -1,8 +1,20 @@
+from typing import Optional
+
 from strawberry.types.graphql import OperationType
 
 
 class CannotGetOperationTypeError(Exception):
     """Internal error raised when we cannot get the operation type from a GraphQL document."""
+
+    def __init__(self, operation_name: Optional[str]) -> None:
+        self.operation_name = operation_name
+
+    def as_http_error_reason(self) -> str:
+        return (
+            "Can't get GraphQL operation type"
+            if self.operation_name is None
+            else f'Unknown operation named "{self.operation_name}".'
+        )
 
 
 class InvalidOperationTypeError(Exception):

--- a/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
@@ -224,7 +224,7 @@ class BaseGraphQLTransportWSHandler(Generic[Context, RootValue]):
         except RuntimeError:
             # Unlike in the other protocol implementations, we access the operation type
             # before executing the operation. Therefore, we don't get a nice
-            # CannotGetOperationTypeError, but rather the underlying a RuntimeError.
+            # CannotGetOperationTypeError, but rather the underlying RuntimeError.
             e = CannotGetOperationTypeError(operation_name)
             await self.websocket.close(
                 code=4400,

--- a/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
@@ -20,6 +20,7 @@ from strawberry.http.exceptions import (
     WebSocketDisconnected,
 )
 from strawberry.http.typevars import Context, RootValue
+from strawberry.schema.exceptions import CannotGetOperationTypeError
 from strawberry.subscriptions.protocols.graphql_transport_ws.types import (
     CompleteMessage,
     ConnectionInitMessage,
@@ -221,13 +222,13 @@ class BaseGraphQLTransportWSHandler(Generic[Context, RootValue]):
         try:
             operation_type = get_operation_type(graphql_document, operation_name)
         except RuntimeError:
+            # Unlike in the other protocol implementations, we access the operation type
+            # before executing the operation. Therefore, we don't get a nice
+            # CannotGetOperationTypeError, but rather the underlying a RuntimeError.
+            e = CannotGetOperationTypeError(operation_name)
             await self.websocket.close(
                 code=4400,
-                reason=(
-                    f'Unknown operation named "{operation_name}".'
-                    if operation_name
-                    else "Can't get GraphQL operation type"
-                ),
+                reason=e.as_http_error_reason(),
             )
             return
 

--- a/strawberry/subscriptions/protocols/graphql_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_ws/handlers.py
@@ -194,18 +194,12 @@ class BaseGraphQLWSHandler(Generic[Context, RootValue]):
 
             await self.send_message(CompleteMessage(type="complete", id=operation_id))
 
-        except CannotGetOperationTypeError:
+        except CannotGetOperationTypeError as e:
             await self.send_message(
                 ErrorMessage(
                     type="error",
                     id=operation_id,
-                    payload={
-                        "message": (
-                            f'Unknown operation named "{operation_name}".'
-                            if operation_name
-                            else "Can't get GraphQL operation type"
-                        )
-                    },
+                    payload={"message": e.as_http_error_reason()},
                 )
             )
         except asyncio.CancelledError:

--- a/strawberry/types/execution.py
+++ b/strawberry/types/execution.py
@@ -57,7 +57,7 @@ class ExecutionContext:
 
     @property
     def operation_name(self) -> Optional[str]:
-        if self._provided_operation_name:
+        if self._provided_operation_name is not None:
             return self._provided_operation_name
 
         definition = self._get_first_operation()

--- a/strawberry/utils/operation.py
+++ b/strawberry/utils/operation.py
@@ -25,7 +25,7 @@ def get_operation_type(
 ) -> OperationType:
     definition: Optional[OperationDefinitionNode] = None
 
-    if operation_name:
+    if operation_name is not None:
         for d in graphql_document.definitions:
             if not isinstance(d, OperationDefinitionNode):
                 continue

--- a/tests/http/clients/aiohttp.py
+++ b/tests/http/clients/aiohttp.py
@@ -96,6 +96,7 @@ class AioHttpClient(HttpClient):
         self,
         method: Literal["get", "post"],
         query: Optional[str] = None,
+        operation_name: Optional[str] = None,
         variables: Optional[dict[str, object]] = None,
         files: Optional[dict[str, BytesIO]] = None,
         headers: Optional[dict[str, str]] = None,
@@ -105,6 +106,7 @@ class AioHttpClient(HttpClient):
         async with TestClient(TestServer(self.app)) as client:
             body = self._build_body(
                 query=query,
+                operation_name=operation_name,
                 variables=variables,
                 files=files,
                 method=method,

--- a/tests/http/clients/asgi.py
+++ b/tests/http/clients/asgi.py
@@ -100,6 +100,7 @@ class AsgiHttpClient(HttpClient):
         self,
         method: Literal["get", "post"],
         query: Optional[str] = None,
+        operation_name: Optional[str] = None,
         variables: Optional[dict[str, object]] = None,
         files: Optional[dict[str, BytesIO]] = None,
         headers: Optional[dict[str, str]] = None,
@@ -108,6 +109,7 @@ class AsgiHttpClient(HttpClient):
     ) -> Response:
         body = self._build_body(
             query=query,
+            operation_name=operation_name,
             variables=variables,
             files=files,
             method=method,

--- a/tests/http/clients/base.py
+++ b/tests/http/clients/base.py
@@ -115,6 +115,7 @@ class HttpClient(abc.ABC):
         self,
         method: Literal["get", "post"],
         query: Optional[str] = None,
+        operation_name: Optional[str] = None,
         variables: Optional[dict[str, object]] = None,
         files: Optional[dict[str, BytesIO]] = None,
         headers: Optional[dict[str, str]] = None,
@@ -150,6 +151,7 @@ class HttpClient(abc.ABC):
         self,
         query: str,
         method: Literal["get", "post"] = "post",
+        operation_name: Optional[str] = None,
         variables: Optional[dict[str, object]] = None,
         files: Optional[dict[str, BytesIO]] = None,
         headers: Optional[dict[str, str]] = None,
@@ -158,6 +160,7 @@ class HttpClient(abc.ABC):
         return await self._graphql_request(
             method,
             query=query,
+            operation_name=operation_name,
             headers=headers,
             variables=variables,
             files=files,
@@ -186,6 +189,7 @@ class HttpClient(abc.ABC):
     def _build_body(
         self,
         query: Optional[str] = None,
+        operation_name: Optional[str] = None,
         variables: Optional[dict[str, object]] = None,
         files: Optional[dict[str, BytesIO]] = None,
         method: Literal["get", "post"] = "post",
@@ -198,6 +202,9 @@ class HttpClient(abc.ABC):
             return None
 
         body: dict[str, object] = {"query": query}
+
+        if operation_name is not None:
+            body["operationName"] = operation_name
 
         if variables:
             body["variables"] = variables

--- a/tests/http/clients/chalice.py
+++ b/tests/http/clients/chalice.py
@@ -73,6 +73,7 @@ class ChaliceHttpClient(HttpClient):
         self,
         method: Literal["get", "post"],
         query: Optional[str] = None,
+        operation_name: Optional[str] = None,
         variables: Optional[dict[str, object]] = None,
         files: Optional[dict[str, BytesIO]] = None,
         headers: Optional[dict[str, str]] = None,
@@ -81,6 +82,7 @@ class ChaliceHttpClient(HttpClient):
     ) -> Response:
         body = self._build_body(
             query=query,
+            operation_name=operation_name,
             variables=variables,
             files=files,
             method=method,

--- a/tests/http/clients/channels.py
+++ b/tests/http/clients/channels.py
@@ -183,6 +183,7 @@ class ChannelsHttpClient(HttpClient):
         self,
         method: Literal["get", "post"],
         query: Optional[str] = None,
+        operation_name: Optional[str] = None,
         variables: Optional[dict[str, object]] = None,
         files: Optional[dict[str, BytesIO]] = None,
         headers: Optional[dict[str, str]] = None,
@@ -191,6 +192,7 @@ class ChannelsHttpClient(HttpClient):
     ) -> Response:
         body = self._build_body(
             query=query,
+            operation_name=operation_name,
             variables=variables,
             files=files,
             method=method,

--- a/tests/http/clients/django.py
+++ b/tests/http/clients/django.py
@@ -93,6 +93,7 @@ class DjangoHttpClient(HttpClient):
         self,
         method: Literal["get", "post"],
         query: Optional[str] = None,
+        operation_name: Optional[str] = None,
         variables: Optional[dict[str, object]] = None,
         files: Optional[dict[str, BytesIO]] = None,
         headers: Optional[dict[str, str]] = None,
@@ -104,6 +105,7 @@ class DjangoHttpClient(HttpClient):
 
         body = self._build_body(
             query=query,
+            operation_name=operation_name,
             variables=variables,
             files=files,
             method=method,

--- a/tests/http/clients/fastapi.py
+++ b/tests/http/clients/fastapi.py
@@ -123,6 +123,7 @@ class FastAPIHttpClient(HttpClient):
         self,
         method: Literal["get", "post"],
         query: Optional[str] = None,
+        operation_name: Optional[str] = None,
         variables: Optional[dict[str, object]] = None,
         files: Optional[dict[str, BytesIO]] = None,
         headers: Optional[dict[str, str]] = None,
@@ -131,6 +132,7 @@ class FastAPIHttpClient(HttpClient):
     ) -> Response:
         body = self._build_body(
             query=query,
+            operation_name=operation_name,
             variables=variables,
             files=files,
             method=method,

--- a/tests/http/clients/flask.py
+++ b/tests/http/clients/flask.py
@@ -85,6 +85,7 @@ class FlaskHttpClient(HttpClient):
         self,
         method: Literal["get", "post"],
         query: Optional[str] = None,
+        operation_name: Optional[str] = None,
         variables: Optional[dict[str, object]] = None,
         files: Optional[dict[str, BytesIO]] = None,
         headers: Optional[dict[str, str]] = None,
@@ -93,6 +94,7 @@ class FlaskHttpClient(HttpClient):
     ) -> Response:
         body = self._build_body(
             query=query,
+            operation_name=operation_name,
             variables=variables,
             files=files,
             method=method,

--- a/tests/http/clients/litestar.py
+++ b/tests/http/clients/litestar.py
@@ -100,6 +100,7 @@ class LitestarHttpClient(HttpClient):
         self,
         method: Literal["get", "post"],
         query: Optional[str] = None,
+        operation_name: Optional[str] = None,
         variables: Optional[dict[str, object]] = None,
         files: Optional[dict[str, BytesIO]] = None,
         headers: Optional[dict[str, str]] = None,
@@ -108,6 +109,7 @@ class LitestarHttpClient(HttpClient):
     ) -> Response:
         if body := self._build_body(
             query=query,
+            operation_name=operation_name,
             variables=variables,
             files=files,
             method=method,

--- a/tests/http/clients/quart.py
+++ b/tests/http/clients/quart.py
@@ -139,6 +139,7 @@ class QuartHttpClient(HttpClient):
         self,
         method: Literal["get", "post"],
         query: Optional[str] = None,
+        operation_name: Optional[str] = None,
         variables: Optional[dict[str, object]] = None,
         files: Optional[dict[str, BytesIO]] = None,
         headers: Optional[dict[str, str]] = None,
@@ -147,6 +148,7 @@ class QuartHttpClient(HttpClient):
     ) -> Response:
         body = self._build_body(
             query=query,
+            operation_name=operation_name,
             variables=variables,
             files=files,
             method=method,

--- a/tests/http/clients/sanic.py
+++ b/tests/http/clients/sanic.py
@@ -72,6 +72,7 @@ class SanicHttpClient(HttpClient):
         self,
         method: Literal["get", "post"],
         query: Optional[str] = None,
+        operation_name: Optional[str] = None,
         variables: Optional[dict[str, object]] = None,
         files: Optional[dict[str, BytesIO]] = None,
         headers: Optional[dict[str, str]] = None,
@@ -80,6 +81,7 @@ class SanicHttpClient(HttpClient):
     ) -> Response:
         body = self._build_body(
             query=query,
+            operation_name=operation_name,
             variables=variables,
             files=files,
             method=method,

--- a/tests/http/test_graphql_over_http_spec.py
+++ b/tests/http/test_graphql_over_http_spec.py
@@ -275,10 +275,6 @@ async def test_13ee(http_client):
     assert "errors" not in response.json
 
 
-@pytest.mark.xfail(
-    reason="OPTIONAL - Currently results in lots of CannotGetOperationTypeErrors",
-    raises=AssertionError,
-)
 @pytest.mark.parametrize(
     "invalid",
     [{"obj": "ect"}, 0, False, ["array"]],

--- a/tests/http/test_query.py
+++ b/tests/http/test_query.py
@@ -277,7 +277,7 @@ async def test_operation_selection(
 
 
 @pytest.mark.parametrize(
-    ("operation_name"),
+    "operation_name",
     ["", "Query3"],
 )
 async def test_invalid_operation_selection(http_client: HttpClient, operation_name):

--- a/tests/websockets/test_graphql_ws.py
+++ b/tests/websockets/test_graphql_ws.py
@@ -80,7 +80,6 @@ async def test_simple_subscription(ws: WebSocketClient):
     [
         ({}, "Hi1"),
         ({"operationName": None}, "Hi1"),
-        ({"operationName": ""}, "Hi1"),
         ({"operationName": "Subscription1"}, "Hi1"),
         ({"operationName": "Subscription2"}, "Hi2"),
     ],
@@ -114,7 +113,11 @@ async def test_operation_selection(
     assert complete_message["id"] == "demo"
 
 
-async def test_invalid_operation_selection(ws: WebSocketClient):
+@pytest.mark.parametrize(
+    ("operation_name"),
+    ["", "Subscription2"],
+)
+async def test_invalid_operation_selection(ws: WebSocketClient, operation_name):
     await ws.send_legacy_message(
         {
             "type": "start",
@@ -123,7 +126,7 @@ async def test_invalid_operation_selection(ws: WebSocketClient):
                 "query": """
                     subscription Subscription1 { echo(message: "Hi1") }
                 """,
-                "operationName": "Subscription2",
+                "operationName": operation_name,
             },
         }
     )
@@ -132,7 +135,7 @@ async def test_invalid_operation_selection(ws: WebSocketClient):
     assert error_message["type"] == "error"
     assert error_message["id"] == "demo"
     assert error_message["payload"] == {
-        "message": 'Unknown operation named "Subscription2".'
+        "message": f'Unknown operation named "{operation_name}".'
     }
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This PR fixes various scenarios in which operation selection did not work correctly over HTTP. One WS edge case was also fixed. HTTP and WS behave the same now, and both follow the spec.

Previously, we didn't even have HTTP tests for any of this. Also, our test clients were not set up to test operation selection. That's why this PR got a little bigger.

To summarize the operation selection behaviour:
- If no operationName is defined, use the first operation in the document
- If operationName is defined, find that operation in the document and execute it

The tricky parts are all the edge cases. e.g., the operationName is invalid, empty, or no matching operation exists in the document.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #3120
* Fixes #3288

## Summary by Sourcery

Fix operation selection behavior across HTTP and WebSocket protocols to align with the GraphQL specification and unify error handling

Bug Fixes:
- Correct operation selection logic to default to the first operation when no operationName is provided
- Handle empty or invalid operationName values by returning appropriate 400 errors with consistent messages
- Ensure WebSocket subscriptions follow the same operation selection rules as HTTP

Enhancements:
- Expose operation_name parameter in all HTTP client implementations
- Introduce CannotGetOperationTypeError.as_http_error_reason for standardized error reasons
- Refine operation_name detection logic to only treat explicit None as “no name” rather than empty string

Documentation:
- Add release note summarizing operation selection fixes in RELEASE.md

Tests:
- Add HTTP tests covering single/multiple operations and invalid operationName scenarios
- Expand WebSocket tests to parameterize valid and invalid operationName cases