### PR TITLE
fix: support lists in maybe annotation

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+This release fixes an issue that caused schema generation with `Maybe` to fail when using lists, such as `Maybe[List[User]]`.

--- a/strawberry/annotation.py
+++ b/strawberry/annotation.py
@@ -145,7 +145,8 @@ class StrawberryAnnotation:
             return evaled_type
         if self._is_list(evaled_type):
             return self.create_list(evaled_type)
-        if type_of := self._get_maybe_type(evaled_type):
+        if type_of := self._is_maybe(evaled_type):
+            return self.create_maybe(evaled_type)
             return StrawberryMaybe(
                 of_type=type_of,
             )
@@ -223,6 +224,17 @@ class StrawberryAnnotation:
         ).resolve()
 
         return StrawberryOptional(of_type)
+
+    def create_maybe(self, evaled_type: TypeVar) -> StrawberryMaybe:
+        # we expect a single arg to the evaled type,
+        # as unions on input types are not supported
+        # and maybe[t] already represents t | None
+        inner_type = get_args(evaled_type)[0]
+
+        of_type = StrawberryAnnotation(
+            annotation=inner_type, namespace=self.namespace
+        ).resolve()
+        return StrawberryMaybe(of_type)
 
     def create_type_var(self, evaled_type: TypeVar) -> StrawberryTypeVar:
         return StrawberryTypeVar(evaled_type)
@@ -320,8 +332,8 @@ class StrawberryAnnotation:
         )
 
     @classmethod
-    def _get_maybe_type(cls, annotation: Any) -> type | None:
-        return get_args(annotation)[0] if _annotation_is_maybe(annotation) else None
+    def _is_maybe(cls, annotation: Any) -> bool:
+        return _annotation_is_maybe(annotation)
 
     @classmethod
     def _is_strawberry_type(cls, evaled_type: Any) -> bool:

--- a/strawberry/annotation.py
+++ b/strawberry/annotation.py
@@ -145,11 +145,8 @@ class StrawberryAnnotation:
             return evaled_type
         if self._is_list(evaled_type):
             return self.create_list(evaled_type)
-        if type_of := self._is_maybe(evaled_type):
+        if self._is_maybe(evaled_type):
             return self.create_maybe(evaled_type)
-            return StrawberryMaybe(
-                of_type=type_of,
-            )
 
         if self._is_graphql_generic(evaled_type):
             if any(is_type_var(type_) for type_ in get_args(evaled_type)):
@@ -225,7 +222,7 @@ class StrawberryAnnotation:
 
         return StrawberryOptional(of_type)
 
-    def create_maybe(self, evaled_type: TypeVar) -> StrawberryMaybe:
+    def create_maybe(self, evaled_type: Any) -> StrawberryMaybe:
         # we expect a single arg to the evaled type,
         # as unions on input types are not supported
         # and maybe[t] already represents t | None

--- a/tests/schema/test_maybe.py
+++ b/tests/schema/test_maybe.py
@@ -160,11 +160,7 @@ def test_maybe_list():
     class Query:
         @strawberry.field
         def test(self, data: InputData) -> str:
-            if data.items is None:
-                return "No `items` key"
-            if data.items.value is None:
-                return "`items` is `None`"
-            return f"{len(data.items.value)} items passed"
+            return "I am a test, and I received: " + str(data.items)
 
     schema = strawberry.Schema(Query)
 

--- a/tests/schema/test_maybe.py
+++ b/tests/schema/test_maybe.py
@@ -149,3 +149,32 @@ def test_optional_argument_maybe() -> None:
     )
     assert not result.errors
     assert result.data == {"hello": "None"}
+
+
+def test_maybe_list():
+    @strawberry.input
+    class InputData:
+        items: strawberry.Maybe[list[str]]
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def test(self, data: InputData) -> str:
+            if data.items is None:
+                return "No `items` key"
+            if data.items.value is None:
+                return "`items` is `None`"
+            return f"{len(data.items.value)} items passed"
+
+    schema = strawberry.Schema(Query)
+
+    assert str(schema) == dedent(
+        """\
+        input InputData {
+          items: [String!]
+        }
+
+        type Query {
+          test(data: InputData!): String!
+        }"""
+    )


### PR DESCRIPTION
This PR fixes the issue reported in #3889. StrawberryMaybe was missing a StrawberryAnnotation wrapped around the inner type of the Maybe generic. Hence, lists would not be converted to StrawberryList.
fixes #3889 

## Summary by Sourcery

Fix handling of list types in StrawberryMaybe annotations by resolving the inner annotation before wrapping it in a Maybe

Bug Fixes:
- Ensure StrawberryMaybe converts list types to StrawberryList by delegating inner type through StrawberryAnnotation

Enhancements:
- Introduce create_maybe helper and replace _get_maybe_type with _is_maybe for clearer Maybe detection in annotation resolution

Tests:
- Add test_maybe_list to verify correct GraphQL schema generation for Maybe[list[str]] inputs

## Summary by Sourcery

Fix support for list types inside Maybe annotations by resolving inner annotations before wrapping in StrawberryMaybe, streamline Maybe detection with a new helper, and add tests for Maybe[list[str]] support

Bug Fixes:
- Properly convert list types inside StrawberryMaybe to StrawberryList by resolving the inner type first

Enhancements:
- Introduce a create_maybe helper and replace _get_maybe_type with _is_maybe for clearer Maybe handling in annotation resolution

Tests:
- Add test_maybe_list to verify correct schema generation for Maybe[list[str]] inputs