### PR TITLE
:arrow_up: Upgrade minimum Typer version to fix CLI commands

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Bumped minimum Typer version to fix strawberry CLI commands.

--- a/poetry.lock
+++ b/poetry.lock
@@ -6295,4 +6295,4 @@ sanic = ["sanic"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "3b606c1f1f5f966116d41df85ba0967b5ec20ca403c1af952da3770c7fac8df0"
+content-hash = "5cf0ff0ad77dc736874c34e4b1084d8257d168d136eab0f2b0326120ca576ae9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ debug-server = [
   "uvicorn>=0.11.6",
   "websockets>=15.0.1,<16",
   "python-multipart>=0.0.7",
-  "typer>=0.7.0",
+  "typer>=0.12.4",
   "pygments~=2.3",
   "rich>=12.0.0",
   "libcst",
@@ -60,7 +60,7 @@ sanic = ["sanic>=20.12.2"]
 fastapi = ["fastapi>=0.65.2", "python-multipart>=0.0.7"]
 chalice = ["chalice~=1.22"]
 cli = [
-  "typer>=0.7.0",
+  "typer>=0.12.4",
   "pygments~=2.3",
   "rich>=12.0.0",
   "libcst",
@@ -97,7 +97,7 @@ dev = [
   "python-multipart (>=0.0.7)",
   "rich (>=12.5.1)",
   "sanic-testing (>=22.9,<24.0)",
-  "typer (>=0.7.0)",
+  "typer (>=0.12.4)",
   "types-aiofiles (>=24.1.0.20250326,<25.0.0.0)",
   "types-certifi (>=2021.10.8,<2022.0.0)",
   "types-chardet (>=5.0.4,<6.0.0)",


### PR DESCRIPTION
## Description

The changelog of Typer 0.12.4 contains the following relevant change:
- 🐛 Fix support for UnionType (e.g. str | None) with Python 3.11. PR [#548](https://github.com/fastapi/typer/pull/548) by [@jonaslb](https://github.com/jonaslb).

Upgrading Typer fixes issues where running strawberry commands produce the following error:
`RuntimeError: Type not yet supported: list[pathlib.Path] | None`

While there is test coverage for strawberry CLI commands, the locked version of typer is 0.19+ which is why the issue was not visible through unit testing. This change was tested by changing the installed version of typer on my personal project and seeing if the strawberry commands worked.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* [4046](https://github.com/strawberry-graphql/strawberry/issues/4046)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Upgrade minimum Typer version to 0.12.4 to fix CLI support for UnionType arguments in strawberry commands

Bug Fixes:
- Bump Typer dependency to >=0.12.4 to resolve CLI runtime errors with UnionType types

Documentation:
- Add RELEASE.md documenting the patch release for the Typer version bump