### PR TITLE
fix: resolve Annotated union inside generic subclass

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+Fix `Annotated[Union[A, B], strawberry.union("Name")]` raising `TypeError` when
+used as a type parameter in a generic subclass (e.g., `class Items(Listing[ItemResponse])`).

--- a/strawberry/types/base.py
+++ b/strawberry/types/base.py
@@ -4,12 +4,14 @@ import dataclasses
 from abc import ABC, abstractmethod
 from typing import (
     TYPE_CHECKING,
+    Annotated,
     Any,
     ClassVar,
     Generic,
     Literal,
     TypeGuard,
     TypeVar,
+    get_origin,
     overload,
 )
 from typing_extensions import Protocol, Self, deprecated
@@ -131,6 +133,11 @@ class StrawberryContainer(StrawberryType):
             isinstance(self.of_type, StrawberryType) and self.of_type.is_graphql_generic
         ):
             of_type_copy = self.of_type.copy_with(type_var_map)
+
+        if get_origin(of_type_copy) is Annotated:
+            from strawberry.annotation import StrawberryAnnotation
+
+            of_type_copy = StrawberryAnnotation(of_type_copy).resolve()
 
         return type(self)(of_type_copy)
 


### PR DESCRIPTION
## Summary

- Fix #4207 — `Annotated[Union[A, B], strawberry.union("Name")]` raises `TypeError` when used as a type parameter in a generic subclass (e.g., `class Items(Listing[ItemResponse])`)
- Root cause: `StrawberryContainer.copy_with()` returns the raw `Annotated` wrapper from the type var map without resolving it, so the schema converter hits an unresolved type
- Added a check in `copy_with()` to resolve `Annotated` types via `StrawberryAnnotation` after type var substitution

## Test plan

- [x] Added regression test `test_annotated_union_inside_generic_subclass`
- [x] Verified test fails before fix and passes after
- [x] Ran `test_union.py`, `test_generic_objects.py`, `test_generics.py` — all 85 tests pass

## Summary by Sourcery

Resolve failures when using annotated unions as type parameters in generic subclasses and add a regression test to cover this scenario.

Bug Fixes:
- Fix handling of Annotated union types within generic subclasses so schema construction no longer raises a TypeError.

Tests:
- Add regression test ensuring Annotated unions used as generic subclass parameters work correctly in queries.