### PR TITLE
Fix invalid query parameters were not handled

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+Release type: patch
+
+In this release, we updated Strawberry to gracefully handle requests containing
+an invalid `query` parameter. Previously, such requests could result in internal
+server errors, but now they will return a 400 Bad Request response with an
+appropriate error message, conforming to the GraphQL over HTTP specification.

--- a/strawberry/http/async_base_view.py
+++ b/strawberry/http/async_base_view.py
@@ -533,7 +533,7 @@ class AsyncBaseHTTPView(
         if not isinstance(query, (str, type(None))):
             raise HTTPException(
                 400,
-                "GraphQL operations must contain a non-empty `query` or a `persistedQuery` extension.",
+                "The GraphQL operation's `query` must be a string or null, if provided.",
             )
 
         return GraphQLRequestData(

--- a/strawberry/http/async_base_view.py
+++ b/strawberry/http/async_base_view.py
@@ -529,8 +529,15 @@ class AsyncBaseHTTPView(
         else:
             raise HTTPException(400, "Unsupported content type")
 
+        query = data.get("query")
+        if not isinstance(query, (str, type(None))):
+            raise HTTPException(
+                400,
+                "GraphQL operations must contain a non-empty `query` or a `persistedQuery` extension.",
+            )
+
         return GraphQLRequestData(
-            query=data.get("query"),
+            query=query,
             variables=data.get("variables"),
             operation_name=data.get("operationName"),
             extensions=data.get("extensions"),

--- a/strawberry/http/sync_base_view.py
+++ b/strawberry/http/sync_base_view.py
@@ -154,8 +154,15 @@ class SyncBaseHTTPView(
         else:
             raise HTTPException(400, "Unsupported content type")
 
+        query = data.get("query")
+        if not isinstance(query, (str, type(None))):
+            raise HTTPException(
+                400,
+                "GraphQL operations must contain a non-empty `query` or a `persistedQuery` extension.",
+            )
+
         return GraphQLRequestData(
-            query=data.get("query"),
+            query=query,
             variables=data.get("variables"),
             operation_name=data.get("operationName"),
             extensions=data.get("extensions"),

--- a/strawberry/http/sync_base_view.py
+++ b/strawberry/http/sync_base_view.py
@@ -158,7 +158,7 @@ class SyncBaseHTTPView(
         if not isinstance(query, (str, type(None))):
             raise HTTPException(
                 400,
-                "GraphQL operations must contain a non-empty `query` or a `persistedQuery` extension.",
+                "The GraphQL operation's `query` must be a string or null, if provided.",
             )
 
         return GraphQLRequestData(

--- a/tests/http/test_graphql_over_http_spec.py
+++ b/tests/http/test_graphql_over_http_spec.py
@@ -214,10 +214,6 @@ async def test_423l(http_client):
     assert response.status_code == 400
 
 
-@pytest.mark.xfail(
-    reason="OPTIONAL - Currently results in lots of TypeErrors",
-    raises=AssertionError,
-)
 @pytest.mark.parametrize(
     "invalid",
     [{"obj": "ect"}, 0, False, ["array"]],

--- a/tests/http/test_query.py
+++ b/tests/http/test_query.py
@@ -208,7 +208,7 @@ async def test_requests_with_invalid_query_parameter_are_rejected(
     )
 
     assert response.status_code == 400
-    message = "GraphQL operations must contain a non-empty `query` or a `persistedQuery` extension."
+    message = "The GraphQL operation's `query` must be a string or null, if provided."
 
     if isinstance(http_client, ChaliceHttpClient):
         # Our Chalice integration purposely wraps errors messages with a JSON object


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
This PR updates our views to gracefully handle requests containing an invalid `query` parameter.

Previously, this resulted in TypeErrors internally. Now we're returning a 400 Bad Request response, conforming to the GraphQL over HTTP specification.

Bonus: pylance is now happier too

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Summary by Sourcery

Return HTTP 400 for requests with invalid `query` parameter types to conform to the GraphQL over HTTP spec.

Bug Fixes:
- Reject non-string `query` parameters with a 400 Bad Request and descriptive error message in both async and sync HTTP views.

Documentation:
- Include a release note in RELEASE.md describing the new invalid query handling.

Tests:
- Add parametrized tests to verify invalid `query` parameter values are rejected and remove the previous xfail marker for this scenario.