### PR TITLE
fix: typo in breaking changes docs

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -5,7 +5,7 @@ title: List of breaking changes and deprecations
 # List of breaking changes and deprecations
 
 - [Version 0.285.0 - 10 November 2025](./breaking-changes/0.285.0.md)
-- [Version 0.285.0 - 6 October 2025](./breaking-changes/0.283.0.md)
+- [Version 0.283.0 - 6 October 2025](./breaking-changes/0.283.0.md)
 - [Version 0.279.0 - 19 August 2025](./breaking-changes/0.279.0.md)
 - [Version 0.278.1 - 5 August 2025](./breaking-changes/0.278.1.md)
 - [Version 0.268.0 - 10 May 2025](./breaking-changes/0.268.0.md)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

 Fix version typo in breaking changes page.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Documentation:
- Fix an incorrect version number in the breaking-changes listing to match the linked 0.283.0 release.