### PR TITLE
feat: allow passing config as a TypedDict to Schema

### DIFF
--- a/strawberry/federation/schema.py
+++ b/strawberry/federation/schema.py
@@ -7,7 +7,6 @@ from typing import (
     Any,
     Literal,
     NewType,
-    Optional,
     Union,
     cast,
 )

--- a/strawberry/federation/schema.py
+++ b/strawberry/federation/schema.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
 
     from strawberry.extensions import SchemaExtension
     from strawberry.federation.schema_directives import ComposeDirective
-    from strawberry.schema.config import StrawberryConfig
+    from strawberry.schema.config import StrawberryConfig, StrawberryConfigDict
     from strawberry.schema_directive import StrawberrySchemaDirective
     from strawberry.types.enum import StrawberryEnumDefinition
 
@@ -55,7 +55,7 @@ class Schema(BaseSchema):
         types: Iterable[type] = (),
         extensions: Iterable[Union[type["SchemaExtension"], "SchemaExtension"]] = (),
         execution_context_class: type["GraphQLExecutionContext"] | None = None,
-        config: Optional["StrawberryConfig"] = None,
+        config: StrawberryConfig | StrawberryConfigDict | None = None,
         scalar_overrides: dict[object, Union[type, "ScalarWrapper", "ScalarDefinition"]]
         | None = None,
         schema_directives: Iterable[object] = (),

--- a/strawberry/schema/config.py
+++ b/strawberry/schema/config.py
@@ -17,6 +17,19 @@ class BatchingConfig(TypedDict):
     max_operations: int
 
 
+class StrawberryConfigDict(TypedDict, total=False):
+    auto_camel_case: bool
+    name_converter: NameConverter
+    default_resolver: Callable[[Any, str], object]
+    relay_max_results: int
+    relay_use_legacy_global_id: bool
+    disable_field_suggestions: bool
+    info_class: type[Info]
+    enable_experimental_incremental_execution: bool
+    scalar_map: Mapping[object, ScalarDefinition]
+    batching_config: BatchingConfig | None
+
+
 @dataclass
 class StrawberryConfig:
     """Configuration for a Strawberry GraphQL schema.
@@ -59,4 +72,4 @@ class StrawberryConfig:
             raise TypeError("`info_class` must be a subclass of strawberry.Info")
 
 
-__all__ = ["StrawberryConfig"]
+__all__ = ["StrawberryConfig", "StrawberryConfigDict"]

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -76,7 +76,7 @@ from ._graphql_core import (
     subscribe,
 )
 from .base import BaseSchema
-from .config import StrawberryConfig
+from .config import StrawberryConfig, StrawberryConfigDict
 from .exceptions import CannotGetOperationTypeError, InvalidOperationTypeError
 
 if TYPE_CHECKING:
@@ -216,7 +216,7 @@ class Schema(BaseSchema):
         types: Iterable[type | StrawberryType] = (),
         extensions: Iterable[type[SchemaExtension] | SchemaExtension] = (),
         execution_context_class: type[GraphQLExecutionContext] | None = None,
-        config: StrawberryConfig | None = None,
+        config: StrawberryConfig | StrawberryConfigDict | None = None,
         scalar_overrides: (
             Mapping[object, type | ScalarWrapper | ScalarDefinition] | None
         ) = None,
@@ -266,7 +266,10 @@ class Schema(BaseSchema):
         self.execution_context_class = (
             execution_context_class or StrawberryGraphQLCoreExecutionContext
         )
-        self.config = config or StrawberryConfig()
+        if isinstance(config, dict):
+            self.config = StrawberryConfig(**config)
+        else:
+            self.config = config or StrawberryConfig()
 
         self.schema_converter = GraphQLCoreConverter(
             self.config,


### PR DESCRIPTION
This PR allows passing the schema configuration as a dictionary (TypedDict) to the `strawberry.Schema` constructor, as suggested in #2942.

### Changes:
- Added `StrawberryConfigDict` TypedDict in `strawberry/schema/config.py`.
- Updated `strawberry.Schema` to accept `StrawberryConfigDict` and convert it to `StrawberryConfig` internally.

Example usage:
```python
import strawberry

schema = strawberry.Schema(query=Query, config={"auto_camel_case": False})
```

Fixes #2942

## Summary by Sourcery

Allow passing schema configuration as a TypedDict to the Strawberry Schema constructor.

New Features:
- Support providing schema configuration as a StrawberryConfigDict TypedDict when constructing a Schema.

Enhancements:
- Expose the new StrawberryConfigDict TypedDict in the schema config module exports.