### PR TITLE
fix: fix DuplicatedTypeName exception raised for nested generics

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,28 @@
+Release type: patch
+
+This release fixes an issue where `DuplicatedTypeName` exception would be raised
+for nested generics like in the example below:
+
+```python
+from typing import Generic, TypeVar
+
+import strawberry
+
+T = TypeVar("T")
+
+
+@strawberry.type
+class Wrapper(Generic[T]):
+    value: T
+
+
+@strawberry.type
+class Query:
+    a: Wrapper[Wrapper[int]]
+    b: Wrapper[Wrapper[int]]
+
+
+schema = strawberry.Schema(query=Query)
+```
+
+This piece of code and similar ones will now work correctly.


### PR DESCRIPTION
Fix #2599

## Summary by Sourcery

Prevent errors when handling nested generic types by implementing recursive comparison of type definitions

Bug Fixes:
- Prevent DuplicatedTypeName exception from being raised for nested generic types

Enhancements:
- Refactor nested generic type equality check into a new is_same_type_definition helper method

Documentation:
- Add RELEASE.md entry describing the fix for nested generics

Tests:
- Add test to ensure nested generics with identical parameters do not trigger name duplication errors