### PR TITLE
fix(types): pass doc as positional arg for Python 3.14+ compatibility

### DIFF
--- a/strawberry/types/field.py
+++ b/strawberry/types/field.py
@@ -104,20 +104,30 @@ class StrawberryField(dataclasses.Field):
             "kw_only": True,
         }
 
-        # doc was added to python 3.14 and it is required
+        # doc was added to python 3.14 as a required positional argument
         if sys.version_info >= (3, 14):
-            kwargs["doc"] = None
-
-        super().__init__(
-            default=default,
-            default_factory=default_factory,  # type: ignore
-            init=is_basic_field,
-            repr=is_basic_field,
-            compare=is_basic_field,
-            hash=None,
-            metadata=metadata or {},
-            **kwargs,
-        )
+            super().__init__(
+                default=default,
+                default_factory=default_factory,  # type: ignore
+                init=is_basic_field,
+                repr=is_basic_field,
+                compare=is_basic_field,
+                hash=None,
+                metadata=metadata or {},
+                doc=None,
+                **kwargs,
+            )
+        else:
+            super().__init__(
+                default=default,
+                default_factory=default_factory,  # type: ignore
+                init=is_basic_field,
+                repr=is_basic_field,
+                compare=is_basic_field,
+                hash=None,
+                metadata=metadata or {},
+                **kwargs,
+            )
 
         self.graphql_name = graphql_name
         if python_name is not None:


### PR DESCRIPTION
In Python 3.14, `dataclasses.Field.__init__` gained a required `doc` positional parameter (PEP 749). The current code attempts to pass it via `**kwargs`, which raises `TypeError: Field.__init__() missing 1 required positional argument: doc` because the parameter cannot be accepted as a keyword argument.

**Change:** Pass `doc=None` explicitly as a positional argument in the `super().__init__()` call when running on Python 3.14+, instead of adding it to `kwargs`.

Fixes #4269

## Summary by Sourcery

Bug Fixes:
- Fix Field.__init__ calls on Python 3.14+ by passing the required doc parameter positionally instead of via kwargs.