### PR TITLE
refactor: Use a more type-friendly way to define scalars

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,38 @@
+Release type: minor
+
+Deprecate passing a class to `strawberry.scalar()`. Use `scalar_map` in
+`StrawberryConfig` instead for better type checking support.
+
+```python
+# Before (deprecated)
+Base64 = strawberry.scalar(
+    NewType("Base64", bytes),
+    serialize=lambda v: base64.b64encode(v).decode(),
+    parse_value=lambda v: base64.b64decode(v),
+)
+```
+
+Instead, use `scalar_map` in `StrawberryConfig`:
+
+```python
+# Recommended
+Base64 = NewType("Base64", bytes)
+
+schema = strawberry.Schema(
+    query=Query,
+    config=StrawberryConfig(
+        scalar_map={
+            Base64: strawberry.scalar(
+                name="Base64",
+                serialize=lambda v: base64.b64encode(v).decode(),
+                parse_value=lambda v: base64.b64decode(v),
+            )
+        }
+    ),
+)
+```
+
+This release also removes internal scalar wrapper exports (`Date`, `DateTime`,
+etc.) from `strawberry.schema.types.base_scalars`. Most users are likely not
+using these, but if you were, a codemod is available to help with the migration:
+`strawberry upgrade replace-scalar-wrappers .`

--- a/docs/breaking-changes/0.288.0.md
+++ b/docs/breaking-changes/0.288.0.md
@@ -1,0 +1,60 @@
+---
+title: 0.288.0 Breaking Changes
+slug: breaking-changes/0.288.0
+---
+
+# v0.288.0 Breaking Changes
+
+This release deprecates passing a class (or type) to `strawberry.scalar()`. Use
+`scalar_map` in `StrawberryConfig` instead.
+
+## Deprecated: `strawberry.scalar(cls, ...)`
+
+The pattern of wrapping a type with `strawberry.scalar()` is deprecated:
+
+```python
+# Deprecated
+Base64 = strawberry.scalar(
+    NewType("Base64", bytes),
+    serialize=lambda v: base64.b64encode(v).decode(),
+    parse_value=lambda v: base64.b64decode(v),
+)
+```
+
+Instead, use `scalar_map` in `StrawberryConfig`:
+
+```python
+# Recommended
+from typing import NewType
+from strawberry.schema.config import StrawberryConfig
+
+Base64 = NewType("Base64", bytes)
+
+schema = strawberry.Schema(
+    query=Query,
+    config=StrawberryConfig(
+        scalar_map={
+            Base64: strawberry.scalar(
+                name="Base64",
+                serialize=lambda v: base64.b64encode(v).decode(),
+                parse_value=lambda v: base64.b64decode(v),
+            )
+        }
+    ),
+)
+```
+
+This approach provides better type checking support because your custom scalar
+stays a proper type that type checkers (mypy, pyright, ty) can understand. The
+previous pattern of wrapping types with `strawberry.scalar()` returned a
+`ScalarWrapper` object, which type checkers could not use as a valid type
+annotation, causing errors like "Variable not allowed in type expression".
+
+## Removed: Scalar wrapper exports
+
+The scalar wrapper exports (`Date`, `DateTime`, `Time`, `Decimal`, `UUID`,
+`Void`) from `strawberry.schema.types.base_scalars` have been removed. Use
+standard Python types directly instead (`datetime.date`, `datetime.datetime`,
+etc.).
+
+A codemod is available: `strawberry upgrade replace-scalar-wrappers .`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,6 +166,7 @@ asyncio_mode = "auto"
 filterwarnings = [
   "ignore::DeprecationWarning:strawberry.*.resolver",
   "ignore:LazyType is deprecated:DeprecationWarning",
+  "ignore:Passing a class to strawberry.scalar:DeprecationWarning",
   "ignore::DeprecationWarning:ddtrace.internal",
   "ignore::DeprecationWarning:django.utils.encoding",
   # ignoring the text instead of the whole warning because we'd

--- a/strawberry/cli/commands/upgrade/__init__.py
+++ b/strawberry/cli/commands/upgrade/__init__.py
@@ -11,6 +11,7 @@ from libcst.codemod import CodemodContext
 from strawberry.cli.app import app
 from strawberry.codemods.annotated_unions import ConvertUnionToAnnotatedUnion
 from strawberry.codemods.maybe_optional import ConvertMaybeToOptional
+from strawberry.codemods.replace_scalar_wrappers import ReplaceScalarWrappers
 from strawberry.codemods.update_imports import UpdateImportsCodemod
 
 from ._run_codemod import run_codemod
@@ -19,6 +20,7 @@ codemods = {
     "annotated-union": ConvertUnionToAnnotatedUnion,
     "update-imports": UpdateImportsCodemod,
     "maybe-optional": ConvertMaybeToOptional,
+    "replace-scalar-wrappers": ReplaceScalarWrappers,
 }
 
 
@@ -47,14 +49,23 @@ def upgrade(
 
         raise typer.Exit(2)
 
-    transformer: ConvertUnionToAnnotatedUnion | UpdateImportsCodemod
+    context = CodemodContext()
+    transformer: (
+        UpdateImportsCodemod
+        | ReplaceScalarWrappers
+        | ConvertMaybeToOptional
+        | ConvertUnionToAnnotatedUnion
+    )
 
     if codemod == "update-imports":
-        transformer = UpdateImportsCodemod(context=CodemodContext())
-
+        transformer = UpdateImportsCodemod(context=context)
+    elif codemod == "replace-scalar-wrappers":
+        transformer = ReplaceScalarWrappers(context=context)
+    elif codemod == "maybe-optional":
+        transformer = ConvertMaybeToOptional(context=context)
     else:
         transformer = ConvertUnionToAnnotatedUnion(
-            CodemodContext(),
+            context,
             use_pipe_syntax=True,
             use_typing_extensions=use_typing_extensions,
         )

--- a/strawberry/codemods/__init__.py
+++ b/strawberry/codemods/__init__.py
@@ -1,9 +1,11 @@
 from .annotated_unions import ConvertUnionToAnnotatedUnion
 from .maybe_optional import ConvertMaybeToOptional
+from .replace_scalar_wrappers import ReplaceScalarWrappers
 from .update_imports import UpdateImportsCodemod
 
 __all__ = [
     "ConvertMaybeToOptional",
     "ConvertUnionToAnnotatedUnion",
+    "ReplaceScalarWrappers",
     "UpdateImportsCodemod",
 ]

--- a/strawberry/codemods/replace_scalar_wrappers.py
+++ b/strawberry/codemods/replace_scalar_wrappers.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import libcst as cst
+import libcst.matchers as m
+from libcst.codemod import CodemodContext, VisitorBasedCodemodCommand
+from libcst.codemod.visitors import AddImportsVisitor
+
+# Mapping from old scalar wrapper names to their replacements
+# Format: old_name -> (module, import_name, usage_name)
+# If usage_name is None, it means we use module.import_name
+SCALAR_REPLACEMENTS: dict[str, tuple[str, str, str | None]] = {
+    "Date": ("datetime", "date", "datetime.date"),
+    "DateTime": ("datetime", "datetime", "datetime.datetime"),
+    "Time": ("datetime", "time", "datetime.time"),
+    "Decimal": ("decimal", "Decimal", None),
+    "UUID": ("uuid", "UUID", None),
+}
+
+
+class ReplaceScalarWrappers(VisitorBasedCodemodCommand):
+    DESCRIPTION: str = (
+        "Replaces deprecated scalar wrapper imports from "
+        "strawberry.schema.types.base_scalars with their actual Python types. "
+        "For example: Date -> datetime.date, UUID -> uuid.UUID"
+    )
+    METADATA_DEPENDENCIES = (cst.metadata.ParentNodeProvider,)
+
+    def __init__(self, context: CodemodContext) -> None:
+        super().__init__(context)
+        # Track which scalars are imported and need replacement
+        self._imported_scalars: dict[str, str] = {}  # alias -> original_name
+
+    def visit_ImportFrom(self, node: cst.ImportFrom) -> bool | None:  # noqa: N802
+        """Track imports from strawberry.schema.types.base_scalars."""
+        if not m.matches(
+            node,
+            m.ImportFrom(
+                module=m.Attribute(
+                    value=m.Attribute(
+                        value=m.Attribute(
+                            value=m.Name("strawberry"),
+                            attr=m.Name("schema"),
+                        ),
+                        attr=m.Name("types"),
+                    ),
+                    attr=m.Name("base_scalars"),
+                )
+            ),
+        ):
+            return True
+
+        if isinstance(node.names, cst.ImportStar):
+            return True
+
+        for name in node.names:
+            if isinstance(name, cst.ImportAlias):
+                original_name = (
+                    name.name.value if isinstance(name.name, cst.Name) else None
+                )
+                if original_name and original_name in SCALAR_REPLACEMENTS:
+                    # Get the alias if present, otherwise use the original name
+                    alias = (
+                        name.asname.name.value
+                        if name.asname and isinstance(name.asname.name, cst.Name)
+                        else original_name
+                    )
+                    self._imported_scalars[alias] = original_name
+
+        return True
+
+    def leave_ImportFrom(  # noqa: N802
+        self, original_node: cst.ImportFrom, updated_node: cst.ImportFrom
+    ) -> cst.ImportFrom | cst.RemovalSentinel:
+        """Remove or update imports from strawberry.schema.types.base_scalars."""
+        if not m.matches(
+            original_node,
+            m.ImportFrom(
+                module=m.Attribute(
+                    value=m.Attribute(
+                        value=m.Attribute(
+                            value=m.Name("strawberry"),
+                            attr=m.Name("schema"),
+                        ),
+                        attr=m.Name("types"),
+                    ),
+                    attr=m.Name("base_scalars"),
+                )
+            ),
+        ):
+            return updated_node
+
+        if isinstance(original_node.names, cst.ImportStar):
+            return updated_node
+
+        # Filter out the scalar wrappers we're replacing
+        remaining_names: list[cst.ImportAlias] = [
+            name
+            for name in original_node.names
+            if (
+                isinstance(name, cst.ImportAlias)
+                and isinstance(name.name, cst.Name)
+                and name.name.value not in SCALAR_REPLACEMENTS
+            )
+        ]
+
+        # Add the replacement imports for all imported scalars
+        for original_name in self._imported_scalars.values():
+            module, import_name, usage_name = SCALAR_REPLACEMENTS[original_name]
+
+            if usage_name and usage_name.startswith("datetime."):
+                # For datetime types, we import the module
+                AddImportsVisitor.add_needed_import(self.context, module)
+            else:
+                # For other types, we import the specific name
+                AddImportsVisitor.add_needed_import(self.context, module, import_name)
+
+        if not remaining_names:
+            # Remove the entire import statement
+            return cst.RemovalSentinel.REMOVE
+
+        # Update the import to only include non-scalar names
+        return updated_node.with_changes(
+            names=remaining_names,
+        )
+
+    def leave_Name(  # noqa: N802
+        self, original_node: cst.Name, updated_node: cst.Name
+    ) -> cst.BaseExpression:
+        """Replace usages of imported scalar wrappers with their actual types."""
+        if original_node.value not in self._imported_scalars:
+            return updated_node
+
+        # Don't replace names that are part of import statements
+        try:
+            parent = self.get_metadata(cst.metadata.ParentNodeProvider, original_node)
+            if isinstance(parent, (cst.ImportAlias, cst.AsName)):
+                return updated_node
+        except KeyError:
+            pass
+
+        original_name = self._imported_scalars[original_node.value]
+        _module, import_name, usage_name = SCALAR_REPLACEMENTS[original_name]
+
+        if usage_name:
+            # Return module.name (e.g., datetime.date)
+            parts = usage_name.split(".")
+            if len(parts) == 2:
+                return cst.Attribute(
+                    value=cst.Name(parts[0]),
+                    attr=cst.Name(parts[1]),
+                )
+
+        # Return just the name (e.g., UUID, Decimal)
+        return cst.Name(import_name)

--- a/strawberry/ext/mypy_plugin.py
+++ b/strawberry/ext/mypy_plugin.py
@@ -237,7 +237,17 @@ def enum_hook(ctx: DynamicClassDefContext) -> None:
 
 
 def scalar_hook(ctx: DynamicClassDefContext) -> None:
+    # If there are no positional arguments, this is the new scalar(name="...")
+    # pattern which returns a ScalarDefinition - no mypy magic needed
+    if not ctx.call.args:
+        return
+
     first_argument = ctx.call.args[0]
+
+    # If the first argument is a string (StrExpr), this is scalar(name="...")
+    # which returns a ScalarDefinition - no mypy magic needed
+    if not isinstance(first_argument, (NameExpr, CallExpr, IndexExpr, MemberExpr)):
+        return
 
     if isinstance(first_argument, NameExpr):
         if not first_argument.node:

--- a/strawberry/federation/field.py
+++ b/strawberry/federation/field.py
@@ -11,6 +11,8 @@ from typing import (
 from strawberry.types.field import field as base_field
 from strawberry.types.unset import UNSET
 
+from .types import FieldSet
+
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Mapping, Sequence
     from typing import Literal
@@ -238,10 +240,10 @@ def field(
         directives.append(Policy(policies=policy))
 
     if provides:
-        directives.append(Provides(fields=" ".join(provides)))
+        directives.append(Provides(fields=FieldSet(" ".join(provides))))
 
     if requires:
-        directives.append(Requires(fields=" ".join(requires)))
+        directives.append(Requires(fields=FieldSet(" ".join(requires))))
 
     if requires_scopes:
         directives.append(RequiresScopes(scopes=requires_scopes))

--- a/strawberry/federation/object_type.py
+++ b/strawberry/federation/object_type.py
@@ -14,6 +14,7 @@ from strawberry.types.object_type import type as base_type
 from strawberry.types.unset import UNSET
 
 from .field import field
+from .types import FieldSet
 
 if TYPE_CHECKING:
     from .schema_directives import Key
@@ -56,7 +57,7 @@ def _impl_type(
     directives = list(directives)
 
     directives.extend(
-        Key(fields=key, resolvable=UNSET) if isinstance(key, str) else key
+        Key(fields=FieldSet(key), resolvable=UNSET) if isinstance(key, str) else key
         for key in keys
     )
 

--- a/strawberry/federation/types.py
+++ b/strawberry/federation/types.py
@@ -1,11 +1,13 @@
 from enum import Enum
+from typing import NewType
 
 from strawberry.types.enum import enum
-from strawberry.types.scalar import scalar
 
-FieldSet = scalar(str, name="_FieldSet")
+FieldSet = NewType("FieldSet", str)
+"""Represents a selection set for federation @requires, @provides, @key directives."""
 
-LinkImport = scalar(object, name="link__Import")
+LinkImport = NewType("LinkImport", object)
+"""Represents an import for the @link directive."""
 
 
 @enum(name="link__Purpose")

--- a/strawberry/file_uploads/scalars.py
+++ b/strawberry/file_uploads/scalars.py
@@ -1,7 +1,5 @@
 from typing import NewType
 
-from strawberry.types.scalar import scalar
-
-Upload = scalar(NewType("Upload", bytes), parse_value=lambda x: x)
+Upload = NewType("Upload", bytes)
 
 __all__ = ["Upload"]

--- a/strawberry/scalars.py
+++ b/strawberry/scalars.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
-import base64
 from typing import TYPE_CHECKING, Any, NewType
-
-from strawberry.types.scalar import scalar
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -14,47 +11,17 @@ if TYPE_CHECKING:
 ID = NewType("ID", str)
 """Represent the GraphQL `ID` scalar type."""
 
-JSON = scalar(
-    NewType("JSON", object),  # mypy doesn't like `NewType("name", Any)`
-    description=(
-        "The `JSON` scalar type represents JSON values as specified by "
-        "[ECMA-404]"
-        "(https://ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf)."
-    ),
-    specified_by_url=(
-        "https://ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf"
-    ),
-    serialize=lambda v: v,
-    parse_value=lambda v: v,
-)
+JSON = NewType("JSON", object)
+"""Represent the GraphQL `JSON` scalar type for arbitrary JSON values."""
 
-Base16 = scalar(
-    NewType("Base16", bytes),
-    description="Represents binary data as Base16-encoded (hexadecimal) strings.",
-    specified_by_url="https://datatracker.ietf.org/doc/html/rfc4648.html#section-8",
-    serialize=lambda v: base64.b16encode(v).decode("utf-8"),
-    parse_value=lambda v: base64.b16decode(v.encode("utf-8"), casefold=True),
-)
+Base16 = NewType("Base16", bytes)
+"""Represent binary data as Base16-encoded (hexadecimal) strings."""
 
-Base32 = scalar(
-    NewType("Base32", bytes),
-    description=(
-        "Represents binary data as Base32-encoded strings, using the standard alphabet."
-    ),
-    specified_by_url=("https://datatracker.ietf.org/doc/html/rfc4648.html#section-6"),
-    serialize=lambda v: base64.b32encode(v).decode("utf-8"),
-    parse_value=lambda v: base64.b32decode(v.encode("utf-8"), casefold=True),
-)
+Base32 = NewType("Base32", bytes)
+"""Represent binary data as Base32-encoded strings."""
 
-Base64 = scalar(
-    NewType("Base64", bytes),
-    description=(
-        "Represents binary data as Base64-encoded strings, using the standard alphabet."
-    ),
-    specified_by_url="https://datatracker.ietf.org/doc/html/rfc4648.html#section-4",
-    serialize=lambda v: base64.b64encode(v).decode("utf-8"),
-    parse_value=lambda v: base64.b64decode(v.encode("utf-8")),
-)
+Base64 = NewType("Base64", bytes)
+"""Represent binary data as Base64-encoded strings."""
 
 
 def is_scalar(
@@ -67,4 +34,11 @@ def is_scalar(
     return hasattr(annotation, "_scalar_definition")
 
 
-__all__ = ["ID", "JSON", "Base16", "Base32", "Base64", "is_scalar"]
+__all__ = [
+    "ID",
+    "JSON",
+    "Base16",
+    "Base32",
+    "Base64",
+    "is_scalar",
+]

--- a/strawberry/schema/config.py
+++ b/strawberry/schema/config.py
@@ -8,7 +8,9 @@ from strawberry.types.info import Info
 from .name_converter import NameConverter
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Mapping
+
+    from strawberry.types.scalar import ScalarDefinition
 
 
 class BatchingConfig(TypedDict):
@@ -17,6 +19,23 @@ class BatchingConfig(TypedDict):
 
 @dataclass
 class StrawberryConfig:
+    """Configuration for a Strawberry GraphQL schema.
+
+    Attributes:
+        auto_camel_case: Whether to automatically convert field names to camelCase.
+        name_converter: The name converter to use for type/field names.
+        default_resolver: The default resolver function for fields.
+        relay_max_results: Maximum results for Relay connections.
+        relay_use_legacy_global_id: Use legacy GlobalID format for Relay.
+        disable_field_suggestions: Disable field suggestions in error messages.
+        info_class: Custom Info class to use.
+        enable_experimental_incremental_execution: Enable @defer/@stream support.
+        scalar_map: A mapping of types to their scalar definitions. This allows
+            any type (including NewType) to be used as a GraphQL scalar with
+            proper type checking support.
+        batching_config: Configuration for operation batching.
+    """
+
     auto_camel_case: InitVar[bool] = None  # pyright: reportGeneralTypeIssues=false
     name_converter: NameConverter = field(default_factory=NameConverter)
     default_resolver: Callable[[Any, str], object] = getattr
@@ -26,6 +45,7 @@ class StrawberryConfig:
     info_class: type[Info] = Info
     enable_experimental_incremental_execution: bool = False
     _unsafe_disable_same_type_validation: bool = False
+    scalar_map: Mapping[object, ScalarDefinition] = field(default_factory=dict)
     batching_config: BatchingConfig | None = None
 
     def __post_init__(

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -269,6 +269,7 @@ class Schema(BaseSchema):
         self.schema_converter = GraphQLCoreConverter(
             self.config,
             scalar_overrides=scalar_overrides or {},  # type: ignore
+            scalar_map=self.config.scalar_map,
             get_fields=self.get_fields,
         )
 

--- a/strawberry/schema/types/base_scalars.py
+++ b/strawberry/schema/types/base_scalars.py
@@ -7,7 +7,7 @@ from operator import methodcaller
 import dateutil.parser
 from graphql import GraphQLError
 
-from strawberry.types.scalar import scalar
+from strawberry.types.scalar import ScalarDefinition
 
 
 def wrap_parser(parser: Callable, type_: str) -> Callable:
@@ -32,41 +32,54 @@ def parse_decimal(value: object) -> decimal.Decimal:
 isoformat = methodcaller("isoformat")
 
 
-Date = scalar(
-    datetime.date,
+DateDefinition: ScalarDefinition = ScalarDefinition(
     name="Date",
     description="Date (isoformat)",
+    specified_by_url=None,
     serialize=isoformat,
     parse_value=wrap_parser(datetime.date.fromisoformat, "Date"),
+    parse_literal=None,
+    origin=datetime.date,
 )
-DateTime = scalar(
-    datetime.datetime,
+
+DateTimeDefinition: ScalarDefinition = ScalarDefinition(
     name="DateTime",
     description="Date with time (isoformat)",
+    specified_by_url=None,
     serialize=isoformat,
     parse_value=wrap_parser(dateutil.parser.isoparse, "DateTime"),
+    parse_literal=None,
+    origin=datetime.datetime,
 )
-Time = scalar(
-    datetime.time,
+
+TimeDefinition: ScalarDefinition = ScalarDefinition(
     name="Time",
     description="Time (isoformat)",
+    specified_by_url=None,
     serialize=isoformat,
     parse_value=wrap_parser(datetime.time.fromisoformat, "Time"),
+    parse_literal=None,
+    origin=datetime.time,
 )
 
-Decimal = scalar(
-    decimal.Decimal,
+DecimalDefinition: ScalarDefinition = ScalarDefinition(
     name="Decimal",
     description="Decimal (fixed-point)",
+    specified_by_url=None,
     serialize=str,
     parse_value=parse_decimal,
+    parse_literal=None,
+    origin=decimal.Decimal,
 )
 
-UUID = scalar(
-    uuid.UUID,
+UUIDDefinition: ScalarDefinition = ScalarDefinition(
     name="UUID",
+    description=None,
+    specified_by_url=None,
     serialize=str,
     parse_value=wrap_parser(uuid.UUID, "UUID"),
+    parse_literal=None,
+    origin=uuid.UUID,
 )
 
 
@@ -75,12 +88,22 @@ def _verify_void(x: None) -> None:
         raise ValueError(f"Expected 'None', got '{x}'")
 
 
-Void = scalar(
-    type(None),
+VoidDefinition: ScalarDefinition = ScalarDefinition(
     name="Void",
+    description="Represents NULL values",
+    specified_by_url=None,
     serialize=_verify_void,
     parse_value=_verify_void,
-    description="Represents NULL values",
+    parse_literal=None,
+    origin=type(None),
 )
 
-__all__ = ["UUID", "Date", "DateTime", "Decimal", "Time", "Void"]
+
+__all__ = [
+    "DateDefinition",
+    "DateTimeDefinition",
+    "DecimalDefinition",
+    "TimeDefinition",
+    "UUIDDefinition",
+    "VoidDefinition",
+]

--- a/strawberry/types/scalar.py
+++ b/strawberry/types/scalar.py
@@ -120,8 +120,23 @@ def _process_scalar(
 
 @overload
 def scalar(
+    cls: None = None,
     *,
-    name: str | None = None,
+    name: str,
+    description: str | None = None,
+    specified_by_url: str | None = None,
+    serialize: Callable = identity,
+    parse_value: Callable | None = None,
+    parse_literal: Callable | None = None,
+    directives: Iterable[object] = (),
+) -> ScalarDefinition: ...
+
+
+@overload
+def scalar(
+    cls: None = None,
+    *,
+    name: None = None,
     description: str | None = None,
     specified_by_url: str | None = None,
     serialize: Callable = identity,
@@ -161,8 +176,22 @@ def scalar(
 ) -> Any:
     """Annotates a class or type as a GraphQL custom scalar.
 
+    This function can be used in three ways:
+
+    1. With a `name` but no `cls`: Returns a `ScalarDefinition` for use in
+       `StrawberryConfig.scalar_map`. This is the recommended approach as it
+       provides proper type checking support.
+
+    2. As a decorator (no `cls`): Returns a decorator function. When the `cls`
+       argument is provided inline, this is deprecated in favor of using
+       `scalar_map`.
+
+    3. With a `cls` argument (deprecated): Wraps the class/type directly.
+       This approach is deprecated because it causes type checker issues.
+       Use `scalar_map` in `StrawberryConfig` instead.
+
     Args:
-        cls: The class or type to annotate.
+        cls: The class or type to annotate (deprecated, use scalar_map instead).
         name: The GraphQL name of the scalar.
         description: The description of the scalar.
         specified_by_url: The URL of the specification.
@@ -172,37 +201,83 @@ def scalar(
         directives: The directives to apply to the scalar.
 
     Returns:
-        The decorated class or type.
+        A `ScalarDefinition` when called with `name` only, a decorator function
+        when called without arguments, or the wrapped type when called with `cls`.
 
     Example usages:
 
-    ```python
-    strawberry.scalar(
-        datetime.date,
-        serialize=lambda value: value.isoformat(),
-        parse_value=datetime.parse_date,
-    )
+    Recommended approach using scalar_map:
 
+    ```python
+    from typing import NewType
+    import strawberry
+    from strawberry.schema.config import StrawberryConfig
+
+    # Define the type
+    Base64 = NewType("Base64", bytes)
+
+    # Configure the scalar in schema config
+    schema = strawberry.Schema(
+        query=Query,
+        config=StrawberryConfig(
+            scalar_map={
+                Base64: strawberry.scalar(
+                    name="Base64",
+                    serialize=lambda v: base64.b64encode(v).decode(),
+                    parse_value=lambda v: base64.b64decode(v),
+                )
+            }
+        ),
+    )
+    ```
+
+    Legacy approach (deprecated):
+
+    ```python
     Base64Encoded = strawberry.scalar(
         NewType("Base64Encoded", bytes),
         serialize=base64.b64encode,
         parse_value=base64.b64decode,
     )
-
-
-    @strawberry.scalar(
-        serialize=lambda value: ",".join(value.items),
-        parse_value=lambda value: CustomList(value.split(",")),
-    )
-    class CustomList:
-        def __init__(self, items):
-            self.items = items
     ```
     """
+    from strawberry.exceptions.handler import should_use_rich_exceptions
+
+    _source_file = None
+    _source_line = None
+
+    if should_use_rich_exceptions():
+        frame = sys._getframe(1)
+        _source_file = frame.f_code.co_filename
+        _source_line = frame.f_lineno
+
+    if cls is None and name is not None:
+        return ScalarDefinition(
+            name=name,
+            description=description,
+            specified_by_url=specified_by_url,
+            serialize=serialize,
+            parse_literal=parse_literal,
+            parse_value=parse_value,
+            directives=directives,
+            origin=None,
+            _source_file=_source_file,
+            _source_line=_source_line,
+        )
+
     if parse_value is None:
         parse_value = cls
 
     def wrap(cls: _T) -> ScalarWrapper:
+        import warnings
+
+        warnings.warn(
+            "Passing a class to strawberry.scalar() is deprecated. "
+            "Use StrawberryConfig.scalar_map instead for better type checking support. "
+            "See: https://strawberry.rocks/docs/types/scalars",
+            DeprecationWarning,
+            stacklevel=3,
+        )
         return _process_scalar(
             cls,
             name=name,

--- a/tests/codemods/test_replace_scalar_wrappers.py
+++ b/tests/codemods/test_replace_scalar_wrappers.py
@@ -1,0 +1,171 @@
+from libcst.codemod import CodemodTest
+
+from strawberry.codemods.replace_scalar_wrappers import ReplaceScalarWrappers
+
+
+class TestReplaceScalarWrappers(CodemodTest):
+    TRANSFORM = ReplaceScalarWrappers
+
+    def test_replace_date(self) -> None:
+        before = """
+            from strawberry.schema.types.base_scalars import Date
+
+            field: Date
+        """
+
+        after = """
+            import datetime
+
+            field: datetime.date
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_replace_datetime(self) -> None:
+        before = """
+            from strawberry.schema.types.base_scalars import DateTime
+
+            field: DateTime
+        """
+
+        after = """
+            import datetime
+
+            field: datetime.datetime
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_replace_time(self) -> None:
+        before = """
+            from strawberry.schema.types.base_scalars import Time
+
+            field: Time
+        """
+
+        after = """
+            import datetime
+
+            field: datetime.time
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_replace_decimal(self) -> None:
+        before = """
+            from strawberry.schema.types.base_scalars import Decimal
+
+            field: Decimal
+        """
+
+        after = """
+            from decimal import Decimal
+
+            field: Decimal
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_replace_uuid(self) -> None:
+        before = """
+            from strawberry.schema.types.base_scalars import UUID
+
+            field: UUID
+        """
+
+        after = """
+            from uuid import UUID
+
+            field: UUID
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_replace_multiple_scalars(self) -> None:
+        before = """
+            from strawberry.schema.types.base_scalars import Date, DateTime, UUID
+
+            date_field: Date
+            datetime_field: DateTime
+            uuid_field: UUID
+        """
+
+        after = """
+            import datetime
+            from uuid import UUID
+
+            date_field: datetime.date
+            datetime_field: datetime.datetime
+            uuid_field: UUID
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_preserve_other_imports(self) -> None:
+        before = """
+            from strawberry.schema.types.base_scalars import Date, DateDefinition
+
+            field: Date
+        """
+
+        after = """
+            from strawberry.schema.types.base_scalars import DateDefinition
+            import datetime
+
+            field: datetime.date
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_no_changes_when_no_scalar_imports(self) -> None:
+        before = """
+            from strawberry.schema.types.base_scalars import DateDefinition
+
+            definition = DateDefinition
+        """
+
+        after = """
+            from strawberry.schema.types.base_scalars import DateDefinition
+
+            definition = DateDefinition
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_replace_aliased_import(self) -> None:
+        before = """
+            from strawberry.schema.types.base_scalars import Date as MyDate
+
+            field: MyDate
+        """
+
+        after = """
+            import datetime
+
+            field: datetime.date
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_imported_but_unused_scalar(self) -> None:
+        """Test behavior when a scalar is imported but not used.
+
+        The codemod adds replacement imports for all imported scalars,
+        even if they're not used. Removing unused imports is a separate
+        concern that tools like ruff or autoflake can handle.
+        """
+        before = """
+            from strawberry.schema.types.base_scalars import Date, UUID
+
+            field: Date
+        """
+
+        # Both datetime and uuid imports are added since both were imported
+        after = """
+            import datetime
+            from uuid import UUID
+
+            field: datetime.date
+        """
+
+        self.assertCodemod(before, after)

--- a/tests/schema/test_extensions.py
+++ b/tests/schema/test_extensions.py
@@ -99,6 +99,8 @@ def test_enum():
 
 
 def test_scalar():
+    from strawberry.schema.types.scalar import DEFAULT_SCALAR_REGISTRY
+
     @strawberry.type()
     class Query:
         hello: JSON
@@ -109,7 +111,7 @@ def test_scalar():
 
     assert (
         graphql_schema.get_type("JSON").extensions[DEFINITION_BACKREF]
-        is JSON._scalar_definition
+        is DEFAULT_SCALAR_REGISTRY[JSON]
     )
 
 

--- a/tests/types/resolving/test_union_pipe.py
+++ b/tests/types/resolving/test_union_pipe.py
@@ -1,3 +1,4 @@
+import datetime
 import typing
 from typing import Union
 
@@ -6,7 +7,6 @@ import pytest
 import strawberry
 from strawberry.annotation import StrawberryAnnotation
 from strawberry.exceptions.invalid_union_type import InvalidUnionTypeError
-from strawberry.schema.types.base_scalars import Date, DateTime
 from strawberry.types.base import StrawberryOptional
 from strawberry.types.union import StrawberryUnion
 
@@ -100,4 +100,8 @@ def test_raises_error_when_piping_with_scalar():
     match="Type `date` cannot be used in a GraphQL Union",
 )
 def test_raises_error_when_piping_with_custom_scalar():
-    StrawberryAnnotation(Date | DateTime)
+    @strawberry.type
+    class Query:
+        field: datetime.date | datetime.datetime
+
+    strawberry.Schema(query=Query)


### PR DESCRIPTION
Fixes #4074
Fixes #4065
Fixes #3579
Fixes #3312
Fixes #3102
Fixes #1689

## Summary by Sourcery

Refactor scalar handling to treat built-in and custom scalars as proper NewTypes, route their GraphQL behavior through a new scalar_map configuration, and deprecate passing classes directly to strawberry.scalar() in favor of more type-checker-friendly patterns.

New Features:
- Add StrawberryConfig.scalar_map to configure GraphQL scalar behavior for arbitrary Python and NewType types with proper type-checking support.
- Introduce a codemod (replace-scalar-wrappers) and CLI entry to migrate deprecated scalar wrapper usages to standard Python types.
- Register federation-specific scalars (_Any, _FieldSet, link__Import) via scalar_map-compatible definitions and scalar overrides.

Bug Fixes:
- Ensure mypy, pyright, and ty correctly infer and accept built-in scalars like JSON and Base64 as NewTypes without invalid type expression errors.
- Fix type resolution for scalar usage in unions and schema extensions now that scalar wrappers are removed.

Enhancements:
- Rework internal scalar registry to use ScalarDefinition instances directly and centralize JSON/Base16/Base32/Base64 behavior there.
- Extend strawberry.scalar() to support returning bare ScalarDefinition objects when called with name=..., and emit deprecation warnings when wrapping classes directly.
- Update federation schema construction to integrate federation-specific scalars cleanly with the new scalar registry and overrides.
- Adjust type-checker plugin behavior to recognize the new scalar(name=...) usage pattern.

Documentation:
- Update scalar documentation to demonstrate using NewType plus StrawberryConfig.scalar_map for custom scalars, overriding built-ins, BigInt usage, and third-party datetime types.
- Add a breaking changes note for v0.288.0 documenting the deprecation of class-wrapping scalars and removal of scalar wrapper exports.

Tests:
- Add and update type-checker tests to validate scalar NewType behavior across mypy, pyright, and ty.
- Add schema tests for scalar_map with NewType, overriding built-ins, combining scalar_map with scalar_overrides, direct ScalarDefinition creation, and built-in scalars as NewTypes.
- Add codemod tests covering replacement of deprecated scalar wrapper imports with standard Python types.
- Adjust existing tests to align with removed scalar wrappers and new scalar registry behavior.

Chores:
- Suppress the new deprecation warning for class-based strawberry.scalar() usage in pytest configuration.
- Add a release note describing the scalar refactor, deprecation, and migration guidance.