### PR TITLE
Fix invalid variables parameters were not handled

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+Release type: patch
+
+In this release, we updated Strawberry to gracefully handle requests containing
+an invalid `variables` parameter. Previously, such requests could result in
+internal server errors. Now, Strawberry will return a 400 Bad Request response
+with a clear error message, conforming to the GraphQL over HTTP specification.

--- a/strawberry/http/async_base_view.py
+++ b/strawberry/http/async_base_view.py
@@ -536,9 +536,16 @@ class AsyncBaseHTTPView(
                 "The GraphQL operation's `query` must be a string or null, if provided.",
             )
 
+        variables = data.get("variables")
+        if not isinstance(variables, (dict, type(None))):
+            raise HTTPException(
+                400,
+                "The GraphQL operation's `variables` must be an object or null, if provided.",
+            )
+
         return GraphQLRequestData(
             query=query,
-            variables=data.get("variables"),
+            variables=variables,
             operation_name=data.get("operationName"),
             extensions=data.get("extensions"),
             protocol=protocol,

--- a/strawberry/http/sync_base_view.py
+++ b/strawberry/http/sync_base_view.py
@@ -161,9 +161,16 @@ class SyncBaseHTTPView(
                 "The GraphQL operation's `query` must be a string or null, if provided.",
             )
 
+        variables = data.get("variables")
+        if not isinstance(variables, (dict, type(None))):
+            raise HTTPException(
+                400,
+                "The GraphQL operation's `variables` must be an object or null, if provided.",
+            )
+
         return GraphQLRequestData(
             query=query,
-            variables=data.get("variables"),
+            variables=variables,
             operation_name=data.get("operationName"),
             extensions=data.get("extensions"),
         )

--- a/tests/http/clients/base.py
+++ b/tests/http/clients/base.py
@@ -206,7 +206,7 @@ class HttpClient(abc.ABC):
         if operation_name is not None:
             body["operationName"] = operation_name
 
-        if variables:
+        if variables is not None:
             body["variables"] = variables
 
         if extensions:

--- a/tests/http/test_graphql_over_http_spec.py
+++ b/tests/http/test_graphql_over_http_spec.py
@@ -369,9 +369,6 @@ async def test_022_(http_client, parameter):
     assert "errors" not in response.json
 
 
-@pytest.mark.xfail(
-    reason="OPTIONAL - Currently results in lots of TypeErrors", raises=AssertionError
-)
 @pytest.mark.parametrize(
     "invalid",
     ["string", 0, False, ["array"]],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Similar to #3927, this PR updates our views to handle requests containing an invalid `variables` parameter gracefully.

Previously, this resulted in TypeErrors internally. Now we're returning a 400 Bad Request response, conforming to the GraphQL over HTTP specification.

And again: pylance is happier

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation
