### PR TITLE
Test query batching with vars, ops, and extensions

### DIFF
--- a/tests/http/test_query_batching.py
+++ b/tests/http/test_query_batching.py
@@ -1,11 +1,15 @@
+import pytest
+
 import strawberry
 from strawberry.schema.config import StrawberryConfig
+from tests.conftest import skip_if_gql_32
 from tests.http.clients.base import HttpClient
 from tests.views.schema import Mutation, MyExtension, Query, Subscription
 
 
-async def test_batch_graphql_query(http_client_class: type[HttpClient]):
-    http_client = http_client_class(
+@pytest.fixture
+def batching_http_client(http_client_class: type[HttpClient]) -> HttpClient:
+    return http_client_class(
         schema=strawberry.Schema(
             query=Query,
             mutation=Mutation,
@@ -15,7 +19,9 @@ async def test_batch_graphql_query(http_client_class: type[HttpClient]):
         )
     )
 
-    response = await http_client.post(
+
+async def test_batching_works_with_multiple_queries(batching_http_client):
+    response = await batching_http_client.post(
         url="/graphql",
         json=[
             {"query": "{ hello }"},
@@ -28,6 +34,122 @@ async def test_batch_graphql_query(http_client_class: type[HttpClient]):
     assert response.json == [
         {"data": {"hello": "Hello world"}, "extensions": {"example": "example"}},
         {"data": {"hello": "Hello world"}, "extensions": {"example": "example"}},
+    ]
+
+
+async def test_batching_works_with_single_query(batching_http_client):
+    response = await batching_http_client.post(
+        url="/graphql",
+        json=[
+            {"query": "{ hello }"},
+        ],
+        headers={"content-type": "application/json"},
+    )
+
+    assert response.status_code == 200
+    assert response.json == [
+        {"data": {"hello": "Hello world"}, "extensions": {"example": "example"}},
+    ]
+
+
+async def test_variables_can_be_supplied_per_query(batching_http_client):
+    response = await batching_http_client.post(
+        url="/graphql",
+        json=[
+            {
+                "query": "query InjectedVariables($name: String!) { hello(name: $name) }",
+                "variables": {"name": "Alice"},
+            },
+            {
+                "query": "query InjectedVariables($name: String!) { hello(name: $name) }",
+                "variables": {"name": "Bob"},
+            },
+            {"query": "query NoVariables{ hello }"},
+        ],
+        headers={"content-type": "application/json"},
+    )
+
+    assert response.status_code == 200
+    assert response.json == [
+        {"data": {"hello": "Hello Alice"}, "extensions": {"example": "example"}},
+        {"data": {"hello": "Hello Bob"}, "extensions": {"example": "example"}},
+        {"data": {"hello": "Hello world"}, "extensions": {"example": "example"}},
+    ]
+
+
+async def test_operations_can_be_selected_per_query(batching_http_client):
+    response = await batching_http_client.post(
+        url="/graphql",
+        json=[
+            {
+                "query": 'query Op1 { hello(name: "Op1") } query Op2 { hello(name: "Op2") }',
+                "operationName": "Op1",
+            },
+            {
+                "query": 'query Op1 { hello(name: "Op1") } query Op2 { hello(name: "Op2") }',
+                "operationName": "Op2",
+            },
+        ],
+        headers={"content-type": "application/json"},
+    )
+
+    assert response.status_code == 200
+    assert response.json == [
+        {"data": {"hello": "Hello Op1"}, "extensions": {"example": "example"}},
+        {"data": {"hello": "Hello Op2"}, "extensions": {"example": "example"}},
+    ]
+
+
+@skip_if_gql_32("formatting is different in gql 3.2")
+async def test_extensions_are_handled_per_query(batching_http_client):
+    response = await batching_http_client.post(
+        url="/graphql",
+        json=[
+            {
+                "query": 'query { valueFromExtensions(key: "test") }',
+                "extensions": {"test": "op1-value"},
+            },
+            {
+                "query": 'query { valueFromExtensions(key: "test") }',
+                "extensions": {"test": "op2-value"},
+            },
+        ],
+        headers={"content-type": "application/json"},
+    )
+
+    assert response.status_code == 200
+    assert response.json == [
+        {
+            "data": {"valueFromExtensions": "op1-value"},
+            "extensions": {"example": "example"},
+        },
+        {
+            "data": {"valueFromExtensions": "op2-value"},
+            "extensions": {"example": "example"},
+        },
+    ]
+
+
+async def test_context_is_shared_between_operations(batching_http_client):
+    response = await batching_http_client.post(
+        url="/graphql",
+        json=[
+            {"query": 'mutation { updateContext(key: "test", value: "shared-value") }'},
+            {"query": 'query { valueFromContext(key: "test") }'},
+        ],
+        headers={"content-type": "application/json"},
+    )
+
+    assert response.status_code == 200
+    assert response.json == [
+        {
+            "data": {"updateContext": True},
+            "extensions": {"example": "example"},
+        },
+        {
+            "data": {"valueFromContext": "shared-value"},
+            "extensions": {"example": "example"},
+        },
     ]
 
 

--- a/tests/views/schema.py
+++ b/tests/views/schema.py
@@ -125,8 +125,10 @@ class Query:
         return type(self).__name__
 
     @strawberry.field
-    def value_from_context(self, info: strawberry.Info) -> str:
-        return info.context["custom_value"]
+    def value_from_context(
+        self, info: strawberry.Info, key: str = "custom_value"
+    ) -> str:
+        return info.context[key]
 
     @strawberry.field
     def value_from_extensions(self, info: strawberry.Info, key: str) -> str:
@@ -186,6 +188,11 @@ class Mutation:
     def match_text(self, text_file: Upload, pattern: str) -> str:
         text = text_file.read().decode()
         return pattern if pattern in text else ""
+
+    @strawberry.mutation
+    def update_context(self, info: strawberry.Info, key: str, value: str) -> bool:
+        info.context[key] = value
+        return True
 
 
 @strawberry.type


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
This PR adds extra query batching tests, making sure supplying variables, selecting operations, using operation extensions, and context sharing work as expected.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Summary by Sourcery

Add comprehensive tests for HTTP GraphQL query batching covering single/multiple queries, variables, operation selection, extensions, and shared context, and extend the test schema to support dynamic context key access and context updates.

Enhancements:
- Allow value_from_context field to accept a dynamic key parameter
- Add update_context mutation to enable modifying context during tests

Tests:
- Add tests to verify batching works with multiple and single queries
- Add tests to verify per-query variable injection
- Add tests to verify operationName selection in batched queries
- Add tests to verify per-query extensions handling
- Add test to verify shared context across batched operations