### PR TITLE
Fix unhandled aiohttp connection reset error

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,5 @@
 Release type: patch
 
 In this release, we updated the `aiohttp` integration to handle
-`ConnectionResetError`s, which can occur when a WebSocket connection is
-unexpectedly closed, gracefully.
+`aiohttp.ClientConnectionResetError`s, which can occur when a WebSocket
+connection is unexpectedly closed, gracefully.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+Release type: patch
+
+In this release, we updated the `aiohttp` integration to handle
+`ConnectionResetError`s, which can occur when a WebSocket connection is
+unexpectedly closed, gracefully.

--- a/strawberry/aiohttp/views.py
+++ b/strawberry/aiohttp/views.py
@@ -109,7 +109,7 @@ class AiohttpWebSocketAdapter(AsyncWebSocketAdapter):
     async def send_json(self, message: Mapping[str, object]) -> None:
         try:
             await self.ws.send_str(self.view.encode_json(message))
-        except RuntimeError as exc:
+        except (RuntimeError, ConnectionResetError) as exc:
             raise WebSocketDisconnected from exc
 
     async def close(self, code: int, reason: str) -> None:

--- a/strawberry/aiohttp/views.py
+++ b/strawberry/aiohttp/views.py
@@ -15,7 +15,7 @@ from typing import (
 )
 from typing_extensions import TypeGuard
 
-from aiohttp import http, web
+from aiohttp import ClientConnectionResetError, http, web
 from aiohttp.multipart import BodyPartReader
 from strawberry.http.async_base_view import (
     AsyncBaseHTTPView,
@@ -109,7 +109,7 @@ class AiohttpWebSocketAdapter(AsyncWebSocketAdapter):
     async def send_json(self, message: Mapping[str, object]) -> None:
         try:
             await self.ws.send_str(self.view.encode_json(message))
-        except (RuntimeError, ConnectionResetError) as exc:
+        except (RuntimeError, ClientConnectionResetError) as exc:
             raise WebSocketDisconnected from exc
 
     async def close(self, code: int, reason: str) -> None:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
This PR fixes an unhandled exception in the `aiohttp` integration.

When a client unexpectedly disconnects, an `aiohttp.ClientConnectionResetError` is raised by `aiohttp`. So far, this was unhandled because it's not mentioned [in the docs](https://docs.aiohttp.org/en/stable/web_reference.html#aiohttp.web.WebSocketResponse.send_str). Luckily, we have Sentry :)

<details>
<summary>For reference, here's the upstream code raising these exceptions:</summary>

- https://github.com/aio-libs/aiohttp/blob/7c3afd2211aeacd077e7f11a3e1bf9b9234a7610/aiohttp/_websocket/writer.py#L71-L72
- https://github.com/aio-libs/aiohttp/blob/7c3afd2211aeacd077e7f11a3e1bf9b9234a7610/aiohttp/_websocket/writer.py#L125-L126

</details>

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation
