### PR TITLE
fix: support custom directive definitions in schema codegen (option 1, ignoring)

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,13 @@
+Release type: patch
+
+This release fixes schema codegen to support custom directive definitions. Previously, schemas containing custom directives like `@authz` would fail with `NotImplementedError: Unknown definition None`. Now directive definitions are gracefully skipped since they don't require code generation.
+
+```graphql
+directive @authz(resource: String!, action: String!) on FIELD_DEFINITION
+
+type Query {
+    hello: String! @authz(resource: "greeting", action: "read")
+}
+```
+
+This also fixes the error message for truly unknown definition types to show the actual type name instead of `None`.

--- a/strawberry/schema_codegen/__init__.py
+++ b/strawberry/schema_codegen/__init__.py
@@ -9,6 +9,7 @@ from typing_extensions import Protocol
 
 import libcst as cst
 from graphql import (
+    DirectiveDefinitionNode,
     EnumTypeDefinitionNode,
     EnumValueDefinitionNode,
     FieldDefinitionNode,
@@ -748,8 +749,14 @@ def codegen(schema: str) -> str:
                 _is_federation_link_directive(directive)
                 for directive in graphql_definition.directives
             )
+        elif isinstance(graphql_definition, DirectiveDefinitionNode):
+            # Custom directive definitions don't need code generation,
+            # they're only used by the GraphQL schema itself
+            pass
         else:
-            raise NotImplementedError(f"Unknown definition {definition}")
+            raise NotImplementedError(
+                f"Unknown definition {type(graphql_definition).__name__}"
+            )
 
         if definition is not None:
             definitions[definition.name] = definition

--- a/tests/cli/test_schema_codegen.py
+++ b/tests/cli/test_schema_codegen.py
@@ -5,8 +5,10 @@ from typer import Typer
 from typer.testing import CliRunner
 
 schema = """
+directive @foo on FIELD_DEFINITION
+
 type Query {
-    hello: String!
+    hello: String! @foo
 }
 """
 


### PR DESCRIPTION
## Description

Previously, schemas containing custom directive definitions would fail with `NotImplementedError: Unknown definition None`. Now directive definitions are gracefully skipped.

Also fixes the error message for unknown definitions to show the actual type name instead of `None`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/strawberry-graphql/strawberry/issues/4050#issuecomment-3567122712

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Support custom directive definitions in schema code generation and clarify errors for unsupported GraphQL definition types.

Bug Fixes:
- Handle custom directive definitions in schema codegen without raising errors by skipping them during generation.
- Improve the NotImplementedError message for unknown GraphQL definition types to include the actual type name.

Documentation:
- Add release notes documenting the schema codegen fix for custom directives and the improved unknown definition error message.

Tests:
- Extend schema codegen CLI tests to cover schemas that define and use custom directives.