### PR TITLE
Patch _inject_default_for_maybe_annotations

### DIFF
--- a/strawberry/types/maybe.py
+++ b/strawberry/types/maybe.py
@@ -1,5 +1,5 @@
 import typing
-from typing import TYPE_CHECKING, Any, Generic, TypeVar, Union
+from typing import TYPE_CHECKING, Annotated, Any, Generic, TypeVar, Union
 from typing_extensions import TypeAlias
 
 T = TypeVar("T")
@@ -38,7 +38,10 @@ else:
 
 
 def _annotation_is_maybe(annotation: Any) -> bool:
-    return (orig := typing.get_origin(annotation)) and orig is Maybe
+    orig = typing.get_origin(annotation)
+    if orig is Annotated:
+        return _annotation_is_maybe(typing.get_args(annotation)[0])
+    return orig is Maybe
 
 
 __all__ = [

--- a/strawberry/types/object_type.py
+++ b/strawberry/types/object_type.py
@@ -129,8 +129,15 @@ def _inject_default_for_maybe_annotations(
 ) -> None:
     """Inject `= None` for fields with `Maybe` annotations and no default value."""
     for name, annotation in annotations.copy().items():
-        if _annotation_is_maybe(annotation) and not hasattr(cls, name):
-            setattr(cls, name, None)
+        if _annotation_is_maybe(annotation):
+            if not hasattr(cls, name):
+                setattr(cls, name, None)
+            elif (
+                isinstance(attr := getattr(cls, name), StrawberryField)
+                and isinstance(attr.default, dataclasses._MISSING_TYPE)
+                and isinstance(attr.default_factory, dataclasses._MISSING_TYPE)
+            ):
+                attr.default = None
 
 
 def _process_type(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

> [!IMPORTANT]
>
> This PR is still a draft as I will not have time to write tests for the change for awhile.
> Help in this regard would be appreciated.


## Description

This patch fixes a bug where input `strawberry.Maybe` input fields would fail to have a default `None` injected when annotated or set with `strawberry.field`.

Previously, this would cause this example input to require `name` to be set, despite it being marked `Maybe`

```python
@strawberry.input
class Example:
    name: strawberry.Maybe[str] = strawberry.field(description="This strawberry.field annotation was breaking in default injection")
```

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #3962

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
