### PR TITLE
fix: fall back to is_type_of for union generics

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+Release type: patch
+
+Fix union type resolution to fall back to `is_type_of` for generic unions when
+type matching fails. This allows returning domain/ORM objects from generic union
+fields without spurious union type errors.

--- a/strawberry/types/union.py
+++ b/strawberry/types/union.py
@@ -206,6 +206,14 @@ class StrawberryUnion(StrawberryType):
             else:
                 return_type = None
 
+            # If we couldn't resolve from type matching, try using is_type_of
+            if return_type is None:
+                for inner_type in type_.types:
+                    if inner_type.is_type_of is not None and inner_type.is_type_of(
+                        root, info
+                    ):
+                        return inner_type.name
+
             # Make sure the found type is expected by the Union
             if return_type is None or return_type not in type_.types:
                 raise UnallowedReturnTypeForUnion(


### PR DESCRIPTION
Ensure union type resolution consults is_type_of when generic matching can’t identify the concrete type, enabling ORM/domain objects to resolve correctly.

Also, add a regression test covering unions that include generic types and domain object instances.

Fix #4052

## Summary by Sourcery

Improve union type resolution to fall back to is_type_of when generic matching fails, and add a regression test for unions involving generics and domain objects.

Bug Fixes:
- Ensure union types consult is_type_of when generic matching cannot determine the concrete type, allowing domain/ORM objects in unions with generics to resolve correctly.

Tests:
- Add a regression test covering unions that include generic types backed by domain objects to verify is_type_of-based resolution.