### PR TITLE
Remove deprecated extension legacy hooks

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,22 @@
+Release type: minor
+
+Remove deprecated extension legacy hooks (`on_request_start`, `on_request_end`, `on_validation_start`, `on_validation_end`, `on_parsing_start`, `on_parsing_end`), deprecated since [0.159.0](https://github.com/strawberry-graphql/strawberry/releases/tag/0.159.0).
+
+### Migration guide
+
+**Before (deprecated):**
+```python
+class MyExtension(SchemaExtension):
+    def on_request_start(self): ...
+
+    def on_request_end(self): ...
+```
+
+**After:**
+```python
+class MyExtension(SchemaExtension):
+    def on_operation(self):
+        # on_request_start logic
+        yield
+        # on_request_end logic
+```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
 Release type: minor
 
-Remove deprecated extension legacy hooks (`on_request_start`, `on_request_end`, `on_validation_start`, `on_validation_end`, `on_parsing_start`, `on_parsing_end`), deprecated since [0.159.0](https://github.com/strawberry-graphql/strawberry/releases/tag/0.159.0).
+Remove deprecated legacy extension hooks (`on_request_start`, `on_request_end`, `on_validation_start`, `on_validation_end`, `on_parsing_start`, `on_parsing_end`), deprecated since [0.159.0](https://github.com/strawberry-graphql/strawberry/releases/tag/0.159.0).
 
 ### Migration guide
 

--- a/strawberry/extensions/context.py
+++ b/strawberry/extensions/context.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import contextlib
 import inspect
 import types
-import warnings
 from asyncio import iscoroutinefunction
 from typing import (
     TYPE_CHECKING,
@@ -12,13 +11,13 @@ from typing import (
 )
 
 from strawberry.extensions import SchemaExtension
-from strawberry.utils.await_maybe import AwaitableOrValue, await_maybe
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Callable, Iterator
     from types import TracebackType
 
     from strawberry.extensions.base_extension import Hook
+    from strawberry.utils.await_maybe import AwaitableOrValue
 
 
 class WrappedHook(NamedTuple):
@@ -35,22 +34,11 @@ class ExtensionContextManagerBase:
     __slots__ = (
         "async_exit_stack",
         "default_hook",
-        "deprecation_message",
         "exit_stack",
         "hooks",
     )
 
-    def __init_subclass__(cls) -> None:
-        cls.DEPRECATION_MESSAGE = (
-            f"Event driven styled extensions for "
-            f"{cls.LEGACY_ENTER} or {cls.LEGACY_EXIT}"
-            f" are deprecated, use {cls.HOOK_NAME} instead"
-        )
-
     HOOK_NAME: str
-    DEPRECATION_MESSAGE: str
-    LEGACY_ENTER: str
-    LEGACY_EXIT: str
 
     def __init__(self, extensions: list[SchemaExtension]) -> None:
         self.hooks: list[WrappedHook] = []
@@ -61,20 +49,8 @@ class ExtensionContextManagerBase:
                 self.hooks.append(hook)
 
     def get_hook(self, extension: SchemaExtension) -> WrappedHook | None:
-        on_start = getattr(extension, self.LEGACY_ENTER, None)
-        on_end = getattr(extension, self.LEGACY_EXIT, None)
-
-        is_legacy = on_start is not None or on_end is not None
         hook_fn: Hook | None = getattr(type(extension), self.HOOK_NAME)
         hook_fn = hook_fn if hook_fn is not self.default_hook else None
-        if is_legacy and hook_fn is not None:
-            raise ValueError(
-                f"{extension} defines both legacy and new style extension hooks for "
-                "{self.HOOK_NAME}"
-            )
-        if is_legacy:
-            warnings.warn(self.DEPRECATION_MESSAGE, DeprecationWarning, stacklevel=3)
-            return self.from_legacy(extension, on_start, on_end)
 
         if hook_fn:
             if inspect.isgeneratorfunction(hook_fn):
@@ -102,38 +78,6 @@ class ExtensionContextManagerBase:
             )
 
         return None  # Current extension does not define a hook for this lifecycle stage
-
-    @staticmethod
-    def from_legacy(
-        extension: SchemaExtension,
-        on_start: Callable[[], None] | None = None,
-        on_end: Callable[[], None] | None = None,
-    ) -> WrappedHook:
-        if iscoroutinefunction(on_start) or iscoroutinefunction(on_end):
-
-            @contextlib.asynccontextmanager
-            async def iterator() -> AsyncIterator:
-                if on_start:
-                    await await_maybe(on_start())
-
-                yield
-
-                if on_end:
-                    await await_maybe(on_end())
-
-            return WrappedHook(extension=extension, hook=iterator, is_async=True)
-
-        @contextlib.contextmanager
-        def iterator_async() -> Iterator[None]:
-            if on_start:
-                on_start()
-
-            yield
-
-            if on_end:
-                on_end()
-
-        return WrappedHook(extension=extension, hook=iterator_async, is_async=False)
 
     @staticmethod
     def from_callable(
@@ -199,23 +143,15 @@ class ExtensionContextManagerBase:
 
 class OperationContextManager(ExtensionContextManagerBase):
     HOOK_NAME = SchemaExtension.on_operation.__name__
-    LEGACY_ENTER = "on_request_start"
-    LEGACY_EXIT = "on_request_end"
 
 
 class ValidationContextManager(ExtensionContextManagerBase):
     HOOK_NAME = SchemaExtension.on_validate.__name__
-    LEGACY_ENTER = "on_validation_start"
-    LEGACY_EXIT = "on_validation_end"
 
 
 class ParsingContextManager(ExtensionContextManagerBase):
     HOOK_NAME = SchemaExtension.on_parse.__name__
-    LEGACY_ENTER = "on_parsing_start"
-    LEGACY_EXIT = "on_parsing_end"
 
 
 class ExecutingContextManager(ExtensionContextManagerBase):
     HOOK_NAME = SchemaExtension.on_execute.__name__
-    LEGACY_ENTER = "on_executing_start"
-    LEGACY_EXIT = "on_executing_end"


### PR DESCRIPTION
## Description

Remove deprecated extension legacy hooks (`on_request_start`, `on_request_end`, `on_validation_start`, `on_validation_end`, `on_parsing_start`, `on_parsing_end`), deprecated since [0.159.0](https://github.com/strawberry-graphql/strawberry/releases/tag/0.159.0).

### Migration guide

**Before (deprecated):**
```python
class MyExtension(SchemaExtension):
    def on_request_start(self):
        ...

    def on_request_end(self):
        ...
```

**After:**
```python
class MyExtension(SchemaExtension):
    def on_operation(self):
        # on_request_start logic
        yield
        # on_request_end logic
```

## Types of Changes

- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Remove support for legacy extension lifecycle hooks in favour of the new event-driven hooks.

Enhancements:
- Simplify extension context managers to only handle the new hook API and drop legacy compatibility paths, including mixed legacy/new validation.

Documentation:
- Add release notes and migration guide for removing deprecated extension legacy hooks.

Tests:
- Remove tests for legacy hook behaviour and update references to the new hook names in existing tests.