### PR TITLE
feat: use TypedDict for Python query codegen

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,28 @@
+Release type: minor
+
+This release changes the Python query codegen plugin to generate `TypedDict` classes instead of plain classes. This provides better type safety for dictionary-like access patterns commonly used when working with JSON responses from GraphQL APIs.
+
+**Before:**
+
+```python
+class MyQueryResult:
+    user: str
+```
+
+**After:**
+
+```python
+from typing_extensions import TypedDict
+
+
+class MyQueryResult(TypedDict):
+    user: str
+```
+
+Optional fields with default values now use `NotRequired` instead of the `= value` syntax (which TypedDict doesn't support):
+
+```python
+class PersonInput(TypedDict):
+    name: str
+    age: NotRequired[Optional[int]]  # was: age: Optional[int] = None
+```

--- a/docs/codegen/query-codegen.md
+++ b/docs/codegen/query-codegen.md
@@ -76,17 +76,24 @@ strawberry codegen --schema schema --output-dir ./output -p python query.graphql
 We'll get the following output inside `output/query.py`:
 
 ```python
-class MyQueryResultUserPost:
+from typing_extensions import TypedDict
+
+
+class MyQueryResultUserPost(TypedDict):
     title: str
 
 
-class MyQueryResultUser:
+class MyQueryResultUser(TypedDict):
     post: MyQueryResultUserPost
 
 
-class MyQueryResult:
+class MyQueryResult(TypedDict):
     user: MyQueryResultUser
 ```
+
+The generated types are `TypedDict` classes, which provide type safety for
+dictionary-like access patterns commonly used when working with JSON responses
+from GraphQL APIs.
 
 ## Why is this useful?
 

--- a/tests/codegen/snapshots/python/alias.py
+++ b/tests/codegen/snapshots/python/alias.py
@@ -1,8 +1,10 @@
-class OperationNameResultLazy:
+from typing_extensions import TypedDict
+
+class OperationNameResultLazy(TypedDict):
     # alias for something
     lazy: bool
 
-class OperationNameResult:
+class OperationNameResult(TypedDict):
     id: str
     # alias for id
     second_id: str

--- a/tests/codegen/snapshots/python/basic.py
+++ b/tests/codegen/snapshots/python/basic.py
@@ -1,11 +1,12 @@
+from typing_extensions import TypedDict
 from uuid import UUID
 from datetime import date, datetime, time
 from decimal import Decimal
 
-class OperationNameResultLazy:
+class OperationNameResultLazy(TypedDict):
     something: bool
 
-class OperationNameResult:
+class OperationNameResult(TypedDict):
     id: str
     integer: int
     float: float

--- a/tests/codegen/snapshots/python/custom_scalar.py
+++ b/tests/codegen/snapshots/python/custom_scalar.py
@@ -1,6 +1,7 @@
+from typing_extensions import TypedDict
 from typing import NewType
 
 JSON = NewType("JSON", str)
 
-class OperationNameResult:
+class OperationNameResult(TypedDict):
     json: JSON

--- a/tests/codegen/snapshots/python/enum.py
+++ b/tests/codegen/snapshots/python/enum.py
@@ -1,3 +1,4 @@
+from typing_extensions import TypedDict
 from enum import Enum
 
 class Color(Enum):
@@ -5,5 +6,5 @@ class Color(Enum):
     GREEN = "GREEN"
     BLUE = "BLUE"
 
-class OperationNameResult:
+class OperationNameResult(TypedDict):
     enum: Color

--- a/tests/codegen/snapshots/python/fragment.py
+++ b/tests/codegen/snapshots/python/fragment.py
@@ -1,6 +1,8 @@
-class PersonName:
+from typing_extensions import TypedDict
+
+class PersonName(TypedDict):
     # typename: Person
     name: str
 
-class OperationNameResult:
+class OperationNameResult(TypedDict):
     person: PersonName

--- a/tests/codegen/snapshots/python/generic_types.py
+++ b/tests/codegen/snapshots/python/generic_types.py
@@ -1,16 +1,17 @@
+from typing_extensions import TypedDict
 from typing import List
 
-class ListLifeGenericResultListLifeItems1:
+class ListLifeGenericResultListLifeItems1(TypedDict):
     name: str
     age: int
 
-class ListLifeGenericResultListLifeItems2:
+class ListLifeGenericResultListLifeItems2(TypedDict):
     name: str
     age: int
 
-class ListLifeGenericResultListLife:
+class ListLifeGenericResultListLife(TypedDict):
     items1: list[ListLifeGenericResultListLifeItems1]
     items2: list[ListLifeGenericResultListLifeItems2]
 
-class ListLifeGenericResult:
+class ListLifeGenericResult(TypedDict):
     list_life: ListLifeGenericResultListLife

--- a/tests/codegen/snapshots/python/interface.py
+++ b/tests/codegen/snapshots/python/interface.py
@@ -1,5 +1,7 @@
-class OperationNameResultInterface:
+from typing_extensions import TypedDict
+
+class OperationNameResultInterface(TypedDict):
     id: str
 
-class OperationNameResult:
+class OperationNameResult(TypedDict):
     interface: OperationNameResultInterface

--- a/tests/codegen/snapshots/python/interface_fragments.py
+++ b/tests/codegen/snapshots/python/interface_fragments.py
@@ -1,16 +1,17 @@
+from typing_extensions import TypedDict
 from typing import Union
 
-class OperationNameResultInterfaceBlogPost:
+class OperationNameResultInterfaceBlogPost(TypedDict):
     # typename: BlogPost
     id: str
     title: str
 
-class OperationNameResultInterfaceImage:
+class OperationNameResultInterfaceImage(TypedDict):
     # typename: Image
     id: str
     url: str
 
 OperationNameResultInterface = Union[OperationNameResultInterfaceBlogPost, OperationNameResultInterfaceImage]
 
-class OperationNameResult:
+class OperationNameResult(TypedDict):
     interface: OperationNameResultInterface

--- a/tests/codegen/snapshots/python/interface_fragments_with_spread.py
+++ b/tests/codegen/snapshots/python/interface_fragments_with_spread.py
@@ -1,20 +1,21 @@
+from typing_extensions import TypedDict
 from typing import Union
 
-class PartialBlogPost:
+class PartialBlogPost(TypedDict):
     # typename: BlogPost
     title: str
 
-class OperationNameResultInterfaceBlogPost:
+class OperationNameResultInterfaceBlogPost(TypedDict):
     # typename: BlogPost
     id: str
     title: str
 
-class OperationNameResultInterfaceImage:
+class OperationNameResultInterfaceImage(TypedDict):
     # typename: Image
     id: str
     url: str
 
 OperationNameResultInterface = Union[OperationNameResultInterfaceBlogPost, OperationNameResultInterfaceImage]
 
-class OperationNameResult:
+class OperationNameResult(TypedDict):
     interface: OperationNameResultInterface

--- a/tests/codegen/snapshots/python/interface_single_fragment.py
+++ b/tests/codegen/snapshots/python/interface_single_fragment.py
@@ -1,7 +1,9 @@
-class OperationNameResultInterfaceBlogPost:
+from typing_extensions import TypedDict
+
+class OperationNameResultInterfaceBlogPost(TypedDict):
     # typename: BlogPost
     id: str
     title: str
 
-class OperationNameResult:
+class OperationNameResult(TypedDict):
     interface: OperationNameResultInterfaceBlogPost

--- a/tests/codegen/snapshots/python/multiple_types.py
+++ b/tests/codegen/snapshots/python/multiple_types.py
@@ -1,11 +1,12 @@
+from typing_extensions import TypedDict
 from typing import List
 
-class OperationNameResultPerson:
+class OperationNameResultPerson(TypedDict):
     name: str
 
-class OperationNameResultListOfPeople:
+class OperationNameResultListOfPeople(TypedDict):
     name: str
 
-class OperationNameResult:
+class OperationNameResult(TypedDict):
     person: OperationNameResultPerson
     list_of_people: list[OperationNameResultListOfPeople]

--- a/tests/codegen/snapshots/python/multiple_types_optional.py
+++ b/tests/codegen/snapshots/python/multiple_types_optional.py
@@ -1,7 +1,8 @@
+from typing_extensions import TypedDict
 from typing import Optional
 
-class OperationNameResultOptionalPerson:
+class OperationNameResultOptionalPerson(TypedDict):
     name: str
 
-class OperationNameResult:
+class OperationNameResult(TypedDict):
     optional_person: Optional[OperationNameResultOptionalPerson]

--- a/tests/codegen/snapshots/python/mutation-fragment.py
+++ b/tests/codegen/snapshots/python/mutation-fragment.py
@@ -1,9 +1,11 @@
-class IdFragment:
+from typing_extensions import TypedDict
+
+class IdFragment(TypedDict):
     # typename: BlogPost
     id: str
 
-class addBookResult:
+class addBookResult(TypedDict):
     add_book: IdFragment
 
-class addBookVariables:
+class addBookVariables(TypedDict):
     input: str

--- a/tests/codegen/snapshots/python/mutation.py
+++ b/tests/codegen/snapshots/python/mutation.py
@@ -1,8 +1,10 @@
-class addBookResultAddBook:
+from typing_extensions import TypedDict
+
+class addBookResultAddBook(TypedDict):
     id: str
 
-class addBookResult:
+class addBookResult(TypedDict):
     add_book: addBookResultAddBook
 
-class addBookVariables:
+class addBookVariables(TypedDict):
     input: str

--- a/tests/codegen/snapshots/python/mutation_with_object.py
+++ b/tests/codegen/snapshots/python/mutation_with_object.py
@@ -1,13 +1,14 @@
+from typing_extensions import NotRequired, TypedDict
 from typing import List, Optional
 from enum import Enum
 
-class AddBlogPostsResultAddBlogPostsPosts:
+class AddBlogPostsResultAddBlogPostsPosts(TypedDict):
     title: str
 
-class AddBlogPostsResultAddBlogPosts:
+class AddBlogPostsResultAddBlogPosts(TypedDict):
     posts: list[AddBlogPostsResultAddBlogPostsPosts]
 
-class AddBlogPostsResult:
+class AddBlogPostsResult(TypedDict):
     add_blog_posts: AddBlogPostsResultAddBlogPosts
 
 class Color(Enum):
@@ -15,13 +16,13 @@ class Color(Enum):
     GREEN = "GREEN"
     BLUE = "BLUE"
 
-class BlogPostInput:
-    title: str = "I replaced my doorbell.  You wouldn't believe what happened next!"
-    color: Color = Color.RED
-    pi: float = 3.14159
-    a_bool: bool = True
-    an_int: int = 42
-    an_optional_int: Optional[int] = None
+class BlogPostInput(TypedDict):
+    title: NotRequired[str]
+    color: NotRequired[Color]
+    pi: NotRequired[float]
+    a_bool: NotRequired[bool]
+    an_int: NotRequired[int]
+    an_optional_int: NotRequired[Optional[int]]
 
-class AddBlogPostsVariables:
+class AddBlogPostsVariables(TypedDict):
     input: list[BlogPostInput]

--- a/tests/codegen/snapshots/python/nullable_list_of_non_scalars.py
+++ b/tests/codegen/snapshots/python/nullable_list_of_non_scalars.py
@@ -1,8 +1,9 @@
+from typing_extensions import TypedDict
 from typing import List, Optional
 
-class OperationNameResultOptionalListOfPeople:
+class OperationNameResultOptionalListOfPeople(TypedDict):
     name: str
     age: int
 
-class OperationNameResult:
+class OperationNameResult(TypedDict):
     optional_list_of_people: Optional[list[OperationNameResultOptionalListOfPeople]]

--- a/tests/codegen/snapshots/python/optional_and_lists.py
+++ b/tests/codegen/snapshots/python/optional_and_lists.py
@@ -1,6 +1,7 @@
+from typing_extensions import TypedDict
 from typing import List, Optional
 
-class OperationNameResult:
+class OperationNameResult(TypedDict):
     optional_int: Optional[int]
     list_of_int: list[int]
     list_of_optional_int: list[Optional[int]]

--- a/tests/codegen/snapshots/python/union.py
+++ b/tests/codegen/snapshots/python/union.py
@@ -1,25 +1,26 @@
+from typing_extensions import TypedDict
 from typing import Optional, Union
 
-class OperationNameResultUnionAnimal:
+class OperationNameResultUnionAnimal(TypedDict):
     # typename: Animal
     age: int
 
-class OperationNameResultUnionPerson:
+class OperationNameResultUnionPerson(TypedDict):
     # typename: Person
     name: str
 
 OperationNameResultUnion = Union[OperationNameResultUnionAnimal, OperationNameResultUnionPerson]
 
-class OperationNameResultOptionalUnionAnimal:
+class OperationNameResultOptionalUnionAnimal(TypedDict):
     # typename: Animal
     age: int
 
-class OperationNameResultOptionalUnionPerson:
+class OperationNameResultOptionalUnionPerson(TypedDict):
     # typename: Person
     name: str
 
 OperationNameResultOptionalUnion = Union[OperationNameResultOptionalUnionAnimal, OperationNameResultOptionalUnionPerson]
 
-class OperationNameResult:
+class OperationNameResult(TypedDict):
     union: OperationNameResultUnion
     optional_union: Optional[OperationNameResultOptionalUnion]

--- a/tests/codegen/snapshots/python/union_return.py
+++ b/tests/codegen/snapshots/python/union_return.py
@@ -1,7 +1,9 @@
-class OperationNameResultGetPersonOrAnimalPerson:
+from typing_extensions import TypedDict
+
+class OperationNameResultGetPersonOrAnimalPerson(TypedDict):
     # typename: Person
     name: str
     age: int
 
-class OperationNameResult:
+class OperationNameResult(TypedDict):
     get_person_or_animal: OperationNameResultGetPersonOrAnimalPerson

--- a/tests/codegen/snapshots/python/union_with_one_type.py
+++ b/tests/codegen/snapshots/python/union_with_one_type.py
@@ -1,7 +1,9 @@
-class OperationNameResultUnionAnimal:
+from typing_extensions import TypedDict
+
+class OperationNameResultUnionAnimal(TypedDict):
     # typename: Animal
     age: int
     name: str
 
-class OperationNameResult:
+class OperationNameResult(TypedDict):
     union: OperationNameResultUnionAnimal

--- a/tests/codegen/snapshots/python/union_with_typename.py
+++ b/tests/codegen/snapshots/python/union_with_typename.py
@@ -1,25 +1,26 @@
+from typing_extensions import TypedDict
 from typing import Optional, Union
 
-class OperationNameResultUnionAnimal:
+class OperationNameResultUnionAnimal(TypedDict):
     # typename: Animal
     age: int
 
-class OperationNameResultUnionPerson:
+class OperationNameResultUnionPerson(TypedDict):
     # typename: Person
     name: str
 
 OperationNameResultUnion = Union[OperationNameResultUnionAnimal, OperationNameResultUnionPerson]
 
-class OperationNameResultOptionalUnionAnimal:
+class OperationNameResultOptionalUnionAnimal(TypedDict):
     # typename: Animal
     age: int
 
-class OperationNameResultOptionalUnionPerson:
+class OperationNameResultOptionalUnionPerson(TypedDict):
     # typename: Person
     name: str
 
 OperationNameResultOptionalUnion = Union[OperationNameResultOptionalUnionAnimal, OperationNameResultOptionalUnionPerson]
 
-class OperationNameResult:
+class OperationNameResult(TypedDict):
     union: OperationNameResultUnion
     optional_union: Optional[OperationNameResultOptionalUnion]

--- a/tests/codegen/snapshots/python/union_with_typename_and_fragment.py
+++ b/tests/codegen/snapshots/python/union_with_typename_and_fragment.py
@@ -1,21 +1,22 @@
+from typing_extensions import TypedDict
 from typing import Optional, Union
 
-class AnimalProjection:
+class AnimalProjection(TypedDict):
     # typename: Animal
     age: int
 
-class OperationNameResultUnionPerson:
+class OperationNameResultUnionPerson(TypedDict):
     # typename: Person
     name: str
 
 OperationNameResultUnion = Union[AnimalProjection, OperationNameResultUnionPerson]
 
-class OperationNameResultOptionalUnionPerson:
+class OperationNameResultOptionalUnionPerson(TypedDict):
     # typename: Person
     name: str
 
 OperationNameResultOptionalUnion = Union[AnimalProjection, OperationNameResultOptionalUnionPerson]
 
-class OperationNameResult:
+class OperationNameResult(TypedDict):
     union: OperationNameResultUnion
     optional_union: Optional[OperationNameResultOptionalUnion]

--- a/tests/codegen/snapshots/python/variables.py
+++ b/tests/codegen/snapshots/python/variables.py
@@ -1,13 +1,14 @@
+from typing_extensions import NotRequired, TypedDict
 from typing import List, Optional
 
-class OperationNameResult:
+class OperationNameResult(TypedDict):
     with_inputs: bool
 
-class PersonInput:
+class PersonInput(TypedDict):
     name: str
-    age: Optional[int] = None
+    age: NotRequired[Optional[int]]
 
-class ExampleInput:
+class ExampleInput(TypedDict):
     id: str
     name: str
     age: int
@@ -15,7 +16,7 @@ class ExampleInput:
     people: list[PersonInput]
     optional_people: Optional[list[PersonInput]]
 
-class OperationNameVariables:
+class OperationNameVariables(TypedDict):
     id: Optional[str]
     input: ExampleInput
     ids: list[str]

--- a/tests/codegen/snapshots/python/with_directives.py
+++ b/tests/codegen/snapshots/python/with_directives.py
@@ -1,5 +1,7 @@
-class OperationNameResultPerson:
+from typing_extensions import TypedDict
+
+class OperationNameResultPerson(TypedDict):
     name: str
 
-class OperationNameResult:
+class OperationNameResult(TypedDict):
     person: OperationNameResultPerson

--- a/tests/codegen/snapshots/relay/python/relay_alias.py
+++ b/tests/codegen/snapshots/relay/python/relay_alias.py
@@ -1,8 +1,10 @@
-class RelayAliasResultNode:
+from typing_extensions import TypedDict
+
+class RelayAliasResultNode(TypedDict):
     # alias for id
     nodeId: str
     # alias for name
     userName: str
 
-class RelayAliasResult:
+class RelayAliasResult(TypedDict):
     node: RelayAliasResultNode

--- a/tests/codegen/snapshots/relay/python/relay_fragment.py
+++ b/tests/codegen/snapshots/relay/python/relay_fragment.py
@@ -1,7 +1,9 @@
-class UserFields:
+from typing_extensions import TypedDict
+
+class UserFields(TypedDict):
     # typename: User
     id: str
     name: str
 
-class RelayFragmentResult:
+class RelayFragmentResult(TypedDict):
     node: UserFields

--- a/tests/codegen/snapshots/relay/python/relay_list.py
+++ b/tests/codegen/snapshots/relay/python/relay_list.py
@@ -1,8 +1,9 @@
+from typing_extensions import TypedDict
 from typing import List
 
-class RelayListResultUsers:
+class RelayListResultUsers(TypedDict):
     id: str
     name: str
 
-class RelayListResult:
+class RelayListResult(TypedDict):
     users: list[RelayListResultUsers]

--- a/tests/codegen/snapshots/relay/python/relay_nested_nodes.py
+++ b/tests/codegen/snapshots/relay/python/relay_nested_nodes.py
@@ -1,11 +1,13 @@
-class RelayNestedNodesResultPostAuthor:
+from typing_extensions import TypedDict
+
+class RelayNestedNodesResultPostAuthor(TypedDict):
     id: str
     name: str
 
-class RelayNestedNodesResultPost:
+class RelayNestedNodesResultPost(TypedDict):
     id: str
     title: str
     author: RelayNestedNodesResultPostAuthor
 
-class RelayNestedNodesResult:
+class RelayNestedNodesResult(TypedDict):
     post: RelayNestedNodesResultPost

--- a/tests/codegen/snapshots/relay/python/relay_node_id.py
+++ b/tests/codegen/snapshots/relay/python/relay_node_id.py
@@ -1,7 +1,9 @@
-class GetNodeWithIDResultNodeUser:
+from typing_extensions import TypedDict
+
+class GetNodeWithIDResultNodeUser(TypedDict):
     # typename: User
     id: str
     name: str
 
-class GetNodeWithIDResult:
+class GetNodeWithIDResult(TypedDict):
     node: GetNodeWithIDResultNodeUser

--- a/tests/codegen/snapshots/relay/python/relay_variables.py
+++ b/tests/codegen/snapshots/relay/python/relay_variables.py
@@ -1,9 +1,11 @@
-class RelayVariablesResultNode:
+from typing_extensions import TypedDict
+
+class RelayVariablesResultNode(TypedDict):
     id: str
     name: str
 
-class RelayVariablesResult:
+class RelayVariablesResult(TypedDict):
     node: RelayVariablesResultNode
 
-class RelayVariablesVariables:
+class RelayVariablesVariables(TypedDict):
     nodeId: str


### PR DESCRIPTION
Use TypedDict for Python query codegen.

## Description

- Change Python query codegen plugin to generate TypedDict classes instead of plain classes
- Use NotRequired for optional fields with default values (TypedDict doesn't support = syntax)
- Update documentation with new TypedDict output examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Types of Changes

- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/strawberry-graphql/strawberry/issues/4050

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Switch Python query code generation to use TypedDict-based result and input types and improve schema codegen handling of custom directives and errors.

New Features:
- Support custom directive definitions in schema code generation by skipping them without failing.

Enhancements:
- Generate Python query result and input types as TypedDicts instead of plain classes for better type safety.
- Represent optional fields with default values in generated Python code using NotRequired[...] annotations.
- Improve schema codegen error messages to report the actual unknown definition type name.

Documentation:
- Update query codegen documentation to show TypedDict-based Python output examples.
- Add release notes describing the TypedDict migration and custom directive handling in schema codegen.

Tests:
- Add a CLI schema codegen test to verify schemas with custom directives are processed successfully.