### PR TITLE
Export UploadDefinition for proper type checking with file uploads

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,27 @@
+Release type: patch
+
+This release adds `UploadDefinition` to `strawberry.file_uploads`, which can be
+used with `scalar_overrides` to map framework-specific upload types to the
+`Upload` scalar. This enables proper type checking with mypy/pyright when using
+file uploads.
+
+Example usage with Starlette/FastAPI:
+
+```python
+from starlette.datastructures import UploadFile
+from strawberry.file_uploads import UploadDefinition
+
+schema = strawberry.Schema(
+    query=Query, mutation=Mutation, scalar_overrides={UploadFile: UploadDefinition}
+)
+
+
+@strawberry.type
+class Mutation:
+    @strawberry.mutation
+    async def read_file(self, file: UploadFile) -> str:
+        return (await file.read()).decode("utf-8")
+```
+
+With this configuration, the `file` parameter is correctly typed as `UploadFile`,
+giving you proper IDE autocomplete and type checking.

--- a/docs/guides/file-upload.md
+++ b/docs/guides/file-upload.md
@@ -38,20 +38,35 @@ runtime depends on the integration:
 | [Sanic](/docs/integrations/sanic)         | [`sanic.request.File`](https://sanic.readthedocs.io/en/stable/sanic/api/core.html#sanic.request.File)                                                 |
 | [Starlette](/docs/integrations/starlette) | [`starlette.datastructures.UploadFile`](https://www.starlette.io/requests/#request-files)                                                             |
 
-In order to have the correct runtime type in resolver type annotations you can
-set a scalar override based on the integrations above. For example with
-Starlette:
+In order to have the correct runtime type in resolver type annotations (which
+also gives you proper type checking with mypy/pyright), you can set a scalar
+override based on the integrations above. For example with Starlette:
 
 ```python
 import strawberry
 from starlette.datastructures import UploadFile
-from strawberry.file_uploads import Upload
+from strawberry.file_uploads import UploadDefinition
 
 schema = strawberry.Schema(
-  ...
-  scalar_overrides={UploadFile: Upload}
+    query=Query,
+    mutation=Mutation,
+    scalar_overrides={UploadFile: UploadDefinition},
 )
 ```
+
+With this configuration, you can use the framework's upload type directly in
+your resolvers:
+
+```python
+@strawberry.type
+class Mutation:
+    @strawberry.mutation
+    async def read_file(self, file: UploadFile) -> str:
+        return (await file.read()).decode("utf-8")
+```
+
+This gives you proper IDE autocomplete and type checking, since the type
+annotation matches the actual runtime type.
 
 ## ASGI / FastAPI / Starlette
 

--- a/strawberry/file_uploads/__init__.py
+++ b/strawberry/file_uploads/__init__.py
@@ -1,3 +1,3 @@
-from .scalars import Upload
+from .scalars import Upload, UploadDefinition
 
-__all__ = ["Upload"]
+__all__ = ["Upload", "UploadDefinition"]

--- a/strawberry/file_uploads/scalars.py
+++ b/strawberry/file_uploads/scalars.py
@@ -1,5 +1,14 @@
 from typing import NewType
 
+from strawberry.types.scalar import scalar
+
 Upload = NewType("Upload", bytes)
 
-__all__ = ["Upload"]
+UploadDefinition = scalar(
+    name="Upload",
+    description="Represents a file upload.",
+    serialize=lambda v: v,
+    parse_value=lambda v: v,
+)
+
+__all__ = ["Upload", "UploadDefinition"]

--- a/strawberry/schema/types/scalar.py
+++ b/strawberry/schema/types/scalar.py
@@ -12,7 +12,7 @@ from graphql import (
     GraphQLString,
 )
 
-from strawberry.file_uploads.scalars import Upload
+from strawberry.file_uploads.scalars import Upload, UploadDefinition
 from strawberry.scalars import ID, JSON, Base16, Base32, Base64
 from strawberry.schema.types import base_scalars
 from strawberry.types.scalar import ScalarDefinition, scalar
@@ -54,12 +54,7 @@ DEFAULT_SCALAR_REGISTRY: dict[object, ScalarDefinition] = {
     bool: _make_scalar_definition(GraphQLBoolean),
     ID: _make_scalar_definition(GraphQLID),
     UUID: base_scalars.UUIDDefinition,
-    Upload: scalar(
-        name="Upload",
-        description="Represents a file upload.",
-        serialize=lambda v: v,
-        parse_value=lambda v: v,
-    ),
+    Upload: UploadDefinition,
     datetime.date: base_scalars.DateDefinition,
     datetime.datetime: base_scalars.DateTimeDefinition,
     datetime.time: base_scalars.TimeDefinition,


### PR DESCRIPTION
## Summary

- Adds `UploadDefinition` to `strawberry.file_uploads` which can be used with `scalar_overrides` to map framework-specific upload types (like `UploadFile`) to the `Upload` scalar
- Updates documentation to show the correct usage pattern for proper type checking
- Fixes the broken documentation example that used `scalar_overrides={UploadFile: Upload}` (which doesn't work since `Upload` is now a `NewType`, not a `ScalarDefinition`)

## Example usage

```python
from starlette.datastructures import UploadFile
from strawberry.file_uploads import UploadDefinition

schema = strawberry.Schema(
    query=Query,
    mutation=Mutation,
    scalar_overrides={UploadFile: UploadDefinition},
)

@strawberry.type
class Mutation:
    @strawberry.mutation
    async def read_file(self, file: UploadFile) -> str:  # mypy happy!
        return (await file.read()).decode("utf-8")
```

Fixes #4143

## Test plan

- [x] Verified `UploadDefinition` works with `scalar_overrides`
- [x] Ran existing upload and scalar tests - all pass

## Summary by Sourcery

Add a dedicated Upload scalar definition for file uploads and expose it for use with scalar overrides to improve runtime typing and type checking.

New Features:
- Expose UploadDefinition in strawberry.file_uploads for use in scalar_overrides when mapping framework-specific upload types to the Upload scalar.

Enhancements:
- Refactor the Upload scalar registration to reuse the shared UploadDefinition.
- Improve file upload documentation with correct scalar_overrides usage and resolver examples for better type checking and IDE support.

Documentation:
- Update the file upload guide to document UploadDefinition usage and demonstrate framework upload types in resolver annotations.

Chores:
- Add a RELEASE.md entry describing the new UploadDefinition and its impact on type checking for file uploads.

/cc @jonfinerty