### PR TITLE
⚡️ Speed up function `should_resolve_list_connection_edges` by 46%

### DIFF
--- a/strawberry/relay/utils.py
+++ b/strawberry/relay/utils.py
@@ -94,8 +94,7 @@ def should_resolve_list_connection_edges(info: Info) -> bool:
             and selection.name in resolve_for_field_names
         ):
             return True
-        nested_selections = getattr(selection, "selections", None)
-        if nested_selections:
+        if nested_selections := getattr(selection, "selections", None):
             stack.extend(nested_selections)
     return False
 

--- a/strawberry/relay/utils.py
+++ b/strawberry/relay/utils.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any, Union
 from typing_extensions import Self, assert_never
 
 from strawberry.types.base import StrawberryObjectDefinition
-from strawberry.types.info import Info
 from strawberry.types.nodes import InlineFragment
 
 if TYPE_CHECKING:
@@ -84,10 +83,9 @@ def should_resolve_list_connection_edges(info: Info) -> bool:
 
     """
     resolve_for_field_names = {"edges", "pageInfo"}
-    # Use a stack for iterative DFS, much faster than recursion
+    # Recursively inspect the selection to check if the user requested to resolve the `edges` field.
     stack = []
     for selection_field in info.selected_fields:
-        # Push all top-level selections onto the stack
         stack.extend(selection_field.selections)
     while stack:
         selection = stack.pop()
@@ -96,8 +94,6 @@ def should_resolve_list_connection_edges(info: Info) -> bool:
             and selection.name in resolve_for_field_names
         ):
             return True
-        # InlineFragment or any other Selection: examine nested selections (if any)
-        # Use getattr to avoid attribute error if selections doesn't exist
         nested_selections = getattr(selection, "selections", None)
         if nested_selections:
             stack.extend(nested_selections)


### PR DESCRIPTION
Saurabh's comment - This should speedup resolving of connections 
### 📄 46% (0.46x) speedup for ***`should_resolve_list_connection_edges` in `strawberry/relay/utils.py`***

⏱️ Runtime :   **`1.18 milliseconds`**  **→** **`805 microseconds`** (best of `82` runs)
### 📝 Explanation and details

The efficiency improvement focuses on two major issues in the profile.

- The **nested for-loops** iterating through selections and recursing with a function that checks every node. This was incurring deep call overhead and duplicate checks.
- The **recursive _check_selection** can be replaced with an iterative approach using a stack to avoid deep Python recursion and to exit immediately on the first match.



**Summary of changes:**
- Eliminated all recursion by rewriting as a single iterative DFS using a stack, minimizing Python frame overhead.
- Only a single scan through the selection tree with immediate exit on finding a match (`edges`/`pageInfo`).

**You can expect** a substantial runtime improvement, especially with deeply nested or large queries, plus removal of risk of hitting the recursion limit.


✅ **Correctness verification report:**

| Test                        | Status            |
| --------------------------- | ----------------- |
| ⚙️ Existing Unit Tests | 🔘 **None Found** |
| 🌀 Generated Regression Tests | ✅ **53 Passed** |
| ⏪ Replay Tests | 🔘 **None Found** |
| 🔎 Concolic Coverage Tests | 🔘 **None Found** |
|📊 Tests Coverage       | 100.0% |
<details>
<summary>🌀 Generated Regression Tests and Runtime</summary>

```python
from __future__ import annotations

from types import SimpleNamespace

# imports
import pytest  # used for our unit tests
from strawberry.relay.utils import should_resolve_list_connection_edges

# --- Minimal stubs for Info, Selection, InlineFragment to allow unit testing ---
# These are simplified stand-ins for strawberry.types.info.Info and strawberry.types.nodes.Selection, InlineFragment

class Selection:
    def __init__(self, name=None, selections=None):
        self.name = name
        self.selections = selections or []

class InlineFragment(Selection):
    def __init__(self, selections=None):
        # InlineFragment has no name
        super().__init__(name=None, selections=selections)

class Info:
    def __init__(self, selected_fields):
        self.selected_fields = selected_fields
from strawberry.relay.utils import should_resolve_list_connection_edges

# --- Unit tests ---

# Helper factory to build mock selection fields
def make_selection(name=None, selections=None):
    return Selection(name=name, selections=selections)

def make_inline_fragment(selections=None):
    return InlineFragment(selections=selections)

def make_info(selected_fields):
    # selected_fields is a list of objects with a .selections attribute (list of Selection)
    return Info(selected_fields=selected_fields)

# 1. BASIC TEST CASES

def test_no_selected_fields_returns_false():
    # No fields selected at all
    info = make_info([])
    codeflash_output = should_resolve_list_connection_edges(info) # 1.12μs -> 975ns (15.3% faster)

def test_selected_fields_no_selections_returns_false():
    # Selected fields exist, but none have selections
    info = make_info([SimpleNamespace(selections=[])])
    codeflash_output = should_resolve_list_connection_edges(info) # 1.10μs -> 1.09μs (1.29% faster)

def test_edges_field_selected_directly_returns_true():
    # 'edges' is selected directly
    sel = make_selection('edges')
    info = make_info([SimpleNamespace(selections=[sel])])
    codeflash_output = should_resolve_list_connection_edges(info) # 1.74μs -> 1.82μs (4.67% slower)

def test_pageinfo_field_selected_returns_true():
    # 'pageInfo' is selected directly (should also trigger True)
    sel = make_selection('pageInfo')
    info = make_info([SimpleNamespace(selections=[sel])])
    codeflash_output = should_resolve_list_connection_edges(info) # 1.43μs -> 1.51μs (5.16% slower)

def test_other_field_selected_returns_false():
    # Some other field is selected, not 'edges' or 'pageInfo'
    sel = make_selection('foo')
    info = make_info([SimpleNamespace(selections=[sel])])
    codeflash_output = should_resolve_list_connection_edges(info) # 1.95μs -> 1.76μs (10.8% faster)

def test_edges_nested_in_selection_returns_true():
    # 'edges' is nested inside another selection
    inner = make_selection('edges')
    outer = make_selection('foo', selections=[inner])
    info = make_info([SimpleNamespace(selections=[outer])])
    codeflash_output = should_resolve_list_connection_edges(info) # 4.01μs -> 1.92μs (109% faster)

def test_pageinfo_nested_in_selection_returns_true():
    # 'pageInfo' is nested inside another selection
    inner = make_selection('pageInfo')
    outer = make_selection('foo', selections=[inner])
    info = make_info([SimpleNamespace(selections=[outer])])
    codeflash_output = should_resolve_list_connection_edges(info) # 3.41μs -> 1.90μs (79.7% faster)

def test_multiple_selected_fields_one_with_edges_returns_true():
    # Multiple selected fields, only one contains 'edges'
    sel1 = make_selection('foo')
    sel2 = make_selection('edges')
    info = make_info([
        SimpleNamespace(selections=[sel1]),
        SimpleNamespace(selections=[sel2]),
    ])
    codeflash_output = should_resolve_list_connection_edges(info) # 1.90μs -> 1.52μs (24.5% faster)

def test_multiple_selected_fields_none_with_edges_returns_false():
    # Multiple selected fields, none contain 'edges' or 'pageInfo'
    sel1 = make_selection('foo')
    sel2 = make_selection('bar')
    info = make_info([
        SimpleNamespace(selections=[sel1]),
        SimpleNamespace(selections=[sel2]),
    ])
    codeflash_output = should_resolve_list_connection_edges(info) # 1.68μs -> 1.98μs (15.0% slower)

# 2. EDGE TEST CASES

def test_edges_in_inline_fragment_returns_true():
    # 'edges' is inside an InlineFragment
    inner = make_selection('edges')
    fragment = make_inline_fragment([inner])
    outer = make_selection('foo', selections=[fragment])
    info = make_info([SimpleNamespace(selections=[outer])])
    codeflash_output = should_resolve_list_connection_edges(info) # 4.48μs -> 2.40μs (87.1% faster)

def test_edges_deeply_nested_returns_true():
    # 'edges' is nested multiple levels deep
    s3 = make_selection('edges')
    s2 = make_selection('bar', selections=[s3])
    s1 = make_selection('foo', selections=[s2])
    info = make_info([SimpleNamespace(selections=[s1])])
    codeflash_output = should_resolve_list_connection_edges(info) # 3.88μs -> 1.99μs (95.3% faster)

def test_edges_in_multiple_branches_returns_true():
    # 'edges' appears in one branch, not the other
    s1 = make_selection('foo', selections=[make_selection('edges')])
    s2 = make_selection('bar', selections=[make_selection('baz')])
    info = make_info([SimpleNamespace(selections=[s1, s2])])
    codeflash_output = should_resolve_list_connection_edges(info) # 2.99μs -> 2.25μs (32.8% faster)

def test_edges_in_inline_fragment_only_returns_true():
    # Only an InlineFragment contains 'edges'
    fragment = make_inline_fragment([make_selection('edges')])
    info = make_info([SimpleNamespace(selections=[fragment])])
    codeflash_output = should_resolve_list_connection_edges(info) # 3.18μs -> 1.86μs (71.2% faster)

def test_empty_inline_fragment_returns_false():
    # InlineFragment with no selections
    fragment = make_inline_fragment([])
    info = make_info([SimpleNamespace(selections=[fragment])])
    codeflash_output = should_resolve_list_connection_edges(info) # 1.48μs -> 1.66μs (10.7% slower)

def test_inline_fragment_with_non_edges_returns_false():
    # InlineFragment with non-edges field
    fragment = make_inline_fragment([make_selection('foo')])
    info = make_info([SimpleNamespace(selections=[fragment])])
    codeflash_output = should_resolve_list_connection_edges(info) # 2.81μs -> 2.13μs (32.2% faster)

def test_case_sensitivity_edges_returns_false():
    # 'Edges' (capitalized) should not match 'edges'
    sel = make_selection('Edges')
    info = make_info([SimpleNamespace(selections=[sel])])
    codeflash_output = should_resolve_list_connection_edges(info) # 1.44μs -> 1.60μs (9.99% slower)

def test_case_sensitivity_pageinfo_returns_false():
    # 'PageInfo' (capitalized) should not match 'pageInfo'
    sel = make_selection('PageInfo')
    info = make_info([SimpleNamespace(selections=[sel])])
    codeflash_output = should_resolve_list_connection_edges(info) # 1.51μs -> 1.59μs (5.40% slower)

def test_edges_and_pageinfo_both_selected_returns_true():
    # Both 'edges' and 'pageInfo' selected, should still return True
    sel1 = make_selection('edges')
    sel2 = make_selection('pageInfo')
    info = make_info([SimpleNamespace(selections=[sel1, sel2])])
    codeflash_output = should_resolve_list_connection_edges(info) # 1.39μs -> 1.44μs (3.06% slower)

def test_edges_and_pageinfo_nested_both_selected_returns_true():
    # Both 'edges' and 'pageInfo' nested in different branches
    sel1 = make_selection('foo', selections=[make_selection('edges')])
    sel2 = make_selection('bar', selections=[make_selection('pageInfo')])
    info = make_info([SimpleNamespace(selections=[sel1, sel2])])
    codeflash_output = should_resolve_list_connection_edges(info) # 3.59μs -> 1.95μs (84.2% faster)

def test_edges_and_pageinfo_not_selected_returns_false():
    # Both 'edges' and 'pageInfo' not selected, only other fields
    sel1 = make_selection('foo')
    sel2 = make_selection('bar')
    info = make_info([SimpleNamespace(selections=[sel1, sel2])])
    codeflash_output = should_resolve_list_connection_edges(info) # 1.75μs -> 1.82μs (3.96% slower)

def test_selection_with_none_name_returns_false():
    # Selection with name=None should not match
    sel = make_selection()
    info = make_info([SimpleNamespace(selections=[sel])])
    codeflash_output = should_resolve_list_connection_edges(info) # 1.48μs -> 1.59μs (7.03% slower)

def test_selection_with_empty_name_returns_false():
    # Selection with empty string name should not match
    sel = make_selection('')
    info = make_info([SimpleNamespace(selections=[sel])])
    codeflash_output = should_resolve_list_connection_edges(info) # 1.50μs -> 1.62μs (7.60% slower)

def test_selection_with_none_and_edges_returns_true():
    # One selection with None, one with 'edges'
    sel1 = make_selection()
    sel2 = make_selection('edges')
    info = make_info([SimpleNamespace(selections=[sel1, sel2])])
    codeflash_output = should_resolve_list_connection_edges(info) # 1.77μs -> 1.42μs (24.6% faster)

def test_selection_with_empty_and_pageinfo_returns_true():
    # One selection with empty string, one with 'pageInfo'
    sel1 = make_selection('')
    sel2 = make_selection('pageInfo')
    info = make_info([SimpleNamespace(selections=[sel1, sel2])])
    codeflash_output = should_resolve_list_connection_edges(info) # 1.72μs -> 1.44μs (20.0% faster)

# 3. LARGE SCALE TEST CASES

def test_large_number_of_non_edges_fields_returns_false():
    # 500 selections, none are 'edges' or 'pageInfo'
    selections = [make_selection(f'field{i}') for i in range(500)]
    info = make_info([SimpleNamespace(selections=selections)])
    codeflash_output = should_resolve_list_connection_edges(info) # 37.9μs -> 43.4μs (12.8% slower)

def test_large_number_of_fields_one_edges_returns_true():
    # 499 non-edges, 1 'edges' at the end
    selections = [make_selection(f'field{i}') for i in range(499)]
    selections.append(make_selection('edges'))
    info = make_info([SimpleNamespace(selections=selections)])
    codeflash_output = should_resolve_list_connection_edges(info) # 37.2μs -> 2.75μs (1251% faster)

def test_large_nested_structure_edges_deep_returns_true():
    # Deeply nested structure, 'edges' at the bottom
    depth = 100
    leaf = make_selection('edges')
    for _ in range(depth):
        leaf = make_selection('foo', selections=[leaf])
    info = make_info([SimpleNamespace(selections=[leaf])])
    codeflash_output = should_resolve_list_connection_edges(info) # 83.6μs -> 10.2μs (723% faster)

def test_large_number_of_selected_fields_one_with_edges_returns_true():
    # 999 selected_fields, only the last one contains 'edges'
    selected_fields = []
    for i in range(998):
        selected_fields.append(SimpleNamespace(selections=[make_selection(f'field{i}')]))
    selected_fields.append(SimpleNamespace(selections=[make_selection('edges')]))
    info = make_info(selected_fields)
    codeflash_output = should_resolve_list_connection_edges(info) # 111μs -> 35.5μs (214% faster)

def test_large_number_of_selected_fields_none_with_edges_returns_false():
    # 1000 selected_fields, none contain 'edges' or 'pageInfo'
    selected_fields = [SimpleNamespace(selections=[make_selection(f'field{i}')]) for i in range(1000)]
    info = make_info(selected_fields)
    codeflash_output = should_resolve_list_connection_edges(info) # 110μs -> 114μs (3.51% slower)

def test_large_branching_tree_edges_in_one_leaf_returns_true():
    # Tree: root -> 10 branches, each with 10 leaves; only one leaf is 'edges'
    leaves = [make_selection(f'leaf{i}') for i in range(99)]
    leaves.append(make_selection('edges'))
    import random
    random.shuffle(leaves)
    branches = [make_selection(f'branch{i}', selections=[leaves[i*10 + j] for j in range(10)]) for i in range(10)]
    root = make_selection('root', selections=branches)
    info = make_info([SimpleNamespace(selections=[root])])
    codeflash_output = should_resolve_list_connection_edges(info) # 10.9μs -> 8.14μs (34.0% faster)

def test_large_branching_tree_no_edges_returns_false():
    # Tree: root -> 10 branches, each with 10 leaves; no 'edges'
    leaves = [make_selection(f'leaf{i}') for i in range(100)]
    branches = [make_selection(f'branch{i}', selections=[leaves[i*10 + j] for j in range(10)]) for i in range(10)]
    root = make_selection('root', selections=branches)
    info = make_info([SimpleNamespace(selections=[root])])
    codeflash_output = should_resolve_list_connection_edges(info) # 13.4μs -> 12.9μs (3.82% faster)
# codeflash_output is used to check that the output of the original code is the same as that of the optimized code.

from __future__ import annotations

from types import SimpleNamespace

# imports
import pytest  # used for our unit tests
from strawberry.relay.utils import should_resolve_list_connection_edges


# Mocks for strawberry.types.info.Info, strawberry.types.nodes.Selection, InlineFragment
class Selection:
    def __init__(self, name=None, selections=None):
        self.name = name
        self.selections = selections or []

class InlineFragment(Selection):
    def __init__(self, selections=None):
        super().__init__(name=None, selections=selections or [])

class Info:
    def __init__(self, selected_fields):
        self.selected_fields = selected_fields
from strawberry.relay.utils import should_resolve_list_connection_edges

# unit tests

# ----------------------------
# Basic Test Cases
# ----------------------------

def test_should_resolve_edges_direct():
    # Direct selection of 'edges' at root
    info = Info(selected_fields=[
        SimpleNamespace(selections=[Selection(name="edges")])
    ])
    codeflash_output = should_resolve_list_connection_edges(info) # 1.48μs -> 1.52μs (2.44% slower)

def test_should_resolve_pageinfo_direct():
    # Direct selection of 'pageInfo' at root
    info = Info(selected_fields=[
        SimpleNamespace(selections=[Selection(name="pageInfo")])
    ])
    codeflash_output = should_resolve_list_connection_edges(info) # 1.50μs -> 1.45μs (3.45% faster)

def test_should_not_resolve_other_fields():
    # Only unrelated fields selected
    info = Info(selected_fields=[
        SimpleNamespace(selections=[Selection(name="nodes"), Selection(name="count")])
    ])
    codeflash_output = should_resolve_list_connection_edges(info) # 1.81μs -> 1.91μs (4.93% slower)

def test_should_resolve_edges_nested():
    # 'edges' nested inside another selection
    info = Info(selected_fields=[
        SimpleNamespace(selections=[
            Selection(name="foo", selections=[
                Selection(name="edges")
            ])
        ])
    ])
    codeflash_output = should_resolve_list_connection_edges(info) # 3.49μs -> 1.83μs (90.9% faster)

def test_should_not_resolve_when_empty():
    # No selections at all
    info = Info(selected_fields=[])
    codeflash_output = should_resolve_list_connection_edges(info) # 879ns -> 782ns (12.4% faster)

# ----------------------------
# Edge Test Cases
# ----------------------------

def test_should_resolve_edges_with_inline_fragment():
    # 'edges' inside an InlineFragment
    info = Info(selected_fields=[
        SimpleNamespace(selections=[
            InlineFragment(selections=[
                Selection(name="edges")
            ])
        ])
    ])
    codeflash_output = should_resolve_list_connection_edges(info) # 3.71μs -> 1.99μs (86.1% faster)

def test_should_not_resolve_with_only_inline_fragment_and_no_edges():
    # InlineFragment with unrelated fields only
    info = Info(selected_fields=[
        SimpleNamespace(selections=[
            InlineFragment(selections=[
                Selection(name="foo"),
                Selection(name="bar")
            ])
        ])
    ])
    codeflash_output = should_resolve_list_connection_edges(info) # 2.73μs -> 2.23μs (22.3% faster)

def test_should_resolve_edges_deeply_nested():
    # 'edges' deeply nested in multiple layers
    info = Info(selected_fields=[
        SimpleNamespace(selections=[
            Selection(name="foo", selections=[
                Selection(name="bar", selections=[
                    Selection(name="baz", selections=[
                        Selection(name="edges")
                    ])
                ])
            ])
        ])
    ])
    codeflash_output = should_resolve_list_connection_edges(info) # 4.94μs -> 2.11μs (134% faster)

def test_should_not_resolve_with_similar_names():
    # Fields with similar names to 'edges' but not exactly 'edges' or 'pageInfo'
    info = Info(selected_fields=[
        SimpleNamespace(selections=[
            Selection(name="edge"),
            Selection(name="edgess"),
            Selection(name="pageinfo"),
            Selection(name="page_Info"),
        ])
    ])
    codeflash_output = should_resolve_list_connection_edges(info) # 2.01μs -> 2.08μs (3.42% slower)

def test_should_resolve_edges_multiple_selected_fields():
    # Multiple selected_fields, only one contains 'edges'
    info = Info(selected_fields=[
        SimpleNamespace(selections=[
            Selection(name="foo")
        ]),
        SimpleNamespace(selections=[
            Selection(name="edges")
        ])
    ])
    codeflash_output = should_resolve_list_connection_edges(info) # 1.82μs -> 1.43μs (26.6% faster)

def test_should_resolve_edges_multiple_edges():
    # Multiple 'edges' fields in different places
    info = Info(selected_fields=[
        SimpleNamespace(selections=[
            Selection(name="foo", selections=[
                Selection(name="edges")
            ]),
            Selection(name="edges")
        ])
    ])
    codeflash_output = should_resolve_list_connection_edges(info) # 3.54μs -> 1.43μs (148% faster)

def test_should_resolve_pageinfo_nested():
    # 'pageInfo' nested inside another selection
    info = Info(selected_fields=[
        SimpleNamespace(selections=[
            Selection(name="foo", selections=[
                Selection(name="pageInfo")
            ])
        ])
    ])
    codeflash_output = should_resolve_list_connection_edges(info) # 3.15μs -> 1.84μs (71.3% faster)

def test_should_not_resolve_if_edges_is_none():
    # Selection with name=None should not cause True
    info = Info(selected_fields=[
        SimpleNamespace(selections=[Selection(name=None)])
    ])
    codeflash_output = should_resolve_list_connection_edges(info) # 1.46μs -> 1.60μs (8.63% slower)


def test_should_resolve_edges_with_mixed_inline_fragments():
    # 'edges' within a mix of InlineFragment and normal selections
    info = Info(selected_fields=[
        SimpleNamespace(selections=[
            InlineFragment(selections=[
                Selection(name="foo", selections=[
                    Selection(name="edges")
                ])
            ]),
            Selection(name="bar")
        ])
    ])
    codeflash_output = should_resolve_list_connection_edges(info) # 4.73μs -> 2.69μs (75.8% faster)

# ----------------------------
# Large Scale Test Cases
# ----------------------------

def test_should_not_resolve_large_unrelated_structure():
    # Large tree with no 'edges' or 'pageInfo'
    def make_deep_tree(depth, width):
        if depth == 0:
            return []
        return [Selection(name=f"field_{d}_{w}", selections=make_deep_tree(depth-1, width)) for w in range(width) for d in range(1)]
    info = Info(selected_fields=[
        SimpleNamespace(selections=make_deep_tree(5, 5))
    ])
    codeflash_output = should_resolve_list_connection_edges(info) # 436μs -> 349μs (24.9% faster)

def test_should_resolve_edges_large_structure():
    # Large tree with 'edges' at a deep node
    def make_deep_tree_with_edges(depth, width, insert_at_depth):
        if depth == 0:
            return []
        if depth == insert_at_depth:
            # Insert 'edges' at this depth
            return [Selection(name="edges")]
        return [Selection(name=f"field_{d}_{w}", selections=make_deep_tree_with_edges(depth-1, width, insert_at_depth)) for w in range(width) for d in range(1)]
    info = Info(selected_fields=[
        SimpleNamespace(selections=make_deep_tree_with_edges(6, 3, 2))
    ])
    codeflash_output = should_resolve_list_connection_edges(info) # 5.52μs -> 2.65μs (108% faster)

def test_should_resolve_edges_many_selected_fields():
    # Many selected_fields, only one contains 'edges'
    fields = [SimpleNamespace(selections=[Selection(name=f"foo_{i}")]) for i in range(998)]
    fields.append(SimpleNamespace(selections=[Selection(name="edges")]))
    info = Info(selected_fields=fields)
    codeflash_output = should_resolve_list_connection_edges(info) # 110μs -> 35.9μs (207% faster)

def test_should_not_resolve_edges_many_selected_fields_none_have_edges():
    # Many selected_fields, none contain 'edges'
    fields = [SimpleNamespace(selections=[Selection(name=f"foo_{i}")]) for i in range(1000)]
    info = Info(selected_fields=fields)
    codeflash_output = should_resolve_list_connection_edges(info) # 110μs -> 114μs (3.77% slower)

def test_should_resolve_edges_large_nested_inline_fragments():
    # Deeply nested InlineFragments with 'edges' at the bottom
    sel = Selection(name="edges")
    for _ in range(10):
        sel = InlineFragment(selections=[sel])
    info = Info(selected_fields=[
        SimpleNamespace(selections=[sel])
    ])
    codeflash_output = should_resolve_list_connection_edges(info) # 8.80μs -> 3.08μs (185% faster)

# ----------------------------
# Additional Robustness Test Cases
# ----------------------------

def test_should_resolve_edges_with_mixed_types():
    # Mixed Selection and InlineFragment at various levels
    info = Info(selected_fields=[
        SimpleNamespace(selections=[
            Selection(name="foo", selections=[
                InlineFragment(selections=[
                    Selection(name="bar", selections=[
                        Selection(name="edges")
                    ])
                ])
            ])
        ])
    ])
    codeflash_output = should_resolve_list_connection_edges(info) # 4.58μs -> 2.21μs (107% faster)

def test_should_not_resolve_when_all_selections_empty():
    # All selections are empty lists
    info = Info(selected_fields=[
        SimpleNamespace(selections=[]),
        SimpleNamespace(selections=[])
    ])
    codeflash_output = should_resolve_list_connection_edges(info) # 1.02μs -> 1.06μs (3.58% slower)

def test_should_resolve_edges_with_multiple_levels_and_fields():
    # Multiple levels, some branches have 'edges', others don't
    info = Info(selected_fields=[
        SimpleNamespace(selections=[
            Selection(name="foo", selections=[
                Selection(name="bar", selections=[
                    Selection(name="baz"),
                    Selection(name="edges")
                ])
            ]),
            Selection(name="qux")
        ])
    ])
    codeflash_output = should_resolve_list_connection_edges(info) # 4.12μs -> 2.29μs (80.4% faster)
# codeflash_output is used to check that the output of the original code is the same as that of the optimized code.
```

</details>


[![Codeflash](https://img.shields.io/badge/Optimized%20with-Codeflash-yellow?style=flat&color=%23ffc428&logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNDgwIiBoZWlnaHQ9ImF1dG8iIHZpZXdCb3g9IjAgMCA0ODAgMjgwIiBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTI4Ni43IDAuMzc4NDE4SDIwMS43NTFMNTAuOTAxIDE0OC45MTFIMTM1Ljg1MUwwLjk2MDkzOCAyODEuOTk5SDk1LjQzNTJMMjgyLjMyNCA4OS45NjE2SDE5Ni4zNDVMMjg2LjcgMC4zNzg0MThaIiBmaWxsPSIjRkZDMDQzIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMzExLjYwNyAwLjM3ODkwNkwyNTguNTc4IDU0Ljk1MjZIMzc5LjU2N0w0MzIuMzM5IDAuMzc4OTA2SDMxMS42MDdaIiBmaWxsPSIjMEIwQTBBIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMzA5LjU0NyA4OS45NjAxTDI1Ni41MTggMTQ0LjI3NkgzNzcuNTA2TDQzMC4wMjEgODkuNzAyNkgzMDkuNTQ3Vjg5Ljk2MDFaIiBmaWxsPSIjMEIwQTBBIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjQyLjg3MyAxNjQuNjZMMTg5Ljg0NCAyMTkuMjM0SDMxMC44MzNMMzYzLjM0NyAxNjQuNjZIMjQyLjg3M1oiIGZpbGw9IiMwQjBBMEEiLz4KPC9zdmc+Cg==)](https://codeflash.ai)
## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Summary by Sourcery

Rewrite `should_resolve_list_connection_edges` to use an iterative stack-based traversal instead of recursion, improving performance and eliminating recursion depth concerns.

Enhancements:
- Replace recursive `_check_selection` helper with an iterative depth-first search using a stack
- Remove unused `Selection` import and simplify selection scanning logic
- Improve execution speed by approximately 46% and avoid Python recursion overhead