### PR TITLE
Rename errors to pre-execution-errors

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,7 @@
+Release type: patch
+
+This release renames the `ExecutionContext.errors` attribute to `ExecutionContext.pre_execution_errors` to better reflect its purpose. The old `errors` attribute is now deprecated but still available for backward compatibility.
+
+The `pre_execution_errors` attribute specifically stores errors that occur during the pre-execution phase (parsing and validation), making the distinction clearer from errors that might occur during the actual execution phase.
+
+For backward compatibility, accessing `ExecutionContext.errors` will now emit a deprecation warning and return the value of `pre_execution_errors`.

--- a/strawberry/extensions/validation_cache.py
+++ b/strawberry/extensions/validation_cache.py
@@ -43,7 +43,7 @@ class ValidationCache(SchemaExtension):
             execution_context.graphql_document,
             execution_context.validation_rules,
         )
-        execution_context.errors = errors
+        execution_context.pre_execution_errors = errors
         yield
 
 

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -129,9 +129,12 @@ def validate_document(
 def _run_validation(execution_context: ExecutionContext) -> None:
     # Check if there are any validation rules or if validation has
     # already been run by an extension
-    if len(execution_context.validation_rules) > 0 and execution_context.errors is None:
+    if (
+        len(execution_context.validation_rules) > 0
+        and execution_context.pre_execution_errors is None
+    ):
         assert execution_context.graphql_document
-        execution_context.errors = validate_document(
+        execution_context.pre_execution_errors = validate_document(
             execution_context.schema._schema,
             execution_context.graphql_document,
             execution_context.validation_rules,
@@ -489,12 +492,12 @@ class Schema(BaseSchema):
                     context.graphql_document = parse(context.query)
 
             except GraphQLError as error:
-                context.errors = [error]
+                context.pre_execution_errors = [error]
                 return PreExecutionError(data=None, errors=[error])
 
             except Exception as error:  # noqa: BLE001
                 error = GraphQLError(str(error), original_error=error)
-                context.errors = [error]
+                context.pre_execution_errors = [error]
                 return PreExecutionError(data=None, errors=[error])
 
         try:
@@ -507,10 +510,10 @@ class Schema(BaseSchema):
 
         async with extensions_runner.validation():
             _run_validation(context)
-            if context.errors:
+            if context.pre_execution_errors:
                 return PreExecutionError(
                     data=None,
-                    errors=context.errors,
+                    errors=context.pre_execution_errors,
                 )
 
         return None
@@ -527,7 +530,7 @@ class Schema(BaseSchema):
         # Set errors on the context so that it's easier
         # to access in extensions
         if result.errors:
-            context.errors = result.errors
+            context.pre_execution_errors = result.errors
             if not skip_process_errors:
                 self._process_errors(result.errors, context)
         if isinstance(result, GraphQLExecutionResult):
@@ -604,7 +607,7 @@ class Schema(BaseSchema):
                     # Also set errors on the execution_context so that it's easier
                     # to access in extensions
                     if result.errors:
-                        execution_context.errors = result.errors
+                        execution_context.pre_execution_errors = result.errors
 
                         # Run the `Schema.process_errors` function here before
                         # extensions have a chance to modify them (see the MaskErrors
@@ -677,7 +680,7 @@ class Schema(BaseSchema):
                             )
 
                     except GraphQLError as error:
-                        execution_context.errors = [error]
+                        execution_context.pre_execution_errors = [error]
                         self._process_errors([error], execution_context)
                         return ExecutionResult(
                             data=None,
@@ -697,13 +700,13 @@ class Schema(BaseSchema):
 
                 with extensions_runner.validation():
                     _run_validation(execution_context)
-                    if execution_context.errors:
+                    if execution_context.pre_execution_errors:
                         self._process_errors(
-                            execution_context.errors, execution_context
+                            execution_context.pre_execution_errors, execution_context
                         )
                         return ExecutionResult(
                             data=None,
-                            errors=execution_context.errors,
+                            errors=execution_context.pre_execution_errors,
                             extensions=extensions_runner.get_extensions_results_sync(),
                         )
 
@@ -733,7 +736,7 @@ class Schema(BaseSchema):
                         # Also set errors on the context so that it's easier
                         # to access in extensions
                         if result.errors:
-                            execution_context.errors = result.errors
+                            execution_context.pre_execution_errors = result.errors
 
                             # Run the `Schema.process_errors` function here before
                             # extensions have a chance to modify them (see the MaskErrors
@@ -748,7 +751,7 @@ class Schema(BaseSchema):
             raise
         except Exception as exc:  # noqa: BLE001
             errors = [_coerce_error(exc)]
-            execution_context.errors = errors
+            execution_context.pre_execution_errors = errors
             self._process_errors(errors, execution_context)
             return ExecutionResult(
                 data=None,

--- a/strawberry/types/execution.py
+++ b/strawberry/types/execution.py
@@ -7,7 +7,7 @@ from typing import (
     Optional,
     runtime_checkable,
 )
-from typing_extensions import Protocol, TypedDict
+from typing_extensions import Protocol, TypedDict, deprecated
 
 from graphql import specified_rules
 
@@ -85,6 +85,12 @@ class ExecutionContext:
             return None
 
         return get_first_operation(graphql_document)
+
+    @property
+    @deprecated("Use 'pre_execution_errors' instead")
+    def errors(self) -> Optional[list[GraphQLError]]:
+        """Deprecated: Use pre_execution_errors instead."""
+        return self.pre_execution_errors
 
 
 @dataclasses.dataclass

--- a/strawberry/types/execution.py
+++ b/strawberry/types/execution.py
@@ -48,7 +48,7 @@ class ExecutionContext:
     # Values that get populated during the GraphQL execution so that they can be
     # accessed by extensions
     graphql_document: Optional[DocumentNode] = None
-    errors: Optional[list[GraphQLError]] = None
+    pre_execution_errors: Optional[list[GraphQLError]] = None
     result: Optional[GraphQLExecutionResult] = None
     extensions_results: dict[str, Any] = dataclasses.field(default_factory=dict)
 

--- a/tests/schema/extensions/schema_extensions/test_extensions.py
+++ b/tests/schema/extensions/schema_extensions/test_extensions.py
@@ -132,7 +132,7 @@ def test_extension_access_to_errors():
         def on_operation(self):
             nonlocal execution_errors
             yield
-            execution_errors = self.execution_context.errors
+            execution_errors = self.execution_context.pre_execution_errors
 
     @strawberry.type
     class Person:
@@ -823,7 +823,7 @@ def test_on_parsing_end_is_called_with_parsing_errors():
             nonlocal execution_errors
             yield
             execution_context = self.execution_context
-            execution_errors = execution_context.errors
+            execution_errors = execution_context.pre_execution_errors
 
     @strawberry.type
     class Query:


### PR DESCRIPTION
## Summary by Sourcery

Rename the ExecutionContext.errors field to pre_execution_errors to clarify the timing of error handling and update all references and tests accordingly

Enhancements:
- Replace all occurrences of context.errors with context.pre_execution_errors during parsing, validation, and execution stages
- Rename the errors attribute in ExecutionContext to pre_execution_errors to better reflect pre-execution error storage

Tests:
- Update schema extension tests to reference pre_execution_errors instead of errors