### PR TITLE
Benchmark graphql-core PR #249 (msgspec performance)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 ]
 requires-python = ">=3.10,<4.0"
 dependencies = [
-  "graphql-core>=3.2.0,<3.4.0",
+  "graphql-core @ git+https://github.com/corydolphin/graphql-core.git@msgspec-performance",
   "typing-extensions>=4.5.0",
   "python-dateutil>=2.7",
   "packaging>=23",


### PR DESCRIPTION
## Summary

Test graphql-core PR https://github.com/graphql-python/graphql-core/pull/249 which introduces significant performance improvements using `msgspec.Struct` for AST nodes.

The PR claims:
- **5.3x faster parsing** (81ms → 15.4ms)
- **13x faster serialization** with msgpack
- **4.7x faster deserialization**

This PR temporarily uses the `msgspec-performance` branch from that PR to run our benchmarks and see the actual impact on Strawberry.

## Test plan

- CI benchmarks will run with the new graphql-core version
- Compare CodSpeed results against main branch