### PR TITLE
feat(tests): add ty type checker support to typechecker tests

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -179,6 +179,7 @@ def tests_typecheckers(session: Session) -> None:
     session.install("pyright")
     session.install("pydantic")
     session.install("mypy")
+    session.install("ty")
 
     session.run(
         "pytest",

--- a/tests/typecheckers/test_auto.py
+++ b/tests/typecheckers/test_auto.py
@@ -1,9 +1,9 @@
 from inline_snapshot import snapshot
 
-from .utils.marks import requires_mypy, requires_pyright, skip_on_windows
+from .utils.marks import requires_mypy, requires_pyright, requires_ty, skip_on_windows
 from .utils.typecheck import Result, typecheck
 
-pytestmark = [skip_on_windows, requires_pyright, requires_mypy]
+pytestmark = [skip_on_windows, requires_pyright, requires_mypy, requires_ty]
 
 
 CODE = """
@@ -56,5 +56,27 @@ def test_auto():
             Result(type="note", message='Revealed type is "Any"', line=14, column=13),
             Result(type="note", message='Revealed type is "Any"', line=15, column=13),
             Result(type="note", message='Revealed type is "Any"', line=16, column=13),
+        ]
+    )
+    assert result.ty == snapshot(
+        [
+            Result(
+                type="information",
+                message="Revealed type: `Any`",
+                line=14,
+                column=13,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `Any`",
+                line=15,
+                column=13,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `Any`",
+                line=16,
+                column=13,
+            ),
         ]
     )

--- a/tests/typecheckers/test_directives.py
+++ b/tests/typecheckers/test_directives.py
@@ -1,9 +1,9 @@
 from inline_snapshot import snapshot
 
-from .utils.marks import requires_mypy, requires_pyright, skip_on_windows
+from .utils.marks import requires_mypy, requires_pyright, requires_ty, skip_on_windows
 from .utils.typecheck import Result, typecheck
 
-pytestmark = [skip_on_windows, requires_pyright, requires_mypy]
+pytestmark = [skip_on_windows, requires_pyright, requires_mypy, requires_ty]
 
 
 CODE = """
@@ -46,5 +46,15 @@ def test():
                 line=16,
                 column=13,
             )
+        ]
+    )
+    assert results.ty == snapshot(
+        [
+            Result(
+                type="information",
+                message="Revealed type: `StrawberryDirective[Unknown]`",
+                line=16,
+                column=13,
+            ),
         ]
     )

--- a/tests/typecheckers/test_enum.py
+++ b/tests/typecheckers/test_enum.py
@@ -1,9 +1,9 @@
 from inline_snapshot import snapshot
 
-from .utils.marks import requires_mypy, requires_pyright, skip_on_windows
+from .utils.marks import requires_mypy, requires_pyright, requires_ty, skip_on_windows
 from .utils.typecheck import Result, typecheck
 
-pytestmark = [skip_on_windows, requires_pyright, requires_mypy]
+pytestmark = [skip_on_windows, requires_pyright, requires_mypy, requires_ty]
 
 CODE_WITH_DECORATOR = """
 from enum import Enum
@@ -51,6 +51,22 @@ def test_enum_with_decorator():
             Result(
                 type="note",
                 message='Revealed type is "Literal[mypy_test.IceCreamFlavour.VANILLA]?"',
+                line=13,
+                column=13,
+            ),
+        ]
+    )
+    assert results.ty == snapshot(
+        [
+            Result(
+                type="information",
+                message="Revealed type: `<class 'IceCreamFlavour'>`",
+                line=12,
+                column=13,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `Literal[IceCreamFlavour.VANILLA]`",
                 line=13,
                 column=13,
             ),
@@ -109,6 +125,22 @@ def test_enum_with_decorator_and_name():
             ),
         ]
     )
+    assert results.ty == snapshot(
+        [
+            Result(
+                type="information",
+                message="Revealed type: `<class 'Flavour'>`",
+                line=12,
+                column=13,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `Literal[Flavour.VANILLA]`",
+                line=13,
+                column=13,
+            ),
+        ]
+    )
 
 
 CODE_WITH_MANUAL_DECORATOR = """
@@ -156,6 +188,22 @@ def test_enum_with_manual_decorator():
             Result(
                 type="note",
                 message='Revealed type is "Literal[mypy_test.IceCreamFlavour.VANILLA]?"',
+                line=12,
+                column=13,
+            ),
+        ]
+    )
+    assert results.ty == snapshot(
+        [
+            Result(
+                type="information",
+                message="Revealed type: `<class 'IceCreamFlavour'>`",
+                line=11,
+                column=13,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `Literal[IceCreamFlavour.VANILLA]`",
                 line=12,
                 column=13,
             ),
@@ -213,6 +261,22 @@ def test_enum_with_manual_decorator_and_name():
             ),
         ]
     )
+    assert results.ty == snapshot(
+        [
+            Result(
+                type="information",
+                message="Revealed type: `Unknown`",
+                line=11,
+                column=13,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `Unknown`",
+                line=12,
+                column=13,
+            ),
+        ]
+    )
 
 
 CODE_WITH_DEPRECATION_REASON = """
@@ -263,6 +327,22 @@ def test_enum_deprecated():
             Result(
                 type="note",
                 message='Revealed type is "Literal[mypy_test.IceCreamFlavour.STRAWBERRY]?"',
+                line=15,
+                column=13,
+            ),
+        ]
+    )
+    assert results.ty == snapshot(
+        [
+            Result(
+                type="information",
+                message="Revealed type: `<class 'IceCreamFlavour'>`",
+                line=14,
+                column=13,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `Literal[IceCreamFlavour.STRAWBERRY]`",
                 line=15,
                 column=13,
             ),

--- a/tests/typecheckers/test_fastapi.py
+++ b/tests/typecheckers/test_fastapi.py
@@ -1,9 +1,9 @@
 from inline_snapshot import snapshot
 
-from .utils.marks import requires_mypy, requires_pyright, skip_on_windows
+from .utils.marks import requires_mypy, requires_pyright, requires_ty, skip_on_windows
 from .utils.typecheck import Result, typecheck
 
-pytestmark = [skip_on_windows, requires_pyright, requires_mypy]
+pytestmark = [skip_on_windows, requires_pyright, requires_mypy, requires_ty]
 
 CODE_ROUTER_WITH_CONTEXT = """
 import strawberry
@@ -55,6 +55,16 @@ def test_router_with_context():
             Result(
                 type="note",
                 message='Revealed type is "strawberry.fastapi.router.GraphQLRouter[mypy_test.Context, None]"',
+                line=29,
+                column=13,
+            ),
+        ]
+    )
+    assert results.ty == snapshot(
+        [
+            Result(
+                type="information",
+                message="Revealed type: `GraphQLRouter[Context, None]`",
                 line=29,
                 column=13,
             ),
@@ -112,6 +122,16 @@ def test_router_with_async_context():
             Result(
                 type="note",
                 message='Revealed type is "strawberry.fastapi.router.GraphQLRouter[mypy_test.Context, None]"',
+                line=29,
+                column=13,
+            ),
+        ]
+    )
+    assert results.ty == snapshot(
+        [
+            Result(
+                type="information",
+                message="Revealed type: `GraphQLRouter[Context, None]`",
                 line=29,
                 column=13,
             ),

--- a/tests/typecheckers/test_federation.py
+++ b/tests/typecheckers/test_federation.py
@@ -1,9 +1,9 @@
 from inline_snapshot import snapshot
 
-from .utils.marks import requires_mypy, requires_pyright, skip_on_windows
+from .utils.marks import requires_mypy, requires_pyright, requires_ty, skip_on_windows
 from .utils.typecheck import Result, typecheck
 
-pytestmark = [skip_on_windows, requires_pyright, requires_mypy]
+pytestmark = [skip_on_windows, requires_pyright, requires_mypy, requires_ty]
 
 
 CODE = """
@@ -71,6 +71,34 @@ def test_federation_type():
             Result(
                 type="note",
                 message='Revealed type is "def (self: mypy_test.User, *, name: builtins.str)"',
+                line=19,
+                column=13,
+            ),
+        ]
+    )
+    assert results.ty == snapshot(
+        [
+            Result(
+                type="error",
+                message="No argument provided for required parameter `name`",
+                line=16,
+                column=1,
+            ),
+            Result(
+                type="error",
+                message="Argument `n` does not match any known parameter",
+                line=16,
+                column=6,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `<class 'User'>`",
+                line=18,
+                column=13,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `(self: User, *, name: str) -> None`",
                 line=19,
                 column=13,
             ),
@@ -144,6 +172,34 @@ def test_federation_interface():
             ),
         ]
     )
+    assert results.ty == snapshot(
+        [
+            Result(
+                type="error",
+                message="No argument provided for required parameter `name`",
+                line=12,
+                column=1,
+            ),
+            Result(
+                type="error",
+                message="Argument `n` does not match any known parameter",
+                line=12,
+                column=6,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `<class 'User'>`",
+                line=14,
+                column=13,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `(self: User, *, name: str, age: int) -> None`",
+                line=15,
+                column=13,
+            ),
+        ]
+    )
 
 
 CODE_INPUT = """
@@ -205,6 +261,34 @@ def test_federation_input():
             Result(
                 type="note",
                 message='Revealed type is "def (self: mypy_test.User, *, name: builtins.str)"',
+                line=13,
+                column=13,
+            ),
+        ]
+    )
+    assert results.ty == snapshot(
+        [
+            Result(
+                type="error",
+                message="No argument provided for required parameter `name`",
+                line=10,
+                column=1,
+            ),
+            Result(
+                type="error",
+                message="Argument `n` does not match any known parameter",
+                line=10,
+                column=6,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `<class 'User'>`",
+                line=12,
+                column=13,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `(self: User, *, name: str) -> None`",
                 line=13,
                 column=13,
             ),

--- a/tests/typecheckers/test_federation_fields.py
+++ b/tests/typecheckers/test_federation_fields.py
@@ -1,9 +1,9 @@
 from inline_snapshot import snapshot
 
-from .utils.marks import requires_mypy, requires_pyright, skip_on_windows
+from .utils.marks import requires_mypy, requires_pyright, requires_ty, skip_on_windows
 from .utils.typecheck import Result, typecheck
 
-pytestmark = [skip_on_windows, requires_pyright, requires_mypy]
+pytestmark = [skip_on_windows, requires_pyright, requires_mypy, requires_ty]
 
 CODE = """
 import strawberry
@@ -121,6 +121,58 @@ def test():
             Result(
                 type="note",
                 message='Revealed type is "def (self: mypy_test.UserInput, *, age: builtins.int, name: builtins.str)"',
+                line=33,
+                column=13,
+            ),
+        ]
+    )
+    assert results.ty == snapshot(
+        [
+            Result(
+                type="error",
+                message="No argument provided for required parameter `name`",
+                line=24,
+                column=1,
+            ),
+            Result(
+                type="error",
+                message="Argument `n` does not match any known parameter",
+                line=24,
+                column=6,
+            ),
+            Result(
+                type="error",
+                message="No argument provided for required parameter `name`",
+                line=27,
+                column=1,
+            ),
+            Result(
+                type="error",
+                message="Argument `n` does not match any known parameter",
+                line=27,
+                column=11,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `<class 'User'>`",
+                line=29,
+                column=13,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `(self: User, *, age: int, name: str) -> None`",
+                line=30,
+                column=13,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `<class 'UserInput'>`",
+                line=32,
+                column=13,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `(self: UserInput, *, age: int, name: str) -> None`",
                 line=33,
                 column=13,
             ),

--- a/tests/typecheckers/test_federation_params.py
+++ b/tests/typecheckers/test_federation_params.py
@@ -1,9 +1,9 @@
 from inline_snapshot import snapshot
 
-from .utils.marks import requires_mypy, requires_pyright, skip_on_windows
+from .utils.marks import requires_mypy, requires_pyright, requires_ty, skip_on_windows
 from .utils.typecheck import Result, typecheck
 
-pytestmark = [skip_on_windows, requires_pyright, requires_mypy]
+pytestmark = [skip_on_windows, requires_pyright, requires_mypy, requires_ty]
 
 
 CODE = """
@@ -42,5 +42,21 @@ def test():
                 line=11,
                 column=1,
             )
+        ]
+    )
+    assert results.ty == snapshot(
+        [
+            Result(
+                type="error",
+                message="No argument provided for required parameter `name`",
+                line=11,
+                column=1,
+            ),
+            Result(
+                type="error",
+                message="Argument `n` does not match any known parameter",
+                line=11,
+                column=11,
+            ),
         ]
     )

--- a/tests/typecheckers/test_fields.py
+++ b/tests/typecheckers/test_fields.py
@@ -1,9 +1,9 @@
 from inline_snapshot import snapshot
 
-from .utils.marks import requires_mypy, requires_pyright, skip_on_windows
+from .utils.marks import requires_mypy, requires_pyright, requires_ty, skip_on_windows
 from .utils.typecheck import Result, typecheck
 
-pytestmark = [skip_on_windows, requires_pyright, requires_mypy]
+pytestmark = [skip_on_windows, requires_pyright, requires_mypy, requires_ty]
 
 
 CODE = """
@@ -66,6 +66,34 @@ def test():
             Result(
                 type="note",
                 message='Revealed type is "def (self: mypy_test.User, *, name: builtins.str)"',
+                line=14,
+                column=13,
+            ),
+        ]
+    )
+    assert results.ty == snapshot(
+        [
+            Result(
+                type="error",
+                message="No argument provided for required parameter `name`",
+                line=11,
+                column=1,
+            ),
+            Result(
+                type="error",
+                message="Argument `n` does not match any known parameter",
+                line=11,
+                column=6,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `<class 'User'>`",
+                line=13,
+                column=13,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `(self: User, *, name: str) -> None`",
                 line=14,
                 column=13,
             ),

--- a/tests/typecheckers/test_fields_input.py
+++ b/tests/typecheckers/test_fields_input.py
@@ -1,9 +1,9 @@
 from inline_snapshot import snapshot
 
-from .utils.marks import requires_mypy, requires_pyright, skip_on_windows
+from .utils.marks import requires_mypy, requires_pyright, requires_ty, skip_on_windows
 from .utils.typecheck import Result, typecheck
 
-pytestmark = [skip_on_windows, requires_pyright, requires_mypy]
+pytestmark = [skip_on_windows, requires_pyright, requires_mypy, requires_ty]
 
 
 CODE = """
@@ -66,6 +66,34 @@ def test():
             Result(
                 type="note",
                 message='Revealed type is "def (self: mypy_test.User, *, name: builtins.str)"',
+                line=14,
+                column=13,
+            ),
+        ]
+    )
+    assert results.ty == snapshot(
+        [
+            Result(
+                type="error",
+                message="No argument provided for required parameter `name`",
+                line=11,
+                column=1,
+            ),
+            Result(
+                type="error",
+                message="Argument `n` does not match any known parameter",
+                line=11,
+                column=6,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `<class 'User'>`",
+                line=13,
+                column=13,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `(self: User, *, name: str) -> None`",
                 line=14,
                 column=13,
             ),

--- a/tests/typecheckers/test_fields_keyword.py
+++ b/tests/typecheckers/test_fields_keyword.py
@@ -1,9 +1,9 @@
 from inline_snapshot import snapshot
 
-from .utils.marks import requires_mypy, requires_pyright, skip_on_windows
+from .utils.marks import requires_mypy, requires_pyright, requires_ty, skip_on_windows
 from .utils.typecheck import Result, typecheck
 
-pytestmark = [skip_on_windows, requires_pyright, requires_mypy]
+pytestmark = [skip_on_windows, requires_pyright, requires_mypy, requires_ty]
 
 
 CODE = """
@@ -51,6 +51,28 @@ def test():
             Result(
                 type="note",
                 message='Revealed type is "def (self: mypy_test.User, *, name: builtins.str)"',
+                line=12,
+                column=13,
+            ),
+        ]
+    )
+    assert results.ty == snapshot(
+        [
+            Result(
+                type="error",
+                message="No argument provided for required parameter `name`",
+                line=10,
+                column=1,
+            ),
+            Result(
+                type="error",
+                message="Too many positional arguments: expected 0, got 1",
+                line=10,
+                column=6,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `(self: User, *, name: str) -> None`",
                 line=12,
                 column=13,
             ),

--- a/tests/typecheckers/test_fields_resolver.py
+++ b/tests/typecheckers/test_fields_resolver.py
@@ -1,9 +1,9 @@
 from inline_snapshot import snapshot
 
-from .utils.marks import requires_mypy, requires_pyright, skip_on_windows
+from .utils.marks import requires_mypy, requires_pyright, requires_ty, skip_on_windows
 from .utils.typecheck import Result, typecheck
 
-pytestmark = [skip_on_windows, requires_pyright, requires_mypy]
+pytestmark = [skip_on_windows, requires_pyright, requires_mypy, requires_ty]
 
 
 CODE = """
@@ -70,6 +70,34 @@ def test():
             Result(
                 type="note",
                 message='Revealed type is "def (self: mypy_test.User, *, name: builtins.str)"',
+                line=18,
+                column=13,
+            ),
+        ]
+    )
+    assert results.ty == snapshot(
+        [
+            Result(
+                type="error",
+                message="No argument provided for required parameter `name`",
+                line=15,
+                column=1,
+            ),
+            Result(
+                type="error",
+                message="Argument `n` does not match any known parameter",
+                line=15,
+                column=6,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `<class 'User'>`",
+                line=17,
+                column=13,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `(self: User, *, name: str) -> None`",
                 line=18,
                 column=13,
             ),

--- a/tests/typecheckers/test_fields_resolver_async.py
+++ b/tests/typecheckers/test_fields_resolver_async.py
@@ -1,9 +1,9 @@
 from inline_snapshot import snapshot
 
-from .utils.marks import requires_mypy, requires_pyright, skip_on_windows
+from .utils.marks import requires_mypy, requires_pyright, requires_ty, skip_on_windows
 from .utils.typecheck import Result, typecheck
 
-pytestmark = [skip_on_windows, requires_pyright, requires_mypy]
+pytestmark = [skip_on_windows, requires_pyright, requires_mypy, requires_ty]
 
 CODE = """
 import strawberry
@@ -85,6 +85,34 @@ def test():
             Result(
                 type="note",
                 message='Revealed type is "def (self: mypy_test.User, *, name: builtins.str)"',
+                line=19,
+                column=13,
+            ),
+        ]
+    )
+    assert results.ty == snapshot(
+        [
+            Result(
+                type="error",
+                message="No argument provided for required parameter `name`",
+                line=16,
+                column=1,
+            ),
+            Result(
+                type="error",
+                message="Argument `n` does not match any known parameter",
+                line=16,
+                column=6,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `<class 'User'>`",
+                line=18,
+                column=13,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `(self: User, *, name: str) -> None`",
                 line=19,
                 column=13,
             ),

--- a/tests/typecheckers/test_info.py
+++ b/tests/typecheckers/test_info.py
@@ -1,9 +1,9 @@
 from inline_snapshot import snapshot
 
-from .utils.marks import requires_mypy, requires_pyright, skip_on_windows
+from .utils.marks import requires_mypy, requires_pyright, requires_ty, skip_on_windows
 from .utils.typecheck import Result, typecheck
 
-pytestmark = [skip_on_windows, requires_pyright, requires_mypy]
+pytestmark = [skip_on_windows, requires_pyright, requires_mypy, requires_ty]
 
 
 def test_with_params():
@@ -37,6 +37,22 @@ def example(info: strawberry.Info[None, None]) -> None:
         [
             Result(type="note", message='Revealed type is "None"', line=5, column=17),
             Result(type="note", message='Revealed type is "None"', line=6, column=17),
+        ]
+    )
+    assert results.ty == snapshot(
+        [
+            Result(
+                type="information",
+                message="Revealed type: `None`",
+                line=5,
+                column=17,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `None`",
+                line=6,
+                column=17,
+            ),
         ]
     )
 
@@ -74,6 +90,22 @@ def example(info: strawberry.Info[None]) -> None:
             Result(type="note", message='Revealed type is "Any"', line=6, column=17),
         ]
     )
+    assert results.ty == snapshot(
+        [
+            Result(
+                type="information",
+                message="Revealed type: `None`",
+                line=5,
+                column=17,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `Any`",
+                line=6,
+                column=17,
+            ),
+        ]
+    )
 
 
 def test_without_params():
@@ -107,5 +139,21 @@ def example(info: strawberry.Info) -> None:
         [
             Result(type="note", message='Revealed type is "Any"', line=5, column=17),
             Result(type="note", message='Revealed type is "Any"', line=6, column=17),
+        ]
+    )
+    assert results.ty == snapshot(
+        [
+            Result(
+                type="information",
+                message="Revealed type: `Any`",
+                line=5,
+                column=17,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `Any`",
+                line=6,
+                column=17,
+            ),
         ]
     )

--- a/tests/typecheckers/test_interface.py
+++ b/tests/typecheckers/test_interface.py
@@ -1,9 +1,9 @@
 from inline_snapshot import snapshot
 
-from .utils.marks import requires_mypy, requires_pyright, skip_on_windows
+from .utils.marks import requires_mypy, requires_pyright, requires_ty, skip_on_windows
 from .utils.typecheck import Result, typecheck
 
-pytestmark = [skip_on_windows, requires_pyright, requires_mypy]
+pytestmark = [skip_on_windows, requires_pyright, requires_mypy, requires_ty]
 
 
 CODE = """
@@ -41,6 +41,16 @@ def test():
             )
         ]
     )
+    assert results.ty == snapshot(
+        [
+            Result(
+                type="information",
+                message="Revealed type: `<class 'Node'>`",
+                line=9,
+                column=13,
+            ),
+        ]
+    )
 
 
 CODE_2 = """
@@ -76,5 +86,15 @@ def test_calling():
                 line=9,
                 column=13,
             )
+        ]
+    )
+    assert results.ty == snapshot(
+        [
+            Result(
+                type="information",
+                message="Revealed type: `<class 'Node'>`",
+                line=9,
+                column=13,
+            ),
         ]
     )

--- a/tests/typecheckers/test_maybe.py
+++ b/tests/typecheckers/test_maybe.py
@@ -1,9 +1,9 @@
 from inline_snapshot import snapshot
 
-from .utils.marks import requires_mypy, requires_pyright, skip_on_windows
+from .utils.marks import requires_mypy, requires_pyright, requires_ty, skip_on_windows
 from .utils.typecheck import Result, typecheck
 
-pytestmark = [skip_on_windows, requires_pyright, requires_mypy]
+pytestmark = [skip_on_windows, requires_pyright, requires_mypy, requires_ty]
 
 
 CODE = """
@@ -55,6 +55,22 @@ def test_maybe() -> None:
             Result(
                 type="note",
                 message='Revealed type is "strawberry.types.maybe.Some[builtins.str]"',
+                line=15,
+                column=17,
+            ),
+        ]
+    )
+    assert result.ty == snapshot(
+        [
+            Result(
+                type="information",
+                message="Revealed type: `Some[str] | None`",
+                line=12,
+                column=13,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `Some[str] & ~AlwaysFalsy`",
                 line=15,
                 column=17,
             ),

--- a/tests/typecheckers/test_params.py
+++ b/tests/typecheckers/test_params.py
@@ -1,9 +1,9 @@
 from inline_snapshot import snapshot
 
-from .utils.marks import requires_mypy, requires_pyright, skip_on_windows
+from .utils.marks import requires_mypy, requires_pyright, requires_ty, skip_on_windows
 from .utils.typecheck import Result, typecheck
 
-pytestmark = [skip_on_windows, requires_pyright, requires_mypy]
+pytestmark = [skip_on_windows, requires_pyright, requires_mypy, requires_ty]
 
 CODE = """
 import strawberry
@@ -61,6 +61,34 @@ def test():
                 message='Unexpected keyword argument "n" for "UserInput"',
                 line=19,
                 column=1,
+            ),
+        ]
+    )
+    assert results.ty == snapshot(
+        [
+            Result(
+                type="error",
+                message="No argument provided for required parameter `name`",
+                line=16,
+                column=1,
+            ),
+            Result(
+                type="error",
+                message="Argument `n` does not match any known parameter",
+                line=16,
+                column=11,
+            ),
+            Result(
+                type="error",
+                message="No argument provided for required parameter `name`",
+                line=19,
+                column=1,
+            ),
+            Result(
+                type="error",
+                message="Argument `n` does not match any known parameter",
+                line=19,
+                column=11,
             ),
         ]
     )

--- a/tests/typecheckers/test_private.py
+++ b/tests/typecheckers/test_private.py
@@ -1,9 +1,9 @@
 from inline_snapshot import snapshot
 
-from .utils.marks import requires_mypy, requires_pyright, skip_on_windows
+from .utils.marks import requires_mypy, requires_pyright, requires_ty, skip_on_windows
 from .utils.typecheck import Result, typecheck
 
-pytestmark = [skip_on_windows, requires_pyright, requires_mypy]
+pytestmark = [skip_on_windows, requires_pyright, requires_mypy, requires_ty]
 
 
 CODE = """
@@ -67,6 +67,34 @@ def test():
             Result(
                 type="note",
                 message='Revealed type is "builtins.int"',
+                line=15,
+                column=13,
+            ),
+        ]
+    )
+    assert results.ty == snapshot(
+        [
+            Result(
+                type="error",
+                message="No arguments provided for required parameters `name`, `age`",
+                line=12,
+                column=1,
+            ),
+            Result(
+                type="error",
+                message="Argument `n` does not match any known parameter",
+                line=12,
+                column=6,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `str`",
+                line=14,
+                column=13,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `int`",
                 line=15,
                 column=13,
             ),

--- a/tests/typecheckers/test_relay.py
+++ b/tests/typecheckers/test_relay.py
@@ -1,9 +1,9 @@
 from inline_snapshot import snapshot
 
-from .utils.marks import requires_mypy, requires_pyright, skip_on_windows
+from .utils.marks import requires_mypy, requires_pyright, requires_ty, skip_on_windows
 from .utils.typecheck import Result, typecheck
 
-pytestmark = [skip_on_windows, requires_pyright, requires_mypy]
+pytestmark = [skip_on_windows, requires_pyright, requires_mypy, requires_ty]
 
 
 CODE = """
@@ -351,5 +351,147 @@ def test():
             Result(type="note", message='Revealed type is "Any"', line=141, column=13),
             Result(type="note", message='Revealed type is "Any"', line=142, column=13),
             Result(type="note", message='Revealed type is "Any"', line=143, column=13),
+        ]
+    )
+    assert results.ty == snapshot(
+        [
+            Result(
+                type="error",
+                message="Function always implicitly returns `None`, which is not assignable to return type `Self@resolve_connection`",
+                line=48,
+                column=10,
+            ),
+            Result(
+                type="error",
+                message="Function always implicitly returns `None`, which is not assignable to return type `list[Fruit]`",
+                line=56,
+                column=26,
+            ),
+            Result(
+                type="error",
+                message="Function always implicitly returns `None`, which is not assignable to return type `list[Fruit]`",
+                line=79,
+                column=10,
+            ),
+            Result(
+                type="error",
+                message="Function always implicitly returns `None`, which is not assignable to return type `Iterator[Fruit]`",
+                line=87,
+                column=10,
+            ),
+            Result(
+                type="error",
+                message="Function always implicitly returns `None`, which is not assignable to return type `Iterable[Fruit]`",
+                line=95,
+                column=10,
+            ),
+            Result(
+                type="error",
+                message="Function always implicitly returns `None`, which is not assignable to return type `Generator[Fruit, None, None]`",
+                line=103,
+                column=10,
+            ),
+            Result(
+                type="error",
+                message="Function always implicitly returns `None`, which is not assignable to return type `AsyncIterator[Fruit]`",
+                line=111,
+                column=10,
+            ),
+            Result(
+                type="error",
+                message="Function always implicitly returns `None`, which is not assignable to return type `AsyncIterable[Fruit]`",
+                line=119,
+                column=10,
+            ),
+            Result(
+                type="error",
+                message="Function always implicitly returns `None`, which is not assignable to return type `AsyncGenerator[Fruit, None]`",
+                line=127,
+                column=10,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `Node`",
+                line=130,
+                column=13,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `list[Node]`",
+                line=131,
+                column=13,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `Node | None`",
+                line=132,
+                column=13,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `list[Node | None]`",
+                line=133,
+                column=13,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `Connection[Fruit]`",
+                line=134,
+                column=13,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `Connection[Fruit]`",
+                line=135,
+                column=13,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `FruitCustomPaginationConnection`",
+                line=136,
+                column=13,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `Any`",
+                line=137,
+                column=13,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `Any`",
+                line=138,
+                column=13,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `Any`",
+                line=139,
+                column=13,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `Any`",
+                line=140,
+                column=13,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `Any`",
+                line=141,
+                column=13,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `Any`",
+                line=142,
+                column=13,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `Any`",
+                line=143,
+                column=13,
+            ),
         ]
     )

--- a/tests/typecheckers/test_scalars.py
+++ b/tests/typecheckers/test_scalars.py
@@ -1,9 +1,9 @@
 from inline_snapshot import snapshot
 
-from .utils.marks import requires_mypy, requires_pyright, skip_on_windows
+from .utils.marks import requires_mypy, requires_pyright, requires_ty, skip_on_windows
 from .utils.typecheck import Result, typecheck
 
-pytestmark = [skip_on_windows, requires_pyright, requires_mypy]
+pytestmark = [skip_on_windows, requires_pyright, requires_mypy, requires_ty]
 
 
 CODE = """
@@ -89,6 +89,64 @@ def test():
             Result(type="note", message='Revealed type is "Any"', line=27, column=13),
         ]
     )
+    assert results.ty == snapshot(
+        [
+            Result(
+                type="error",
+                message="Variable of type `NewType` is not allowed in a type expression",
+                line=9,
+                column=11,
+            ),
+            Result(
+                type="error",
+                message="Variable of type `NewType` is not allowed in a type expression",
+                line=10,
+                column=13,
+            ),
+            Result(
+                type="error",
+                message="Variable of type `NewType` is not allowed in a type expression",
+                line=11,
+                column=13,
+            ),
+            Result(
+                type="error",
+                message="Variable of type `NewType` is not allowed in a type expression",
+                line=12,
+                column=13,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `ID`",
+                line=23,
+                column=13,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `Unknown`",
+                line=24,
+                column=13,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `Unknown`",
+                line=25,
+                column=13,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `Unknown`",
+                line=26,
+                column=13,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `Unknown`",
+                line=27,
+                column=13,
+            ),
+        ]
+    )
 
 
 CODE_SCHEMA_OVERRIDES = """
@@ -133,5 +191,15 @@ def test_schema_overrides():
                 line=17,
                 column=13,
             )
+        ]
+    )
+    assert results.ty == snapshot(
+        [
+            Result(
+                type="information",
+                message="Revealed type: `<class 'datetime'>`",
+                line=17,
+                column=13,
+            ),
         ]
     )

--- a/tests/typecheckers/test_type.py
+++ b/tests/typecheckers/test_type.py
@@ -1,9 +1,9 @@
 from inline_snapshot import snapshot
 
-from .utils.marks import requires_mypy, requires_pyright, skip_on_windows
+from .utils.marks import requires_mypy, requires_pyright, requires_ty, skip_on_windows
 from .utils.typecheck import Result, typecheck
 
-pytestmark = [skip_on_windows, requires_pyright, requires_mypy]
+pytestmark = [skip_on_windows, requires_pyright, requires_mypy, requires_ty]
 
 CODE = """
 import strawberry
@@ -129,6 +129,58 @@ def test():
             Result(
                 type="note",
                 message='Revealed type is "strawberry.types.base.StrawberryList"',
+                line=19,
+                column=13,
+            ),
+        ]
+    )
+    assert results.ty == snapshot(
+        [
+            Result(
+                type="information",
+                message="Revealed type: `StrawberryOptional`",
+                line=11,
+                column=13,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `StrawberryList`",
+                line=12,
+                column=13,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `StrawberryOptional`",
+                line=13,
+                column=13,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `StrawberryList`",
+                line=14,
+                column=13,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `StrawberryOptional`",
+                line=16,
+                column=13,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `StrawberryList`",
+                line=17,
+                column=13,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `StrawberryOptional`",
+                line=18,
+                column=13,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `StrawberryList`",
                 line=19,
                 column=13,
             ),

--- a/tests/typecheckers/test_union.py
+++ b/tests/typecheckers/test_union.py
@@ -1,9 +1,9 @@
 from inline_snapshot import snapshot
 
-from .utils.marks import requires_mypy, requires_pyright, skip_on_windows
+from .utils.marks import requires_mypy, requires_pyright, requires_ty, skip_on_windows
 from .utils.typecheck import Result, typecheck
 
-pytestmark = [skip_on_windows, requires_pyright, requires_mypy]
+pytestmark = [skip_on_windows, requires_pyright, requires_mypy, requires_ty]
 
 
 CODE = """
@@ -59,6 +59,22 @@ def test():
             Result(
                 type="note",
                 message='Revealed type is "mypy_test.User | mypy_test.Error"',
+                line=23,
+                column=13,
+            ),
+        ]
+    )
+    assert results.ty == snapshot(
+        [
+            Result(
+                type="information",
+                message="Revealed type: `<special-form 'typing.Annotated[User | Error, <metadata>]'>`",
+                line=19,
+                column=13,
+            ),
+            Result(
+                type="information",
+                message="Revealed type: `User`",
                 line=23,
                 column=13,
             ),

--- a/tests/typecheckers/utils/marks.py
+++ b/tests/typecheckers/utils/marks.py
@@ -12,6 +12,10 @@ def mypy_exists() -> bool:
     return shutil.which("mypy") is not None
 
 
+def ty_exists() -> bool:
+    return shutil.which("ty") is not None
+
+
 skip_on_windows = pytest.mark.skipif(
     sys.platform == "win32",
     reason="Do not run pyright on windows due to path issues",
@@ -25,4 +29,9 @@ requires_pyright = pytest.mark.skipif(
 requires_mypy = pytest.mark.skipif(
     not mypy_exists(),
     reason="These tests require mypy",
+)
+
+requires_ty = pytest.mark.skipif(
+    not ty_exists(),
+    reason="These tests require ty",
 )

--- a/tests/typecheckers/utils/ty.py
+++ b/tests/typecheckers/utils/ty.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import os
+import pathlib
+import re
+import subprocess
+import tempfile
+from typing import cast
+
+from .result import Result, ResultType
+
+
+def run_ty(code: str, strict: bool = True) -> list[Result]:
+    # ty uses concise output format which includes revealed type info
+    # Format: <file>:<line>:<col>: <severity>[<check_name>] <message>
+    args = [
+        "ty",
+        "check",
+        "--output-format",
+        "concise",
+        # Ignore the warning about using reveal_type without importing it
+        "--ignore",
+        "undefined-reveal",
+        "--color",
+        "never",
+    ]
+
+    with tempfile.TemporaryDirectory() as directory:
+        module_path = pathlib.Path(directory) / "ty_test.py"
+        module_path.write_text(code)
+
+        process_result = subprocess.run(
+            [*args, str(module_path)],
+            check=False,
+            capture_output=True,
+            env={
+                "PATH": os.environ["PATH"],
+            },
+        )
+
+        full_output = (
+            process_result.stdout.decode("utf-8")
+            + "\n"
+            + process_result.stderr.decode("utf-8")
+        )
+        full_output = full_output.strip()
+
+        results: list[Result] = []
+
+        # Parse the concise output format
+        # Format: <file>:<line>:<col>: <severity>[<check_name>] <message>
+        pattern = re.compile(r"^.*?:(\d+):(\d+): (error|warning|info)\[[\w-]+\] (.+)$")
+
+        for raw_line in full_output.split("\n"):
+            line = raw_line.strip()
+            if not line:
+                continue
+
+            match = pattern.match(line)
+            if match:
+                line_num = int(match.group(1))
+                col_num = int(match.group(2))
+                severity = match.group(3)
+                message = match.group(4)
+
+                # Map ty severities to our ResultType
+                # ty uses: error, warning, info
+                # Our ResultType uses: error, information, note
+                type_mapping = {
+                    "error": "error",
+                    "warning": "error",  # treat warnings as errors for consistency
+                    "info": "information",
+                }
+                result_type = type_mapping.get(severity, "note")
+
+                results.append(
+                    Result(
+                        type=cast("ResultType", result_type),
+                        message=message.strip(),
+                        line=line_num,
+                        column=col_num,
+                    )
+                )
+
+        # Sort results by line, column, and message for consistent ordering
+        results.sort(key=lambda x: (x.line, x.column, x.message))
+
+        return results

--- a/tests/typecheckers/utils/typecheck.py
+++ b/tests/typecheckers/utils/typecheck.py
@@ -6,20 +6,24 @@ from dataclasses import dataclass
 from .mypy import run_mypy
 from .pyright import run_pyright
 from .result import Result
+from .ty import run_ty
 
 
 @dataclass
 class TypecheckResult:
     pyright: list[Result]
     mypy: list[Result]
+    ty: list[Result]
 
 
 def typecheck(code: str, strict: bool = True) -> TypecheckResult:
     with concurrent.futures.ThreadPoolExecutor() as executor:
         pyright_future = executor.submit(run_pyright, code, strict=strict)
         mypy_future = executor.submit(run_mypy, code, strict=strict)
+        ty_future = executor.submit(run_ty, code, strict=strict)
 
         pyright_results = pyright_future.result()
         mypy_results = mypy_future.result()
+        ty_results = ty_future.result()
 
-    return TypecheckResult(pyright=pyright_results, mypy=mypy_results)
+    return TypecheckResult(pyright=pyright_results, mypy=mypy_results, ty=ty_results)


### PR DESCRIPTION
## Summary
- Add support for [ty](https://github.com/astral-sh/ty) (Astral's new Python type checker) alongside mypy and pyright in the typechecker test suite
- ty is an extremely fast Python type checker written in Rust by the creators of ruff and uv
- All 32 typechecker tests pass with the new ty assertions

## Changes
- Add `tests/typecheckers/utils/ty.py` - new module to run ty and parse its concise output format
- Add `requires_ty` pytest mark in `marks.py` for conditional test skipping
- Update `typecheck.py` to run ty in parallel with mypy and pyright
- Update `noxfile.py` to install ty in the typecheckers test session
- Add ty snapshot assertions to all 21 typechecker test files

## Test plan
- [x] Run `pytest tests/typecheckers/` - all 32 tests pass
- [ ] CI should pass with the new ty type checker tests

## Summary by Sourcery

Add the ty Python type checker to the typechecker test suite and integrate its results alongside mypy and pyright.

New Features:
- Capture and assert ty type checker diagnostics in typechecker tests alongside mypy and pyright.

Enhancements:
- Introduce a ty runner utility that invokes ty with concise output and normalizes its diagnostics into existing Result structures.
- Add a pytest mark to conditionally run tests that require ty and apply it across typechecker test modules.

Build:
- Ensure the tests_typecheckers nox session installs the ty type checker.

Tests:
- Extend existing typechecker tests to validate ty output snapshots across relay, federation, enums, scalars, fields, interfaces, FastAPI integration, unions, directives, and related scenarios.