### PR TITLE
Add example for giving an argument a description

### DIFF
--- a/docs/general/queries.md
+++ b/docs/general/queries.md
@@ -101,3 +101,20 @@ class Query:
                 return fruit
         return None
 ```
+
+### Argument Descriptions
+
+Use `Annotated` to give a field argument a description:
+
+```python
+from typing import Annotated 
+import strawberry
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def fruit(
+        self,
+        startswith: Annotated[str, strawberry.argument(description="a prefix by which to filter fruits ")],
+    ) -> str | None: ...
+```


### PR DESCRIPTION
## Description

Small PR to add an example of giving a field a description

(I wonder if this use case is worth a dedicated helper?) 

## Types of Changes

- [x] Documentation

## Checklist

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
