### PR TITLE
Remove the deprecated --log-operations docs

### DIFF
--- a/docs/guides/server.md
+++ b/docs/guides/server.md
@@ -26,16 +26,3 @@ this url [http://localhost:8000/graphql](http://localhost:8000/graphql).
 Strawberry's built in server automatically reloads when changes to the module
 containing the `schema` are detected. This way you can spend more time
 prototyping your API rather than restarting development servers.
-
-## Disabling operation logging
-
-By default Strawberry's built in server logs all operations that are executed.
-This can be useful for debugging but can also be annoying if you are
-prototyping.
-
-To disable operation logging you can use the `--log-operations` configuration
-flag:
-
-```shell
-strawberry server package.module:schema --log-operations False
-```


### PR DESCRIPTION
## Description

This PR removes the docs for the no longer existing `--log-operations` CLI option.

This debug server CLI option was removed a while ago and can now be removed from the documentation.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation
