### PR TITLE
Fix e2e tests used deprecated dev server command

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -44,13 +44,13 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          poetry install --extras debug-server
+          poetry install --extras cli
           poetry run pip install graphql-core==3.3.0a9
 
       - name: Start Strawberry server
         run: |
           cd e2e
-          poetry run strawberry server app:schema --port 8000 &
+          poetry run strawberry dev app:schema --port 8000 &
           echo $! > server.pid
           sleep 5  # Wait for server to start
 


### PR DESCRIPTION
## Description

This PR fixes that the e2e workflow still tried to use the deprecated strawberry server command.

(my bad, `rg` didn't include hidden files when I searched for "strawberry server")

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Summary by Sourcery

Fix E2E test workflow to use the current Strawberry dev server command and correct installation extras

Bug Fixes:
- Replace deprecated `strawberry server` invocation with `strawberry dev` in the e2e workflow
- Update Poetry install extras from `debug-server` to `cli` for the E2E environment