### PR TITLE
fix: resolve Info type recognition for TYPE_CHECKING imports and TypeAliasType

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,12 @@
+Release type: patch
+
+Fixed a bug where using `relay.node()` or `relay.connection()` would raise a
+`DeprecationWarning` about "Argument name-based matching of 'info'", even though
+the `info` parameter was correctly annotated.
+
+This also fixes the same warning when using Python 3.12+ type alias syntax for
+`Info`, such as `type MyInfo = strawberry.Info[Context, None]`.
+
+The fix recognizes `strawberry.Info` and `strawberry.Parent` annotations (with
+or without generic parameters) when they appear as string forward references.
+Only fully qualified names are matched to avoid confusion with user-defined types.

--- a/strawberry/field_extensions/input_mutation.py
+++ b/strawberry/field_extensions/input_mutation.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
-from typing import (
-    TYPE_CHECKING,
-    Any,
-)
+from typing import Any
 
 import strawberry
 from strawberry.annotation import StrawberryAnnotation
@@ -15,9 +12,6 @@ from strawberry.extensions.field_extension import (
 from strawberry.types.arguments import StrawberryArgument
 from strawberry.types.field import StrawberryField
 from strawberry.utils.str_converters import capitalize_first, to_camel_case
-
-if TYPE_CHECKING:
-    from strawberry.types.info import Info
 
 
 class InputMutationExtension(FieldExtension):
@@ -64,7 +58,7 @@ class InputMutationExtension(FieldExtension):
         self,
         next_: SyncExtensionResolver,
         source: Any,
-        info: Info,
+        info: strawberry.Info,
         **kwargs: Any,
     ) -> Any:
         input_args = kwargs.pop("input")
@@ -79,7 +73,7 @@ class InputMutationExtension(FieldExtension):
         self,
         next_: AsyncExtensionResolver,
         source: Any,
-        info: Info,
+        info: strawberry.Info,
         **kwargs: Any,
     ) -> Any:
         input_args = kwargs.pop("input")

--- a/strawberry/relay/fields.py
+++ b/strawberry/relay/fields.py
@@ -49,8 +49,8 @@ from .types import Connection, GlobalID, Node
 if TYPE_CHECKING:
     from typing import Literal
 
+    import strawberry
     from strawberry.permission import BasePermission
-    from strawberry.types.info import Info
 
 
 class NodeExtension(FieldExtension):
@@ -65,12 +65,20 @@ class NodeExtension(FieldExtension):
         field.base_resolver = StrawberryResolver(resolver, type_override=field.type)
 
     def resolve(
-        self, next_: SyncExtensionResolver, source: Any, info: Info, **kwargs: Any
+        self,
+        next_: SyncExtensionResolver,
+        source: Any,
+        info: strawberry.Info,
+        **kwargs: Any,
     ) -> Any:
         return next_(source, info, **kwargs)
 
     async def resolve_async(
-        self, next_: SyncExtensionResolver, source: Any, info: Info, **kwargs: Any
+        self,
+        next_: SyncExtensionResolver,
+        source: Any,
+        info: strawberry.Info,
+        **kwargs: Any,
     ) -> Any:
         retval = next_(source, info, **kwargs)
         # If the resolve_nodes method is not async, retval will not actually
@@ -81,12 +89,12 @@ class NodeExtension(FieldExtension):
 
     def get_node_resolver(
         self, field: StrawberryField
-    ) -> Callable[[Info, GlobalID], Node | None | Awaitable[Node | None]]:
+    ) -> Callable[[strawberry.Info, GlobalID], Node | None | Awaitable[Node | None]]:
         type_ = field.type
         is_optional = isinstance(type_, StrawberryOptional)
 
         def resolver(
-            info: Info,
+            info: strawberry.Info,
             id: Annotated[GlobalID, argument(description="The ID of the object.")],
         ) -> Node | None | Awaitable[Node | None]:
             node_type = id.resolve_type(info)
@@ -114,13 +122,15 @@ class NodeExtension(FieldExtension):
 
     def get_node_list_resolver(
         self, field: StrawberryField
-    ) -> Callable[[Info, list[GlobalID]], list[Node] | Awaitable[list[Node]]]:
+    ) -> Callable[
+        [strawberry.Info, list[GlobalID]], list[Node] | Awaitable[list[Node]]
+    ]:
         type_ = field.type
         assert isinstance(type_, StrawberryList)
         is_optional = isinstance(type_.of_type, StrawberryOptional)
 
         def resolver(
-            info: Info,
+            info: strawberry.Info,
             ids: Annotated[
                 list[GlobalID], argument(description="The IDs of the objects.")
             ],
@@ -306,7 +316,7 @@ class ConnectionExtension(FieldExtension):
         self,
         next_: SyncExtensionResolver,
         source: Any,
-        info: Info,
+        info: strawberry.Info,
         *,
         before: str | None = None,
         after: str | None = None,
@@ -329,7 +339,7 @@ class ConnectionExtension(FieldExtension):
         self,
         next_: AsyncExtensionResolver,
         source: Any,
-        info: Info,
+        info: strawberry.Info,
         *,
         before: str | None = None,
         after: str | None = None,

--- a/strawberry/relay/utils.py
+++ b/strawberry/relay/utils.py
@@ -10,7 +10,7 @@ from strawberry.types.base import StrawberryObjectDefinition
 from strawberry.types.nodes import InlineFragment
 
 if TYPE_CHECKING:
-    from strawberry.types.info import Info
+    import strawberry
 
 
 def from_base64(value: str) -> tuple[str, str]:
@@ -71,7 +71,7 @@ def to_base64(type_: str | type | StrawberryObjectDefinition, node_id: Any) -> s
     return base64.b64encode(f"{type_name}:{node_id}".encode()).decode()
 
 
-def should_resolve_list_connection_edges(info: Info) -> bool:
+def should_resolve_list_connection_edges(info: strawberry.Info) -> bool:
     """Check if the user requested to resolve the `edges` field of a connection.
 
     Args:
@@ -113,7 +113,7 @@ class SliceMetadata:
     @classmethod
     def from_arguments(
         cls,
-        info: Info,
+        info: strawberry.Info,
         *,
         before: str | None = None,
         after: str | None = None,


### PR DESCRIPTION
Fix #3995
Fix #4057
Fix #2851

## Summary by Sourcery

Ensure Info parameter recognition works correctly in resolvers and relay utilities when using forward references, TYPE_CHECKING imports, and Python 3.12 type alias syntax, preventing spurious deprecation warnings.

Bug Fixes:
- Fix detection of reserved Info parameters when annotations fail to evaluate and are represented as strings or ForwardRef objects, including support for TypeAliasType in Python 3.12+.
- Prevent DeprecationWarning about name-based matching of 'info' when using relay.node(), relay.connection(), or Info defined via Python 3.12 type alias syntax.

Enhancements:
- Update relay and input mutation extensions, as well as relay utilities, to consistently use strawberry.Info type hints for resolver parameters.
- Add dedicated helpers to match Info types from string and forward reference annotations across different import and annotation styles.

Documentation:
- Add a release note documenting the patch-level fix for Info type recognition and the associated deprecation warning behavior.

Tests:
- Add tests covering Info recognition from string and ForwardRef annotations, relay.node usage without deprecation warnings, and Info defined via Python 3.12 type alias syntax.