### PR TITLE
Fix MaskErrors for synchronous pre-execution errors

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,18 @@
+---
+release type: patch
+social_messages:
+  x: >-
+    {project_name} {version} is out! This release ensures `MaskErrors` also
+    masks parsing and validation errors during synchronous execution. 🍓
+    https://strawberry.rocks/release/{version}
+  linkedin: >-
+    {project_name} {version} is out. This release fixes `MaskErrors` so
+    synchronous parsing and validation failures no longer expose their original
+    error details.
+---
+
+This release fixes `MaskErrors` leaking parsing and validation error details
+during synchronous execution.
+
+Synchronous execution now masks pre-execution errors consistently with
+asynchronous execution, including when `ValidationCache` is enabled.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,8 +11,8 @@ social_messages:
     error details.
 ---
 
-This release fixes `MaskErrors` leaking parsing and validation error details
-during synchronous execution.
+This release fixes an issue where `MaskErrors` leaked parsing and validation
+error details during synchronous execution.
 
 Synchronous execution now masks pre-execution errors consistently with
 asynchronous execution, including when `ValidationCache` is enabled.

--- a/strawberry/extensions/mask_errors.py
+++ b/strawberry/extensions/mask_errors.py
@@ -83,11 +83,6 @@ class MaskErrors(SchemaExtension):
             self._process_result(result)
         elif initial_result := getattr(result, "initial_result", None):
             self._process_result(initial_result)
-        # Synchronous parsing and validation failures don't populate `result`.
-        elif pre_execution_errors := self.execution_context.pre_execution_errors:
-            self.execution_context.pre_execution_errors = self._process_errors(
-                pre_execution_errors
-            )
 
     def on_stream_result(self, result: StreamExecutionResult) -> Iterator[None]:
         """Mask errors before a streamed execution result reaches the client."""

--- a/strawberry/extensions/mask_errors.py
+++ b/strawberry/extensions/mask_errors.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable, Iterator
-from typing import Any
+from typing import Protocol, runtime_checkable
 
 from graphql import ExecutionResult as GraphQLExecutionResult
 from graphql.error import GraphQLError
@@ -9,6 +9,11 @@ from strawberry.types.execution import (
     ExecutionResult as StrawberryExecutionResult,
 )
 from strawberry.types.execution import StreamExecutionResult
+
+
+@runtime_checkable
+class _ResultWithErrors(Protocol):
+    errors: list[GraphQLError] | None
 
 
 def default_should_mask_error(_: GraphQLError) -> bool:
@@ -50,11 +55,9 @@ class MaskErrors(SchemaExtension):
 
         return processed_errors
 
-    # TODO: proper typing
-    def _process_result(self, result: Any) -> None:
-        errors = getattr(result, "errors", None)
-        if errors:
-            result.errors = self._process_errors(errors)
+    def _process_result(self, result: object) -> None:
+        if isinstance(result, _ResultWithErrors) and result.errors:
+            result.errors = self._process_errors(result.errors)
 
     def _process_stream_result(self, result: StreamExecutionResult) -> None:
         self._process_result(result)

--- a/strawberry/extensions/mask_errors.py
+++ b/strawberry/extensions/mask_errors.py
@@ -39,12 +39,7 @@ class MaskErrors(SchemaExtension):
             original_error=None,
         )
 
-    # TODO: proper typing
-    def _process_result(self, result: Any) -> None:
-        errors = getattr(result, "errors", None)
-        if not errors:
-            return
-
+    def _process_errors(self, errors: list[GraphQLError]) -> list[GraphQLError]:
         processed_errors: list[GraphQLError] = []
 
         for error in errors:
@@ -53,7 +48,13 @@ class MaskErrors(SchemaExtension):
             else:
                 processed_errors.append(error)
 
-        result.errors = processed_errors
+        return processed_errors
+
+    # TODO: proper typing
+    def _process_result(self, result: Any) -> None:
+        errors = getattr(result, "errors", None)
+        if errors:
+            result.errors = self._process_errors(errors)
 
     def _process_stream_result(self, result: StreamExecutionResult) -> None:
         self._process_result(result)
@@ -79,6 +80,11 @@ class MaskErrors(SchemaExtension):
             self._process_result(result)
         elif initial_result := getattr(result, "initial_result", None):
             self._process_result(initial_result)
+        # Synchronous parsing and validation failures don't populate `result`.
+        elif pre_execution_errors := self.execution_context.pre_execution_errors:
+            self.execution_context.pre_execution_errors = self._process_errors(
+                pre_execution_errors
+            )
 
     def on_stream_result(self, result: StreamExecutionResult) -> Iterator[None]:
         """Mask errors before a streamed execution result reaches the client."""

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -831,54 +831,63 @@ class Schema(BaseSchema):
             operation_extensions, sync=True
         )
 
+        pre_execution_result: ExecutionResult | None = None
+
         try:
             with extensions_runner.operation():
                 # Note: In graphql-core the schema would be validated here but in
                 # Strawberry we are validating it at initialisation time instead
-                if (
-                    pre_execution_result := self._prepare_operation_sync(
-                        execution_context, extensions_runner
-                    )
-                ) is not None:
-                    return pre_execution_result
+                pre_execution_result = self._prepare_operation_sync(
+                    execution_context, extensions_runner
+                )
 
-                assert execution_context.graphql_document is not None
-                with extensions_runner.executing():
-                    if not execution_context.result:
-                        result = execute_function(
-                            self._schema,
-                            execution_context.graphql_document,
-                            root_value=execution_context.root_value,
-                            middleware=middleware_manager,
-                            variable_values=execution_context.variables,
-                            operation_name=execution_context.operation_name,
-                            context_value=execution_context.context,
-                            is_awaitable=optimized_is_awaitable,
-                            **execution_context_class_kwargs(
-                                self.execution_context_class
-                            ),
-                            **custom_context_kwargs,
-                        )
-
-                        if isawaitable(result):
-                            result = cast("Awaitable[GraphQLExecutionResult]", result)
-                            ensure_future(result).cancel()
-                            raise RuntimeError(  # noqa: TRY301
-                                "GraphQL execution failed to complete synchronously."
+                if pre_execution_result is None:
+                    assert execution_context.graphql_document is not None
+                    with extensions_runner.executing():
+                        if not execution_context.result:
+                            result = execute_function(
+                                self._schema,
+                                execution_context.graphql_document,
+                                root_value=execution_context.root_value,
+                                middleware=middleware_manager,
+                                variable_values=execution_context.variables,
+                                operation_name=execution_context.operation_name,
+                                context_value=execution_context.context,
+                                is_awaitable=optimized_is_awaitable,
+                                **execution_context_class_kwargs(
+                                    self.execution_context_class
+                                ),
+                                **custom_context_kwargs,
                             )
 
-                        result = cast("GraphQLExecutionResult", result)
-                        execution_context.result = result
-                        # Also set errors on the context so that it's easier
-                        # to access in extensions
-                        if result.errors:
-                            execution_context.pre_execution_errors = result.errors
+                            if isawaitable(result):
+                                result = cast(
+                                    "Awaitable[GraphQLExecutionResult]", result
+                                )
+                                ensure_future(result).cancel()
+                                raise RuntimeError(  # noqa: TRY301
+                                    "GraphQL execution failed to complete synchronously."
+                                )
 
-                            # Run the `Schema.process_errors` function here before
-                            # extensions have a chance to modify them (see the MaskErrors
-                            # extension). That way we can log the original errors but
-                            # only return a sanitised version to the client.
-                            self._process_errors(result.errors, execution_context)
+                            result = cast("GraphQLExecutionResult", result)
+                            execution_context.result = result
+                            # Also set errors on the context so that it's easier
+                            # to access in extensions
+                            if result.errors:
+                                execution_context.pre_execution_errors = result.errors
+
+                                # Run the `Schema.process_errors` function here before
+                                # extensions have a chance to modify them (see the
+                                # MaskErrors extension). That way we can log the original
+                                # errors but only return a sanitised version to the client.
+                                self._process_errors(result.errors, execution_context)
+
+            if pre_execution_result is not None:
+                # Operation hooks may replace pre-execution errors (for example,
+                # MaskErrors anonymises them), so finalise the returned result only
+                # after those hooks have completed.
+                pre_execution_result.errors = execution_context.pre_execution_errors
+                return pre_execution_result
         except (
             MissingQueryError,
             CannotGetOperationTypeError,
@@ -894,6 +903,8 @@ class Schema(BaseSchema):
                 errors=errors,
                 extensions=extensions_runner.get_extensions_results_sync(),
             )
+
+        assert execution_context.result is not None
         return ExecutionResult(
             data=execution_context.result.data,
             errors=execution_context.result.errors,

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -831,63 +831,57 @@ class Schema(BaseSchema):
             operation_extensions, sync=True
         )
 
-        pre_execution_result: ExecutionResult | None = None
-
         try:
             with extensions_runner.operation():
                 # Note: In graphql-core the schema would be validated here but in
                 # Strawberry we are validating it at initialisation time instead
-                pre_execution_result = self._prepare_operation_sync(
-                    execution_context, extensions_runner
-                )
+                if (
+                    pre_execution_result := self._prepare_operation_sync(
+                        execution_context, extensions_runner
+                    )
+                ) is not None:
+                    # Match the async path by exposing pre-execution results to
+                    # operation extensions before their hooks unwind.
+                    execution_context.result = pre_execution_result
+                    return pre_execution_result
 
-                if pre_execution_result is None:
-                    assert execution_context.graphql_document is not None
-                    with extensions_runner.executing():
-                        if not execution_context.result:
-                            result = execute_function(
-                                self._schema,
-                                execution_context.graphql_document,
-                                root_value=execution_context.root_value,
-                                middleware=middleware_manager,
-                                variable_values=execution_context.variables,
-                                operation_name=execution_context.operation_name,
-                                context_value=execution_context.context,
-                                is_awaitable=optimized_is_awaitable,
-                                **execution_context_class_kwargs(
-                                    self.execution_context_class
-                                ),
-                                **custom_context_kwargs,
+                assert execution_context.graphql_document is not None
+                with extensions_runner.executing():
+                    if not execution_context.result:
+                        result = execute_function(
+                            self._schema,
+                            execution_context.graphql_document,
+                            root_value=execution_context.root_value,
+                            middleware=middleware_manager,
+                            variable_values=execution_context.variables,
+                            operation_name=execution_context.operation_name,
+                            context_value=execution_context.context,
+                            is_awaitable=optimized_is_awaitable,
+                            **execution_context_class_kwargs(
+                                self.execution_context_class
+                            ),
+                            **custom_context_kwargs,
+                        )
+
+                        if isawaitable(result):
+                            result = cast("Awaitable[GraphQLExecutionResult]", result)
+                            ensure_future(result).cancel()
+                            raise RuntimeError(  # noqa: TRY301
+                                "GraphQL execution failed to complete synchronously."
                             )
 
-                            if isawaitable(result):
-                                result = cast(
-                                    "Awaitable[GraphQLExecutionResult]", result
-                                )
-                                ensure_future(result).cancel()
-                                raise RuntimeError(  # noqa: TRY301
-                                    "GraphQL execution failed to complete synchronously."
-                                )
+                        result = cast("GraphQLExecutionResult", result)
+                        execution_context.result = result
+                        # Also set errors on the context so that it's easier
+                        # to access in extensions
+                        if result.errors:
+                            execution_context.pre_execution_errors = result.errors
 
-                            result = cast("GraphQLExecutionResult", result)
-                            execution_context.result = result
-                            # Also set errors on the context so that it's easier
-                            # to access in extensions
-                            if result.errors:
-                                execution_context.pre_execution_errors = result.errors
-
-                                # Run the `Schema.process_errors` function here before
-                                # extensions have a chance to modify them (see the
-                                # MaskErrors extension). That way we can log the original
-                                # errors but only return a sanitised version to the client.
-                                self._process_errors(result.errors, execution_context)
-
-            if pre_execution_result is not None:
-                # Operation hooks may replace pre-execution errors (for example,
-                # MaskErrors anonymises them), so finalise the returned result only
-                # after those hooks have completed.
-                pre_execution_result.errors = execution_context.pre_execution_errors
-                return pre_execution_result
+                            # Run the `Schema.process_errors` function here before
+                            # extensions have a chance to modify them (see the MaskErrors
+                            # extension). That way we can log the original errors but
+                            # only return a sanitised version to the client.
+                            self._process_errors(result.errors, execution_context)
         except (
             MissingQueryError,
             CannotGetOperationTypeError,
@@ -903,8 +897,6 @@ class Schema(BaseSchema):
                 errors=errors,
                 extensions=extensions_runner.get_extensions_results_sync(),
             )
-
-        assert execution_context.result is not None
         return ExecutionResult(
             data=execution_context.result.data,
             errors=execution_context.result.errors,

--- a/tests/schema/extensions/test_mask_errors.py
+++ b/tests/schema/extensions/test_mask_errors.py
@@ -28,6 +28,7 @@ def test_mask_pre_execution_errors_sync(query: str):
 
     result = schema.execute_sync(query)
 
+    assert result.data is None
     assert result.errors is not None
     assert [error.message for error in result.errors] == ["Unexpected error."]
 
@@ -48,6 +49,7 @@ def test_mask_cached_validation_errors_sync():
     results = (schema.execute_sync(query), schema.execute_sync(query))
 
     for result in results:
+        assert result.data is None
         assert result.errors is not None
         assert [error.message for error in result.errors] == ["Unexpected error."]
 
@@ -74,6 +76,7 @@ async def test_mask_pre_execution_errors_async(query: str):
 
     result = await schema.execute(query)
 
+    assert result.data is None
     assert result.errors is not None
     assert [error.message for error in result.errors] == ["Unexpected error."]
 

--- a/tests/schema/extensions/test_mask_errors.py
+++ b/tests/schema/extensions/test_mask_errors.py
@@ -32,6 +32,26 @@ def test_mask_pre_execution_errors_sync(query: str):
     assert [error.message for error in result.errors] == ["Unexpected error."]
 
 
+def test_mask_cached_validation_errors_sync():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def test_field(self) -> str:
+            return "TestField"
+
+    schema = strawberry.Schema(
+        query=Query,
+        extensions=[ValidationCache, MaskErrors],
+    )
+
+    query = "query { missingField }"
+    results = (schema.execute_sync(query), schema.execute_sync(query))
+
+    for result in results:
+        assert result.errors is not None
+        assert [error.message for error in result.errors] == ["Unexpected error."]
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "query",

--- a/tests/schema/extensions/test_mask_errors.py
+++ b/tests/schema/extensions/test_mask_errors.py
@@ -4,7 +4,32 @@ import pytest
 from graphql.error import GraphQLError
 
 import strawberry
-from strawberry.extensions import MaskErrors
+from strawberry.extensions import MaskErrors, ValidationCache
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "query { testField( }",
+        "query { missingField }",
+    ],
+)
+def test_mask_pre_execution_errors_sync(query: str):
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def test_field(self) -> str:
+            return "TestField"
+
+    schema = strawberry.Schema(
+        query=Query,
+        extensions=[ValidationCache, MaskErrors],
+    )
+
+    result = schema.execute_sync(query)
+
+    assert result.errors is not None
+    assert [error.message for error in result.errors] == ["Unexpected error."]
 
 
 def test_mask_all_errors():

--- a/tests/schema/extensions/test_mask_errors.py
+++ b/tests/schema/extensions/test_mask_errors.py
@@ -32,6 +32,32 @@ def test_mask_pre_execution_errors_sync(query: str):
     assert [error.message for error in result.errors] == ["Unexpected error."]
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "query",
+    [
+        "query { testField( }",
+        "query { missingField }",
+    ],
+)
+async def test_mask_pre_execution_errors_async(query: str):
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def test_field(self) -> str:
+            return "TestField"
+
+    schema = strawberry.Schema(
+        query=Query,
+        extensions=[ValidationCache, MaskErrors],
+    )
+
+    result = await schema.execute(query)
+
+    assert result.errors is not None
+    assert [error.message for error in result.errors] == ["Unexpected error."]
+
+
 def test_mask_all_errors():
     @strawberry.type
     class Query:


### PR DESCRIPTION
## Description

This fixes `MaskErrors` so parsing and validation errors are also masked during synchronous execution, including when `ValidationCache` supplies the validation result. 🍓

The sync path previously returned its pre-execution result from inside the operation lifecycle. After-yield extension hooks could update `execution_context.pre_execution_errors`, but the already-created return object retained the original errors.

This update:

- lets `MaskErrors` process `pre_execution_errors` when no execution result exists
- finalises the synchronous pre-execution result after operation hooks complete
- preserves the existing execution and streamed-result masking paths
- adds regression coverage for syntax and cached validation failures

Fixes #3844.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation-only change

## Validation

- `uv run pytest tests/schema/extensions/test_mask_errors.py -q` — 9 passed
- `uv run pytest tests/schema/extensions/ -q` — 174 passed, 10 skipped
- `uv run mypy --config-file mypy.ini` — 240 source files clean
- `uv run ruff check .` — passed
- `uv run ruff format --check .` — 647 files formatted

## Summary by Sourcery

Fix masking of pre-execution errors during synchronous execution so error details are consistently hidden, and add regression coverage and release notes for this behavior.

Bug Fixes:
- Ensure MaskErrors also masks parsing and validation errors for synchronous execution, including when ValidationCache is used.

Enhancements:
- Refine MaskErrors error processing to operate on a typed result-with-errors protocol shared across sync, async, and streamed executions.

Documentation:
- Add release notes describing the fix for synchronous masking of parsing and validation errors.

Tests:
- Add sync and async tests verifying that pre-execution parsing and validation errors are masked when using ValidationCache with MaskErrors.