### PR TITLE
Refactor federation functions to share federation params TypedDicts and processing functions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,7 @@
+Release type: minor
+
+Add `strawberry.federation.params` module with shared TypedDicts (`FederationFieldParams`, `FederationInterfaceParams`, `FederationTypeParams`) and processing functions (`process_federation_field_directives`, `process_federation_type_directives`) for federation directives.
+
+These TypedDicts can be consumed via `Unpack[...]` to avoid duplicating federation parameter lists across packages. The processing functions are extracted from inline logic previously in `field.py` and `object_type.py`.
+
+Also fixes a bug where `inaccessible=False` incorrectly added the `Inaccessible` directive on types/interfaces.

--- a/strawberry/federation/field.py
+++ b/strawberry/federation/field.py
@@ -7,14 +7,14 @@ from typing import (
     TypeVar,
     overload,
 )
+from typing_extensions import Unpack
 
 from strawberry.types.field import field as base_field
-from strawberry.types.unset import UNSET
 
-from .types import FieldSet
+from .params import FederationFieldParams, process_federation_field_directives
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable, Mapping, Sequence
+    from collections.abc import Callable, Mapping, Sequence
     from typing import Literal
 
     from strawberry.extensions.field_extension import FieldExtension
@@ -23,10 +23,7 @@ if TYPE_CHECKING:
         _RESOLVER_TYPE,
         _RESOLVER_TYPE_ASYNC,
         _RESOLVER_TYPE_SYNC,
-        StrawberryField,
     )
-
-    from .schema_directives import Override
 
 T = TypeVar("T")
 
@@ -41,16 +38,6 @@ def field(
     name: str | None = None,
     is_subscription: bool = False,
     description: str | None = None,
-    authenticated: bool = False,
-    external: bool = False,
-    inaccessible: bool = False,
-    policy: list[list[str]] | None = None,
-    provides: list[str] | None = None,
-    override: Override | str | None = None,
-    requires: list[str] | None = None,
-    requires_scopes: list[list[str]] | None = None,
-    tags: Iterable[str] | None = (),
-    shareable: bool = False,
     init: Literal[False] = False,
     permission_classes: list[type[BasePermission]] | None = None,
     deprecation_reason: str | None = None,
@@ -60,6 +47,7 @@ def field(
     directives: Sequence[object] | None = (),
     extensions: list[FieldExtension] | None = None,
     graphql_type: Any | None = None,
+    **federation_kwargs: Unpack[FederationFieldParams],
 ) -> T: ...
 
 
@@ -70,16 +58,6 @@ def field(
     name: str | None = None,
     is_subscription: bool = False,
     description: str | None = None,
-    authenticated: bool = False,
-    external: bool = False,
-    inaccessible: bool = False,
-    policy: list[list[str]] | None = None,
-    provides: list[str] | None = None,
-    override: Override | str | None = None,
-    requires: list[str] | None = None,
-    requires_scopes: list[list[str]] | None = None,
-    tags: Iterable[str] | None = (),
-    shareable: bool = False,
     init: Literal[False] = False,
     permission_classes: list[type[BasePermission]] | None = None,
     deprecation_reason: str | None = None,
@@ -89,6 +67,7 @@ def field(
     directives: Sequence[object] | None = (),
     extensions: list[FieldExtension] | None = None,
     graphql_type: Any | None = None,
+    **federation_kwargs: Unpack[FederationFieldParams],
 ) -> T: ...
 
 
@@ -98,16 +77,6 @@ def field(
     name: str | None = None,
     is_subscription: bool = False,
     description: str | None = None,
-    authenticated: bool = False,
-    external: bool = False,
-    inaccessible: bool = False,
-    policy: list[list[str]] | None = None,
-    provides: list[str] | None = None,
-    override: Override | str | None = None,
-    requires: list[str] | None = None,
-    requires_scopes: list[list[str]] | None = None,
-    tags: Iterable[str] | None = (),
-    shareable: bool = False,
     init: Literal[True] = True,
     permission_classes: list[type[BasePermission]] | None = None,
     deprecation_reason: str | None = None,
@@ -117,63 +86,8 @@ def field(
     directives: Sequence[object] | None = (),
     extensions: list[FieldExtension] | None = None,
     graphql_type: Any | None = None,
+    **federation_kwargs: Unpack[FederationFieldParams],
 ) -> Any: ...
-
-
-@overload
-def field(
-    resolver: _RESOLVER_TYPE_ASYNC[T],
-    *,
-    name: str | None = None,
-    is_subscription: bool = False,
-    description: str | None = None,
-    authenticated: bool = False,
-    external: bool = False,
-    inaccessible: bool = False,
-    policy: list[list[str]] | None = None,
-    provides: list[str] | None = None,
-    override: Override | str | None = None,
-    requires: list[str] | None = None,
-    requires_scopes: list[list[str]] | None = None,
-    tags: Iterable[str] | None = (),
-    shareable: bool = False,
-    permission_classes: list[type[BasePermission]] | None = None,
-    deprecation_reason: str | None = None,
-    default: Any = dataclasses.MISSING,
-    default_factory: Callable[..., object] | object = dataclasses.MISSING,
-    metadata: Mapping[Any, Any] | None = None,
-    directives: Sequence[object] | None = (),
-    extensions: list[FieldExtension] | None = None,
-    graphql_type: Any | None = None,
-) -> StrawberryField: ...
-
-
-@overload
-def field(
-    resolver: _RESOLVER_TYPE_SYNC[T],
-    *,
-    name: str | None = None,
-    is_subscription: bool = False,
-    description: str | None = None,
-    authenticated: bool = False,
-    external: bool = False,
-    inaccessible: bool = False,
-    policy: list[list[str]] | None = None,
-    provides: list[str] | None = None,
-    override: Override | str | None = None,
-    requires: list[str] | None = None,
-    requires_scopes: list[list[str]] | None = None,
-    tags: Iterable[str] | None = (),
-    shareable: bool = False,
-    permission_classes: list[type[BasePermission]] | None = None,
-    deprecation_reason: str | None = None,
-    default: Any = dataclasses.MISSING,
-    default_factory: Callable[..., object] | object = dataclasses.MISSING,
-    metadata: Mapping[Any, Any] | None = None,
-    directives: Sequence[object] | None = (),
-    extensions: list[FieldExtension] | None = None,
-    graphql_type: Any | None = None,
-) -> StrawberryField: ...
 
 
 def field(
@@ -182,16 +96,6 @@ def field(
     name: str | None = None,
     is_subscription: bool = False,
     description: str | None = None,
-    authenticated: bool = False,
-    external: bool = False,
-    inaccessible: bool = False,
-    policy: list[list[str]] | None = None,
-    provides: list[str] | None = None,
-    override: Override | str | None = None,
-    requires: list[str] | None = None,
-    requires_scopes: list[list[str]] | None = None,
-    tags: Iterable[str] | None = (),
-    shareable: bool = False,
     permission_classes: list[type[BasePermission]] | None = None,
     deprecation_reason: str | None = None,
     default: Any = dataclasses.MISSING,
@@ -204,55 +108,9 @@ def field(
     # is added in the constructor or not. It is not used to change
     # any behavior at the moment.
     init: Literal[True, False] | None = None,
+    **federation_kwargs: Unpack[FederationFieldParams],
 ) -> Any:
-    from .schema_directives import (
-        Authenticated,
-        External,
-        Inaccessible,
-        Override,
-        Policy,
-        Provides,
-        Requires,
-        RequiresScopes,
-        Shareable,
-        Tag,
-    )
-
-    directives = list(directives or [])
-
-    if authenticated:
-        directives.append(Authenticated())
-
-    if external:
-        directives.append(External())
-
-    if inaccessible:
-        directives.append(Inaccessible())
-
-    if override:
-        directives.append(
-            Override(override_from=override, label=UNSET)
-            if isinstance(override, str)
-            else override
-        )
-
-    if policy:
-        directives.append(Policy(policies=policy))
-
-    if provides:
-        directives.append(Provides(fields=FieldSet(" ".join(provides))))
-
-    if requires:
-        directives.append(Requires(fields=FieldSet(" ".join(requires))))
-
-    if requires_scopes:
-        directives.append(RequiresScopes(scopes=requires_scopes))
-
-    if shareable:
-        directives.append(Shareable())
-
-    if tags:
-        directives.extend(Tag(name=tag) for tag in tags)
+    directives = process_federation_field_directives(directives, **federation_kwargs)
 
     return base_field(  # type: ignore
         resolver=resolver,  # type: ignore

--- a/strawberry/federation/params.py
+++ b/strawberry/federation/params.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from typing_extensions import TypedDict
+
+from strawberry.types.unset import UNSET
+
+from .types import FieldSet
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+    from .schema_directives import Key, Override
+
+
+class FederationFieldParams(TypedDict, total=False):
+    authenticated: bool
+    external: bool
+    inaccessible: bool
+    policy: Sequence[Sequence[str]]
+    provides: Sequence[str]
+    override: Override | str
+    requires: Sequence[str]
+    requires_scopes: Sequence[Sequence[str]]
+    shareable: bool
+    tags: Sequence[str]
+
+
+class FederationInterfaceParams(TypedDict, total=False):
+    keys: Sequence[Key | str]
+    authenticated: bool
+    inaccessible: bool
+    policy: Sequence[Sequence[str]]
+    requires_scopes: Sequence[Sequence[str]]
+    tags: Sequence[str]
+
+
+class FederationTypeParams(FederationInterfaceParams, total=False):
+    extend: bool
+    shareable: bool
+
+
+def process_federation_field_directives(
+    directives: Sequence[object] | None,
+    *,
+    authenticated: bool = False,
+    external: bool = False,
+    inaccessible: bool = False,
+    policy: Sequence[Sequence[str]] | None = None,
+    provides: Sequence[str] | None = None,
+    override: Override | str | None = None,
+    requires: Sequence[str] | None = None,
+    requires_scopes: Sequence[Sequence[str]] | None = None,
+    shareable: bool = False,
+    tags: Sequence[str] | None = None,
+) -> list[object]:
+    from .schema_directives import (
+        Authenticated,
+        External,
+        Inaccessible,
+        Policy,
+        Provides,
+        Requires,
+        RequiresScopes,
+        Shareable,
+        Tag,
+    )
+    from .schema_directives import (
+        Override as OverrideDirective,
+    )
+
+    result = list(directives or [])
+
+    if authenticated:
+        result.append(Authenticated())
+
+    if external:
+        result.append(External())
+
+    if inaccessible:
+        result.append(Inaccessible())
+
+    if override:
+        result.append(
+            OverrideDirective(override_from=override, label=UNSET)
+            if isinstance(override, str)
+            else override
+        )
+
+    if policy:
+        result.append(Policy(policies=[list(p) for p in policy]))
+
+    if provides:
+        result.append(Provides(fields=FieldSet(" ".join(provides))))
+
+    if requires:
+        result.append(Requires(fields=FieldSet(" ".join(requires))))
+
+    if requires_scopes:
+        result.append(RequiresScopes(scopes=[list(s) for s in requires_scopes]))
+
+    if shareable:
+        result.append(Shareable())
+
+    if tags:
+        result.extend(Tag(name=tag) for tag in tags)
+
+    return result
+
+
+def process_federation_type_directives(
+    directives: Iterable[object] | None,
+    *,
+    keys: Iterable[Key | str] = (),
+    extend: bool = False,
+    shareable: bool = False,
+    inaccessible: bool = False,
+    authenticated: bool = False,
+    policy: Sequence[Sequence[str]] | None = None,
+    requires_scopes: Sequence[Sequence[str]] | None = None,
+    tags: Sequence[str] = (),
+) -> tuple[list[object], bool]:
+    from .schema_directives import (
+        Authenticated,
+        Inaccessible,
+        Policy,
+        RequiresScopes,
+        Shareable,
+        Tag,
+    )
+    from .schema_directives import (
+        Key as KeyDirective,
+    )
+
+    result = list(directives or [])
+
+    result.extend(
+        KeyDirective(fields=FieldSet(key), resolvable=UNSET)
+        if isinstance(key, str)
+        else key
+        for key in keys
+    )
+
+    if authenticated:
+        result.append(Authenticated())
+
+    if inaccessible:
+        result.append(Inaccessible())
+
+    if policy:
+        result.append(Policy(policies=[list(p) for p in policy]))
+
+    if requires_scopes:
+        result.append(RequiresScopes(scopes=[list(s) for s in requires_scopes]))
+
+    if shareable:
+        result.append(Shareable())
+
+    if tags:
+        result.extend(Tag(name=tag) for tag in tags)
+
+    return result, extend
+
+
+__all__ = [
+    "FederationFieldParams",
+    "FederationInterfaceParams",
+    "FederationTypeParams",
+    "process_federation_field_directives",
+    "process_federation_type_directives",
+]


### PR DESCRIPTION
## Summary

- Add `strawberry.federation.params` module with `FederationFieldParams`, `FederationInterfaceParams`, and `FederationTypeParams` TypedDicts consumable via `Unpack[...]`
- Extract `process_federation_field_directives()` and `process_federation_type_directives()` from inline logic in `field.py` and `object_type.py`
- Fix `inaccessible` bug in `_impl_type` where `inaccessible=False` incorrectly added the `Inaccessible` directive

## Summary by Sourcery

Introduce shared federation parameter definitions and directive-processing helpers and refactor field and type decorators to use them while correcting directive handling for inaccessible types.

New Features:
- Add federation parameter TypedDicts for fields, interfaces, and types that can be reused via Unpack[...] across decorators.
- Provide shared helper functions to translate federation parameters into directive instances for fields and types/interfaces.

Bug Fixes:
- Fix incorrect addition of the Inaccessible directive when the inaccessible parameter is explicitly set to False.

Enhancements:
- Refactor federation field and type decorators to delegate directive construction to shared processing helpers, reducing duplication and centralizing logic.

## Summary by Sourcery

Introduce shared federation parameter definitions and directive-processing helpers and refactor federation decorators to use them while correcting inaccessible directive handling.

New Features:
- Add strawberry.federation.params module with reusable TypedDicts for federation field, interface, and type parameters.
- Provide shared helper functions to convert federation parameters into directive instances for fields and types/interfaces.

Bug Fixes:
- Fix incorrect addition of the Inaccessible directive when inaccessible is explicitly set to False on types and interfaces.

Enhancements:
- Refactor federation field, type, and interface decorators to delegate directive construction to shared processing helpers, reducing duplicated logic.

Documentation:
- Document the new federation params module and bug fix in RELEASE.md.