### PR TITLE
fix: handle lazy connection type

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: fix
+
+This release adds support for lazy types in ConnectionExtension.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,3 @@
-Release type: fix
+Release type: patch
 
 This release adds support for lazy types in ConnectionExtension.

--- a/strawberry/relay/fields.py
+++ b/strawberry/relay/fields.py
@@ -261,7 +261,12 @@ class ConnectionExtension(FieldExtension):
         if isinstance(f_type, StrawberryOptional):
             f_type = f_type.of_type
 
+        if isinstance(f_type, LazyType):
+            f_type = f_type.resolve_type()
+
         type_origin = get_origin(f_type) if is_generic_alias(f_type) else f_type
+        if isinstance(type_origin, LazyType):
+            type_origin = type_origin.resolve_type()
 
         if not isinstance(type_origin, type) or not issubclass(type_origin, Connection):
             raise RelayWrongAnnotationError(field.name, cast("type", field.origin))

--- a/tests/relay/test_connection.py
+++ b/tests/relay/test_connection.py
@@ -1,6 +1,6 @@
 import sys
 from collections.abc import Iterable
-from typing import Any, Optional, Annotated
+from typing import Annotated, Any, Optional
 from typing_extensions import Self
 
 import pytest
@@ -73,10 +73,17 @@ def test_nullable_connection_with_optional():
     assert result.data == {"users": None}
     assert not result.errors
 
+
 def test_lazy_optional_connection():
     @strawberry.type
     class Query:
-        @strawberry.relay.connection(Optional[Annotated["UserConnection", strawberry.lazy("tests.relay.test_connection")]])
+        @strawberry.relay.connection(
+            Optional[
+                Annotated[
+                    "UserConnection", strawberry.lazy("tests.relay.test_connection")
+                ]
+            ]
+        )
         def users(self) -> Optional[list[User]]:
             return None
 

--- a/tests/relay/test_connection.py
+++ b/tests/relay/test_connection.py
@@ -1,6 +1,6 @@
 import sys
 from collections.abc import Iterable
-from typing import Any, Optional
+from typing import Any, Optional, Annotated
 from typing_extensions import Self
 
 import pytest
@@ -68,6 +68,30 @@ def test_nullable_connection_with_optional():
             }
         }
     """
+
+    result = schema.execute_sync(query)
+    assert result.data == {"users": None}
+    assert not result.errors
+
+def test_lazy_optional_connection():
+    @strawberry.type
+    class Query:
+        @strawberry.relay.connection(Optional[Annotated["UserConnection", strawberry.lazy("tests.relay.test_connection")]])
+        def users(self) -> Optional[list[User]]:
+            return None
+
+    schema = strawberry.Schema(query=Query)
+    query = """
+            query {
+                users {
+                    edges {
+                        node {
+                            name
+                        }
+                    }
+                }
+            }
+        """
 
     result = schema.execute_sync(query)
     assert result.data == {"users": None}

--- a/tests/relay/test_connection.py
+++ b/tests/relay/test_connection.py
@@ -8,7 +8,7 @@ import pytest
 import strawberry
 from strawberry.permission import BasePermission
 from strawberry.relay import Connection, Node, PageInfo, to_base64
-from strawberry.relay.types import ListConnection, Edge
+from strawberry.relay.types import Edge, ListConnection
 from strawberry.schema.config import StrawberryConfig
 
 
@@ -65,13 +65,9 @@ class UserConnection(Connection[User]):
                 start_cursor=None,
                 end_cursor=None,
             ),
-            edges=[Edge(
-                cursor=user_node_id,
-                node=User(
-                    id=user_node_id
-                )
-            )],
+            edges=[Edge(cursor=user_node_id, node=User(id=user_node_id))],
         )
+
 
 class TestPermission(BasePermission):
     message = "Not allowed"
@@ -142,7 +138,8 @@ def test_lazy_optional_connection():
         @strawberry.relay.connection(
             Optional[
                 Annotated[
-                    "EmptyUserConnection", strawberry.lazy("tests.relay.test_connection")
+                    "EmptyUserConnection",
+                    strawberry.lazy("tests.relay.test_connection"),
                 ]
             ]
         )


### PR DESCRIPTION
Fixes `ConnectionExtension`, so if a lazy connection type is specified via `graphql_type` argument, it is resolved.

## Types of Changes

- [ ] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Resolve lazy connection types in Strawberry Relay to correctly handle connections specified via lazy annotations.

Bug Fixes:
- Add resolution for LazyType on field type and type origin in Relay field application to support lazy connection types.

Tests:
- Add test for lazy optional connection to verify correct resolution of lazy connection types.