### PR TITLE
fix: consider field annotations for generic detection

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,39 @@
+Release type: patch
+
+Fix nested generics with resolver-backed fields to avoid duplicate type names.
+
+Example (previously raised `DuplicatedTypeName`):
+
+```python
+import strawberry
+
+
+@strawberry.type
+class Collection[T]:
+    field1: list[T] = strawberry.field(resolver=lambda: [])
+
+
+@strawberry.type
+class Container[T]:
+    items: list[T]
+
+
+@strawberry.type
+class TypeA: ...
+
+
+@strawberry.type
+class TypeB: ...
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def a(self) -> Container[Collection[TypeA]]: ...
+
+    @strawberry.field
+    def b(self) -> Container[Collection[TypeB]]: ...
+
+
+strawberry.Schema(query=Query)
+```

--- a/strawberry/types/field.py
+++ b/strawberry/types/field.py
@@ -258,11 +258,10 @@ class StrawberryField(dataclasses.Field):
 
     @property
     def is_graphql_generic(self) -> bool:
-        return (
-            self.base_resolver.is_graphql_generic
-            if self.base_resolver
-            else _is_generic(self.type)
-        )
+        if self.base_resolver:
+            return self.base_resolver.is_graphql_generic or _is_generic(self.type)
+
+        return _is_generic(self.type)
 
     def _python_name(self) -> str | None:
         if self.name:


### PR DESCRIPTION
Ensure generic detection accounts for field annotations even when a resolver is present so nested concrete generics get unique names and avoid DuplicatedTypeName collisions.

Fix #4139

## Summary by Sourcery

Adjust generic detection for fields to consider both resolver and type annotations to avoid duplicated type names for nested generics.

Bug Fixes:
- Prevent duplicated GraphQL type names when using nested concrete generics on fields that also define resolvers.

Tests:
- Add a regression test ensuring multiple levels of nested generics with resolvers generate distinct schema type names.