### PR TITLE
fix: fix generics resolution when using Annotated unions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,46 @@
+Release type: patch
+
+This release fixes the resolution of `Generics` when specializing using a union
+defined with `Annotated`, like in the example below:
+
+```python
+from typing import Annotated, Generic, TypeVar, Union
+import strawberry
+
+T = TypeVar("T")
+
+
+@strawberry.type
+class User:
+    name: str
+    age: int
+
+
+@strawberry.type
+class ProUser:
+    name: str
+    age: float
+
+
+@strawberry.type
+class GenType(Generic[T]):
+    data: T
+
+
+GeneralUser = Annotated[Union[User, ProUser], strawberry.union("GeneralUser")]
+
+
+@strawberry.type
+class Response(GenType[GeneralUser]): ...
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def user(self) -> Response: ...
+
+
+schema = strawberry.Schema(query=Query)
+```
+
+Before this would raise a `TypeError`, now it works as expected.

--- a/strawberry/annotation.py
+++ b/strawberry/annotation.py
@@ -173,7 +173,7 @@ class StrawberryAnnotation:
         if self._is_lazy_type(evaled_type):
             return evaled_type
         if self._is_streamable(evaled_type, args):
-            return self.create_list(list[evaled_type])  # type: ignore[valid-type]
+            return self.create_list(list[evaled_type])
         if self._is_list(evaled_type):
             return self.create_list(evaled_type)
         if self._is_maybe(evaled_type):

--- a/strawberry/annotation.py
+++ b/strawberry/annotation.py
@@ -125,16 +125,44 @@ class StrawberryAnnotation:
 
         return evaled_type, []
 
-    def resolve(self) -> Union[StrawberryType, type]:
+    def resolve(
+        self,
+        *,
+        type_definition: Optional[StrawberryObjectDefinition] = None,
+    ) -> Union[StrawberryType, type]:
         """Return resolved (transformed) annotation."""
-        if self.__resolve_cache__ is None:
-            self.__resolve_cache__ = self._resolve()
+        if (resolved := self.__resolve_cache__) is None:
+            resolved = self._resolve()
+            self.__resolve_cache__ = resolved
 
-        return self.__resolve_cache__
+        # If this is a generic field, try to resolve it using its origin's
+        # specialized type_var_map
+        if self._is_type_generic(resolved) and type_definition is not None:
+            from strawberry.types.base import StrawberryType
+
+            specialized_type_var_map = type_definition.specialized_type_var_map
+            if specialized_type_var_map and isinstance(resolved, StrawberryType):
+                resolved = resolved.copy_with(specialized_type_var_map)
+
+            # If the field is still generic, try to resolve it from the type_definition
+            # that is asking for it.
+            if (
+                self._is_type_generic(resolved)
+                and type_definition.type_var_map
+                and isinstance(resolved, StrawberryType)
+            ):
+                resolved = resolved.copy_with(type_definition.type_var_map)
+
+            # Resolve the type again to resolve any `Annotated` types
+            resolved = self._resolve_evaled_type(resolved)
+
+        return resolved
 
     def _resolve(self) -> Union[StrawberryType, type]:
         evaled_type = cast("Any", self.evaluate())
+        return self._resolve_evaled_type(evaled_type)
 
+    def _resolve_evaled_type(self, evaled_type: Any) -> Union[StrawberryType, type]:
         if is_private(evaled_type):
             return evaled_type
 
@@ -291,6 +319,20 @@ class StrawberryAnnotation:
         if not isinstance(annotation, type):
             return False
         return issubclass(annotation, Enum)
+
+    @classmethod
+    def _is_type_generic(cls, type_: Union[StrawberryType, type]) -> bool:
+        """Returns True if `resolver_type` is generic else False."""
+        from strawberry.types.base import StrawberryType
+
+        if isinstance(type_, StrawberryType):
+            return type_.is_graphql_generic
+
+        # solves the Generic subclass case
+        if has_object_definition(type_):
+            return type_.__strawberry_definition__.is_graphql_generic
+
+        return False
 
     @classmethod
     def _is_graphql_generic(cls, annotation: Any) -> bool:


### PR DESCRIPTION
Fix #3289

## Summary by Sourcery

Fix generic type resolution for Annotated unions by passing type definition context to annotation resolution and applying appropriate type variable mappings

Enhancements:
- Pass type_definition into annotation.resolve and apply specialized and type_var_map to StrawberryType generics
- Introduce _resolve_evaled_type helper and _is_type_generic predicate for cleaner resolution logic
- Remove old in-field generic resolution logic to centralize behavior

Documentation:
- Add release note describing the patch for generics resolution with Annotated unions

Tests:
- Add test for using Annotated Union inside a generic type to validate correct schema output