### PR TITLE
chore: update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.10
+    rev: v0.14.1
     hooks:
       - id: ruff-format
         exclude: ^tests/\w+/snapshots/
@@ -31,7 +31,7 @@ repos:
         args: ["--branch", "main"]
 
   - repo: https://github.com/adamchainz/blacken-docs
-    rev: 1.19.1
+    rev: 1.20.0
     hooks:
       - id: blacken-docs
         args: [--skip-errors]

--- a/poetry.lock
+++ b/poetry.lock
@@ -4740,31 +4740,31 @@ docs = ["markdown-include (>=0.8.1)", "mike (>=2.1.3)", "mkdocs-github-admonitio
 
 [[package]]
 name = "ruff"
-version = "0.12.12"
+version = "0.14.1"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
 groups = ["dev"]
 files = [
-    {file = "ruff-0.12.12-py3-none-linux_armv6l.whl", hash = "sha256:de1c4b916d98ab289818e55ce481e2cacfaad7710b01d1f990c497edf217dafc"},
-    {file = "ruff-0.12.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7acd6045e87fac75a0b0cdedacf9ab3e1ad9d929d149785903cff9bb69ad9727"},
-    {file = "ruff-0.12.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:abf4073688d7d6da16611f2f126be86523a8ec4343d15d276c614bda8ec44edb"},
-    {file = "ruff-0.12.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:968e77094b1d7a576992ac078557d1439df678a34c6fe02fd979f973af167577"},
-    {file = "ruff-0.12.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:42a67d16e5b1ffc6d21c5f67851e0e769517fb57a8ebad1d0781b30888aa704e"},
-    {file = "ruff-0.12.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b216ec0a0674e4b1214dcc998a5088e54eaf39417327b19ffefba1c4a1e4971e"},
-    {file = "ruff-0.12.12-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:59f909c0fdd8f1dcdbfed0b9569b8bf428cf144bec87d9de298dcd4723f5bee8"},
-    {file = "ruff-0.12.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9ac93d87047e765336f0c18eacad51dad0c1c33c9df7484c40f98e1d773876f5"},
-    {file = "ruff-0.12.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:01543c137fd3650d322922e8b14cc133b8ea734617c4891c5a9fccf4bfc9aa92"},
-    {file = "ruff-0.12.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2afc2fa864197634e549d87fb1e7b6feb01df0a80fd510d6489e1ce8c0b1cc45"},
-    {file = "ruff-0.12.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:0c0945246f5ad776cb8925e36af2438e66188d2b57d9cf2eed2c382c58b371e5"},
-    {file = "ruff-0.12.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a0fbafe8c58e37aae28b84a80ba1817f2ea552e9450156018a478bf1fa80f4e4"},
-    {file = "ruff-0.12.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:b9c456fb2fc8e1282affa932c9e40f5ec31ec9cbb66751a316bd131273b57c23"},
-    {file = "ruff-0.12.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:5f12856123b0ad0147d90b3961f5c90e7427f9acd4b40050705499c98983f489"},
-    {file = "ruff-0.12.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:26a1b5a2bf7dd2c47e3b46d077cd9c0fc3b93e6c6cc9ed750bd312ae9dc302ee"},
-    {file = "ruff-0.12.12-py3-none-win32.whl", hash = "sha256:173be2bfc142af07a01e3a759aba6f7791aa47acf3604f610b1c36db888df7b1"},
-    {file = "ruff-0.12.12-py3-none-win_amd64.whl", hash = "sha256:e99620bf01884e5f38611934c09dd194eb665b0109104acae3ba6102b600fd0d"},
-    {file = "ruff-0.12.12-py3-none-win_arm64.whl", hash = "sha256:2a8199cab4ce4d72d158319b63370abf60991495fb733db96cd923a34c52d093"},
-    {file = "ruff-0.12.12.tar.gz", hash = "sha256:b86cd3415dbe31b3b46a71c598f4c4b2f550346d1ccf6326b347cc0c8fd063d6"},
+    {file = "ruff-0.14.1-py3-none-linux_armv6l.whl", hash = "sha256:083bfc1f30f4a391ae09c6f4f99d83074416b471775b59288956f5bc18e82f8b"},
+    {file = "ruff-0.14.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:f6fa757cd717f791009f7669fefb09121cc5f7d9bd0ef211371fad68c2b8b224"},
+    {file = "ruff-0.14.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d6191903d39ac156921398e9c86b7354d15e3c93772e7dbf26c9fcae59ceccd5"},
+    {file = "ruff-0.14.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ed04f0e04f7a4587244e5c9d7df50e6b5bf2705d75059f409a6421c593a35896"},
+    {file = "ruff-0.14.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5c9e6cf6cd4acae0febbce29497accd3632fe2025c0c583c8b87e8dbdeae5f61"},
+    {file = "ruff-0.14.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a6fa2458527794ecdfbe45f654e42c61f2503a230545a91af839653a0a93dbc6"},
+    {file = "ruff-0.14.1-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:39f1c392244e338b21d42ab29b8a6392a722c5090032eb49bb4d6defcdb34345"},
+    {file = "ruff-0.14.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7382fa12a26cce1f95070ce450946bec357727aaa428983036362579eadcc5cf"},
+    {file = "ruff-0.14.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dd0bf2be3ae8521e1093a487c4aa3b455882f139787770698530d28ed3fbb37c"},
+    {file = "ruff-0.14.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cabcaa9ccf8089fb4fdb78d17cc0e28241520f50f4c2e88cb6261ed083d85151"},
+    {file = "ruff-0.14.1-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:747d583400f6125ec11a4c14d1c8474bf75d8b419ad22a111a537ec1a952d192"},
+    {file = "ruff-0.14.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:5a6e74c0efd78515a1d13acbfe6c90f0f5bd822aa56b4a6d43a9ffb2ae6e56cd"},
+    {file = "ruff-0.14.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:0ea6a864d2fb41a4b6d5b456ed164302a0d96f4daac630aeba829abfb059d020"},
+    {file = "ruff-0.14.1-py3-none-musllinux_1_2_i686.whl", hash = "sha256:0826b8764f94229604fa255918d1cc45e583e38c21c203248b0bfc9a0e930be5"},
+    {file = "ruff-0.14.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:cbc52160465913a1a3f424c81c62ac8096b6a491468e7d872cb9444a860bc33d"},
+    {file = "ruff-0.14.1-py3-none-win32.whl", hash = "sha256:e037ea374aaaff4103240ae79168c0945ae3d5ae8db190603de3b4012bd1def6"},
+    {file = "ruff-0.14.1-py3-none-win_amd64.whl", hash = "sha256:59d599cdff9c7f925a017f6f2c256c908b094e55967f93f2821b1439928746a1"},
+    {file = "ruff-0.14.1-py3-none-win_arm64.whl", hash = "sha256:e3b443c4c9f16ae850906b8d0a707b2a4c16f8d2f0a7fe65c475c5886665ce44"},
+    {file = "ruff-0.14.1.tar.gz", hash = "sha256:1dd86253060c4772867c61791588627320abcb6ed1577a90ef432ee319729b69"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ pyinstrument = ["pyinstrument>=4.0.0"]
 
 [dependency-groups]
 dev = [
-  "ruff (>=0.12.3,<0.13.0)",
+  "ruff (>=0.14.1,<0.15.0)",
   "asgiref (>=3.2,<4.0)",
   "email-validator (>=1.1.3,<3.0.0)",
   "freezegun (>=1.2.1,<2.0.0)",
@@ -371,7 +371,18 @@ ignore = [
 
 [tool.ruff.lint.isort]
 known-first-party = ["strawberry"]
-known-third-party = ["django", "graphql"]
+known-third-party = [
+  "django",
+  "graphql",
+  "fastapi",
+  "pydantic",
+  "litestar",
+  "aiohttp",
+  "channels",
+  "sanic",
+  "chalice",
+  "quart",
+]
 extra-standard-library = ["typing_extensions"]
 
 [tool.ruff.format]

--- a/strawberry/aiohttp/views.py
+++ b/strawberry/aiohttp/views.py
@@ -9,9 +9,9 @@ from typing import (
     TypeGuard,
 )
 
+from aiohttp import ClientConnectionResetError, http, web
 from lia import AiohttpHTTPRequestAdapter, HTTPException
 
-from aiohttp import ClientConnectionResetError, http, web
 from strawberry.http.async_base_view import (
     AsyncBaseHTTPView,
     AsyncWebSocketAdapter,

--- a/strawberry/chalice/views.py
+++ b/strawberry/chalice/views.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import warnings
 from typing import TYPE_CHECKING
 
+from chalice.app import Request, Response
 from lia import ChaliceHTTPRequestAdapter, HTTPException
 
-from chalice.app import Request, Response
 from strawberry.http.sync_base_view import SyncBaseHTTPView
 from strawberry.http.temporal_response import TemporalResponse
 from strawberry.http.typevars import Context, RootValue

--- a/strawberry/channels/handlers/http_handler.py
+++ b/strawberry/channels/handlers/http_handler.py
@@ -9,13 +9,13 @@ from typing import TYPE_CHECKING, Any, TypeGuard
 from typing_extensions import assert_never
 from urllib.parse import parse_qs
 
+from channels.db import database_sync_to_async
+from channels.generic.http import AsyncHttpConsumer
 from django.conf import settings
 from django.core.files import uploadhandler
 from django.http.multipartparser import MultiPartParser
 from lia import AsyncHTTPRequestAdapter, FormData, HTTPException, SyncHTTPRequestAdapter
 
-from channels.db import database_sync_to_async
-from channels.generic.http import AsyncHttpConsumer
 from strawberry.http.async_base_view import AsyncBaseHTTPView
 from strawberry.http.sync_base_view import SyncBaseHTTPView
 from strawberry.http.temporal_response import TemporalResponse

--- a/strawberry/channels/router.py
+++ b/strawberry/channels/router.py
@@ -9,9 +9,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from django.urls import re_path
-
 from channels.routing import ProtocolTypeRouter, URLRouter
+from django.urls import re_path
 
 from .handlers.http_handler import GraphQLHTTPConsumer
 from .handlers.ws_handler import GraphQLWSConsumer

--- a/strawberry/channels/testing.py
+++ b/strawberry/channels/testing.py
@@ -6,9 +6,9 @@ from typing import (
     Any,
 )
 
+from channels.testing.websocket import WebsocketCommunicator
 from graphql import GraphQLError, GraphQLFormattedError
 
-from channels.testing.websocket import WebsocketCommunicator
 from strawberry.subscriptions import GRAPHQL_TRANSPORT_WS_PROTOCOL, GRAPHQL_WS_PROTOCOL
 from strawberry.subscriptions.protocols.graphql_transport_ws import (
     types as transport_ws_types,

--- a/strawberry/dataloader.py
+++ b/strawberry/dataloader.py
@@ -50,7 +50,7 @@ class Batch(Generic[K, T]):
         return len(self.tasks)
 
 
-class AbstractCache(Generic[K, T], ABC):
+class AbstractCache(ABC, Generic[K, T]):
     @abstractmethod
     def get(self, key: K) -> Future[T] | None:
         pass

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -10,6 +10,10 @@ from typing import (
     cast,
 )
 
+from fastapi import APIRouter, Depends, params
+from fastapi.datastructures import Default
+from fastapi.routing import APIRoute
+from fastapi.utils import generate_unique_id
 from lia import HTTPException, StarletteRequestAdapter
 from starlette import status
 from starlette.background import BackgroundTasks  # noqa: TC002
@@ -23,10 +27,6 @@ from starlette.responses import (
 )
 from starlette.websockets import WebSocket
 
-from fastapi import APIRouter, Depends, params
-from fastapi.datastructures import Default
-from fastapi.routing import APIRoute
-from fastapi.utils import generate_unique_id
 from strawberry.asgi import ASGIWebSocketAdapter
 from strawberry.exceptions import InvalidCustomContext
 from strawberry.fastapi.context import BaseContext, CustomContext

--- a/strawberry/federation/field.py
+++ b/strawberry/federation/field.py
@@ -201,7 +201,7 @@ def field(
     # This init parameter is used by PyRight to determine whether this field
     # is added in the constructor or not. It is not used to change
     # any behavior at the moment.
-    init: Literal[True, False, None] = None,
+    init: Literal[True, False] | None = None,
 ) -> Any:
     from .schema_directives import (
         Authenticated,

--- a/strawberry/flask/views.py
+++ b/strawberry/flask/views.py
@@ -17,6 +17,7 @@ from strawberry.http.typevars import Context, RootValue
 
 if TYPE_CHECKING:
     from flask.typing import ResponseReturnValue
+
     from strawberry.http import GraphQLHTTPResponse
     from strawberry.http.ides import GraphQL_IDE
     from strawberry.schema.base import BaseSchema

--- a/strawberry/litestar/controller.py
+++ b/strawberry/litestar/controller.py
@@ -15,8 +15,6 @@ from typing import (
 )
 
 from lia import HTTPException, LitestarRequestAdapter
-from msgspec import Struct
-
 from litestar import (
     Controller,
     MediaType,
@@ -36,6 +34,8 @@ from litestar.exceptions import (
 )
 from litestar.response.streaming import Stream
 from litestar.status_codes import HTTP_200_OK
+from msgspec import Struct
+
 from strawberry.exceptions import InvalidCustomContext
 from strawberry.http.async_base_view import (
     AsyncBaseHTTPView,
@@ -59,6 +59,7 @@ if TYPE_CHECKING:
     )
 
     from litestar.types import AnyCallable, Dependencies
+
     from strawberry.http import GraphQLHTTPResponse
     from strawberry.http.ides import GraphQL_IDE
     from strawberry.schema import BaseSchema

--- a/strawberry/quart/views.py
+++ b/strawberry/quart/views.py
@@ -6,10 +6,10 @@ from json.decoder import JSONDecodeError
 from typing import TYPE_CHECKING, ClassVar, TypeGuard, Union
 
 from lia import HTTPException, QuartHTTPRequestAdapter
-
 from quart import Request, Response, Websocket, request, websocket
 from quart.ctx import has_websocket_context
 from quart.views import View
+
 from strawberry.http.async_base_view import (
     AsyncBaseHTTPView,
     AsyncWebSocketAdapter,
@@ -25,6 +25,7 @@ from strawberry.subscriptions import GRAPHQL_TRANSPORT_WS_PROTOCOL, GRAPHQL_WS_P
 
 if TYPE_CHECKING:
     from quart.typing import ResponseReturnValue
+
     from strawberry.http import GraphQLHTTPResponse
     from strawberry.schema.base import BaseSchema
 

--- a/strawberry/relay/fields.py
+++ b/strawberry/relay/fields.py
@@ -397,7 +397,7 @@ def connection(
     # This init parameter is used by pyright to determine whether this field
     # is added in the constructor or not. It is not used to change
     # any behaviour at the moment.
-    init: Literal[True, False, None] = None,
+    init: Literal[True, False] | None = None,
 ) -> Any:
     """Annotate a property or a method to create a relay connection field.
 

--- a/strawberry/sanic/context.py
+++ b/strawberry/sanic/context.py
@@ -2,6 +2,7 @@ import warnings
 from typing_extensions import TypedDict
 
 from sanic.request import Request
+
 from strawberry.http.temporal_response import TemporalResponse
 
 

--- a/strawberry/sanic/views.py
+++ b/strawberry/sanic/views.py
@@ -9,10 +9,10 @@ from typing import (
 )
 
 from lia import HTTPException, SanicHTTPRequestAdapter
-
 from sanic.request import Request
 from sanic.response import HTTPResponse, html
 from sanic.views import HTTPMethodView
+
 from strawberry.http.async_base_view import AsyncBaseHTTPView
 from strawberry.http.temporal_response import TemporalResponse
 from strawberry.http.typevars import (

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -104,7 +104,7 @@ FieldType = TypeVar(
 )
 
 
-class FieldConverterProtocol(Generic[FieldType], Protocol):
+class FieldConverterProtocol(Protocol, Generic[FieldType]):
     def __call__(  # pragma: no cover
         self,
         field: StrawberryField,

--- a/strawberry/types/field.py
+++ b/strawberry/types/field.py
@@ -510,7 +510,7 @@ def field(
     # This init parameter is used by PyRight to determine whether this field
     # is added in the constructor or not. It is not used to change
     # any behavior at the moment.
-    init: Literal[True, False, None] = None,
+    init: Literal[True, False] | None = None,
 ) -> Any:
     """Annotates a method or property as a GraphQL field.
 

--- a/strawberry/types/mutation.py
+++ b/strawberry/types/mutation.py
@@ -131,7 +131,7 @@ def mutation(
     # This init parameter is used by PyRight to determine whether this field
     # is added in the constructor or not. It is not used to change
     # any behavior at the moment.
-    init: Literal[True, False, None] = None,
+    init: Literal[True, False] | None = None,
 ) -> Any:
     """Annotates a method or property as a GraphQL mutation.
 
@@ -288,7 +288,7 @@ def subscription(
     directives: Sequence[object] | None = (),
     extensions: list[FieldExtension] | None = None,
     graphql_type: Any | None = None,
-    init: Literal[True, False, None] = None,
+    init: Literal[True, False] | None = None,
 ) -> Any:
     """Annotates a method or property as a GraphQL subscription.
 

--- a/tests/channels/test_layers.py
+++ b/tests/channels/test_layers.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
 @pytest.fixture
 async def ws() -> AsyncGenerator[WebsocketCommunicator, None]:
     from channels.testing import WebsocketCommunicator
+
     from strawberry.channels import GraphQLWSConsumer
 
     client = WebsocketCommunicator(

--- a/tests/experimental/pydantic/test_basic.py
+++ b/tests/experimental/pydantic/test_basic.py
@@ -75,7 +75,7 @@ def test_basic_type_all_fields_warn():
 
     with pytest.raises(
         UserWarning,
-        match=("Using all_fields overrides any explicitly defined fields"),
+        match="Using all_fields overrides any explicitly defined fields",
     ):
 
         @strawberry.experimental.pydantic.type(User, all_fields=True)
@@ -154,7 +154,7 @@ def test_referencing_other_models_fails_when_not_registered():
 
     with pytest.raises(
         strawberry.experimental.pydantic.UnregisteredTypeException,
-        match=("Cannot find a Strawberry Type for (.*) did you forget to register it?"),
+        match=r"Cannot find a Strawberry Type for (.*) did you forget to register it?",
     ):
 
         @strawberry.experimental.pydantic.type(User)
@@ -179,7 +179,7 @@ def test_referencing_other_input_models_fails_when_not_registered():
 
     with pytest.raises(
         strawberry.experimental.pydantic.UnregisteredTypeException,
-        match=("Cannot find a Strawberry Type for (.*) did you forget to register it?"),
+        match=r"Cannot find a Strawberry Type for (.*) did you forget to register it?",
     ):
 
         @strawberry.experimental.pydantic.input(User)

--- a/tests/experimental/pydantic/test_conversion.py
+++ b/tests/experimental/pydantic/test_conversion.py
@@ -896,7 +896,7 @@ def test_get_default_factory_for_field():
 
     with pytest.raises(
         BothDefaultAndDefaultFactoryDefinedError,
-        match=("Not allowed to specify both default and default_factory."),
+        match=r"Not allowed to specify both default and default_factory.",
     ):
         get_default_factory_for_field(field, compat)
 

--- a/tests/fastapi/app.py
+++ b/tests/fastapi/app.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from fastapi import BackgroundTasks, Depends, FastAPI, Request, WebSocket
+
 from strawberry.fastapi import GraphQLRouter
 from tests.views.schema import schema
 

--- a/tests/fastapi/test_context.py
+++ b/tests/fastapi/test_context.py
@@ -24,6 +24,7 @@ def test_base_context():
 def test_with_explicit_class_context_getter():
     from fastapi import Depends, FastAPI
     from fastapi.testclient import TestClient
+
     from strawberry.fastapi import BaseContext, GraphQLRouter
 
     @strawberry.type
@@ -60,6 +61,7 @@ def test_with_explicit_class_context_getter():
 def test_with_implicit_class_context_getter():
     from fastapi import Depends, FastAPI
     from fastapi.testclient import TestClient
+
     from strawberry.fastapi import BaseContext, GraphQLRouter
 
     @strawberry.type
@@ -94,6 +96,7 @@ def test_with_implicit_class_context_getter():
 def test_with_dict_context_getter():
     from fastapi import Depends, FastAPI
     from fastapi.testclient import TestClient
+
     from strawberry.fastapi import GraphQLRouter
 
     @strawberry.type
@@ -126,6 +129,7 @@ def test_with_dict_context_getter():
 def test_without_context_getter():
     from fastapi import FastAPI
     from fastapi.testclient import TestClient
+
     from strawberry.fastapi import GraphQLRouter
 
     @strawberry.type
@@ -151,6 +155,7 @@ def test_without_context_getter():
 def test_with_invalid_context_getter():
     from fastapi import Depends, FastAPI
     from fastapi.testclient import TestClient
+
     from strawberry.fastapi import GraphQLRouter
 
     @strawberry.type
@@ -186,6 +191,7 @@ def test_with_invalid_context_getter():
 def test_class_context_injects_connection_params_over_transport_ws():
     from fastapi import Depends, FastAPI
     from fastapi.testclient import TestClient
+
     from strawberry.fastapi import BaseContext, GraphQLRouter
 
     @strawberry.type
@@ -256,10 +262,10 @@ def test_class_context_injects_connection_params_over_transport_ws():
 
 
 def test_class_context_injects_connection_params_over_ws():
-    from starlette.websockets import WebSocketDisconnect
-
     from fastapi import Depends, FastAPI
     from fastapi.testclient import TestClient
+    from starlette.websockets import WebSocketDisconnect
+
     from strawberry.fastapi import BaseContext, GraphQLRouter
 
     @strawberry.type

--- a/tests/fastapi/test_openapi.py
+++ b/tests/fastapi/test_openapi.py
@@ -8,6 +8,7 @@ class Query:
 
 def test_enable_graphiql_view_and_allow_queries_via_get():
     from fastapi import FastAPI
+
     from strawberry.fastapi import GraphQLRouter
 
     app = FastAPI()
@@ -21,6 +22,7 @@ def test_enable_graphiql_view_and_allow_queries_via_get():
 
 def test_disable_graphiql_view_and_allow_queries_via_get():
     from fastapi import FastAPI
+
     from strawberry.fastapi import GraphQLRouter
 
     app = FastAPI()
@@ -36,6 +38,7 @@ def test_disable_graphiql_view_and_allow_queries_via_get():
 
 def test_graphql_router_with_tags():
     from fastapi import FastAPI
+
     from strawberry.fastapi import GraphQLRouter
 
     app = FastAPI()

--- a/tests/fastapi/test_router.py
+++ b/tests/fastapi/test_router.py
@@ -4,9 +4,9 @@ import strawberry
 
 
 def test_include_router_prefix():
+    from fastapi import FastAPI
     from starlette.testclient import TestClient
 
-    from fastapi import FastAPI
     from strawberry.fastapi import GraphQLRouter
 
     @strawberry.type
@@ -28,9 +28,9 @@ def test_include_router_prefix():
 
 
 def test_graphql_router_path():
+    from fastapi import FastAPI
     from starlette.testclient import TestClient
 
-    from fastapi import FastAPI
     from strawberry.fastapi import GraphQLRouter
 
     @strawberry.type
@@ -53,6 +53,7 @@ def test_graphql_router_path():
 
 def test_missing_path_and_prefix():
     from fastapi import FastAPI
+
     from strawberry.fastapi import GraphQLRouter
 
     @strawberry.type

--- a/tests/fields/test_resolvers.py
+++ b/tests/fields/test_resolvers.py
@@ -288,7 +288,7 @@ def test_raises_error_calling_uncallable_resolver():
 
     with pytest.raises(
         UncallableResolverError,
-        match="Attempted to call resolver (.*) with uncallable function (.*)",
+        match=r"Attempted to call resolver (.*) with uncallable function (.*)",
     ):
         resolver()
 

--- a/tests/http/clients/aiohttp.py
+++ b/tests/http/clients/aiohttp.py
@@ -11,6 +11,7 @@ from aiohttp import web
 from aiohttp.client_ws import ClientWebSocketResponse
 from aiohttp.http_websocket import WSMsgType
 from aiohttp.test_utils import TestClient, TestServer
+
 from strawberry.aiohttp.views import GraphQLView as BaseGraphQLView
 from strawberry.http import GraphQLHTTPResponse
 from strawberry.http.ides import GraphQL_IDE

--- a/tests/http/clients/chalice.py
+++ b/tests/http/clients/chalice.py
@@ -8,6 +8,7 @@ from typing import Any, Literal
 from chalice.app import Chalice
 from chalice.app import Request as ChaliceRequest
 from chalice.test import Client
+
 from strawberry import Schema
 from strawberry.chalice.views import GraphQLView as BaseGraphQLView
 from strawberry.http import GraphQLHTTPResponse

--- a/tests/http/clients/channels.py
+++ b/tests/http/clients/channels.py
@@ -7,9 +7,9 @@ from datetime import timedelta
 from io import BytesIO
 from typing import Any, Literal
 
+from channels.testing import HttpCommunicator, WebsocketCommunicator
 from urllib3 import encode_multipart_formdata
 
-from channels.testing import HttpCommunicator, WebsocketCommunicator
 from strawberry.channels import (
     GraphQLHTTPConsumer,
     GraphQLWSConsumer,

--- a/tests/http/clients/fastapi.py
+++ b/tests/http/clients/fastapi.py
@@ -9,6 +9,7 @@ from typing import Any, Literal
 
 from fastapi import BackgroundTasks, Depends, FastAPI, Request, WebSocket
 from fastapi.testclient import TestClient
+
 from strawberry.fastapi import GraphQLRouter as BaseGraphQLRouter
 from strawberry.http import GraphQLHTTPResponse
 from strawberry.http.ides import GraphQL_IDE

--- a/tests/http/clients/litestar.py
+++ b/tests/http/clients/litestar.py
@@ -11,6 +11,7 @@ from litestar import Litestar, Request
 from litestar.exceptions import WebSocketDisconnect
 from litestar.testing import TestClient
 from litestar.testing.websocket_test_session import WebSocketTestSession
+
 from strawberry.http import GraphQLHTTPResponse
 from strawberry.http.ides import GraphQL_IDE
 from strawberry.litestar import make_graphql_controller

--- a/tests/http/clients/quart.py
+++ b/tests/http/clients/quart.py
@@ -6,14 +6,14 @@ from datetime import timedelta
 from io import BytesIO
 from typing import Any, Literal
 
-from starlette.testclient import TestClient
-from starlette.types import Receive, Scope, Send
-
 from quart import Quart
 from quart import Request as QuartRequest
 from quart import Response as QuartResponse
 from quart import Websocket as QuartWebsocket
 from quart.datastructures import FileStorage
+from starlette.testclient import TestClient
+from starlette.types import Receive, Scope, Send
+
 from strawberry.http import GraphQLHTTPResponse
 from strawberry.http.ides import GraphQL_IDE
 from strawberry.quart.views import GraphQLView as BaseGraphQLView

--- a/tests/http/clients/sanic.py
+++ b/tests/http/clients/sanic.py
@@ -7,6 +7,7 @@ from typing import Any, Literal
 
 from sanic import Sanic
 from sanic.request import Request as SanicRequest
+
 from strawberry.http import GraphQLHTTPResponse
 from strawberry.http.ides import GraphQL_IDE
 from strawberry.http.temporal_response import TemporalResponse
@@ -97,7 +98,7 @@ class SanicHttpClient(HttpClient):
             else:
                 kwargs["content"] = dumps(body)
 
-        request, response = await self.app.asgi_client.request(
+        _request, response = await self.app.asgi_client.request(
             method,
             "/graphql",
             headers=self._get_headers(method=method, headers=headers, files=files),
@@ -117,7 +118,7 @@ class SanicHttpClient(HttpClient):
         method: Literal["head", "get", "post", "patch", "put", "delete"],
         headers: dict[str, str] | None = None,
     ) -> Response:
-        request, response = await self.app.asgi_client.request(
+        _request, response = await self.app.asgi_client.request(
             method,
             url,
             headers=headers,
@@ -145,7 +146,7 @@ class SanicHttpClient(HttpClient):
     ) -> Response:
         body = dumps(json) if json is not None else data
 
-        request, response = await self.app.asgi_client.request(
+        _request, response = await self.app.asgi_client.request(
             "post", url, content=body, headers=headers
         )
 

--- a/tests/litestar/app.py
+++ b/tests/litestar/app.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from litestar import Litestar, Request
 from litestar.di import Provide
+
 from strawberry.litestar import make_graphql_controller
 from tests.views.schema import schema
 

--- a/tests/litestar/conftest.py
+++ b/tests/litestar/conftest.py
@@ -4,6 +4,7 @@ import pytest
 @pytest.fixture
 def test_client():
     from litestar.testing import TestClient
+
     from tests.litestar.app import create_app
 
     app = create_app()
@@ -13,6 +14,7 @@ def test_client():
 @pytest.fixture
 def test_client_keep_alive():
     from litestar.testing import TestClient
+
     from tests.litestar.app import create_app
 
     app = create_app(keep_alive=True, keep_alive_interval=0.1)

--- a/tests/litestar/test_context.py
+++ b/tests/litestar/test_context.py
@@ -12,6 +12,7 @@ def test_with_class_context_getter():
     from litestar import Litestar
     from litestar.di import Provide
     from litestar.testing import TestClient
+
     from strawberry.litestar import BaseContext, make_graphql_controller
 
     @strawberry.type
@@ -56,6 +57,7 @@ def test_with_dict_context_getter():
     from litestar import Litestar
     from litestar.di import Provide
     from litestar.testing import TestClient
+
     from strawberry.litestar import make_graphql_controller
 
     @strawberry.type
@@ -95,6 +97,7 @@ def test_with_dict_context_getter():
 def test_without_context_getter():
     from litestar import Litestar
     from litestar.testing import TestClient
+
     from strawberry.litestar import make_graphql_controller
 
     @strawberry.type
@@ -122,6 +125,7 @@ def test_with_invalid_context_getter():
     from litestar import Litestar
     from litestar.di import Provide
     from litestar.testing import TestClient
+
     from strawberry.litestar import make_graphql_controller
 
     @strawberry.type
@@ -165,6 +169,7 @@ def test_with_invalid_context_getter():
 
 def test_custom_context():
     from litestar.testing import TestClient
+
     from tests.litestar.app import create_app
 
     @strawberry.type
@@ -185,6 +190,7 @@ def test_custom_context():
 
 def test_can_set_background_task():
     from litestar.testing import TestClient
+
     from tests.litestar.app import create_app
 
     task_complete = False

--- a/tests/litestar/test_response_headers.py
+++ b/tests/litestar/test_response_headers.py
@@ -5,6 +5,7 @@ import strawberry
 def test_set_response_headers():
     from litestar import Litestar
     from litestar.testing import TestClient
+
     from strawberry.litestar import make_graphql_controller
 
     @strawberry.type
@@ -31,6 +32,7 @@ def test_set_response_headers():
 def test_set_cookie_headers():
     from litestar import Litestar
     from litestar.testing import TestClient
+
     from strawberry.litestar import make_graphql_controller
 
     @strawberry.type

--- a/tests/litestar/test_response_status.py
+++ b/tests/litestar/test_response_status.py
@@ -5,6 +5,7 @@ import strawberry
 def test_set_custom_http_response_status():
     from litestar import Litestar
     from litestar.testing import TestClient
+
     from strawberry.litestar import make_graphql_controller
 
     @strawberry.type
@@ -28,6 +29,7 @@ def test_set_custom_http_response_status():
 def test_set_without_setting_http_response_status():
     from litestar import Litestar
     from litestar.testing import TestClient
+
     from strawberry.litestar import make_graphql_controller
 
     @strawberry.type

--- a/tests/relay/test_utils.py
+++ b/tests/relay/test_utils.py
@@ -33,7 +33,7 @@ def test_from_base64_with_extra_colon():
 @pytest.mark.parametrize("value", [None, 1, 1.1, "dsadfas"])
 def test_from_base64_non_base64(value: Any):
     with pytest.raises(ValueError):
-        type_name, node_id = from_base64(value)
+        _type_name, _node_id = from_base64(value)
 
 
 @pytest.mark.parametrize(
@@ -46,7 +46,7 @@ def test_from_base64_non_base64(value: Any):
 )
 def test_from_base64_wrong_number_of_args(value: Any):
     with pytest.raises(ValueError):
-        type_name, node_id = from_base64(value)
+        _type_name, _node_id = from_base64(value)
 
 
 def test_to_base64():

--- a/tests/sanic/test_file_upload.py
+++ b/tests/sanic/test_file_upload.py
@@ -29,6 +29,7 @@ class Mutation:
 @pytest.fixture
 def app():
     from sanic import Sanic
+
     from strawberry.sanic.views import GraphQLView
 
     sanic_app = Sanic("sanic_testing")
@@ -47,6 +48,7 @@ def app():
 def test_file_cast(app: Sanic):
     """Tests that the list of files in a sanic Request gets correctly turned into a dictionary"""
     from sanic.request import File
+
     from strawberry.sanic import utils
 
     file_name = "test.txt"

--- a/tests/schema/extensions/test_query_depth_limiter.py
+++ b/tests/schema/extensions/test_query_depth_limiter.py
@@ -236,7 +236,7 @@ def test_should_catch_query_thats_too_deep():
     }
     }
     """
-    errors, result = run_query(query, 4)
+    errors, _result = run_query(query, 4)
 
     assert len(errors) == 1
     assert errors[0].message == "'anonymous' exceeds maximum operation depth of 4"
@@ -245,7 +245,7 @@ def test_should_catch_query_thats_too_deep():
 def test_should_raise_invalid_ignore():
     with pytest.raises(
         TypeError,
-        match="The `should_ignore` argument to `QueryDepthLimiter` must be a callable.",
+        match=r"The `should_ignore` argument to `QueryDepthLimiter` must be a callable.",
     ):
         strawberry.Schema(
             Query, extensions=[QueryDepthLimiter(max_depth=10, should_ignore=True)]

--- a/tests/schema/test_basic.py
+++ b/tests/schema/test_basic.py
@@ -19,7 +19,7 @@ def test_raises_exception_with_unsupported_types():
         example: SomeType
 
     with pytest.raises(
-        TypeError, match="Query fields cannot be resolved. Unexpected type '.*'"
+        TypeError, match=r"Query fields cannot be resolved. Unexpected type '.*'"
     ):
         strawberry.Schema(query=Query)
 

--- a/tests/schema/test_generics.py
+++ b/tests/schema/test_generics.py
@@ -1138,7 +1138,7 @@ def test_generic_interface_extra_types():
         x: str = ""
 
     @strawberry.type
-    class Real(Generic[T], Abstract):
+    class Real(Abstract, Generic[T]):
         y: T
 
     @strawberry.type

--- a/tests/schema/test_schema_generation.py
+++ b/tests/schema/test_schema_generation.py
@@ -53,5 +53,5 @@ def test_schema_fails_on_an_invalid_schema():
     @strawberry.type
     class Query: ...  # Type must have at least one field
 
-    with pytest.raises(ValueError, match="Invalid Schema. Errors.*"):
+    with pytest.raises(ValueError, match=r"Invalid Schema. Errors.*"):
         strawberry.Schema(query=Query)

--- a/tests/test/conftest.py
+++ b/tests/test/conftest.py
@@ -17,6 +17,7 @@ async def aiohttp_graphql_client() -> AsyncGenerator[BaseGraphQLTestClient]:
     try:
         from aiohttp import web
         from aiohttp.test_utils import TestClient, TestServer
+
         from strawberry.aiohttp.test import GraphQLTestClient
         from strawberry.aiohttp.views import GraphQLView
     except ImportError:

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -20,6 +20,6 @@ def test_can_use_info_with_one_argument():
 def test_cannot_use_info_with_more_than_two_arguments():
     with pytest.raises(
         TypeError,
-        match="Too many (arguments|parameters) for <class '.*.Info'>; actual 3, expected 2",
+        match=r"Too many (arguments|parameters) for <class '.*.Info'>; actual 3, expected 2",
     ):
         strawberry.Info[int, str, int]  # type: ignore

--- a/tests/test_type.py
+++ b/tests/test_type.py
@@ -44,6 +44,6 @@ def test_get_object_definition_strict():
 
     with pytest.raises(
         TypeError,
-        match=".* does not have a StrawberryObjectDefinition",
+        match=r".* does not have a StrawberryObjectDefinition",
     ):
         get_object_definition(OtherFruit, strict=True)


### PR DESCRIPTION
https://github.com/strawberry-graphql/strawberry/pull/4032 was sorting imports wrong, so I added our integrations as "known third party"

## Summary by Sourcery

Update pre-commit hooks and import sorting configuration, and apply related code and test adjustments to conform to the new linting rules.

Enhancements:
- Add FastAPI, Pydantic, Litestar, Aiohttp, Channels, Sanic, Chalice, and Quart as known third-party libraries in isort configuration to correct import ordering

Build:
- Bump ruff to 0.14.1 and blacken-docs to 1.20.0 in pre-commit hooks and align dev dependencies in pyproject.toml

Tests:
- Normalize import grouping in tests, add blank lines before Strawberry imports, rename unused variables with underscores, and convert regex matches to raw strings