### PR TITLE
ci: Fix typechecker tests failing on Python 3.14

### DIFF
--- a/tests/typecheckers/utils/mypy.py
+++ b/tests/typecheckers/utils/mypy.py
@@ -52,8 +52,11 @@ def run_mypy(code: str, strict: bool = True) -> list[Result]:
         module_path = pathlib.Path(directory) / "mypy_test.py"
         module_path.write_text(code)
 
+        config_path = pathlib.Path(directory) / "mypy.ini"
+        config_path.write_text("[mypy]\n")
+
         process_result = subprocess.run(
-            [*args, str(module_path)],
+            [*args, "--config-file", str(config_path), str(module_path)],
             check=False,
             capture_output=True,
             env={


### PR DESCRIPTION
## Summary

- Typechecker tests were autodiscovering the project's `mypy.ini` which loads `strawberry.ext.mypy_plugin`. On Python 3.14, the plugin's pydantic V1 compat code fails to import, breaking all 34 mypy-based tests.
- Fix: write a minimal `mypy.ini` in the temp directory and pass `--config-file` so tests are isolated from the project config.

## Test plan

- [ ] `tests/typecheckers/` pass on Python 3.14
- [ ] `tests/typecheckers/` still pass on Python 3.12/3.13

## Summary by Sourcery

Tests:
- Update mypy test helper to write a minimal local mypy.ini and invoke mypy with --config-file so typechecker tests no longer pick up the project-level config.