### PR TITLE
fix: Fix Maybe[T] to reject null values passed via variables

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,11 @@
+Release type: patch
+
+Fixed a bug where `strawberry.Maybe[T]` was incorrectly accepting `null` values when passed through variables
+
+Previously, `Maybe[T]` returned a validation error for literal `null` values in GraphQL queries, but allowed `null` when passed via variables, resulting in `Some(None)` reaching the resolver instead of raising a validation error.
+
+This fix ensures consistent validation behavior for `Maybe[T]` regardless of how the input is provided:
+
+- `Maybe[T]` now returns a validation error for `null` in both literal queries and variables
+- `Maybe[T | None]` continues to accept `null` values as expected
+- Error message indicates to use `Maybe[T | None]` if null values are needed

--- a/strawberry/types/arguments.py
+++ b/strawberry/types/arguments.py
@@ -195,6 +195,16 @@ def convert_argument(
 
             return Some(res)
 
+        if value is None:
+            from strawberry.exceptions import StrawberryGraphQLError
+
+            type_name = getattr(type_.of_type, "__name__", str(type_.of_type))
+            raise StrawberryGraphQLError(
+                f"Expected value of type '{type_name}', found null. "
+                f"Field of type 'Maybe[{type_name}]' cannot be explicitly set to null. "
+                f"Use 'Maybe[{type_name} | None]' if you need to allow null values."
+            )
+
         # This is Maybe[T] - validation for null values is handled by MaybeNullValidationRule
         # Convert the value and wrap in Some()
         res = convert_argument(value, type_.of_type, scalar_registry, config)


### PR DESCRIPTION
Fix #4095

## Summary by Sourcery

Ensure consistent null handling for strawberry.Maybe[T] arguments and document the fix as a patch release.

Bug Fixes:
- Reject null values passed via variables to fields using strawberry.Maybe[T], aligning behavior with literal null handling.

Documentation:
- Document the null-handling fix for strawberry.Maybe[T] in the release notes as a patch update.

Tests:
- Add regression tests covering null handling for strawberry.Maybe[str] in both literal queries and variable-based inputs, including flexible Maybe[T | None] usage.