### PR TITLE
fix: fix federated compatibility tests with python 3.14

### DIFF
--- a/.github/workflows/federation-compatibility.yml
+++ b/.github/workflows/federation-compatibility.yml
@@ -12,6 +12,7 @@ on:
     paths:
       - "strawberry/federation/**"
       - "strawberry/printer/**"
+      - "federation-compatibility/**"
       - "pyproject.toml"
       - "poetry.lock"
       - ".github/workflows/federation-compatibility.yml"

--- a/federation-compatibility/Dockerfile
+++ b/federation-compatibility/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.14-slim
 WORKDIR /web
 
-RUN apt update && apt install -y gcc python3-dev
+RUN apt update && apt install -y gcc g++ python3-dev
 RUN pip install poetry
 
 COPY strawberry ./strawberry


### PR DESCRIPTION
## Summary by Sourcery

Update federation compatibility testing environment and workflow triggers for Python 3.14.

Bug Fixes:
- Ensure federation compatibility Docker image includes C++ compiler required for Python 3.14 dependencies.
- Include federation-compatibility directory changes in the federation compatibility GitHub Actions workflow triggers.