### PR TITLE
ci: Pin Poetry to <2.3 to fix --without flag regression

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3
       - run: uv venv
-      - run: uv pip install poetry nox nox-poetry
+      - run: uv pip install "poetry<2.3" nox nox-poetry
       - id: set-matrix
         shell: bash
         run: |
@@ -63,7 +63,7 @@ jobs:
             3.13
             3.14
 
-      - run: pip install poetry nox nox-poetry uv
+      - run: pip install "poetry<2.3" nox nox-poetry uv
       - run: nox -r -t tests -s "${{ matrix.session.session }}"
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v4
         if: ${{ always() }}


### PR DESCRIPTION
## Summary

This PR fixes two issues causing CI test failures:

### 1. Django Settings in HTTP Tests

The main test suite (`tests()` nox session) was failing because:
- The session runs without `pytest-django` installed
- Django HTTP clients are still being parametrized and tested
- Django's app registry wasn't initialized, causing `AppRegistryNotReady: Apps aren't loaded yet`

**Fix:** Configure Django and call `django.setup()` in the HTTP tests conftest before importing Django-related test clients.

### 2. Mypy Output Parsing

The type checker tests were failing because mypy outputs both JSON lines (errors/warnings) and non-JSON summary lines like `Found 1 error in 1 file`. The test utility was trying to parse all lines as JSON.

**Fix:** Skip non-JSON lines when parsing mypy output, rather than raising an error.

## Test plan

- [x] Verify the Django fix locally
- [ ] CI tests should pass on this PR

## Summary by Sourcery

CI:
- Update GitHub Actions test workflow to install Poetry <2.3 for both uv-based and direct pip setups.