### PR TITLE
chore(deps): update ruff to 0.12.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.13
+    rev: v0.12.3
     hooks:
       - id: ruff-format
         exclude: ^tests/\w+/snapshots/

--- a/poetry.lock
+++ b/poetry.lock
@@ -4498,30 +4498,30 @@ docs = ["markdown_include", "mkdocs", "mkdocs-glightbox", "mkdocs-material-exten
 
 [[package]]
 name = "ruff"
-version = "0.11.11"
+version = "0.12.3"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
 groups = ["dev"]
 files = [
-    {file = "ruff-0.11.11-py3-none-linux_armv6l.whl", hash = "sha256:9924e5ae54125ed8958a4f7de320dab7380f6e9fa3195e3dc3b137c6842a0092"},
-    {file = "ruff-0.11.11-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:c8a93276393d91e952f790148eb226658dd275cddfde96c6ca304873f11d2ae4"},
-    {file = "ruff-0.11.11-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d6e333dbe2e6ae84cdedefa943dfd6434753ad321764fd937eef9d6b62022bcd"},
-    {file = "ruff-0.11.11-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7885d9a5e4c77b24e8c88aba8c80be9255fa22ab326019dac2356cff42089fc6"},
-    {file = "ruff-0.11.11-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1b5ab797fcc09121ed82e9b12b6f27e34859e4227080a42d090881be888755d4"},
-    {file = "ruff-0.11.11-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e231ff3132c1119ece836487a02785f099a43992b95c2f62847d29bace3c75ac"},
-    {file = "ruff-0.11.11-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:a97c9babe1d4081037a90289986925726b802d180cca784ac8da2bbbc335f709"},
-    {file = "ruff-0.11.11-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d8c4ddcbe8a19f59f57fd814b8b117d4fcea9bee7c0492e6cf5fdc22cfa563c8"},
-    {file = "ruff-0.11.11-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6224076c344a7694c6fbbb70d4f2a7b730f6d47d2a9dc1e7f9d9bb583faf390b"},
-    {file = "ruff-0.11.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:882821fcdf7ae8db7a951df1903d9cb032bbe838852e5fc3c2b6c3ab54e39875"},
-    {file = "ruff-0.11.11-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:dcec2d50756463d9df075a26a85a6affbc1b0148873da3997286caf1ce03cae1"},
-    {file = "ruff-0.11.11-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:99c28505ecbaeb6594701a74e395b187ee083ee26478c1a795d35084d53ebd81"},
-    {file = "ruff-0.11.11-py3-none-musllinux_1_2_i686.whl", hash = "sha256:9263f9e5aa4ff1dec765e99810f1cc53f0c868c5329b69f13845f699fe74f639"},
-    {file = "ruff-0.11.11-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:64ac6f885e3ecb2fdbb71de2701d4e34526651f1e8503af8fb30d4915a3fe345"},
-    {file = "ruff-0.11.11-py3-none-win32.whl", hash = "sha256:1adcb9a18802268aaa891ffb67b1c94cd70578f126637118e8099b8e4adcf112"},
-    {file = "ruff-0.11.11-py3-none-win_amd64.whl", hash = "sha256:748b4bb245f11e91a04a4ff0f96e386711df0a30412b9fe0c74d5bdc0e4a531f"},
-    {file = "ruff-0.11.11-py3-none-win_arm64.whl", hash = "sha256:6c51f136c0364ab1b774767aa8b86331bd8e9d414e2d107db7a2189f35ea1f7b"},
-    {file = "ruff-0.11.11.tar.gz", hash = "sha256:7774173cc7c1980e6bf67569ebb7085989a78a103922fb83ef3dfe230cd0687d"},
+    {file = "ruff-0.12.3-py3-none-linux_armv6l.whl", hash = "sha256:47552138f7206454eaf0c4fe827e546e9ddac62c2a3d2585ca54d29a890137a2"},
+    {file = "ruff-0.12.3-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0a9153b000c6fe169bb307f5bd1b691221c4286c133407b8827c406a55282041"},
+    {file = "ruff-0.12.3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fa6b24600cf3b750e48ddb6057e901dd5b9aa426e316addb2a1af185a7509882"},
+    {file = "ruff-0.12.3-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e2506961bf6ead54887ba3562604d69cb430f59b42133d36976421bc8bd45901"},
+    {file = "ruff-0.12.3-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c4faaff1f90cea9d3033cbbcdf1acf5d7fb11d8180758feb31337391691f3df0"},
+    {file = "ruff-0.12.3-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:40dced4a79d7c264389de1c59467d5d5cefd79e7e06d1dfa2c75497b5269a5a6"},
+    {file = "ruff-0.12.3-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:0262d50ba2767ed0fe212aa7e62112a1dcbfd46b858c5bf7bbd11f326998bafc"},
+    {file = "ruff-0.12.3-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:12371aec33e1a3758597c5c631bae9a5286f3c963bdfb4d17acdd2d395406687"},
+    {file = "ruff-0.12.3-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:560f13b6baa49785665276c963edc363f8ad4b4fc910a883e2625bdb14a83a9e"},
+    {file = "ruff-0.12.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:023040a3499f6f974ae9091bcdd0385dd9e9eb4942f231c23c57708147b06311"},
+    {file = "ruff-0.12.3-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:883d844967bffff5ab28bba1a4d246c1a1b2933f48cb9840f3fdc5111c603b07"},
+    {file = "ruff-0.12.3-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:2120d3aa855ff385e0e562fdee14d564c9675edbe41625c87eeab744a7830d12"},
+    {file = "ruff-0.12.3-py3-none-musllinux_1_2_i686.whl", hash = "sha256:6b16647cbb470eaf4750d27dddc6ebf7758b918887b56d39e9c22cce2049082b"},
+    {file = "ruff-0.12.3-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e1417051edb436230023575b149e8ff843a324557fe0a265863b7602df86722f"},
+    {file = "ruff-0.12.3-py3-none-win32.whl", hash = "sha256:dfd45e6e926deb6409d0616078a666ebce93e55e07f0fb0228d4b2608b2c248d"},
+    {file = "ruff-0.12.3-py3-none-win_amd64.whl", hash = "sha256:a946cf1e7ba3209bdef039eb97647f1c77f6f540e5845ec9c114d3af8df873e7"},
+    {file = "ruff-0.12.3-py3-none-win_arm64.whl", hash = "sha256:5f9c7c9c8f84c2d7f27e93674d27136fbf489720251544c4da7fb3d742e011b1"},
+    {file = "ruff-0.12.3.tar.gz", hash = "sha256:f1b5a4b6668fd7b7ea3697d8d98857390b40c1320a63a178eee6be0899ea2d77"},
 ]
 
 [[package]]
@@ -6117,4 +6117,4 @@ sanic = ["sanic"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4.0"
-content-hash = "19861f2db2fea714e61142685afe51468500854b0b103e9f4eca87aa0c1c0692"
+content-hash = "f0efcc147ae2c6c29b1132ebb6d41fc1fed4b6765b84cfaa55b0285de64e5711"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -220,6 +220,7 @@ ignore = [
   # after we drop support for Python 3.9
   "UP006",
   "UP007",
+  "UP045",
 
   # we use asserts in tests and to hint mypy
   "S101",
@@ -308,6 +309,9 @@ ignore = [
   # Don't force if branches to be converted to "or"
   "SIM114",
 
+  # Allow imports inside functions
+  "PLC0415",
+
   # ruff formatter recommends to disable those, as they conflict with it
   # we don't need to ever enable those.
   "COM812",
@@ -324,6 +328,7 @@ ignore = [
   "Q003",
   "W191",
 ]
+exclude = ["tests/python_312/*"] # SyntaxError because we support Python 3.9+
 
 [tool.ruff.lint.per-file-ignores]
 ".github/*" = ["INP001"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ packages = [{ include = "strawberry" }]
 include = ["strawberry/py.typed"]
 
 [tool.poetry.group.dev.dependencies]
-ruff = "^0.11.4"
+ruff = "^0.12.3"
 asgiref = "^3.2"
 email-validator = { version = ">=1.1.3,<3.0.0", optional = false }
 freezegun = "^1.2.1"

--- a/strawberry/cli/__init__.py
+++ b/strawberry/cli/__init__.py
@@ -1,15 +1,15 @@
 try:
     from .app import app
-    from .commands.codegen import codegen as codegen  # noqa: PLC0414
-    from .commands.export_schema import export_schema as export_schema  # noqa: PLC0414
+    from .commands.codegen import codegen as codegen
+    from .commands.export_schema import export_schema as export_schema
     from .commands.locate_definition import (
-        locate_definition as locate_definition,  # noqa: PLC0414
+        locate_definition as locate_definition,
     )
     from .commands.schema_codegen import (
-        schema_codegen as schema_codegen,  # noqa: PLC0414
+        schema_codegen as schema_codegen,
     )
-    from .commands.server import server as server  # noqa: PLC0414
-    from .commands.upgrade import upgrade as upgrade  # noqa: PLC0414
+    from .commands.server import server as server
+    from .commands.upgrade import upgrade as upgrade
 
     def run() -> None:
         app()

--- a/tests/federation/test_schema.py
+++ b/tests/federation/test_schema.py
@@ -329,7 +329,7 @@ def test_federation_schema_warning():
         price: Optional[int]
         weight: Optional[int]
 
-    with pytest.warns(UserWarning) as record:
+    with pytest.warns(UserWarning) as record:  # noqa: PT030
         strawberry.Schema(
             query=ProductFed,
         )

--- a/tests/tools/test_merge_types.py
+++ b/tests/tools/test_merge_types.py
@@ -86,5 +86,5 @@ def test_schema():
 
 def test_fields_override():
     """It should warn when merging results in overriding fields"""
-    with pytest.warns(Warning):
+    with pytest.warns(Warning):  # noqa: PT030
         merge_types("FieldsOverride", (ComplexGreeter, SimpleGreeter))

--- a/tests/types/test_annotation.py
+++ b/tests/types/test_annotation.py
@@ -50,7 +50,7 @@ def test_annotation_hash(type1: Union[object, str], type2: Union[object, str]):
 
 
 def test_eq_on_other_type():
-    class Foo:
+    class Foo:  # noqa: PLW1641
         def __eq__(self, other):
             # Anything that is a strawberry annotation is equal to Foo
             return isinstance(other, StrawberryAnnotation)

--- a/tests/types/test_argument_types.py
+++ b/tests/types/test_argument_types.py
@@ -141,8 +141,8 @@ def test_custom_info_negative():
             _ = info
             return True
 
-        assert not get_info.arguments  # Should have no arguments matched
+    assert not get_info.arguments  # Should have no arguments matched
 
-        info_parameter = get_info.base_resolver.info_parameter
-        assert info_parameter is not None
-        assert info_parameter.name == "info"
+    info_parameter = get_info.base_resolver.info_parameter
+    assert info_parameter is not None
+    assert info_parameter.name == "info"


### PR DESCRIPTION
[This](https://github.com/strawberry-graphql/strawberry/pull/3924) was conflicting and failing, so I decided to update it manually

## Summary by Sourcery

Update ruff linter to version 0.12.3 and adjust code and configuration to satisfy new lint rules.

Enhancements:
- Add new ignore codes (UP045, PLC0415) and exclude Python 3.12 tests in ruff configuration
- Adjust ruff ignore lists to accommodate updated formatter recommendations

Build:
- Bump ruff dependency to ^0.12.3 in pyproject.toml
- Update pre-commit hook to use ruff rev v0.12.3

Tests:
- Add noqa directives (PT030, PLW1641) and correct indentation in tests to comply with updated lint rules

Chores:
- Remove redundant noqa PLC0414 annotations from CLI import statements