### PR TITLE
docs: fix incorrect type annotation in schema extensions resolve example

### DIFF
--- a/docs/guides/custom-extensions.md
+++ b/docs/guides/custom-extensions.md
@@ -39,11 +39,12 @@ check out [field extensions](field-extensions.md).
 Note that `resolve` can also be implemented asynchronously.
 
 ```python
+from graphql import GraphQLResolveInfo
 from strawberry.extensions import SchemaExtension
 
 
 class MyExtension(SchemaExtension):
-    def resolve(self, _next, root, info: strawberry.Info, *args, **kwargs):
+    def resolve(self, _next, root, info: GraphQLResolveInfo, *args, **kwargs):
         return _next(root, info, *args, **kwargs)
 ```
 


### PR DESCRIPTION
## Description

The `resolve` method example in the schema extensions documentation incorrectly showed `info: strawberry.Info` as the type annotation. In practice, `SchemaExtension.resolve` is used as graphql-core middleware and receives a `GraphQLResolveInfo` object, not Strawberry's `Info` wrapper.

This was causing confusion for users trying to follow the docs, as the actual type signature in `strawberry/extensions/base_extension.py` uses `info: GraphQLResolveInfo`.

## Types of Changes
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR
N/A

## Checklist
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Documentation:
- Update the custom extensions guide to show SchemaExtension.resolve receiving GraphQLResolveInfo instead of strawberry.Info, adding the appropriate import in the example.