### PR TITLE
Update code to sastify mypy

### DIFF
--- a/strawberry/aiohttp/views.py
+++ b/strawberry/aiohttp/views.py
@@ -87,7 +87,7 @@ class GraphQLView(
 
     allow_queries_via_get = True
     request_adapter_class = AiohttpHTTPRequestAdapter
-    websocket_adapter_class = AiohttpWebSocketAdapter
+    websocket_adapter_class = AiohttpWebSocketAdapter  # type: ignore
 
     def __init__(
         self,

--- a/strawberry/asgi/__init__.py
+++ b/strawberry/asgi/__init__.py
@@ -93,7 +93,7 @@ class GraphQL(
 ):
     allow_queries_via_get = True
     request_adapter_class = StarletteRequestAdapter
-    websocket_adapter_class = ASGIWebSocketAdapter
+    websocket_adapter_class = ASGIWebSocketAdapter  # type: ignore
 
     def __init__(
         self,

--- a/strawberry/channels/handlers/ws_handler.py
+++ b/strawberry/channels/handlers/ws_handler.py
@@ -102,7 +102,7 @@ class GraphQLWSConsumer(
     ```
     """
 
-    websocket_adapter_class = ChannelsWebSocketAdapter
+    websocket_adapter_class = ChannelsWebSocketAdapter  # type: ignore
 
     def __init__(
         self,

--- a/strawberry/codegen/query_codegen.py
+++ b/strawberry/codegen/query_codegen.py
@@ -13,7 +13,7 @@ from typing import (
     Union,
     cast,
 )
-from typing_extensions import Literal, Protocol
+from typing_extensions import Protocol
 
 import rich
 from graphql import (
@@ -479,7 +479,7 @@ class QueryCodegen:
 
         return GraphQLOperation(
             operation_definition.name.value,
-            kind= operation_definition.operation.value,
+            kind=operation_definition.operation.value,
             selections=self._convert_selection_set(operation_definition.selection_set),
             directives=self._convert_directives(operation_definition.directives),
             variables=variables,

--- a/strawberry/codegen/query_codegen.py
+++ b/strawberry/codegen/query_codegen.py
@@ -473,18 +473,13 @@ class QueryCodegen:
             class_name=result_class_name,
         )
 
-        operation_kind = cast(
-            "Literal['query', 'mutation', 'subscription']",
-            operation_definition.operation.value,
-        )
-
         variables, variables_type = self._convert_variable_definitions(
             operation_definition.variable_definitions, operation_name=operation_name
         )
 
         return GraphQLOperation(
             operation_definition.name.value,
-            kind=operation_kind,
+            kind= operation_definition.operation.value,
             selections=self._convert_selection_set(operation_definition.selection_set),
             directives=self._convert_directives(operation_definition.directives),
             variables=variables,

--- a/strawberry/ext/mypy_plugin.py
+++ b/strawberry/ext/mypy_plugin.py
@@ -355,7 +355,7 @@ def add_static_method_to_class(
         arg_types, arg_kinds, arg_names, return_type, function_type
     )
     if tvar_def:
-        signature.variables = [tvar_def]
+        signature.variables = [tvar_def]  # type: ignore[assignment]
 
     func = FuncDef(name, args, Block([PassStmt()]))
 

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -62,7 +62,7 @@ class GraphQLRouter(
 ):
     allow_queries_via_get = True
     request_adapter_class = StarletteRequestAdapter
-    websocket_adapter_class = ASGIWebSocketAdapter
+    websocket_adapter_class = ASGIWebSocketAdapter  # type: ignore
 
     @staticmethod
     async def __get_root_value() -> None:

--- a/strawberry/litestar/controller.py
+++ b/strawberry/litestar/controller.py
@@ -208,7 +208,7 @@ class GraphQLController(
     }
 
     request_adapter_class = LitestarRequestAdapter
-    websocket_adapter_class = LitestarWebSocketAdapter
+    websocket_adapter_class = LitestarWebSocketAdapter  # type: ignore
 
     allow_queries_via_get: bool = True
     graphiql_allowed_accept: frozenset[str] = frozenset({"text/html", "*/*"})

--- a/strawberry/quart/views.py
+++ b/strawberry/quart/views.py
@@ -78,7 +78,7 @@ class GraphQLView(
     methods: ClassVar[list[str]] = ["GET", "POST"]
     allow_queries_via_get: bool = True
     request_adapter_class = QuartHTTPRequestAdapter
-    websocket_adapter_class = QuartWebSocketAdapter
+    websocket_adapter_class = QuartWebSocketAdapter # type: ignore
 
     def __init__(
         self,

--- a/strawberry/quart/views.py
+++ b/strawberry/quart/views.py
@@ -78,7 +78,7 @@ class GraphQLView(
     methods: ClassVar[list[str]] = ["GET", "POST"]
     allow_queries_via_get: bool = True
     request_adapter_class = QuartHTTPRequestAdapter
-    websocket_adapter_class = QuartWebSocketAdapter # type: ignore
+    websocket_adapter_class = QuartWebSocketAdapter  # type: ignore
 
     def __init__(
         self,

--- a/strawberry/types/field.py
+++ b/strawberry/types/field.py
@@ -292,7 +292,7 @@ class StrawberryField(dataclasses.Field):
         #       removed.
         _ = resolver.arguments
 
-    @property  # type: ignore
+    @property
     def type(
         self,
     ) -> Union[  # type: ignore [valid-type]

--- a/strawberry/types/info.py
+++ b/strawberry/types/info.py
@@ -78,7 +78,7 @@ class Info(Generic[ContextType, RootValueType]):
         https://discuss.python.org/t/passing-only-one-typevar-of-two-when-using-defaults/49134
         """
         if not isinstance(types, tuple):
-            types = (types, Any)  # type: ignore
+            types = (types, Any)
 
         return super().__class_getitem__(types)  # type: ignore
 

--- a/strawberry/utils/typing.py
+++ b/strawberry/utils/typing.py
@@ -132,7 +132,7 @@ def is_concrete_generic(annotation: type) -> bool:
 def is_generic_subclass(annotation: type) -> bool:
     return isinstance(annotation, type) and issubclass(
         annotation,
-        Generic,  # type:ignore
+        Generic
     )
 
 
@@ -182,7 +182,7 @@ def type_has_annotation(type_: object, annotation: type) -> bool:
 def get_parameters(annotation: type) -> Union[tuple[object], tuple[()]]:
     if isinstance(annotation, _GenericAlias) or (
         isinstance(annotation, type)
-        and issubclass(annotation, Generic)  # type:ignore
+        and issubclass(annotation, Generic)
         and annotation is not Generic
     ):
         return annotation.__parameters__  # type: ignore[union-attr]

--- a/strawberry/utils/typing.py
+++ b/strawberry/utils/typing.py
@@ -130,10 +130,7 @@ def is_concrete_generic(annotation: type) -> bool:
 
 
 def is_generic_subclass(annotation: type) -> bool:
-    return isinstance(annotation, type) and issubclass(
-        annotation,
-        Generic
-    )
+    return isinstance(annotation, type) and issubclass(annotation, Generic)
 
 
 def is_generic(annotation: type) -> bool:

--- a/tests/typecheckers/test_maybe.py
+++ b/tests/typecheckers/test_maybe.py
@@ -48,7 +48,7 @@ def test_maybe() -> None:
         [
             Result(
                 type="note",
-                message='Revealed type is "Union[strawberry.types.maybe.Some[builtins.str], None]"',
+                message='Revealed type is "strawberry.types.maybe.Some[builtins.str] | None"',
                 line=12,
                 column=13,
             ),

--- a/tests/typecheckers/test_maybe.py
+++ b/tests/typecheckers/test_maybe.py
@@ -1,3 +1,6 @@
+import sys
+
+import pytest
 from inline_snapshot import snapshot
 
 from .utils.marks import requires_mypy, requires_pyright, skip_on_windows
@@ -24,6 +27,10 @@ if obj.foobar:
 """
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 10),
+    reason="Union type representation differs in Python 3.9",
+)
 def test_maybe() -> None:
     result = typecheck(CODE)
 

--- a/tests/typecheckers/test_relay.py
+++ b/tests/typecheckers/test_relay.py
@@ -316,13 +316,13 @@ def test():
             ),
             Result(
                 type="note",
-                message='Revealed type is "Union[strawberry.relay.types.Node, None]"',
+                message='Revealed type is "strawberry.relay.types.Node | None"',
                 line=132,
                 column=13,
             ),
             Result(
                 type="note",
-                message='Revealed type is "builtins.list[Union[strawberry.relay.types.Node, None]]"',
+                message='Revealed type is "builtins.list[strawberry.relay.types.Node | None]"',
                 line=133,
                 column=13,
             ),

--- a/tests/typecheckers/test_relay.py
+++ b/tests/typecheckers/test_relay.py
@@ -1,3 +1,6 @@
+import sys
+
+import pytest
 from inline_snapshot import snapshot
 
 from .utils.marks import requires_mypy, requires_pyright, skip_on_windows
@@ -152,6 +155,10 @@ reveal_type(Query.fruits_custom_resolver_async_generator)
 """
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 10),
+    reason="Union type representation differs in Python 3.9",
+)
 def test():
     results = typecheck(CODE)
 

--- a/tests/typecheckers/test_scalars.py
+++ b/tests/typecheckers/test_scalars.py
@@ -129,7 +129,7 @@ def test_schema_overrides():
         [
             Result(
                 type="note",
-                message='Revealed type is "def (year: typing.SupportsIndex, month: typing.SupportsIndex, day: typing.SupportsIndex, hour: typing.SupportsIndex =, minute: typing.SupportsIndex =, second: typing.SupportsIndex =, microsecond: typing.SupportsIndex =, tzinfo: Union[datetime.tzinfo, None] =, *, fold: builtins.int =) -> datetime.datetime"',
+                message='Revealed type is "def (year: typing.SupportsIndex, month: typing.SupportsIndex, day: typing.SupportsIndex, hour: typing.SupportsIndex =, minute: typing.SupportsIndex =, second: typing.SupportsIndex =, microsecond: typing.SupportsIndex =, tzinfo: datetime.tzinfo | None =, *, fold: builtins.int =) -> datetime.datetime"',
                 line=17,
                 column=13,
             )

--- a/tests/typecheckers/test_scalars.py
+++ b/tests/typecheckers/test_scalars.py
@@ -1,3 +1,6 @@
+import sys
+
+import pytest
 from inline_snapshot import snapshot
 
 from .utils.marks import requires_mypy, requires_pyright, skip_on_windows
@@ -111,6 +114,10 @@ reveal_type(EpochDateTime)
 """
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 10),
+    reason="Union type representation differs in Python 3.9",
+)
 def test_schema_overrides():
     # TODO: change strict to true when we improve type hints for scalar
     results = typecheck(CODE_SCHEMA_OVERRIDES, strict=False)

--- a/tests/typecheckers/test_union.py
+++ b/tests/typecheckers/test_union.py
@@ -58,7 +58,7 @@ def test():
             ),
             Result(
                 type="note",
-                message='Revealed type is "Union[mypy_test.User, mypy_test.Error]"',
+                message='Revealed type is "mypy_test.User | mypy_test.Error"',
                 line=23,
                 column=13,
             ),

--- a/tests/typecheckers/test_union.py
+++ b/tests/typecheckers/test_union.py
@@ -1,3 +1,6 @@
+import sys
+
+import pytest
 from inline_snapshot import snapshot
 
 from .utils.marks import requires_mypy, requires_pyright, skip_on_windows
@@ -32,6 +35,10 @@ reveal_type(x)
 """
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 10),
+    reason="Union type representation differs in Python 3.9",
+)
 def test():
     results = typecheck(CODE)
 


### PR DESCRIPTION
## Summary by Sourcery

Refine type annotations and silencing to satisfy mypy, simplify type checks, and update tests to PEP 604 union syntax

Enhancements:
- Simplify generic subclass and parameter extraction functions by removing redundant type ignores
- Remove an unnecessary cast in GraphQLOperation kind assignment to improve type inference
- Clean up outdated type ignore directives on property decorators and class getitem

Tests:
- Update typechecker test messages to use PEP 604 '|' union syntax instead of typing.Union in several test files

Chores:
- Add targeted # type: ignore pragmas to websocket_adapter_class declarations across multiple adapters and to signature.variables assignment in the mypy plugin