### PR TITLE
Remove deprecated `Extension` import alias

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,21 @@
+Release type: minor
+
+Remove deprecated `Extension` import alias from `strawberry.extensions`, deprecated since [0.160.0](https://github.com/strawberry-graphql/strawberry/releases/tag/0.160.0).
+
+### Migration guide
+
+**Before (deprecated):**
+```python
+from strawberry.extensions import Extension
+
+
+class MyExtension(Extension): ...
+```
+
+**After:**
+```python
+from strawberry.extensions import SchemaExtension
+
+
+class MyExtension(SchemaExtension): ...
+```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,4 @@
+---
 release type: minor
 social_messages:
   x: >-
@@ -8,8 +9,12 @@ social_messages:
     {project_name} {version} is out. This release removes the deprecated
     `Extension` import alias from `strawberry.extensions`, completing a
     deprecation that started in 0.160.0 — use `SchemaExtension` instead.
+---
 
-This release removes the deprecated `Extension` import alias from `strawberry.extensions`, deprecated since [0.160.0](https://github.com/strawberry-graphql/strawberry/releases/tag/0.160.0). Use `SchemaExtension` instead.
+This release adds a cleaner extension API by removing the deprecated `Extension`
+import alias from `strawberry.extensions`. The alias was deprecated in
+[0.160.0](https://github.com/strawberry-graphql/strawberry/releases/tag/0.160.0);
+import `SchemaExtension` instead.
 
 ### Migration guide
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,15 @@
-Release type: minor
+release type: minor
+social_messages:
+  x: >-
+    {project_name} {version} is out! It removes the deprecated `Extension`
+    alias in favor of `SchemaExtension`. 🍓
+    https://strawberry.rocks/release/{version}
+  linkedin: >-
+    {project_name} {version} is out. This release removes the deprecated
+    `Extension` import alias from `strawberry.extensions`, completing a
+    deprecation that started in 0.160.0 — use `SchemaExtension` instead.
 
-Remove deprecated `Extension` import alias from `strawberry.extensions`, deprecated since [0.160.0](https://github.com/strawberry-graphql/strawberry/releases/tag/0.160.0).
+This release removes the deprecated `Extension` import alias from `strawberry.extensions`, deprecated since [0.160.0](https://github.com/strawberry-graphql/strawberry/releases/tag/0.160.0). Use `SchemaExtension` instead.
 
 ### Migration guide
 

--- a/strawberry/extensions/__init__.py
+++ b/strawberry/extensions/__init__.py
@@ -1,5 +1,3 @@
-import warnings
-
 from .add_validation_rules import AddValidationRules
 from .base_extension import LifecycleStep, SchemaExtension
 from .disable_introspection import DisableIntrospection
@@ -12,22 +10,6 @@ from .parser_cache import ParserCache
 from .pydantic_error_extension import PydanticErrorExtension
 from .query_depth_limiter import IgnoreContext, QueryDepthLimiter
 from .validation_cache import ValidationCache
-
-
-def __getattr__(name: str) -> type[SchemaExtension]:
-    if name == "Extension":
-        warnings.warn(
-            (
-                "importing `Extension` from `strawberry.extensions` "
-                "is deprecated, import `SchemaExtension` instead."
-            ),
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return SchemaExtension
-
-    raise AttributeError(f"module {__name__} has no attribute {name}")
-
 
 __all__ = [
     "AddValidationRules",


### PR DESCRIPTION
## Description

Remove the deprecated `Extension` import alias from `strawberry.extensions`, deprecated since [0.160.0](https://github.com/strawberry-graphql/strawberry/releases/tag/0.160.0).

### Migration guide

**Before (deprecated):**
```python
from strawberry.extensions import Extension

class MyExtension(Extension):
    ...
```

**After:**
```python
from strawberry.extensions import SchemaExtension

class MyExtension(SchemaExtension):
    ...
```

## Types of Changes

- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Remove deprecated Extension alias from the extensions module and document the change for release notes.

Enhancements:
- Remove the deprecated Extension import alias in favour of SchemaExtension to complete the deprecation cycle.

Documentation:
- Add release notes outlining the removal of the Extension alias and providing a migration guide.