### PR TITLE
fix: support custom directive definitions in schema codegen (option 2, generating)

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,27 @@
+Release type: minor
+
+This release improves schema codegen to generate Python stub classes for custom directive definitions. Previously, schemas containing custom directives would fail with `NotImplementedError`. Now directive definitions are converted to Strawberry schema directive classes.
+
+For example, this GraphQL schema:
+```graphql
+directive @authz(resource: String!, action: String!) on FIELD_DEFINITION
+
+type Query {
+    hello: String! @authz(resource: "greeting", action: "read")
+}
+```
+
+Now generates:
+```python
+from strawberry.schema_directive import Location
+
+
+@strawberry.schema_directive(locations=[Location.FIELD_DEFINITION])
+class Authz:
+    resource: str
+    action: str
+```
+
+Note: The generated directives are stubs - they don't contain any behavior logic, which must be implemented separately.
+
+This also fixes the error message for unknown definition types to show the actual type name instead of `None`.

--- a/tests/cli/test_schema_codegen.py
+++ b/tests/cli/test_schema_codegen.py
@@ -5,13 +5,21 @@ from typer import Typer
 from typer.testing import CliRunner
 
 schema = """
+directive @authz(resource: String!, action: String!) on FIELD_DEFINITION
+
 type Query {
-    hello: String!
+    hello: String! @authz(resource: "greeting", action: "read")
 }
 """
 
 expected_output = """
 import strawberry
+from strawberry.schema_directive import Location
+
+@strawberry.schema_directive(locations=[Location.FIELD_DEFINITION])
+class Authz:
+    resource: str
+    action: str
 
 @strawberry.type
 class Query:

--- a/tests/schema_codegen/test_directive.py
+++ b/tests/schema_codegen/test_directive.py
@@ -1,0 +1,121 @@
+import textwrap
+
+from strawberry.schema_codegen import codegen
+
+
+def test_directive_with_arguments():
+    schema = """
+    directive @authz(resource: String!, action: String!) on FIELD_DEFINITION
+
+    type Query {
+        hello: String!
+    }
+    """
+
+    expected = textwrap.dedent(
+        """
+        import strawberry
+        from strawberry.schema_directive import Location
+
+        @strawberry.schema_directive(locations=[Location.FIELD_DEFINITION])
+        class Authz:
+            resource: str
+            action: str
+
+        @strawberry.type
+        class Query:
+            hello: str
+
+        schema = strawberry.Schema(query=Query)
+        """
+    ).strip()
+
+    assert codegen(schema).strip() == expected
+
+
+def test_directive_without_arguments():
+    schema = """
+    directive @deprecated on FIELD_DEFINITION
+
+    type Query {
+        hello: String!
+    }
+    """
+
+    expected = textwrap.dedent(
+        """
+        import strawberry
+        from strawberry.schema_directive import Location
+
+        @strawberry.schema_directive(locations=[Location.FIELD_DEFINITION])
+        class Deprecated:
+            pass
+
+        @strawberry.type
+        class Query:
+            hello: str
+
+        schema = strawberry.Schema(query=Query)
+        """
+    ).strip()
+
+    assert codegen(schema).strip() == expected
+
+
+def test_directive_with_description():
+    schema = '''
+    """Authorization directive for field-level access control"""
+    directive @authz(resource: String!) on FIELD_DEFINITION
+
+    type Query {
+        hello: String!
+    }
+    '''
+
+    expected = textwrap.dedent(
+        """
+        import strawberry
+        from strawberry.schema_directive import Location
+
+        @strawberry.schema_directive(locations=[Location.FIELD_DEFINITION], description="Authorization directive for field-level access control")
+        class Authz:
+            resource: str
+
+        @strawberry.type
+        class Query:
+            hello: str
+
+        schema = strawberry.Schema(query=Query)
+        """
+    ).strip()
+
+    assert codegen(schema).strip() == expected
+
+
+def test_directive_with_multiple_locations():
+    schema = """
+    directive @example on FIELD_DEFINITION | OBJECT | INTERFACE
+
+    type Query {
+        hello: String!
+    }
+    """
+
+    expected = textwrap.dedent(
+        """
+        import strawberry
+        from strawberry.schema_directive import Location
+
+        @strawberry.schema_directive(locations=[Location.FIELD_DEFINITION, Location.OBJECT, Location.INTERFACE])
+        class Example:
+            pass
+
+        @strawberry.type
+        class Query:
+            hello: str
+
+        schema = strawberry.Schema(query=Query)
+        """
+    ).strip()
+
+    assert codegen(schema).strip() == expected

--- a/tests/schema_codegen/test_types.py
+++ b/tests/schema_codegen/test_types.py
@@ -1,5 +1,7 @@
 import textwrap
 
+import pytest
+
 from strawberry.schema_codegen import codegen
 
 
@@ -74,6 +76,22 @@ def test_supports_descriptions():
     ).strip()
 
     assert codegen(schema).strip() == expected
+
+
+def test_codegen_raises_for_unknown_definition():
+    # GraphQL operation definitions (queries) are not supported in schema codegen
+    schema = """
+    query GetUser {
+        user {
+            name
+        }
+    }
+    """
+
+    with pytest.raises(
+        NotImplementedError, match="Unknown definition OperationDefinitionNode"
+    ):
+        codegen(schema)
 
 
 def test_supports_interfaces():


### PR DESCRIPTION
Previously, schemas containing custom directive definitions would fail with `NotImplementedError: Unknown definition None`. Now directive definitions are generated.

Also fixes the error message for unknown definitions to show the actual type name instead of `None`.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/strawberry-graphql/strawberry/issues/4050#issuecomment-3567122712

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Generate schema code for custom directive definitions and improve error reporting for unsupported GraphQL definition types.

New Features:
- Support code generation of Strawberry schema directive stub classes from custom directive definitions in GraphQL schemas.

Bug Fixes:
- Prevent schema codegen from failing with NotImplementedError when encountering directive definitions by handling DirectiveDefinitionNode explicitly.
- Improve the NotImplementedError message for unknown schema definition types to show the actual GraphQL node type name.

Documentation:
- Add release notes describing custom directive schema codegen support and the improved error message behavior.

Tests:
- Extend schema codegen CLI tests to cover generation of directive stubs with arguments and locations.