### PR TITLE
Move the errors page into the general section

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ title: Strawberry docs
 - [Mutations](./general/mutations.md)
 - [Subscriptions](./general/subscriptions.md)
 - [Multipart Subscriptions](./general/multipart-subscriptions.md)
+- [Errors](./errors)
 - [Breaking changes](./breaking-changes.md)
 - [Upgrading Strawberry](./general/upgrades.md)
 - [FAQ](./faq.md)
@@ -41,8 +42,6 @@ title: Strawberry docs
 - [Query codegen](./codegen/query-codegen.md)
 
 ## [Extensions](./extensions)
-
-## [Errors](./errors)
 
 ## Guides
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
This PR moves the [Errors page](https://strawberry.rocks/docs/errors) into the "General" section of the docs (as discussed yesterday).

Previously, unlike virtually all other pages, the "Errors" page was not part of any section in the docs. This made it much harder to discover. Since we have fancy error messages including a link to solutions, it makes sense to introduce them early.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Summary by Sourcery

Documentation:
- Relocate the Errors entry in docs/README.md under the General section instead of its previous standalone position.