### PR TITLE
fix: name conversion for lazy types

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+This release fixes NameConverter to properly handle lazy types.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,3 @@
-Release type: patch
+Release type: minor
 
 This release fixes NameConverter to properly handle lazy types.

--- a/strawberry/schema/name_converter.py
+++ b/strawberry/schema/name_converter.py
@@ -150,8 +150,9 @@ class NameConverter:
         type_ = eval_type(type_)
 
         if isinstance(type_, LazyType):
-            name = type_.type_name
-        elif isinstance(type_, EnumDefinition):
+            type_ = type_.resolve_type()
+
+        if isinstance(type_, EnumDefinition):
             name = type_.name
         elif isinstance(type_, StrawberryUnion):
             name = type_.graphql_name if type_.graphql_name else self.from_union(type_)

--- a/tests/objects/generics/test_names.py
+++ b/tests/objects/generics/test_names.py
@@ -41,9 +41,9 @@ class TypeB:
         ([TypeA], "TypeAExample"),
         ([CustomInt], "CustomIntExample"),
         ([TypeA, TypeB], "TypeATypeBExample"),
-        ([TypeA, LazyType["TypeB", "test_names"]], "TypeATypeBExample"),  # type: ignore
+        ([TypeA, LazyType["TypeB", "tests.objects.generics.test_names"]], "TypeATypeBExample"),  # type: ignore
         (
-            [TypeA, Annotated["TypeB", strawberry.lazy("test_names")]],
+            [TypeA, Annotated["TypeB", strawberry.lazy("tests.objects.generics.test_names")]],
             "TypeATypeBExample",
         ),
     ],

--- a/tests/objects/generics/test_names.py
+++ b/tests/objects/generics/test_names.py
@@ -41,9 +41,17 @@ class TypeB:
         ([TypeA], "TypeAExample"),
         ([CustomInt], "CustomIntExample"),
         ([TypeA, TypeB], "TypeATypeBExample"),
-        ([TypeA, LazyType["TypeB", "tests.objects.generics.test_names"]], "TypeATypeBExample"),  # type: ignore
         (
-            [TypeA, Annotated["TypeB", strawberry.lazy("tests.objects.generics.test_names")]],
+            [TypeA, LazyType["TypeB", "tests.objects.generics.test_names"]],
+            "TypeATypeBExample",
+        ),  # type: ignore
+        (
+            [
+                TypeA,
+                Annotated[
+                    "TypeB", strawberry.lazy("tests.objects.generics.test_names")
+                ],
+            ],
             "TypeATypeBExample",
         ),
     ],

--- a/tests/schema/test_name_converter.py
+++ b/tests/schema/test_name_converter.py
@@ -1,6 +1,6 @@
 import textwrap
 from enum import Enum
-from typing import Generic, Optional, TypeVar, Union, Annotated
+from typing import Annotated, Generic, Optional, TypeVar, Union
 
 import strawberry
 from strawberry.directive import StrawberryDirective
@@ -120,7 +120,12 @@ class Query:
 
     enum: MyEnum = MyEnum.A
     field: Optional[MyGeneric[str]] = None
-    field_with_lazy: MyGeneric[Annotated["TypeWithDifferentNameThanClass", strawberry.lazy("tests.schema.test_name_converter")]] = None
+    field_with_lazy: MyGeneric[
+        Annotated[
+            "TypeWithDifferentNameThanClass",
+            strawberry.lazy("tests.schema.test_name_converter"),
+        ]
+    ] = None
 
     @strawberry.field
     def print(self, enum: MyEnum) -> str:

--- a/tests/schema/test_name_converter.py
+++ b/tests/schema/test_name_converter.py
@@ -222,18 +222,3 @@ def test_can_use_enum_value_with_variable():
     assert not result.errors
 
     assert result.data == {"printX": "a"}
-
-
-# def test_lazy_type_with_different_name_in_generic():
-#     @strawberry.type
-#     class GenericType(Generic[T]):
-#         item: T
-#
-#     @strawberry.type
-#     class _Query:
-#         specialized: GenericType[Annotated["TypeWithDifferentNameThanClass", strawberry.lazy("tests.schema.test_name_converter")]]
-#
-#     _schema = strawberry.Schema(query=_Query)
-#
-#     assert "MyTypeGenericType" in str(_schema)
-#     assert "TypeWithDifferentNameThanClassGenericType" not in str(_schema)

--- a/tests/schema/test_name_converter.py
+++ b/tests/schema/test_name_converter.py
@@ -1,6 +1,6 @@
 import textwrap
 from enum import Enum
-from typing import Generic, Optional, TypeVar, Union
+from typing import Generic, Optional, TypeVar, Union, Annotated
 
 import strawberry
 from strawberry.directive import StrawberryDirective
@@ -78,6 +78,11 @@ class User:
     name: str
 
 
+@strawberry.type(name="MyType")
+class TypeWithDifferentNameThanClass:
+    name: str
+
+
 @strawberry.type
 class Error:
     message: str
@@ -115,6 +120,7 @@ class Query:
 
     enum: MyEnum = MyEnum.A
     field: Optional[MyGeneric[str]] = None
+    field_with_lazy: MyGeneric[Annotated["TypeWithDifferentNameThanClass", strawberry.lazy("tests.schema.test_name_converter")]] = None
 
     @strawberry.field
     def print(self, enum: MyEnum) -> str:
@@ -141,6 +147,14 @@ def test_name_converter():
       BX
     }
 
+    type MyTypeMyGenericXX {
+      valueX: MyTypeX!
+    }
+
+    type MyTypeX {
+      nameX: String!
+    }
+
     interface NodeXX {
       idX: ID!
     }
@@ -148,6 +162,7 @@ def test_name_converter():
     type QueryX {
       enumX: MyEnumX!
       fieldX: StrMyGenericXX
+      fieldWithLazyX: MyTypeMyGenericXX!
       userX(inputX: UserInputX!): UserXErrorXX! @myDirectiveX(name: "my-directive")
       printX(enumX: MyEnumX!): String!
     }
@@ -202,3 +217,18 @@ def test_can_use_enum_value_with_variable():
     assert not result.errors
 
     assert result.data == {"printX": "a"}
+
+
+# def test_lazy_type_with_different_name_in_generic():
+#     @strawberry.type
+#     class GenericType(Generic[T]):
+#         item: T
+#
+#     @strawberry.type
+#     class _Query:
+#         specialized: GenericType[Annotated["TypeWithDifferentNameThanClass", strawberry.lazy("tests.schema.test_name_converter")]]
+#
+#     _schema = strawberry.Schema(query=_Query)
+#
+#     assert "MyTypeGenericType" in str(_schema)
+#     assert "TypeWithDifferentNameThanClassGenericType" not in str(_schema)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

Fixes `NameConverter` to properly handle a case when a lazy type is passed to a generic. 

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Adjusted `NameConverter.get_name_from_type` to properly handle the case when the name of the class is different from the name in the schema.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Fix NameConverter to properly resolve lazy types before determining GraphQL names, ensuring custom schema names and lazy generics are handled correctly.

Bug Fixes:
- Resolve LazyType in NameConverter.get_name_from_type before extracting the type name to handle lazy types inside generics and named types.

Documentation:
- Add RELEASE.md with patch release note.

Tests:
- Add tests in name_converter and generics to cover lazy types in generics and types with custom schema names.