### PR TITLE
bumb codspeed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,7 +110,7 @@ jobs:
         with:
           token: ${{ secrets.CODSPEED_TOKEN }}
           mode: instrumentation
-          run: poetry run pytest tests/benchmarks --codspeed
+          run: poetry run pytest tests/benchmarks --codspeed -p no:codeflash-benchmark
 
   lint:
     name: ✨ Lint


### PR DESCRIPTION
- **Bump codspeed**
- **chore: disable codeflash-benchmark when running codspeed**

## Summary by Sourcery

Update the benchmark CI step to use CodSpeed v4.1.1 with instrumentation mode and disable codeflash-benchmark

CI:
- Bump CodSpeedHQ/action to v4.1.1 in the CI workflow
- Configure the benchmarks step to use instrumentation mode and disable the codeflash-benchmark plugin