### PR TITLE
ci: Fix nox parametrize 'ids' conflict in noxfile

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -1,4 +1,3 @@
-import functools
 import itertools
 from collections.abc import Callable
 from typing import Any
@@ -60,7 +59,7 @@ def with_gql_core_parametrize(name: str, params: list[str]) -> Callable[[Any], A
     arg_names = f"{name}, gql_core"
     combinations = list(itertools.product(params, GQL_CORE_VERSIONS))
     ids = [f"{name}-{comb[0]}__graphql-core-{comb[1]}" for comb in combinations]
-    return functools.partial(nox.parametrize, arg_names, combinations, ids=ids)
+    return nox.parametrize(arg_names, combinations, ids=ids)
 
 
 @session(python=PYTHON_VERSIONS, name="Tests", tags=["tests"])


### PR DESCRIPTION
## Summary

- `with_gql_core_parametrize` used `functools.partial(nox.parametrize, names, values, ids=ids)` which breaks when applied as a decorator — the decorated function fills the `ids` positional parameter while `ids=ids` provides it again as a keyword, causing `TypeError: parametrize_decorator() got multiple values for argument 'ids'`
- Fix: call `nox.parametrize(...)` directly and return the decorator

## Test plan

- [ ] Nox sessions load without `TypeError`
- [ ] CI passes

## Summary by Sourcery

Bug Fixes:
- Correct nox parametrization helper to return the decorator directly instead of a functools.partial that passed duplicate ids arguments.