### PR TITLE
fix: handle PEP 649 NameError in Signature.from_callable for forward refs

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,26 @@
+Release type: patch
+
+Fix `NameError` when using `strawberry.Parent` with forward references on
+Python 3.14+ (PEP 649).
+
+On Python 3.14, annotations are lazily evaluated via `__annotate__` (PEP 649).
+When a resolver references a type via `strawberry.Parent[SomeType]` and
+`SomeType` is defined after the resolver, `inspect.Signature.from_callable()`
+triggers annotation evaluation which raises `NameError`. Strawberry now falls
+back to `inspect.Format.FORWARDREF` to handle this gracefully.
+
+For example, the following code now works on Python 3.14+:
+
+```python
+import strawberry
+
+# Resolver defined before the class it references
+def get_full_name(user: strawberry.Parent[User]) -> str:
+    return f"{user.first_name} {user.last_name}"
+
+@strawberry.type
+class User:
+    first_name: str
+    last_name: str
+    full_name: str = strawberry.field(resolver=get_full_name)
+```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,9 +14,11 @@ For example, the following code now works on Python 3.14+:
 ```python
 import strawberry
 
+
 # Resolver defined before the class it references
 def get_full_name(user: strawberry.Parent[User]) -> str:
     return f"{user.first_name} {user.last_name}"
+
 
 @strawberry.type
 class User:

--- a/strawberry/types/fields/resolver.py
+++ b/strawberry/types/fields/resolver.py
@@ -237,7 +237,23 @@ class StrawberryResolver(Generic[T]):
 
     @cached_property
     def signature(self) -> inspect.Signature:
-        return Signature.from_callable(self._unbound_wrapped_func, follow_wrapped=True)
+        try:
+            return Signature.from_callable(
+                self._unbound_wrapped_func, follow_wrapped=True
+            )
+        except NameError:
+            # On Python 3.14+ (PEP 649), accessing function annotations triggers
+            # deferred evaluation via __annotate__. If the annotation references a
+            # name that doesn't exist yet (e.g. a forward reference to a class
+            # being defined), this raises NameError. Fall back to FORWARDREF format
+            # which wraps unresolvable names in ForwardRef instead of raising.
+            if sys.version_info >= (3, 14):
+                return Signature.from_callable(
+                    self._unbound_wrapped_func,
+                    follow_wrapped=True,
+                    annotation_format=inspect.Format.FORWARDREF,
+                )
+            raise
 
     # TODO: find better name
     @cached_property

--- a/strawberry/types/fields/resolver.py
+++ b/strawberry/types/fields/resolver.py
@@ -247,11 +247,12 @@ class StrawberryResolver(Generic[T]):
             # name that doesn't exist yet (e.g. a forward reference to a class
             # being defined), this raises NameError. Fall back to FORWARDREF format
             # which wraps unresolvable names in ForwardRef instead of raising.
-            if sys.version_info >= (3, 14):
+            forwardref_format = getattr(inspect, "Format", None)
+            if forwardref_format is not None:
                 return Signature.from_callable(
                     self._unbound_wrapped_func,
                     follow_wrapped=True,
-                    annotation_format=inspect.Format.FORWARDREF,
+                    annotation_format=forwardref_format.FORWARDREF,
                 )
             raise
 

--- a/tests/types/test_parent_type_pep649.py
+++ b/tests/types/test_parent_type_pep649.py
@@ -63,6 +63,7 @@ def test_parent_forward_ref_pep649():
         [sys.executable, "-c", code],
         capture_output=True,
         text=True,
+        check=False,
     )
     assert result.returncode == 0, (
         f"Process failed with:\nstdout: {result.stdout}\nstderr: {result.stderr}"
@@ -108,6 +109,7 @@ def test_parent_forward_ref_pep649_async():
         [sys.executable, "-c", code],
         capture_output=True,
         text=True,
+        check=False,
     )
     assert result.returncode == 0, (
         f"Process failed with:\nstdout: {result.stdout}\nstderr: {result.stderr}"
@@ -151,6 +153,7 @@ def test_parent_no_forward_ref_still_works():
         [sys.executable, "-c", code],
         capture_output=True,
         text=True,
+        check=False,
     )
     assert result.returncode == 0, (
         f"Process failed with:\nstdout: {result.stdout}\nstderr: {result.stderr}"

--- a/tests/types/test_parent_type_pep649.py
+++ b/tests/types/test_parent_type_pep649.py
@@ -1,0 +1,158 @@
+"""Tests for strawberry.Parent with PEP 649 deferred annotation evaluation.
+
+On Python 3.14+, annotations are lazily evaluated via __annotate__ (PEP 649).
+When a resolver references a type via strawberry.Parent[SomeType] and SomeType
+is defined after the resolver (forward reference), the deferred evaluation of
+annotations can raise NameError when inspect.Signature.from_callable() triggers
+__annotate__. This test verifies that strawberry handles this case correctly
+by falling back to FORWARDREF format.
+"""
+
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (3, 14),
+    reason="PEP 649 deferred annotations require Python 3.14+",
+)
+
+
+def test_parent_forward_ref_pep649():
+    """Test that strawberry.Parent works with forward references under PEP 649.
+
+    The resolver is defined before the class it references via strawberry.Parent,
+    which causes a NameError during deferred annotation evaluation on Python 3.14+.
+    """
+    code = textwrap.dedent("""\
+        import strawberry
+
+        def get_full_name(user: strawberry.Parent[User]) -> str:
+            return f"{user.first_name} {user.last_name}"
+
+        @strawberry.type
+        class User:
+            first_name: str
+            last_name: str
+            full_name: str = strawberry.field(resolver=get_full_name)
+
+        @strawberry.type
+        class Query:
+            @strawberry.field
+            def user(self) -> User:
+                return User(first_name="John", last_name="Doe")
+
+        schema = strawberry.Schema(query=Query)
+
+        query = "{ user { firstName, lastName, fullName } }"
+        result = schema.execute_sync(query)
+        assert not result.errors, f"Unexpected errors: {result.errors}"
+        assert result.data == {
+            "user": {
+                "firstName": "John",
+                "lastName": "Doe",
+                "fullName": "John Doe",
+            }
+        }
+        print("OK")
+    """)
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"Process failed with:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    assert "OK" in result.stdout
+
+
+def test_parent_forward_ref_pep649_async():
+    """Test that async resolvers with strawberry.Parent forward refs work under PEP 649."""
+    code = textwrap.dedent("""\
+        import asyncio
+        import strawberry
+
+        async def get_children(parent: strawberry.Parent[TreeNode]) -> list[str]:
+            return [f"child_of_{parent.name}"]
+
+        @strawberry.type
+        class TreeNode:
+            name: str
+            children: list[str] = strawberry.field(resolver=get_children)
+
+        @strawberry.type
+        class Query:
+            @strawberry.field
+            def node(self) -> TreeNode:
+                return TreeNode(name="root")
+
+        schema = strawberry.Schema(query=Query)
+
+        query = "{ node { name, children } }"
+        result = asyncio.run(schema.execute(query))
+        assert not result.errors, f"Unexpected errors: {result.errors}"
+        assert result.data == {
+            "node": {
+                "name": "root",
+                "children": ["child_of_root"],
+            }
+        }
+        print("OK")
+    """)
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"Process failed with:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    assert "OK" in result.stdout
+
+
+def test_parent_no_forward_ref_still_works():
+    """Ensure that normal (non-forward-ref) strawberry.Parent still works on 3.14+."""
+    code = textwrap.dedent("""\
+        import strawberry
+
+        @strawberry.type
+        class User:
+            first_name: str
+            last_name: str
+
+        def get_full_name(user: strawberry.Parent[User]) -> str:
+            return f"{user.first_name} {user.last_name}"
+
+        @strawberry.type
+        class UserWithFullName:
+            first_name: str
+            last_name: str
+            full_name: str = strawberry.field(resolver=get_full_name)
+
+        @strawberry.type
+        class Query:
+            @strawberry.field
+            def user(self) -> UserWithFullName:
+                return UserWithFullName(first_name="Jane", last_name="Doe")
+
+        schema = strawberry.Schema(query=Query)
+        result = schema.execute_sync("{ user { fullName } }")
+        assert not result.errors, f"Unexpected errors: {result.errors}"
+        assert result.data == {"user": {"fullName": "Jane Doe"}}
+        print("OK")
+    """)
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"Process failed with:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    assert "OK" in result.stdout


### PR DESCRIPTION
## Description

On Python 3.14+ (PEP 649), function annotations are lazily evaluated via `__annotate__`. When `inspect.Signature.from_callable()` is called on a resolver function, it triggers this deferred evaluation. If the annotation references a name that does not exist yet (e.g. a forward reference to a class currently being defined), this raises `NameError` **before** Strawberry's own error handling in `ReservedType.find()` can intervene.

### Example that fails on Python 3.14

```python
import strawberry

def get_full_name(user: strawberry.Parent[User]) -> str:
    return f"{user.first_name} {user.last_name}"

@strawberry.type
class User:
    first_name: str
    last_name: str
    full_name: str = strawberry.field(resolver=get_full_name)
```

Error:
```
NameError: name 'User' is not defined
```

This pattern works fine on Python ≤3.13 with `from __future__ import annotations` (thanks to #3851), but PEP 649 introduces a different annotation evaluation path where the `NameError` occurs inside `inspect.Signature.from_callable()` rather than during `StrawberryAnnotation.evaluate()`.

### Fix

Catch `NameError` from `Signature.from_callable()` in the `StrawberryResolver.signature` property and fall back to `inspect.Format.FORWARDREF` (new in Python 3.14), which wraps unresolvable names in `ForwardRef` objects instead of raising.

### Changes

- `strawberry/types/fields/resolver.py`: Added `NameError` handling with `Format.FORWARDREF` fallback in `StrawberryResolver.signature`
- `tests/types/test_parent_type_pep649.py`: New test file for PEP 649 forward reference scenarios
- `RELEASE.md`: Patch release note

Related to #3481

## Summary by Sourcery

Handle PEP 649-related NameError in resolver signature inspection and add coverage for strawberry.Parent forward references on Python 3.14+.

Bug Fixes:
- Prevent NameError when inspecting resolver signatures that use strawberry.Parent with forward-referenced types under Python 3.14+ deferred annotation evaluation.

Documentation:
- Add patch release notes describing the PEP 649-related fix for strawberry.Parent forward references and the new Signature.from_callable fallback behaviour.

Tests:
- Add Python 3.14+ integration-style tests validating strawberry.Parent with forward and non-forward references for sync and async resolvers.