### PR TITLE
fix(dataloader): cancel dispatch task when all futures are cancelled

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,5 @@
 ---
-release type: patch
+release type: minor
 ---
 
 Cancel DataLoader dispatch task when all futures are cancelled.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,14 @@
+---
+release type: patch
+---
+
+Cancel DataLoader dispatch task when all futures are cancelled.
+
+Previously, the background task created by `dispatch()` was fire-and-forget — its
+reference was never stored, so it couldn't be cancelled even when no caller was
+waiting for the results. This caused wasted work (e.g. database queries against
+closed sessions) when using `asyncio.TaskGroup` or similar structured concurrency
+patterns that cancel futures on failure.
+
+The dispatch task is now tracked in `Batch._dispatch_task` and automatically
+cancelled when all futures in the batch are cancelled.

--- a/strawberry/dataloader.py
+++ b/strawberry/dataloader.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import dataclasses
 from abc import ABC, abstractmethod
 from asyncio import create_task, gather, get_event_loop
@@ -41,10 +42,24 @@ class LoaderTask(Generic[K, T]):
 class Batch(Generic[K, T]):
     tasks: list[LoaderTask] = dataclasses.field(default_factory=list)
     dispatched: bool = False
+    _dispatch_task: asyncio.Task[None] | None = dataclasses.field(
+        default=None, repr=False
+    )
 
     def add_task(self, key: Any, future: Future) -> None:
         task = LoaderTask[K, T](key, future)
         self.tasks.append(task)
+        future.add_done_callback(self._on_future_done)
+
+    def _on_future_done(self, future: Future) -> None:
+        """Cancel the dispatch task if all futures in the batch are cancelled."""
+        if (
+            future.cancelled()
+            and self._dispatch_task is not None
+            and not self._dispatch_task.done()
+            and all(t.future.cancelled() for t in self.tasks)
+        ):
+            self._dispatch_task.cancel()
 
     def __len__(self) -> int:
         return len(self.tasks)
@@ -224,7 +239,13 @@ def get_current_batch(loader: DataLoader) -> Batch:
 
 
 def dispatch(loader: DataLoader, batch: Batch) -> None:
-    loader.loop.call_soon(create_task, dispatch_batch(loader, batch))
+    def _schedule() -> None:
+        batch._dispatch_task = create_task(dispatch_batch(loader, batch))
+        batch._dispatch_task.add_done_callback(
+            lambda _: setattr(batch, "_dispatch_task", None)
+        )
+
+    loader.loop.call_soon(_schedule)
 
 
 async def dispatch_batch(loader: DataLoader, batch: Batch) -> None:
@@ -235,6 +256,12 @@ async def dispatch_batch(loader: DataLoader, batch: Batch) -> None:
         # Ensure batch is not empty
         # Unlikely, but could happen if the tasks are
         # overriden with preset values
+        return
+
+    # Skip the batch entirely if all futures have already been cancelled.
+    # This avoids calling load_fn (e.g. a database query) when no caller
+    # is waiting for the results.
+    if all(task.future.cancelled() for task in batch.tasks):
         return
 
     # TODO: check if load_fn return an awaitable and it is a list

--- a/tests/test_dataloaders.py
+++ b/tests/test_dataloaders.py
@@ -406,6 +406,148 @@ async def test_cancelled_future_with_failing_loader():
 
 
 @pytest.mark.asyncio
+async def test_all_futures_cancelled_skips_load_fn():
+    """When all futures in a batch are cancelled before dispatch, the load_fn
+    should not be called at all.  This prevents wasted work like database
+    queries whose results no one is waiting for.
+    """
+    call_count = 0
+
+    async def counting_loader(keys: list[int]) -> list[int]:
+        nonlocal call_count
+        call_count += 1
+        return keys
+
+    loader = DataLoader(load_fn=counting_loader, cache=False)
+
+    future_a = cast("Future[Any]", loader.load(1))
+    future_b = cast("Future[Any]", loader.load(2))
+
+    # Cancel all futures before the batch dispatches
+    future_a.cancel()
+    future_b.cancel()
+
+    # Let the event loop dispatch (call_soon → create_task → dispatch_batch)
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert future_a.cancelled()
+    assert future_b.cancelled()
+    assert call_count == 0, "load_fn should not have been called"
+
+
+@pytest.mark.asyncio
+async def test_cancelled_futures_cancel_dispatch_task():
+    """When all futures in a batch are cancelled, the underlying dispatch
+    task should also be cancelled.  This is important for resource cleanup
+    when using asyncio.TaskGroup or similar structured concurrency patterns.
+    """
+
+    async def slow_loader(keys: list[int]) -> list[int]:
+        await asyncio.sleep(10)
+        return keys
+
+    loader = DataLoader(load_fn=slow_loader, cache=False)
+
+    future_a = cast("Future[Any]", loader.load(1))
+    future_b = cast("Future[Any]", loader.load(2))
+
+    # Let call_soon fire so the dispatch task is created
+    await asyncio.sleep(0)
+    # Let the task start and suspend inside slow_loader's asyncio.sleep(10)
+    await asyncio.sleep(0)
+
+    assert loader.batch is not None
+    dispatch_task = loader.batch._dispatch_task
+    assert dispatch_task is not None
+    assert not dispatch_task.done()
+
+    # Cancel all futures — this should cascade to the dispatch task
+    future_a.cancel()
+    future_b.cancel()
+
+    # Give the event loop a chance to run _on_future_done callbacks
+    # and propagate CancelledError to the dispatch task
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert dispatch_task.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_futures_cancel_running_dispatch():
+    """When all futures are cancelled after load_fn has already started,
+    the dispatch task should still be cancelled, interrupting the in-progress
+    load_fn via CancelledError.
+    """
+    load_started = asyncio.Event()
+
+    async def slow_loader(keys: list[int]) -> list[int]:
+        load_started.set()
+        # Block until cancelled
+        await asyncio.sleep(10)
+        return keys
+
+    loader = DataLoader(load_fn=slow_loader, cache=False)
+
+    future_a = cast("Future[Any]", loader.load(1))
+    future_b = cast("Future[Any]", loader.load(2))
+
+    # Let call_soon fire and dispatch_batch start running
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    await load_started.wait()
+
+    assert loader.batch is not None
+    dispatch_task = loader.batch._dispatch_task
+    assert dispatch_task is not None
+    assert not dispatch_task.done()
+
+    # Cancel all futures while load_fn is in progress
+    future_a.cancel()
+    future_b.cancel()
+
+    # Give the event loop a chance to propagate cancellation
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert future_a.cancelled()
+    assert future_b.cancelled()
+    assert dispatch_task.done()
+
+
+@pytest.mark.asyncio
+async def test_partial_cancellation_still_dispatches():
+    """When only some futures in a batch are cancelled, the batch should
+    still dispatch and deliver results for the non-cancelled futures.
+    """
+    call_count = 0
+
+    async def counting_loader(keys: list[int]) -> list[int]:
+        nonlocal call_count
+        call_count += 1
+        return keys
+
+    loader = DataLoader(load_fn=counting_loader, cache=False)
+
+    future_a = cast("Future[Any]", loader.load(1))
+    future_b = cast("Future[Any]", loader.load(2))
+    future_c = cast("Future[Any]", loader.load(3))
+
+    # Cancel only one future
+    future_b.cancel()
+
+    # Let the batch dispatch
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert future_a.result() == 1
+    assert future_b.cancelled()
+    assert future_c.result() == 3
+    assert call_count == 1, "load_fn should still be called for non-cancelled futures"
+
+
+@pytest.mark.asyncio
 async def test_cache_override():
     class TestCache(AbstractCache[int, int]):
         def __init__(self):


### PR DESCRIPTION
## Description

Closes #3606.

When all futures in a DataLoader batch are cancelled (e.g. via `asyncio.TaskGroup` cancellation cascade), the dispatch task now gets cancelled too. Previously, the background task created by `dispatch()` was fire-and-forget — its reference was never stored, so it couldn't be cancelled even when no caller was waiting for the results.

This caused real-world issues where cancelled requests would still trigger database queries, API calls, or other expensive operations via `load_fn`, wasting resources and causing errors when those operations used already-closed resources (like SQLAlchemy sessions).

### Changes

**`strawberry/dataloader.py`:**
- Store dispatch `Task` reference in `Batch._dispatch_task`
- Add `done_callback` on each future to cancel the dispatch task when all futures in the batch are cancelled
- Skip `load_fn` call entirely if all futures are already cancelled before dispatch runs

**`tests/test_dataloaders.py`:**
- `test_all_futures_cancelled_skips_load_fn` — verifies load_fn is never called when all futures are cancelled
- `test_cancelled_futures_cancel_dispatch_task` — verifies the dispatch task itself gets cancelled
- `test_partial_cancellation_still_dispatches` — verifies partial cancellation still delivers results to non-cancelled futures

### Example scenario fixed

```python
async with AsyncSession(engine) as session:
    loader = DataLoader(lambda ids: session.execute(...))

    async with asyncio.TaskGroup() as tg:
        tg.create_task(failing_operation())  # raises, cancels group
        tg.create_task(loader.load(42))      # future cancelled by group
    # Previously: loader's dispatch task still ran against closed session
    # Now: dispatch task is cancelled, no wasted query
```

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation (N/A)
- [x] I have updated the documentation accordingly (N/A)
- [x] I have read the CONTRIBUTING document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed (locally verified)

## Summary by Sourcery

Ensure DataLoader dispatch tasks are cancelled when all associated futures are cancelled to avoid unnecessary work.

Bug Fixes:
- Cancel the DataLoader batch dispatch task when all futures in the batch have been cancelled.
- Skip invoking the batch load function when every future in the batch has already been cancelled before dispatch.

Tests:
- Add tests to verify load_fn is skipped when all futures are cancelled, the dispatch task itself is cancelled, and partially cancelled batches still dispatch for remaining futures.