### PR TITLE
Document the InputMutationExtension

### DIFF
--- a/docs/extensions/input-mutation.md
+++ b/docs/extensions/input-mutation.md
@@ -1,0 +1,76 @@
+---
+title: Input Mutation Extension
+summary: Automatically create Input types for mutations
+tags: QoL
+---
+
+# `InputMutationExtension`
+
+The pattern of defining a mutation that receives a single
+[input type](../types/input-types.md) argument called `input` is a common
+practice in GraphQL. It helps to keep the mutation signatures clean and makes it
+easier to manage complex mutations with multiple arguments.
+
+The `InputMutationExtension` is a Strawberry field extension that allows you to
+define a mutation with multiple arguments without having to manually create an
+input type for it. Instead, it generates an input type based on the arguments of
+the mutation resolver.
+
+## Usage example:
+
+```python
+import strawberry
+from strawberry.field_extensions import InputMutationExtension
+
+
+@strawberry.type
+class User:
+    username: str
+
+
+@strawberry.type
+class Query:
+    hello: str
+
+
+@strawberry.type
+class Mutation:
+    @strawberry.mutation(extensions=[InputMutationExtension()])
+    def register_user(
+        self,
+        username: str,
+        password: str,
+    ) -> User:
+        user = User(username=username)
+        # maybe persist the user in a database
+        return user
+
+
+schema = strawberry.Schema(query=Query, mutation=Mutation)
+```
+
+The Strawberry schema above and the usage of the `InputMutationExtension` will
+result in the following GraphQL schema:
+
+```graphql
+type User {
+  username: String!
+}
+
+input RegisterUserInput {
+  username: String!
+  password: String!
+}
+
+type Mutation {
+  registerUser(input: RegisterUserInput!): User!
+}
+
+type Query {
+  hello: String!
+}
+```
+
+## API reference:
+
+_No arguments_

--- a/docs/general/mutations.md
+++ b/docs/general/mutations.md
@@ -98,8 +98,11 @@ Mutations with void-result go against
 It is usually useful to use a pattern of defining a mutation that receives a
 single [input type](../types/input-types) argument called `input`.
 
-Strawberry provides a helper to create a mutation that automatically creates an
-input type for you, whose attributes are the same as the args in the resolver.
+Strawberry provides the
+[`InputMutationExtension`](../extensions/input-mutation.md), a
+[field extension](../guides/field-extensions.md) that automatically creates an
+input type for you, whose attributes are the same as the arguments in the
+resolver.
 
 For example, suppose we want the mutation defined in the section above to be an
 input mutation. We can add the `InputMutationExtension` to the field like this:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
This PR adds a dedicated page for the `InputMutationExtension`.

Currently, that's our only built-in field extension, and it was previously only mentioned in the mutation docs. Giving it a dedicated page makes it more discoverable, because it'll show up in the list of built-in extensions provided by us.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Summary by Sourcery

Document the InputMutationExtension by adding a dedicated documentation page and updating the mutation guide to reference it

Documentation:
- Add a standalone docs page for InputMutationExtension with its purpose, usage example, generated schema, and API reference
- Update the general mutations guide to reference the new InputMutationExtension as a built-in field extension in Strawberry