### PR TITLE
Fix error type when field with resolver= lacks type annotations

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Raise `MissingFieldAnnotationError` instead of `MissingReturnAnnotationError` when a field using `strawberry.field(resolver=...)` is missing both a type annotation and a resolver return type.

--- a/strawberry/types/object_type.py
+++ b/strawberry/types/object_type.py
@@ -78,6 +78,23 @@ def _check_field_annotations(cls: builtins.type[Any]) -> None:
                 # TODO: Maybe check this immediately when adding resolver to
                 #       field
                 if field_.base_resolver.type_annotation is None:
+                    # Distinguish between @strawberry.field decorator usage
+                    # and strawberry.field(resolver=fn) assignment. For the
+                    # latter, MissingFieldAnnotationError is more helpful
+                    # since the user should annotate the field directly.
+                    resolver_func = field_.base_resolver.wrapped_func
+                    resolver_defined_separately = any(
+                        v is resolver_func
+                        for k, v in cls.__dict__.items()
+                        if k != field_name
+                        and callable(v)
+                        and not isinstance(v, StrawberryField)
+                    )
+                    if (
+                        resolver_defined_separately
+                        or field_name != field_.base_resolver.name
+                    ):
+                        raise MissingFieldAnnotationError(field_name, cls)
                     raise MissingReturnAnnotationError(
                         field_name, resolver=field_.base_resolver
                     )

--- a/strawberry/types/object_type.py
+++ b/strawberry/types/object_type.py
@@ -84,8 +84,7 @@ def _check_field_annotations(cls: builtins.type[Any]) -> None:
                     resolver_defined_separately = any(
                         v is resolver_func
                         for k, v in cls.__dict__.items()
-                        if k != field_name
-                        and not isinstance(v, StrawberryField)
+                        if k != field_name and not isinstance(v, StrawberryField)
                     )
                     if (
                         resolver_defined_separately

--- a/strawberry/types/object_type.py
+++ b/strawberry/types/object_type.py
@@ -80,16 +80,10 @@ def _check_field_annotations(cls: builtins.type[Any]) -> None:
                 if field_.base_resolver.type_annotation is None:
                     # Distinguish @strawberry.field decorator from explicit
                     # strawberry.field(resolver=fn) assignment.
-                    resolver_func = field_.base_resolver.wrapped_func
-                    resolver_defined_separately = any(
-                        v is resolver_func
-                        for k, v in cls.__dict__.items()
-                        if k != field_name and not isinstance(v, StrawberryField)
+                    resolver_qualname = getattr(
+                        field_.base_resolver.wrapped_func, "__qualname__", ""
                     )
-                    if (
-                        resolver_defined_separately
-                        or field_name != field_.base_resolver.name
-                    ):
+                    if resolver_qualname != f"{cls.__qualname__}.{field_name}":
                         raise MissingFieldAnnotationError(field_name, cls)
                     raise MissingReturnAnnotationError(
                         field_name, resolver=field_.base_resolver

--- a/strawberry/types/object_type.py
+++ b/strawberry/types/object_type.py
@@ -78,16 +78,13 @@ def _check_field_annotations(cls: builtins.type[Any]) -> None:
                 # TODO: Maybe check this immediately when adding resolver to
                 #       field
                 if field_.base_resolver.type_annotation is None:
-                    # Distinguish between @strawberry.field decorator usage
-                    # and strawberry.field(resolver=fn) assignment. For the
-                    # latter, MissingFieldAnnotationError is more helpful
-                    # since the user should annotate the field directly.
+                    # Distinguish @strawberry.field decorator from explicit
+                    # strawberry.field(resolver=fn) assignment.
                     resolver_func = field_.base_resolver.wrapped_func
                     resolver_defined_separately = any(
                         v is resolver_func
                         for k, v in cls.__dict__.items()
                         if k != field_name
-                        and callable(v)
                         and not isinstance(v, StrawberryField)
                     )
                     if (

--- a/tests/fields/test_resolvers.py
+++ b/tests/fields/test_resolvers.py
@@ -145,6 +145,24 @@ def test_raises_field_error_when_using_untyped_explicit_resolver():
 
 
 @pytest.mark.raises_strawberry_exception(
+    MissingFieldAnnotationError,
+    match=(
+        'Unable to determine the type of field "goodbye". Either annotate it '
+        "directly, or provide a typed resolver using @strawberry.field."
+    ),
+)
+def test_raises_field_error_when_using_external_untyped_resolver():
+    """Resolver defined outside the class should raise MissingFieldAnnotationError."""
+
+    def adios(self):
+        return -1
+
+    @strawberry.type
+    class Query:
+        goodbye = strawberry.field(resolver=adios)
+
+
+@pytest.mark.raises_strawberry_exception(
     MissingReturnAnnotationError,
     match='Return annotation missing for field "goodbye", did you forget to add it?',
 )

--- a/tests/fields/test_resolvers.py
+++ b/tests/fields/test_resolvers.py
@@ -129,10 +129,13 @@ def test_raises_error_when_return_annotation_missing_async_function():
 
 
 @pytest.mark.raises_strawberry_exception(
-    MissingReturnAnnotationError,
-    match='Return annotation missing for field "goodbye", did you forget to add it?',
+    MissingFieldAnnotationError,
+    match=(
+        'Unable to determine the type of field "goodbye". Either annotate it '
+        "directly, or provide a typed resolver using @strawberry.field."
+    ),
 )
-def test_raises_error_when_return_annotation_missing_resolver():
+def test_raises_field_error_when_using_untyped_explicit_resolver():
     @strawberry.type
     class Query2:
         def adios(self):

--- a/tests/fields/test_resolvers.py
+++ b/tests/fields/test_resolvers.py
@@ -145,6 +145,36 @@ def test_raises_field_error_when_using_untyped_explicit_resolver():
 
 
 @pytest.mark.raises_strawberry_exception(
+    MissingReturnAnnotationError,
+    match='Return annotation missing for field "goodbye", did you forget to add it?',
+)
+def test_raises_return_error_when_explicit_resolver_has_same_name():
+    """When resolver= overwrites the field name, it's indistinguishable from
+    the decorator pattern, so MissingReturnAnnotationError is raised."""
+
+    @strawberry.type
+    class Query:
+        def goodbye(self):
+            return -1
+
+        goodbye = strawberry.field(resolver=goodbye)
+
+
+@pytest.mark.raises_strawberry_exception(
+    MissingReturnAnnotationError,
+    match='Return annotation missing for field "hello", did you forget to add it?',
+)
+def test_raises_return_error_when_using_untyped_decorator_resolver():
+    """Ensure @strawberry.field decorator still raises MissingReturnAnnotationError."""
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def hello(self):
+            return "hello"
+
+
+@pytest.mark.raises_strawberry_exception(
     MissingArgumentsAnnotationsError,
     match=(
         'Missing annotation for argument "query" in field "hello", '

--- a/tests/fields/test_resolvers.py
+++ b/tests/fields/test_resolvers.py
@@ -193,6 +193,82 @@ def test_raises_return_error_when_using_untyped_decorator_resolver():
 
 
 @pytest.mark.raises_strawberry_exception(
+    MissingFieldAnnotationError,
+    match=(
+        'Unable to determine the type of field "goodbye". Either annotate it '
+        "directly, or provide a typed resolver using @strawberry.field."
+    ),
+)
+def test_raises_field_error_when_external_resolver_shares_field_name():
+    """External resolver sharing the field name should still raise MissingFieldAnnotationError."""
+
+    def _make_goodbye():
+        def goodbye(self):
+            return -1
+
+        return goodbye
+
+    external_goodbye = _make_goodbye()
+
+    @strawberry.type
+    class Query:
+        goodbye = strawberry.field(resolver=external_goodbye)
+
+
+@pytest.mark.raises_strawberry_exception(
+    MissingFieldAnnotationError,
+    match=(
+        'Unable to determine the type of field "goodbye". Either annotate it '
+        "directly, or provide a typed resolver using @strawberry.field."
+    ),
+)
+def test_raises_field_error_when_resolver_from_other_class():
+    """Resolver borrowed from an unrelated class should raise MissingFieldAnnotationError."""
+
+    class Other:
+        def adios(self):
+            return -1
+
+    @strawberry.type
+    class Query:
+        goodbye = strawberry.field(resolver=Other.adios)
+
+
+@pytest.mark.raises_strawberry_exception(
+    MissingFieldAnnotationError,
+    match=(
+        'Unable to determine the type of field "goodbye". Either annotate it '
+        "directly, or provide a typed resolver using @strawberry.field."
+    ),
+)
+def test_raises_field_error_when_resolver_from_other_class_shares_field_name():
+    """Resolver from another class sharing the field name should still raise MissingFieldAnnotationError."""
+
+    class Other:
+        def goodbye(self):
+            return -1
+
+    @strawberry.type
+    class Query:
+        goodbye = strawberry.field(resolver=Other.goodbye)
+
+
+@pytest.mark.raises_strawberry_exception(
+    MissingReturnAnnotationError,
+    match='Return annotation missing for field "hello", did you forget to add it?',
+)
+def test_raises_return_error_for_decorator_in_nested_class():
+    """The decorator pattern must still be detected when the class is nested."""
+
+    class Outer:
+        @strawberry.type
+        class Query:
+            @strawberry.field
+            def hello(self):
+                return "hello"
+
+
+@pytest.mark.raises_strawberry_exception(
     MissingArgumentsAnnotationsError,
     match=(
         'Missing annotation for argument "query" in field "hello", '


### PR DESCRIPTION
## Description

When using `strawberry.field(resolver=fn)` where both the field type annotation and the resolver return type are missing, the error raised is `MissingReturnAnnotationError`. This is misleading — `MissingFieldAnnotationError` is more appropriate since it guides the user to annotate the field directly (e.g. `goodbye: int = strawberry.field(resolver=adios)`).

The fix distinguishes `@strawberry.field` decorator usage from explicit `strawberry.field(resolver=fn)` assignment by comparing the resolver's `__qualname__` against `f"{cls.__qualname__}.{field_name}"`. Only the decorator pattern produces a resolver whose qualified name matches the enclosing class and field; every other shape (explicit in-class resolvers, external functions, methods borrowed from another class, module-level functions — including those sharing the field name) correctly raises `MissingFieldAnnotationError`.

### Known limitation

When the resolver is defined inside the class body with the **same name** as the field and overwrites it (e.g. `goodbye = strawberry.field(resolver=goodbye)`), its `__qualname__` is identical to what the decorator pattern would produce, making the two shapes indistinguishable. In this case, `MissingReturnAnnotationError` is raised instead of `MissingFieldAnnotationError`. This is still valid guidance — the user can fix it by adding a return type to the resolver.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #447

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Adjust error handling for untyped Strawberry GraphQL fields using explicit resolvers and expand test coverage accordingly.

Bug Fixes:
- Raise MissingFieldAnnotationError instead of MissingReturnAnnotationError when a field defined with strawberry.field(resolver=...) lacks both a field type annotation and resolver return type, except when indistinguishable from decorator usage.

Documentation:
- Add RELEASE.md entry describing the patch-level change in error behavior for untyped explicit resolvers.

Tests:
- Update and extend resolver-related tests to cover explicit, external, same-name, and decorator-based untyped resolver scenarios.
