### PR TITLE
Fix invalid extensions parameters were not handled

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+Release type: patch
+
+In this release, we updated Strawberry to gracefully handle requests containing
+an invalid `extensions` parameter. Previously, such requests could result in
+internal server errors. Now, Strawberry will return a 400 Bad Request response
+with a clear error message, conforming to the GraphQL over HTTP specification.

--- a/strawberry/http/async_base_view.py
+++ b/strawberry/http/async_base_view.py
@@ -541,11 +541,18 @@ class AsyncBaseHTTPView(
                 "The GraphQL operation's `variables` must be an object or null, if provided.",
             )
 
+        extensions = data.get("extensions")
+        if not isinstance(extensions, (dict, type(None))):
+            raise HTTPException(
+                400,
+                "The GraphQL operation's `extensions` must be an object or null, if provided.",
+            )
+
         return GraphQLRequestData(
             query=query,
             variables=variables,
             operation_name=data.get("operationName"),
-            extensions=data.get("extensions"),
+            extensions=extensions,
             protocol=protocol,
         )
 

--- a/strawberry/http/sync_base_view.py
+++ b/strawberry/http/sync_base_view.py
@@ -166,11 +166,18 @@ class SyncBaseHTTPView(
                 "The GraphQL operation's `variables` must be an object or null, if provided.",
             )
 
+        extensions = data.get("extensions")
+        if not isinstance(extensions, (dict, type(None))):
+            raise HTTPException(
+                400,
+                "The GraphQL operation's `extensions` must be an object or null, if provided.",
+            )
+
         return GraphQLRequestData(
             query=query,
             variables=variables,
             operation_name=data.get("operationName"),
-            extensions=data.get("extensions"),
+            extensions=extensions,
         )
 
     def _handle_errors(

--- a/tests/http/clients/base.py
+++ b/tests/http/clients/base.py
@@ -209,7 +209,7 @@ class HttpClient(abc.ABC):
         if variables is not None:
             body["variables"] = variables
 
-        if extensions:
+        if extensions is not None:
             body["extensions"] = extensions
 
         if files:

--- a/tests/http/test_graphql_over_http_spec.py
+++ b/tests/http/test_graphql_over_http_spec.py
@@ -455,9 +455,6 @@ async def test_6a70(http_client):
     assert "errors" not in response.json
 
 
-@pytest.mark.xfail(
-    reason="OPTIONAL - Currently not supported by Strawberry", raises=AssertionError
-)
 @pytest.mark.parametrize(
     "invalid",
     ["string", 0, False, ["array"]],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
This PR does the same as #3927 and #3932, but for the `extensions` parameter. This is the final PR in this series.

(We're close to full spec compliance, I'll keep taking care of it bit by bit to keep the PRs reviewable.)

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Summary by Sourcery

Validate the `extensions` parameter in GraphQL over HTTP requests per the spec, returning a 400 error when it is not an object or null, and update related tests and client behavior.

Bug Fixes:
- Enforce that the GraphQL `extensions` parameter must be an object or null, returning a 400 Bad Request with a clear error message when invalid input is provided

Enhancements:
- Adjust the HTTP request builder to include the `extensions` field when it is explicitly set to null

Documentation:
- Add a release note outlining the patch for handling invalid `extensions` parameters gracefully

Tests:
- Add tests to verify that invalid `extensions` parameters are rejected with a 400 response
- Remove the xfail marker for invalid `extensions` in the GraphQL over HTTP spec test suite