### PR TITLE
Fix codegen crash with directive definitions and non-string args

### DIFF
--- a/strawberry/schema_codegen/__init__.py
+++ b/strawberry/schema_codegen/__init__.py
@@ -70,35 +70,39 @@ _SCALAR_MAP = {
     "DateTime": cst.Name("datetime"),
 }
 
-_FEDERATION_DIRECTIVE_NAMES = frozenset({
-    "key",
-    "shareable",
-    "inaccessible",
-    "external",
-    "authenticated",
-    "override",
-    "requires",
-    "provides",
-    "tag",
-    "requiresScopes",
-    "policy",
-    "link",
-    "specifiedBy",
-})
+_FEDERATION_DIRECTIVE_NAMES = frozenset(
+    {
+        "key",
+        "shareable",
+        "inaccessible",
+        "external",
+        "authenticated",
+        "override",
+        "requires",
+        "provides",
+        "tag",
+        "requiresScopes",
+        "policy",
+        "link",
+        "specifiedBy",
+    }
+)
 
-_STRAWBERRY_LOCATION_NAMES = frozenset({
-    "SCHEMA",
-    "SCALAR",
-    "OBJECT",
-    "FIELD_DEFINITION",
-    "ARGUMENT_DEFINITION",
-    "INTERFACE",
-    "UNION",
-    "ENUM",
-    "ENUM_VALUE",
-    "INPUT_OBJECT",
-    "INPUT_FIELD_DEFINITION",
-})
+_STRAWBERRY_LOCATION_NAMES = frozenset(
+    {
+        "SCHEMA",
+        "SCALAR",
+        "OBJECT",
+        "FIELD_DEFINITION",
+        "ARGUMENT_DEFINITION",
+        "INTERFACE",
+        "UNION",
+        "ENUM",
+        "ENUM_VALUE",
+        "INPUT_OBJECT",
+        "INPUT_FIELD_DEFINITION",
+    }
+)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -1096,9 +1100,7 @@ def _get_directive_definition(
             )
 
     if not body_lines:
-        body_lines.append(
-            cst.SimpleStatementLine(body=[cst.Expr(cst.Name("pass"))])
-        )
+        body_lines.append(cst.SimpleStatementLine(body=[cst.Expr(cst.Name("pass"))]))
 
     class_definition = cst.ClassDef(
         name=cst.Name(class_name),

--- a/strawberry/schema_codegen/__init__.py
+++ b/strawberry/schema_codegen/__init__.py
@@ -40,7 +40,7 @@ from graphql.language.ast import (
     NullValueNode,
 )
 
-from strawberry.utils.str_converters import to_snake_case
+from strawberry.utils.str_converters import capitalize_first, to_snake_case
 
 if TYPE_CHECKING:
     from graphql.language.ast import ConstDirectiveNode
@@ -69,6 +69,36 @@ _SCALAR_MAP = {
     "Time": cst.Name("time"),
     "DateTime": cst.Name("datetime"),
 }
+
+_FEDERATION_DIRECTIVE_NAMES = frozenset({
+    "key",
+    "shareable",
+    "inaccessible",
+    "external",
+    "authenticated",
+    "override",
+    "requires",
+    "provides",
+    "tag",
+    "requiresScopes",
+    "policy",
+    "link",
+    "specifiedBy",
+})
+
+_STRAWBERRY_LOCATION_NAMES = frozenset({
+    "SCHEMA",
+    "SCALAR",
+    "OBJECT",
+    "FIELD_DEFINITION",
+    "ARGUMENT_DEFINITION",
+    "INTERFACE",
+    "UNION",
+    "ENUM",
+    "ENUM_VALUE",
+    "INPUT_OBJECT",
+    "INPUT_FIELD_DEFINITION",
+})
 
 
 @dataclasses.dataclass(frozen=True)
@@ -283,6 +313,7 @@ def _get_field_value(
     imports: set[Import],
     *,
     default_value: cst.BaseExpression | None = None,
+    directive_definitions: dict[str, str] | None = None,
 ) -> cst.Call | cst.BaseExpression | None:
     description = field.description.value if field.description else None
 
@@ -299,6 +330,13 @@ def _get_field_value(
     directives = _get_directives(field)
 
     apollo_federation_args = _get_federation_arguments(directives, imports)
+
+    if directive_definitions:
+        non_fed_directives_arg = _get_non_federation_directives_arg(
+            directives, directive_definitions
+        )
+        if non_fed_directives_arg is not None:
+            args.append(non_fed_directives_arg)
 
     default_arg = (
         cst.Arg(
@@ -349,6 +387,7 @@ def _get_field(
     imports: set[Import],
     *,
     is_input_field: bool = False,
+    directive_definitions: dict[str, str] | None = None,
 ) -> cst.SimpleStatementLine:
     name = to_snake_case(field.name.value)
     alias: str | None = None
@@ -386,6 +425,7 @@ def _get_field(
                     is_apollo_federation=is_apollo_federation,
                     imports=imports,
                     default_value=default_value,
+                    directive_definitions=directive_definitions,
                 ),
             )
         ]
@@ -512,6 +552,52 @@ def _get_federation_arguments(
     return arguments
 
 
+def _get_non_federation_directives_arg(
+    directives: dict[str, list[dict[str, ArgumentValue]]],
+    directive_definitions: dict[str, str],
+) -> cst.Arg | None:
+    directive_calls: list[cst.Element] = []
+
+    for directive_name, applications in directives.items():
+        if directive_name not in directive_definitions:
+            continue
+
+        class_name = directive_definitions[directive_name]
+
+        for application in applications:
+            call_args = []
+            for arg_name, arg_value in application.items():
+                kwarg_name = to_snake_case(arg_name)
+                if keyword.iskeyword(kwarg_name):
+                    kwarg_name = f"{kwarg_name}_"
+                call_args.append(
+                    cst.Arg(
+                        keyword=cst.Name(kwarg_name),
+                        value=_sanitize_argument(arg_value),
+                        equal=cst.AssignEqual(
+                            cst.SimpleWhitespace(""), cst.SimpleWhitespace("")
+                        ),
+                    )
+                )
+            directive_calls.append(
+                cst.Element(
+                    value=cst.Call(
+                        func=cst.Name(class_name),
+                        args=call_args,
+                    )
+                )
+            )
+
+    if not directive_calls:
+        return None
+
+    return cst.Arg(
+        keyword=cst.Name("directives"),
+        value=cst.List(elements=directive_calls),
+        equal=cst.AssignEqual(cst.SimpleWhitespace(""), cst.SimpleWhitespace("")),
+    )
+
+
 def _get_strawberry_decorator(
     definition: ObjectTypeDefinitionNode
     | ObjectTypeExtensionNode
@@ -519,6 +605,8 @@ def _get_strawberry_decorator(
     | InputObjectTypeDefinitionNode,
     is_apollo_federation: bool,
     imports: set[Import],
+    *,
+    directive_definitions: dict[str, str] | None = None,
 ) -> cst.Decorator:
     type_ = {
         ObjectTypeDefinitionNode: "type",
@@ -559,6 +647,13 @@ def _get_strawberry_decorator(
 
         arguments.extend(federation_arguments)
 
+    if directive_definitions:
+        non_fed_directives_arg = _get_non_federation_directives_arg(
+            directives, directive_definitions
+        )
+        if non_fed_directives_arg is not None:
+            arguments.append(non_fed_directives_arg)
+
     if arguments:
         decorator = cst.Call(
             func=decorator,
@@ -577,8 +672,15 @@ def _get_class_definition(
     | InputObjectTypeDefinitionNode,
     is_apollo_federation: bool,
     imports: set[Import],
+    *,
+    directive_definitions: dict[str, str] | None = None,
 ) -> Definition:
-    decorator = _get_strawberry_decorator(definition, is_apollo_federation, imports)
+    decorator = _get_strawberry_decorator(
+        definition,
+        is_apollo_federation,
+        imports,
+        directive_definitions=directive_definitions,
+    )
 
     interfaces = (
         [interface.name.value for interface in definition.interfaces]
@@ -600,6 +702,7 @@ def _get_class_definition(
                     is_apollo_federation,
                     imports,
                     is_input_field=is_input_type,
+                    directive_definitions=directive_definitions,
                 )
                 for field in definition.fields
             ]
@@ -608,7 +711,25 @@ def _get_class_definition(
         decorators=[decorator],
     )
 
-    return Definition(class_definition, interfaces, definition.name.value)
+    dependencies = list(interfaces)
+
+    if directive_definitions:
+        type_directives = _get_directives(definition)
+        for dir_name in type_directives:
+            if dir_name in directive_definitions:
+                cls = directive_definitions[dir_name]
+                if cls not in dependencies:
+                    dependencies.append(cls)
+
+        for field in definition.fields:
+            field_directives = _get_directives(field)
+            for dir_name in field_directives:
+                if dir_name in directive_definitions:
+                    cls = directive_definitions[dir_name]
+                    if cls not in dependencies:
+                        dependencies.append(cls)
+
+    return Definition(class_definition, dependencies, definition.name.value)
 
 
 def _get_enum_value(enum_value: EnumValueDefinitionNode) -> cst.SimpleStatementLine:
@@ -840,6 +961,156 @@ def _get_scalar_definition(
     return Definition(statement_definition, [], name=definition.name.value)
 
 
+def _get_directive_definition(
+    definition: DirectiveDefinitionNode,
+    imports: set[Import],
+) -> Definition | None:
+    name = definition.name.value
+
+    if name in _FEDERATION_DIRECTIVE_NAMES:
+        return None
+
+    class_name = capitalize_first(name)
+
+    locations = [
+        loc.value
+        for loc in definition.locations
+        if loc.value in _STRAWBERRY_LOCATION_NAMES
+    ]
+
+    if not locations:
+        return None
+
+    location_elements = [
+        cst.Element(
+            value=cst.Attribute(
+                value=cst.Name("Location"),
+                attr=cst.Name(loc),
+            )
+        )
+        for loc in locations
+    ]
+
+    decorator_args: list[cst.Arg] = []
+
+    if definition.description:
+        decorator_args.append(
+            _get_argument("description", definition.description.value)
+        )
+
+    decorator_args.append(
+        cst.Arg(
+            keyword=cst.Name("locations"),
+            value=cst.List(elements=location_elements),
+            equal=cst.AssignEqual(cst.SimpleWhitespace(""), cst.SimpleWhitespace("")),
+        )
+    )
+
+    if definition.repeatable:
+        decorator_args.append(
+            cst.Arg(
+                keyword=cst.Name("repeatable"),
+                value=cst.Name("True"),
+                equal=cst.AssignEqual(
+                    cst.SimpleWhitespace(""), cst.SimpleWhitespace("")
+                ),
+            )
+        )
+
+    decorator = cst.Decorator(
+        decorator=cst.Call(
+            func=cst.Attribute(
+                value=cst.Name("strawberry"),
+                attr=cst.Name("schema_directive"),
+            ),
+            args=decorator_args,
+        ),
+    )
+
+    dependencies: list[str] = []
+    body_lines: list[cst.BaseStatement] = []
+
+    if definition.arguments:
+        for arg in definition.arguments:
+            arg_name = to_snake_case(arg.name.value)
+            alias: str | None = None
+
+            if keyword.iskeyword(arg_name):
+                arg_name = f"{arg_name}_"
+                alias = arg.name.value
+            elif arg_name != arg.name.value:
+                alias = arg.name.value
+
+            field_type_expr = _get_field_type(arg.type)
+
+            base_type = _get_base_type_name(arg.type)
+            if base_type not in _SCALAR_MAP:
+                dependencies.append(base_type)
+
+            default_value: cst.BaseExpression | None = None
+            if arg.default_value is not None:
+                enum_type_name = (
+                    _get_base_type_name(arg.type)
+                    if isinstance(arg.default_value, EnumValueNode)
+                    else None
+                )
+                default_value = _get_default_value_expr(
+                    arg.default_value, enum_type_name=enum_type_name
+                )
+
+            field_value: cst.BaseExpression | None = None
+            if alias is not None:
+                directive_field_args: list[cst.Arg] = [
+                    _get_argument("name", alias),
+                ]
+                if default_value is not None:
+                    directive_field_args.append(
+                        cst.Arg(
+                            keyword=cst.Name("default"),
+                            value=default_value,
+                            equal=cst.AssignEqual(
+                                cst.SimpleWhitespace(""), cst.SimpleWhitespace("")
+                            ),
+                        )
+                    )
+                field_value = cst.Call(
+                    func=cst.Attribute(
+                        value=cst.Name("strawberry"),
+                        attr=cst.Name("directive_field"),
+                    ),
+                    args=directive_field_args,
+                )
+            elif default_value is not None:
+                field_value = default_value
+
+            body_lines.append(
+                cst.SimpleStatementLine(
+                    body=[
+                        cst.AnnAssign(
+                            target=cst.Name(arg_name),
+                            annotation=cst.Annotation(field_type_expr),
+                            value=field_value,
+                        )
+                    ]
+                )
+            )
+
+    if not body_lines:
+        body_lines.append(
+            cst.SimpleStatementLine(body=[cst.Expr(cst.Name("pass"))])
+        )
+
+    class_definition = cst.ClassDef(
+        name=cst.Name(class_name),
+        body=cst.IndentedBlock(body=body_lines),
+        decorators=[decorator],
+    )
+
+    imports.add(Import(module="strawberry.schema_directive", imports=("Location",)))
+
+    return Definition(class_definition, dependencies, class_name)
+
+
 def codegen(schema: str) -> str:
     document = parse(schema)
 
@@ -852,6 +1123,19 @@ def codegen(schema: str) -> str:
     imports: set[Import] = {
         Import(module=None, imports=("strawberry",)),
     }
+
+    # Pre-scan for directive definitions to build name mapping
+    directive_definitions: dict[str, str] = {}
+    for graphql_definition in document.definitions:
+        if isinstance(graphql_definition, DirectiveDefinitionNode):
+            name = graphql_definition.name.value
+            if name not in _FEDERATION_DIRECTIVE_NAMES:
+                has_type_system_location = any(
+                    loc.value in _STRAWBERRY_LOCATION_NAMES
+                    for loc in graphql_definition.locations
+                )
+                if has_type_system_location:
+                    directive_definitions[name] = capitalize_first(name)
 
     # when we encounter a extend schema @link ..., we check if is an apollo federation schema
     # and we use this variable to keep track of it, but at the moment the assumption is that
@@ -872,7 +1156,10 @@ def codegen(schema: str) -> str:
             ),
         ):
             definition = _get_class_definition(
-                graphql_definition, is_apollo_federation, imports
+                graphql_definition,
+                is_apollo_federation,
+                imports,
+                directive_definitions=directive_definitions,
             )
 
         elif isinstance(graphql_definition, EnumTypeDefinitionNode):
@@ -905,7 +1192,7 @@ def codegen(schema: str) -> str:
                 for directive in graphql_definition.directives
             )
         elif isinstance(graphql_definition, DirectiveDefinitionNode):
-            pass
+            definition = _get_directive_definition(graphql_definition, imports)
         else:
             raise NotImplementedError(f"Unknown definition {definition}")
 

--- a/tests/schema_codegen/test_directives.py
+++ b/tests/schema_codegen/test_directives.py
@@ -1,0 +1,397 @@
+import textwrap
+
+from strawberry.schema_codegen import codegen
+
+
+def test_basic_directive_definition():
+    schema = """
+    directive @cached(maxAge: Int!) on FIELD_DEFINITION
+
+    type User {
+        name: String!
+    }
+    """
+
+    expected = textwrap.dedent(
+        """
+        import strawberry
+        from strawberry.schema_directive import Location
+
+        @strawberry.schema_directive(locations=[Location.FIELD_DEFINITION])
+        class Cached:
+            max_age: int = strawberry.directive_field(name="maxAge")
+
+        @strawberry.type
+        class User:
+            name: str
+        """
+    ).strip()
+
+    assert codegen(schema).strip() == expected
+
+
+def test_directive_applied_to_input_field():
+    schema = """
+    directive @limits(max: Int!) on INPUT_FIELD_DEFINITION
+
+    input CreateUserInput {
+        name: String!
+        tags: [String!] @limits(max: 5)
+    }
+    """
+
+    expected = textwrap.dedent(
+        """
+        import strawberry
+        from strawberry.schema_directive import Location
+
+        @strawberry.schema_directive(locations=[Location.INPUT_FIELD_DEFINITION])
+        class Limits:
+            max: int
+
+        @strawberry.input
+        class CreateUserInput:
+            name: str
+            tags: strawberry.Maybe[list[str] | None] = strawberry.field(directives=[Limits(max=5)])
+        """
+    ).strip()
+
+    assert codegen(schema).strip() == expected
+
+
+def test_directive_applied_to_output_type_field():
+    schema = """
+    directive @cached(maxAge: Int!) on FIELD_DEFINITION
+
+    type User {
+        name: String!
+        friends: [String!]! @cached(maxAge: 60)
+    }
+    """
+
+    expected = textwrap.dedent(
+        """
+        import strawberry
+        from strawberry.schema_directive import Location
+
+        @strawberry.schema_directive(locations=[Location.FIELD_DEFINITION])
+        class Cached:
+            max_age: int = strawberry.directive_field(name="maxAge")
+
+        @strawberry.type
+        class User:
+            name: str
+            friends: list[str] = strawberry.field(directives=[Cached(max_age=60)])
+        """
+    ).strip()
+
+    assert codegen(schema).strip() == expected
+
+
+def test_directive_applied_to_type_decorator():
+    schema = """
+    directive @auth(role: String!) on OBJECT
+
+    type User @auth(role: "admin") {
+        id: ID!
+        name: String!
+    }
+    """
+
+    expected = textwrap.dedent(
+        """
+        import strawberry
+        from strawberry.schema_directive import Location
+
+        @strawberry.schema_directive(locations=[Location.OBJECT])
+        class Auth:
+            role: str
+
+        @strawberry.type(directives=[Auth(role="admin")])
+        class User:
+            id: strawberry.ID
+            name: str
+        """
+    ).strip()
+
+    assert codegen(schema).strip() == expected
+
+
+def test_camel_case_argument_names():
+    schema = """
+    directive @rateLimit(maxCalls: Int!, timeWindow: String!) on FIELD_DEFINITION
+
+    type User {
+        name: String!
+    }
+    """
+
+    expected = textwrap.dedent(
+        """
+        import strawberry
+        from strawberry.schema_directive import Location
+
+        @strawberry.schema_directive(locations=[Location.FIELD_DEFINITION])
+        class RateLimit:
+            max_calls: int = strawberry.directive_field(name="maxCalls")
+            time_window: str = strawberry.directive_field(name="timeWindow")
+
+        @strawberry.type
+        class User:
+            name: str
+        """
+    ).strip()
+
+    assert codegen(schema).strip() == expected
+
+
+def test_directive_with_default_values():
+    schema = """
+    directive @cached(maxAge: Int! = 300, scope: String! = "public") on FIELD_DEFINITION
+
+    type User {
+        name: String!
+    }
+    """
+
+    expected = textwrap.dedent(
+        """
+        import strawberry
+        from strawberry.schema_directive import Location
+
+        @strawberry.schema_directive(locations=[Location.FIELD_DEFINITION])
+        class Cached:
+            max_age: int = strawberry.directive_field(name="maxAge", default=300)
+            scope: str = "public"
+
+        @strawberry.type
+        class User:
+            name: str
+        """
+    ).strip()
+
+    assert codegen(schema).strip() == expected
+
+
+def test_repeatable_directive():
+    schema = """
+    directive @label(name: String!) repeatable on OBJECT
+
+    type User {
+        name: String!
+    }
+    """
+
+    expected = textwrap.dedent(
+        """
+        import strawberry
+        from strawberry.schema_directive import Location
+
+        @strawberry.schema_directive(locations=[Location.OBJECT], repeatable=True)
+        class Label:
+            name: str
+
+        @strawberry.type
+        class User:
+            name: str
+        """
+    ).strip()
+
+    assert codegen(schema).strip() == expected
+
+
+def test_multiple_locations():
+    schema = """
+    directive @auth(role: String!) on OBJECT | FIELD_DEFINITION
+
+    type User {
+        name: String!
+    }
+    """
+
+    expected = textwrap.dedent(
+        """
+        import strawberry
+        from strawberry.schema_directive import Location
+
+        @strawberry.schema_directive(locations=[Location.OBJECT, Location.FIELD_DEFINITION])
+        class Auth:
+            role: str
+
+        @strawberry.type
+        class User:
+            name: str
+        """
+    ).strip()
+
+    assert codegen(schema).strip() == expected
+
+
+def test_no_arg_directive():
+    schema = """
+    directive @internal on FIELD_DEFINITION
+
+    type User {
+        name: String!
+    }
+    """
+
+    expected = textwrap.dedent(
+        """
+        import strawberry
+        from strawberry.schema_directive import Location
+
+        @strawberry.schema_directive(locations=[Location.FIELD_DEFINITION])
+        class Internal:
+            pass
+
+        @strawberry.type
+        class User:
+            name: str
+        """
+    ).strip()
+
+    assert codegen(schema).strip() == expected
+
+
+def test_multiple_directives_on_one_field():
+    schema = """
+    directive @cached(maxAge: Int!) on FIELD_DEFINITION
+    directive @auth(role: String!) on FIELD_DEFINITION
+
+    type User {
+        friends: [String!]! @cached(maxAge: 60) @auth(role: "admin")
+    }
+    """
+
+    expected = textwrap.dedent(
+        """
+        import strawberry
+        from strawberry.schema_directive import Location
+
+        @strawberry.schema_directive(locations=[Location.FIELD_DEFINITION])
+        class Cached:
+            max_age: int = strawberry.directive_field(name="maxAge")
+
+        @strawberry.schema_directive(locations=[Location.FIELD_DEFINITION])
+        class Auth:
+            role: str
+
+        @strawberry.type
+        class User:
+            friends: list[str] = strawberry.field(directives=[Cached(max_age=60), Auth(role="admin")])
+        """
+    ).strip()
+
+    assert codegen(schema).strip() == expected
+
+
+def test_directive_with_description():
+    schema = '''
+    """Rate limiting directive"""
+    directive @rateLimit(max: Int!) on FIELD_DEFINITION
+
+    type User {
+        name: String!
+    }
+    '''
+
+    expected = textwrap.dedent(
+        """
+        import strawberry
+        from strawberry.schema_directive import Location
+
+        @strawberry.schema_directive(description="Rate limiting directive", locations=[Location.FIELD_DEFINITION])
+        class RateLimit:
+            max: int
+
+        @strawberry.type
+        class User:
+            name: str
+        """
+    ).strip()
+
+    assert codegen(schema).strip() == expected
+
+
+def test_directive_query_only_location_skipped():
+    """Directives with only execution-time locations should be skipped."""
+    schema = """
+    directive @log on QUERY
+
+    type User {
+        name: String!
+    }
+    """
+
+    expected = textwrap.dedent(
+        """
+        import strawberry
+
+        @strawberry.type
+        class User:
+            name: str
+        """
+    ).strip()
+
+    assert codegen(schema).strip() == expected
+
+
+def test_federation_with_non_federation_directive():
+    """Federation schemas should still generate non-federation directive classes."""
+    schema = """
+    extend schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
+
+    directive @cached(maxAge: Int!) on FIELD_DEFINITION
+
+    type User @key(fields: "id") {
+        id: ID!
+        name: String! @cached(maxAge: 120)
+    }
+    """
+
+    expected = textwrap.dedent(
+        """
+        import strawberry
+        from strawberry.schema_directive import Location
+
+        @strawberry.schema_directive(locations=[Location.FIELD_DEFINITION])
+        class Cached:
+            max_age: int = strawberry.directive_field(name="maxAge")
+
+        @strawberry.federation.type(keys=["id"])
+        class User:
+            id: strawberry.ID
+            name: str = strawberry.field(directives=[Cached(max_age=120)])
+        """
+    ).strip()
+
+    assert codegen(schema).strip() == expected
+
+
+def test_no_arg_directive_applied():
+    """A directive with no args applied to a field generates ClassName() call."""
+    schema = """
+    directive @internal on FIELD_DEFINITION
+
+    type User {
+        secret: String! @internal
+    }
+    """
+
+    expected = textwrap.dedent(
+        """
+        import strawberry
+        from strawberry.schema_directive import Location
+
+        @strawberry.schema_directive(locations=[Location.FIELD_DEFINITION])
+        class Internal:
+            pass
+
+        @strawberry.type
+        class User:
+            secret: str = strawberry.field(directives=[Internal()])
+        """
+    ).strip()
+
+    assert codegen(schema).strip() == expected

--- a/tests/schema_codegen/test_input_types.py
+++ b/tests/schema_codegen/test_input_types.py
@@ -318,7 +318,7 @@ def test_input_field_default_with_description():
 
 
 def test_input_type_with_directive_on_field():
-    """Directive definitions and directives with int args on input fields should not crash."""
+    """Directive definitions and directives with int args on input fields generate directive classes."""
     schema = """
     directive @limits(max: Int!) on INPUT_FIELD_DEFINITION
 
@@ -333,11 +333,16 @@ def test_input_type_with_directive_on_field():
     expected = textwrap.dedent(
         """
         import strawberry
+        from strawberry.schema_directive import Location
+
+        @strawberry.schema_directive(locations=[Location.INPUT_FIELD_DEFINITION])
+        class Limits:
+            max: int
 
         @strawberry.input
         class ConversationMessageInput:
             message: str = strawberry.field(description="The message to send to the conversation.")
-            recordings: strawberry.Maybe[list[str] | None] = strawberry.field(description="Recordings that the model should consider when processing the message.")
+            recordings: strawberry.Maybe[list[str] | None] = strawberry.field(description="Recordings that the model should consider when processing the message.", directives=[Limits(max=10)])
         """
     ).strip()
 

--- a/tests/schema_codegen/test_input_types.py
+++ b/tests/schema_codegen/test_input_types.py
@@ -315,3 +315,30 @@ def test_input_field_default_with_description():
     ).strip()
 
     assert codegen(schema).strip() == expected
+
+
+def test_input_type_with_directive_on_field():
+    """Directive definitions and directives with int args on input fields should not crash."""
+    schema = """
+    directive @limits(max: Int!) on INPUT_FIELD_DEFINITION
+
+    input ConversationMessageInput {
+        "The message to send to the conversation."
+        message: String!
+        "Recordings that the model should consider when processing the message."
+        recordings: [String!] @limits(max: 10)
+    }
+    """
+
+    expected = textwrap.dedent(
+        """
+        import strawberry
+
+        @strawberry.input
+        class ConversationMessageInput:
+            message: str = strawberry.field(description="The message to send to the conversation.")
+            recordings: strawberry.Maybe[list[str] | None] = strawberry.field(description="Recordings that the model should consider when processing the message.")
+        """
+    ).strip()
+
+    assert codegen(schema).strip() == expected


### PR DESCRIPTION
## Summary
I've been using your library and the codegen from a schema and ran in to an issue when using custom directives. I added a failing test case and got an AI to write the fix. I've looked at it myself and it seems to make sense.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Handle directive definitions and non-string directive argument values in schema code generation to prevent crashes when processing input type fields.

Bug Fixes:
- Prevent codegen from raising NotImplementedError when encountering DirectiveDefinitionNode entries in the schema.
- Ensure directive arguments with enum, int, float, and null literal values are correctly parsed and no longer crash codegen.

Enhancements:
- Extend argument sanitization and type aliasing to support int, float, None, and nested lists of these values in generated code.

Tests:
- Add regression test for input types with a directive on a field using an int argument to verify codegen succeeds.