### PR TITLE
fix: relax dependency requirements for python-dateutil/pygments

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: fix
+
+Relax dependency requirements for `python-dateutil` and `pygments` to use >= instead of ~=,
+allowing users to install newer versions of these packages without conflicts.

--- a/poetry.lock
+++ b/poetry.lock
@@ -6295,4 +6295,4 @@ sanic = ["sanic"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "5cf0ff0ad77dc736874c34e4b1084d8257d168d136eab0f2b0326120ca576ae9"
+content-hash = "0c455ff7369362097f1a56fd7a0ca3e7be023f2f93559bf2a761aa72deca9087"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ requires-python = ">=3.10,<4.0"
 dependencies = [
   "graphql-core>=3.2.0,<3.4.0",
   "typing-extensions>=4.5.0",
-  "python-dateutil~=2.7",
+  "python-dateutil>=2.7",
   "packaging>=23",
   "lia-web (>=0.2.1)",
 ]
@@ -46,7 +46,7 @@ debug-server = [
   "websockets>=15.0.1,<16",
   "python-multipart>=0.0.7",
   "typer>=0.12.4",
-  "pygments~=2.3",
+  "pygments>=2.3",
   "rich>=12.0.0",
   "libcst",
 ]


### PR DESCRIPTION
## Summary by Sourcery

Relax dependency constraints for core and debug-server dependencies to allow newer compatible versions.

Enhancements:
- Loosen python-dateutil dependency from a compatible-release constraint to a minimum-version constraint to permit newer releases.
- Loosen pygments debug-server dependency from a compatible-release constraint to a minimum-version constraint to permit newer releases.

Documentation:
- Add a release note describing the relaxed version constraints for python-dateutil and pygments.