### PR TITLE
ci: update codecov action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,9 +78,10 @@ jobs:
 
     steps:
       - uses: actions/download-artifact@v4
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v5
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           verbose: true
 
@@ -165,9 +166,10 @@ jobs:
         run: coverage xml -i
         if: ${{ always() }}
 
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v5
         if: ${{ always() }}
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           verbose: true


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Bump codecov/codecov-action from v4 to v5 in the test workflow and switch to providing CODECOV_TOKEN via environment variables instead of the action input.