### PR TITLE
Update and slightly move the upgrades page

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,8 +14,8 @@ title: Strawberry docs
 - [Subscriptions](./general/subscriptions.md)
 - [Multipart Subscriptions](./general/multipart-subscriptions.md)
 - [Errors](./errors)
-- [Breaking changes](./breaking-changes.md)
 - [Upgrading Strawberry](./general/upgrades.md)
+- [Breaking changes](./breaking-changes.md)
 - [FAQ](./faq.md)
 
 ## Types

--- a/docs/general/upgrades.md
+++ b/docs/general/upgrades.md
@@ -11,13 +11,15 @@ need to make updates to the public API. While we try to deprecate APIs before
 removing them, we also want to make it as easy as possible to upgrade to the
 latest version of Strawberry.
 
-For this reason we provide a CLI command that can automatically upgrade your
-codebase to use the updated APIs.
+For this reason, we provide a CLI command to run Codemods that can automatically
+upgrade your codebase to use the updated APIs.
 
-At the moment we only support updating unions to use the new syntax with
-annotated, but in future we plan to add more commands to help with upgrading.
+Keep an eye on our release notes and the
+[breaking changes](../breaking-changes.md) page to see if a new Codemod is
+available, or if manual changes are required.
 
-Here's how you can use the command to upgrade your codebase:
+Here's an example of how to upgrade your codebase by running a Codemod using the
+Strawberry CLI's `upgrade` command:
 
 ```shell
 strawberry upgrade annotated-union .


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
This PR updates the "Upgrading Strawberry" page to no longer claim we only provide a single codemod.

I also moved it before the "Breaking Changes" page, so that the strawberry upgrade command is introduced first, and so that the breaking changes are sitting at the end of the general section next to the faq.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Summary by Sourcery

Update the Upgrading Strawberry documentation to present the CLI upgrade command as a generic codemod runner, remove outdated single-codemod claims, and reposition the Breaking Changes link after the Upgrading page in the docs navigation.

Documentation:
- Clarify that the `strawberry upgrade` CLI command runs codemods and refer users to release notes and the Breaking Changes page for additional migrations, replacing the outdated single-codemod statement.
- Reorder the documentation sidebar to list Upgrading Strawberry before Breaking Changes in the README navigation.