### PR TITLE
ci: pin all GitHub Actions to commit SHAs for security

### DIFF
--- a/.github/workflows/codeflash.yaml
+++ b/.github/workflows/codeflash.yaml
@@ -23,11 +23,11 @@ jobs:
       CODEFLASH_PR_NUMBER: ${{ github.event.number }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
       - name: Install Project Dependencies

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,12 +19,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@8dca8a82e2fa1a2c8908956f711300f9c4a4f4f6 # v2
         with:
           languages: python
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@8dca8a82e2fa1a2c8908956f711300f9c4a4f4f6 # v2

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@b7a1c7ccf290d58743029c4f6903da283811b979 # v2
 
       - name: Install dependencies
         run: |
@@ -31,12 +31,12 @@ jobs:
           bunx playwright install --with-deps
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
       - name: Install Poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1
         with:
           version: latest
           virtualenvs-create: true
@@ -64,7 +64,7 @@ jobs:
           cd e2e
           bunx playwright test
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: playwright-report

--- a/.github/workflows/federation-compatibility.yml
+++ b/.github/workflows/federation-compatibility.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 
       - run: pipx install poetry
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         id: setup-python
         with:
           python-version: "3.12"
@@ -37,7 +37,7 @@ jobs:
         run: poetry run strawberry export-schema schema:schema > schema.graphql
         working-directory: federation-compatibility
 
-      - uses: apollographql/federation-subgraph-compatibility@v2
+      - uses: apollographql/federation-subgraph-compatibility@b6981fd83d24450a7cbd2d7727196e0ba57614e0 # v2
         with:
           compose: 'federation-compatibility/docker-compose.yml'
           schema: 'federation-compatibility/schema.graphql'

--- a/.github/workflows/invite-contributors.yml
+++ b/.github/workflows/invite-contributors.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Invite contributors
-        uses: strawberry-graphql/invite-to-org-action@v4
+        uses: strawberry-graphql/invite-to-org-action@260b05042142d5cc1af3f87a0547f72389df7fd8 # v4
         with:
           organisation: "strawberry-graphql"
           comment: |

--- a/.github/workflows/issue-manager.yml
+++ b/.github/workflows/issue-manager.yml
@@ -18,7 +18,7 @@ jobs:
   issue-manager:
     runs-on: ubuntu-latest
     steps:
-      - uses: tiangolo/issue-manager@0.6.0
+      - uses: tiangolo/issue-manager@2fb3484ec9279485df8659e8ec73de262431737d # 0.6.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config: >

--- a/.github/workflows/ok-to-preview.yml
+++ b/.github/workflows/ok-to-preview.yml
@@ -54,7 +54,7 @@ jobs:
       shell: python
 
     - name: Create comment
-      uses: peter-evans/create-or-update-comment@v5
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
       with:
         issue-number: ${{ github.event.number }}
         body: ${{ steps.get-comment-message.outputs.message }}

--- a/.github/workflows/pre-release-pr.yml
+++ b/.github/workflows/pre-release-pr.yml
@@ -9,11 +9,11 @@ jobs:
     name: Pre-release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
           ref: ${{ github.event.client_payload.pull_request.head.sha }}
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: "3.10"
       - name: Install deps
@@ -31,7 +31,7 @@ jobs:
         if: steps.check_release.outputs.release == ''
         run: echo "commit=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
       - name: Find Release Comment
-        uses: peter-evans/find-comment@v4
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4
         id: find_comment
         if: steps.check_release.outputs.release == ''
         with:
@@ -40,7 +40,7 @@ jobs:
           comment-author: botberry
           body-includes: "# Pre-release"
       - name: Create or update comment
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
         if: steps.check_release.outputs.release == ''
         with:
           token: ${{ secrets.BOT_TOKEN }}
@@ -65,7 +65,7 @@ jobs:
           poetry publish --username __token__
           echo "version=$(poetry version -s)" >> $GITHUB_OUTPUT
       - name: Create or update comment
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
         if: steps.check_release.outputs.release == ''
         with:
           token: ${{ secrets.BOT_TOKEN }}

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Get PR info
         id: get-info
-        uses: strawberry-graphql/get-pr-info-action@v6
+        uses: strawberry-graphql/get-pr-info-action@a6d95647fa027e52c0d751a225d3864d5c091284 # v6
       - run: echo "${{ steps.get-info.outputs.contributor-twitter-username }}"
 
   skip-if-bot:
@@ -66,7 +66,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
           ref: "refs/pull/${{ github.event.number }}/merge"
 
@@ -84,12 +84,12 @@ jobs:
       tweet: ${{ steps.extract.outputs.tweet }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
           ref: "refs/pull/${{ github.event.number }}/merge"
       - name: Extract tweet message and changelog
         id: extract
-        uses: strawberry-graphql/tweet-actions/read-tweet@v6
+        uses: strawberry-graphql/tweet-actions/read-tweet@b8d51a501ab14ac32d79b61e3a0af5c3add4ead0 # v6
         with:
           changelog: ${{ needs.release-file-check.outputs.changelog }}
           version: "(next)"
@@ -102,7 +102,7 @@ jobs:
     if: ${{ needs.read-tweet-md.outputs.tweet != '' }}
     steps:
       - name: Validate tweet
-        uses: strawberry-graphql/tweet-actions/validate-tweet@v6
+        uses: strawberry-graphql/tweet-actions/validate-tweet@b8d51a501ab14ac32d79b61e3a0af5c3add4ead0 # v6
         with:
           tweet: ${{ needs.read-tweet-md.outputs.tweet }}
 
@@ -112,7 +112,7 @@ jobs:
     if: github.event.pull_request.draft == false
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       - name: Send comment
         uses: ./.github/bot-action
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       change_type: ${{ steps.release-check.outputs.change_type }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 
       - name: Release file check
         uses: ./.github/release-check-action
@@ -32,11 +32,11 @@ jobs:
     outputs:
       version: ${{ steps.get-version.outputs.version }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
           persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: "3.10"
       - name: Install deps
@@ -89,7 +89,7 @@ jobs:
     steps:
       - name: Get PR info
         id: get-info
-        uses: strawberry-graphql/get-pr-info-action@v6
+        uses: strawberry-graphql/get-pr-info-action@a6d95647fa027e52c0d751a225d3864d5c091284 # v6
 
   update-release-on-github:
     name: Update release on GitHub
@@ -97,7 +97,7 @@ jobs:
     needs: [release-file-check, get-contributor-info, release]
     if: ${{ needs.release-file-check.outputs.status == 'OK' }}
     steps:
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: "3.10"
       - name: Install dependencies
@@ -159,10 +159,10 @@ jobs:
       has-tweet-file: ${{ steps.extract.outputs.has-tweet-file }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       - name: Extract tweet message and changelog
         id: extract
-        uses: strawberry-graphql/tweet-actions/read-tweet@v6
+        uses: strawberry-graphql/tweet-actions/read-tweet@b8d51a501ab14ac32d79b61e3a0af5c3add4ead0 # v6
         with:
           changelog: ${{ needs.release-file-check.outputs.changelog }}
           version: ${{ needs.release.outputs.version }}
@@ -176,7 +176,7 @@ jobs:
     if: ${{ needs.release-file-check.outputs.status == 'OK' }}
 
     steps:
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: "3.10"
       - name: Install dependencies
@@ -227,7 +227,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
           persist-credentials: false
       - name: Remove TWEET.md and commit

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Slash Command Dispatch
-        uses: peter-evans/slash-command-dispatch@v5
+        uses: peter-evans/slash-command-dispatch@9bdcd7914ec1b75590b790b844aa3b8eee7c683a # v5
         with:
           token: ${{ secrets.BOT_TOKEN }}
           reaction-token: ${{ secrets.BOT_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,9 +24,9 @@ jobs:
     outputs:
       sessions: ${{ steps.set-matrix.outputs.sessions }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@8d55fbecc275b1c35dbe060458839f8d30439ccf # v3
       - run: uv venv
       - run: uv pip install poetry nox nox-poetry
       - id: set-matrix
@@ -53,8 +53,8 @@ jobs:
         session: ${{ fromJson(needs.generate-jobs-tests.outputs.sessions) }}
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: |
             3.10
@@ -65,7 +65,7 @@ jobs:
 
       - run: pip install poetry nox nox-poetry uv
       - run: nox -r -t tests -s "${{ matrix.session.session }}"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: ${{ always() }}
         with:
           name: coverage-${{ matrix.session.session }}
@@ -77,8 +77,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/download-artifact@v4
-      - uses: codecov/codecov-action@v5
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -96,9 +96,9 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       - run: pipx install poetry
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         id: setup-python
         with:
           python-version: "3.12"
@@ -110,7 +110,7 @@ jobs:
         if: steps.setup-python.outputs.cache-hit != 'true'
 
       - name: Run benchmarks
-        uses: CodSpeedHQ/action@v4
+        uses: CodSpeedHQ/action@0d7de549485db8284c0b87a0d2c0dd871097e641 # v4
         with:
           mode: simulation
           run: poetry run pytest tests/benchmarks --codspeed -p no:codeflash-benchmark
@@ -120,10 +120,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       - run: pipx install poetry
       - run: pipx install coverage
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         id: setup-python
         with:
           python-version: "3.12"
@@ -142,10 +142,10 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       - run: pipx install poetry
       - run: pipx install coverage
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         id: setup-python
         with:
           python-version: "3.11"
@@ -163,7 +163,7 @@ jobs:
         run: coverage xml -i
         if: ${{ always() }}
 
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
         if: ${{ always() }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -18,7 +18,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
           persist-credentials: false
 


### PR DESCRIPTION
## Summary
- Pins all GitHub Actions to their commit SHAs while retaining version comments
- Addresses zizmor security warnings about unpinned action references
- Dependabot will continue to update these actions (supports SHA + version comment format)

## Test plan
- [x] CI workflows should pass with pinned actions
- [ ] Verify Dependabot can detect and update SHA-pinned actions

## Summary by Sourcery

CI:
- Update all GitHub Actions references across workflows to use commit SHA pins instead of floating version tags.