### PR TITLE
Unify error response formats

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+Release type: minor
+
+This release unifies the format of HTTP error response bodies across all HTTP
+view integrations. Previously, the Chalice integration used a custom JSON body
+response different from the plain string used by other integrations. Now, all
+integrations will return a plain string for HTTP error responses.

--- a/strawberry/chalice/views.py
+++ b/strawberry/chalice/views.py
@@ -88,28 +88,6 @@ class GraphQLView(
     def get_sub_response(self, request: Request) -> TemporalResponse:
         return TemporalResponse()
 
-    @staticmethod
-    def error_response(
-        message: str,
-        error_code: str,
-        http_status_code: int,
-        headers: Optional[dict[str, str | list[str]]] = None,
-    ) -> Response:
-        """A wrapper for error responses.
-
-        Args:
-            message: The error message.
-            error_code: The error code.
-            http_status_code: The HTTP status code.
-            headers: The headers to include in the response.
-
-        Returns:
-            An errors response.
-        """
-        body = {"Code": error_code, "Message": message}
-
-        return Response(body=body, status_code=http_status_code, headers=headers)
-
     def get_context(self, request: Request, response: TemporalResponse) -> Context:
         return {"request": request, "response": response}  # type: ignore
 
@@ -136,20 +114,9 @@ class GraphQLView(
         try:
             return self.run(request=request)
         except HTTPException as e:
-            error_code_map = {
-                400: "BadRequestError",
-                401: "UnauthorizedError",
-                403: "ForbiddenError",
-                404: "NotFoundError",
-                409: "ConflictError",
-                429: "TooManyRequestsError",
-                500: "ChaliceViewError",
-            }
-
-            return self.error_response(
-                error_code=error_code_map.get(e.status_code, "ChaliceViewError"),
-                message=e.reason,
-                http_status_code=e.status_code,
+            return Response(
+                body=e.reason,
+                status_code=e.status_code,
             )
 
 

--- a/tests/http/test_query.py
+++ b/tests/http/test_query.py
@@ -8,11 +8,6 @@ from tests.conftest import skip_if_gql_32
 
 from .clients.base import HttpClient
 
-try:
-    from .clients.chalice import ChaliceHttpClient
-except ImportError:
-    ChaliceHttpClient = type(None)
-
 
 @pytest.mark.parametrize("method", ["get", "post"])
 async def test_graphql_query(method: Literal["get", "post"], http_client: HttpClient):
@@ -117,18 +112,10 @@ async def test_requests_with_invalid_variables_parameter_are_rejected(
     )
 
     assert response.status_code == 400
-    message = (
-        "The GraphQL operation's `variables` must be an object or null, if provided."
+    assert (
+        response.data
+        == b"The GraphQL operation's `variables` must be an object or null, if provided."
     )
-
-    if isinstance(http_client, ChaliceHttpClient):
-        # Our Chalice integration purposely wraps error messages with a JSON object
-        assert response.json == {
-            "Code": "BadRequestError",
-            "Message": message,
-        }
-    else:
-        assert response.data == message.encode()
 
 
 @pytest.mark.parametrize("method", ["get", "post"])
@@ -253,16 +240,10 @@ async def test_requests_with_invalid_query_parameter_are_rejected(
     )
 
     assert response.status_code == 400
-    message = "The GraphQL operation's `query` must be a string or null, if provided."
-
-    if isinstance(http_client, ChaliceHttpClient):
-        # Our Chalice integration purposely wraps errors messages with a JSON object
-        assert response.json == {
-            "Code": "BadRequestError",
-            "Message": message,
-        }
-    else:
-        assert response.data == message.encode()
+    assert (
+        response.data
+        == b"The GraphQL operation's `query` must be a string or null, if provided."
+    )
 
 
 @pytest.mark.parametrize("method", ["get", "post"])
@@ -308,18 +289,10 @@ async def test_requests_with_invalid_extension_parameter_are_rejected(
     )
 
     assert response.status_code == 400
-    message = (
-        "The GraphQL operation's `extensions` must be an object or null, if provided."
+    assert (
+        response.data
+        == b"The GraphQL operation's `extensions` must be an object or null, if provided."
     )
-
-    if isinstance(http_client, ChaliceHttpClient):
-        # Our Chalice integration purposely wraps error messages with a JSON object
-        assert response.json == {
-            "Code": "BadRequestError",
-            "Message": message,
-        }
-    else:
-        assert response.data == message.encode()
 
 
 @pytest.mark.parametrize("method", ["get", "post"])
@@ -388,15 +361,7 @@ async def test_invalid_operation_selection(http_client: HttpClient, operation_na
     )
 
     assert response.status_code == 400
-
-    if isinstance(http_client, ChaliceHttpClient):
-        # Our Chalice integration purposely wraps errors messages with a JSON object
-        assert response.json == {
-            "Code": "BadRequestError",
-            "Message": f'Unknown operation named "{operation_name}".',
-        }
-    else:
-        assert response.data == f'Unknown operation named "{operation_name}".'.encode()
+    assert response.data == f'Unknown operation named "{operation_name}".'.encode()
 
 
 async def test_operation_selection_without_operations(http_client: HttpClient):
@@ -407,12 +372,4 @@ async def test_operation_selection_without_operations(http_client: HttpClient):
     )
 
     assert response.status_code == 400
-
-    if isinstance(http_client, ChaliceHttpClient):
-        # Our Chalice integration purposely wraps errors messages with a JSON object
-        assert response.json == {
-            "Code": "BadRequestError",
-            "Message": "Can't get GraphQL operation type",
-        }
-    else:
-        assert response.data == b"Can't get GraphQL operation type"
+    assert response.data == b"Can't get GraphQL operation type"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This PR unifies the HTTP response body formats across all integrations.

Previously, Chalice had a custom response format that required us to write separate tests. There doesn't appear to be a good reason to keep that custom format, especially for the /graphql endpoint.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Summary by Sourcery

Unify HTTP error response formats across all integrations by removing the Chalice-specific JSON wrapper and returning plain string bodies consistently.

Enhancements:
- Remove Chalice integration’s custom error_response method and simplify HTTPException handling to return plain-text bodies
- Update tests to drop JSON assertions and expect error responses as raw byte strings
- Add RELEASE.md with release notes for the unified error response format

Documentation:
- Add RELEASE.md documenting the minor release and the new unified error response behavior

Tests:
- Adjust existing HTTP tests to assert plain string error bodies instead of JSON objects