### PR TITLE
feat(schema-codegen): pyright-clean output + --config for scalar overrides

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,60 @@
+Release type: patch
+
+`strawberry schema-codegen` now produces output that type-checks cleanly
+under pyright's default ruleset for user-defined custom scalars, and the
+`JSON` / `JSONObject` registry entries have been repaired.
+
+Previously, an SDL like:
+
+```graphql
+scalar JSON
+scalar JSONObject
+scalar Foo
+
+type Query {
+  a: JSON!
+  b: JSONObject!
+  c: Foo!
+}
+```
+
+generated code that referenced the non-existent `strawberry.JSON`
+attribute (raising `AttributeError` at schema construction) and emitted
+the deprecated `ScalarWrapper` pattern for `Foo` (`Foo = strawberry.scalar(NewType("Foo", object), ...)`),
+which fails three pyright checks per scalar.
+
+The generated output now uses `from strawberry.scalars import JSON`,
+`from strawberry.scalars import JSON as JSONObject` for the
+community-standard `JSONObject` convention, and a module-level `NewType`
+binding registered through `StrawberryConfig.scalar_map` (the recommended
+Strawberry API for custom scalars) for arbitrary user-defined scalars:
+
+```python
+from __future__ import annotations
+import strawberry
+from strawberry.scalars import JSON
+from strawberry.scalars import JSON as JSONObject
+from strawberry.schema.config import StrawberryConfig
+from typing import NewType
+
+Foo = NewType("Foo", object)
+
+
+@strawberry.type
+class Query:
+    a: JSON
+    b: JSONObject
+    c: Foo
+
+
+schema = strawberry.Schema(
+    query=Query,
+    config=StrawberryConfig(
+        scalar_map={
+            Foo: strawberry.scalar(
+                name="Foo", serialize=lambda v: v, parse_value=lambda v: v
+            ),
+        }
+    ),
+)
+```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,85 +1,39 @@
 Release type: minor
 
-`strawberry schema-codegen` now produces output that type-checks cleanly under
-Pyright's default ruleset for user-defined custom scalars, and adds a
-`-c / --config` option for telling codegen how specific scalars should be
-emitted.
+Two improvements to `strawberry schema-codegen`:
 
-## Pyright-clean custom scalar output
-
-Previously, an SDL like:
-
-```graphql
-scalar Foo
-
-type Query {
-  c: Foo!
-}
-```
-
-generated a `Foo = strawberry.scalar(NewType("Foo", object), ...)` binding,
-which fails three Pyright checks per scalar and uses the deprecated
-`ScalarWrapper` pattern.
-
-The generated output now uses a module-level `NewType` binding plus a
-`scalar_map` registered through `StrawberryConfig` (the recommended Strawberry
-API):
+**Pyright-clean output for custom scalars.** Previously, `scalar Foo` generated
+`Foo = strawberry.scalar(NewType("Foo", object), ...)` — the deprecated
+`ScalarWrapper` pattern, which fails three Pyright checks per scalar. Output
+now uses a module-level `NewType` binding plus a `scalar_map` registered
+through `StrawberryConfig` (the recommended API), preserving descriptions and
+`@specifiedBy` URLs:
 
 ```python
-from __future__ import annotations
-import strawberry
-from strawberry.schema.config import StrawberryConfig
-from strawberry.types.scalar import ScalarDefinition
-from typing import NewType
-
 Foo = NewType("Foo", object)
-
-
-@strawberry.type
-class Query:
-    c: Foo
-
 
 scalar_map: dict[object, ScalarDefinition] = {
     Foo: strawberry.scalar(name="Foo", serialize=lambda v: v, parse_value=lambda v: v),
 }
 
-schema = strawberry.Schema(
-    query=Query,
-    config=StrawberryConfig(scalar_map=scalar_map),
-)
+schema = strawberry.Schema(query=Query, config=StrawberryConfig(scalar_map=scalar_map))
 ```
 
-The `scalar_map` is emitted as a module-level constant so it is preserved even
-when codegen runs against a scalars-only SDL fragment, and so descriptions and
-`@specifiedBy` URLs are never silently dropped.
-
-## Config file
-
-`strawberry schema-codegen` now accepts `-c / --config <file>` pointing at a
-YAML config. The first available section is `scalars:`, a mapping from a
-GraphQL scalar name to a `<module>:<object>` Python target. For each entry,
-codegen imports the target instead of generating a `NewType` plus `scalar_map`
-entry.
+**New `-c / --config <file>` flag.** Point codegen at a YAML config to control
+how specific scalars are emitted. Today the only section is `scalars:`, a
+mapping from a GraphQL scalar name to a `<module>:<object>` Python target —
+codegen imports the target instead of generating a `NewType` for it.
 
 ```yaml
 # codegen.yaml
 scalars:
   JSONObject: strawberry.scalars:JSON
   MyDecimal: my_app.scalars:MyDecimal
-  Date: my_app.scalars:UnixDate
 ```
 
 ```shell
 strawberry schema-codegen schema.graphql -c codegen.yaml
 ```
 
-For a scalar named `JSONObject` mapped to `strawberry.scalars:JSON` the
-generated code now contains `from strawberry.scalars import JSON as JSONObject`
-and skips the `NewType` / `scalar_map` machinery entirely. Overrides win over
-the built-in scalar mappings, so the same mechanism can redirect `Date`,
-`JSON`, `UUID`, etc. to custom implementations.
-
-Note: previous pre-release builds of this branch auto-mapped `JSONObject` to
-`strawberry.scalars.JSON` as a hard-coded convention. That convention has been
-removed — pass it through the config file instead.
+Overrides win over the built-in scalar mappings, so `Date`, `JSON`, `UUID`,
+etc. can also be redirected to custom implementations.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,39 +1,33 @@
-Release type: patch
+Release type: minor
 
-`strawberry schema-codegen` now produces output that type-checks cleanly
-under Pyright's default ruleset for user-defined custom scalars, and the
-`JSON` / `JSONObject` registry entries have been repaired.
+`strawberry schema-codegen` now produces output that type-checks cleanly under
+Pyright's default ruleset for user-defined custom scalars, and adds a
+`-c / --config` option for telling codegen how specific scalars should be
+emitted.
+
+## Pyright-clean custom scalar output
 
 Previously, an SDL like:
 
 ```graphql
-scalar JSON
-scalar JSONObject
 scalar Foo
 
 type Query {
-  a: JSON!
-  b: JSONObject!
   c: Foo!
 }
 ```
 
-generated code that referenced the non-existent `strawberry.JSON`
-attribute (raising `AttributeError` at schema construction) and emitted
-the deprecated `ScalarWrapper` pattern for `Foo` (`Foo = strawberry.scalar(NewType("Foo", object), ...)`),
-which fails three Pyright checks per scalar.
+generated a `Foo = strawberry.scalar(NewType("Foo", object), ...)` binding,
+which fails three Pyright checks per scalar and uses the deprecated
+`ScalarWrapper` pattern.
 
-The generated output now uses `from strawberry.scalars import JSON`,
-`from strawberry.scalars import JSON as JSONObject` for the
-community-standard `JSONObject` convention, and a module-level `NewType`
-binding registered through `StrawberryConfig.scalar_map` (the recommended
-Strawberry API for custom scalars) for arbitrary user-defined scalars:
+The generated output now uses a module-level `NewType` binding plus a
+`scalar_map` registered through `StrawberryConfig` (the recommended Strawberry
+API):
 
 ```python
 from __future__ import annotations
 import strawberry
-from strawberry.scalars import JSON
-from strawberry.scalars import JSON as JSONObject
 from strawberry.schema.config import StrawberryConfig
 from strawberry.types.scalar import ScalarDefinition
 from typing import NewType
@@ -43,8 +37,6 @@ Foo = NewType("Foo", object)
 
 @strawberry.type
 class Query:
-    a: JSON
-    b: JSONObject
     c: Foo
 
 
@@ -58,7 +50,36 @@ schema = strawberry.Schema(
 )
 ```
 
-The `scalar_map` is emitted as a module-level constant so it is preserved
-even when codegen runs against a scalars-only SDL fragment (no
-`Query`/`Mutation`/`Subscription`), and so descriptions and
+The `scalar_map` is emitted as a module-level constant so it is preserved even
+when codegen runs against a scalars-only SDL fragment, and so descriptions and
 `@specifiedBy` URLs are never silently dropped.
+
+## Config file
+
+`strawberry schema-codegen` now accepts `-c / --config <file>` pointing at a
+YAML config. The first available section is `scalars:`, a mapping from a
+GraphQL scalar name to a `<module>:<object>` Python target. For each entry,
+codegen imports the target instead of generating a `NewType` plus `scalar_map`
+entry.
+
+```yaml
+# codegen.yaml
+scalars:
+  JSONObject: strawberry.scalars:JSON
+  MyDecimal: my_app.scalars:MyDecimal
+  Date: my_app.scalars:UnixDate
+```
+
+```shell
+strawberry schema-codegen schema.graphql -c codegen.yaml
+```
+
+For a scalar named `JSONObject` mapped to `strawberry.scalars:JSON` the
+generated code now contains `from strawberry.scalars import JSON as JSONObject`
+and skips the `NewType` / `scalar_map` machinery entirely. Overrides win over
+the built-in scalar mappings, so the same mechanism can redirect `Date`,
+`JSON`, `UUID`, etc. to custom implementations.
+
+Note: previous pre-release builds of this branch auto-mapped `JSONObject` to
+`strawberry.scalars.JSON` as a hard-coded convention. That convention has been
+removed — pass it through the config file instead.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,7 @@
 Release type: patch
 
 `strawberry schema-codegen` now produces output that type-checks cleanly
-under pyright's default ruleset for user-defined custom scalars, and the
+under Pyright's default ruleset for user-defined custom scalars, and the
 `JSON` / `JSONObject` registry entries have been repaired.
 
 Previously, an SDL like:
@@ -21,7 +21,7 @@ type Query {
 generated code that referenced the non-existent `strawberry.JSON`
 attribute (raising `AttributeError` at schema construction) and emitted
 the deprecated `ScalarWrapper` pattern for `Foo` (`Foo = strawberry.scalar(NewType("Foo", object), ...)`),
-which fails three pyright checks per scalar.
+which fails three Pyright checks per scalar.
 
 The generated output now uses `from strawberry.scalars import JSON`,
 `from strawberry.scalars import JSON as JSONObject` for the
@@ -35,6 +35,7 @@ import strawberry
 from strawberry.scalars import JSON
 from strawberry.scalars import JSON as JSONObject
 from strawberry.schema.config import StrawberryConfig
+from strawberry.types.scalar import ScalarDefinition
 from typing import NewType
 
 Foo = NewType("Foo", object)
@@ -47,14 +48,17 @@ class Query:
     c: Foo
 
 
+scalar_map: dict[object, ScalarDefinition] = {
+    Foo: strawberry.scalar(name="Foo", serialize=lambda v: v, parse_value=lambda v: v),
+}
+
 schema = strawberry.Schema(
     query=Query,
-    config=StrawberryConfig(
-        scalar_map={
-            Foo: strawberry.scalar(
-                name="Foo", serialize=lambda v: v, parse_value=lambda v: v
-            ),
-        }
-    ),
+    config=StrawberryConfig(scalar_map=scalar_map),
 )
 ```
+
+The `scalar_map` is emitted as a module-level constant so it is preserved
+even when codegen runs against a scalars-only SDL fragment (no
+`Query`/`Mutation`/`Subscription`), and so descriptions and
+`@specifiedBy` URLs are never silently dropped.

--- a/docs/codegen/schema-codegen.md
+++ b/docs/codegen/schema-codegen.md
@@ -64,10 +64,26 @@ identity `serialize` / `parse_value`:
 
 ```graphql
 scalar Foo
+
+type Query {
+  data: Foo!
+}
 ```
 
 ```python
+from __future__ import annotations
+import strawberry
+from strawberry.schema.config import StrawberryConfig
+from strawberry.types.scalar import ScalarDefinition
+from typing import NewType
+
 Foo = NewType("Foo", object)
+
+
+@strawberry.type
+class Query:
+    data: Foo
+
 
 scalar_map: dict[object, ScalarDefinition] = {
     Foo: strawberry.scalar(name="Foo", serialize=lambda v: v, parse_value=lambda v: v),

--- a/docs/codegen/schema-codegen.md
+++ b/docs/codegen/schema-codegen.md
@@ -44,3 +44,99 @@ class User:
 
 schema = strawberry.Schema(query=Query)
 ```
+
+## Writing the result to a file
+
+By default the generated code is printed to stdout. Pass `-o / --output` to
+write it to a file instead — parent directories are created as needed:
+
+```shell
+strawberry schema-codegen schema.graphql --output schema.py
+```
+
+## Custom scalars
+
+Built-in scalars (`Int`, `Float`, `String`, `Boolean`, `ID`, `JSON`, `UUID`,
+`Decimal`, `Date`, `Time`, `DateTime`) are mapped to their Python / Strawberry
+equivalents automatically. Any other `scalar` declaration is emitted as a
+`NewType` registered through `StrawberryConfig.scalar_map`, with a placeholder
+identity `serialize` / `parse_value`:
+
+```graphql
+scalar Foo
+```
+
+```python
+Foo = NewType("Foo", object)
+
+scalar_map: dict[object, ScalarDefinition] = {
+    Foo: strawberry.scalar(name="Foo", serialize=lambda v: v, parse_value=lambda v: v),
+}
+
+schema = strawberry.Schema(query=Query, config=StrawberryConfig(scalar_map=scalar_map))
+```
+
+You will typically want to replace those identity functions with real
+serialization logic before using the generated schema in production.
+
+## Config file
+
+Pass `-c / --config <file>` to point codegen at a YAML config that controls how
+specific scalars are emitted. Today the only section is `scalars:`, a mapping
+from a GraphQL scalar name to a `<module>:<object>` Python target:
+
+```yaml
+# codegen.yaml
+scalars:
+  JSONObject: strawberry.scalars:JSON
+  MyDecimal: my_app.scalars:MyDecimal
+  Date: my_app.scalars:UnixDate
+```
+
+For each entry, codegen imports the target instead of generating a `NewType`
+plus `scalar_map` entry:
+
+- when `<object>` matches the GraphQL scalar name →
+  `from <module> import <object>`
+- when they differ → `from <module> import <object> as <ScalarName>`
+
+Given the SDL:
+
+```graphql
+scalar JSONObject
+
+type Query {
+  data: JSONObject!
+}
+```
+
+and the config above:
+
+```shell
+strawberry schema-codegen schema.graphql -c codegen.yaml
+```
+
+produces:
+
+```python
+import strawberry
+from strawberry.scalars import JSON as JSONObject
+
+
+@strawberry.type
+class Query:
+    data: JSONObject
+
+
+schema = strawberry.Schema(query=Query)
+```
+
+`JSONObject` is the canonical example: Strawberry does not ship a `JSONObject`
+scalar, but several schemas in the wild use that name as a synonym for `JSON`.
+Pointing it at `strawberry.scalars:JSON` via the config is the recommended way
+to wire that convention up — it is intentionally not a built-in default.
+
+Overrides win over the built-in scalar mappings, so you can also redirect
+`Date`, `JSON`, `UUID`, etc. to custom implementations. Any scalar mentioned in
+the config is excluded from the generated `scalar_map` regardless of whether it
+is normally a built-in or unknown scalar.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ cli = [
   "uvicorn>=0.11.6",
   "websockets>=15.0.1,<17",
   "python-multipart>=0.0.7",
+  "pyyaml>=6.0",
 ]
 litestar = ["litestar>=2; python_version~='3.10'"]
 pyinstrument = ["pyinstrument>=4.0.0"]

--- a/strawberry/cli/commands/schema_codegen.py
+++ b/strawberry/cli/commands/schema_codegen.py
@@ -4,6 +4,7 @@ import typer
 
 from strawberry.cli.app import app
 from strawberry.schema_codegen import codegen
+from strawberry.schema_codegen.config import load_config
 
 
 @app.command(help="Generate code from a query")
@@ -18,8 +19,25 @@ def schema_codegen(
         writable=True,
         resolve_path=True,
     ),
+    config: Path | None = typer.Option(
+        None,
+        "-c",
+        "--config",
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+        help="YAML config file (e.g. scalar overrides).",
+    ),
 ) -> None:
-    generated_output = codegen(schema.read_text())
+    scalar_overrides: dict[str, str] | None = None
+    if config is not None:
+        try:
+            scalar_overrides = load_config(config).scalars or None
+        except (ValueError, TypeError) as exc:
+            raise typer.BadParameter(str(exc), param_hint="--config") from exc
+
+    generated_output = codegen(schema.read_text(), scalar_overrides=scalar_overrides)
 
     if output is None:
         typer.echo(generated_output)

--- a/strawberry/schema_codegen/__init__.py
+++ b/strawberry/schema_codegen/__init__.py
@@ -59,7 +59,6 @@ _SCALAR_MAP = {
         attr=cst.Name("ID"),
     ),
     "JSON": cst.Name("JSON"),
-    "JSONObject": cst.Name("JSONObject"),
     "UUID": cst.Name("UUID"),
     "Decimal": cst.Name("Decimal"),
     "Date": cst.Name("date"),
@@ -129,12 +128,16 @@ def _get_field_type(
     was_non_nullable: bool = False,
     *,
     wrap_in_maybe: bool = False,
+    overridden_scalars: frozenset[str] = frozenset(),
 ) -> cst.BaseExpression:
     expr: cst.BaseExpression | None
 
     if isinstance(field_type, NonNullTypeNode):
         return _get_field_type(
-            field_type.type, was_non_nullable=True, wrap_in_maybe=wrap_in_maybe
+            field_type.type,
+            was_non_nullable=True,
+            wrap_in_maybe=wrap_in_maybe,
+            overridden_scalars=overridden_scalars,
         )
     if isinstance(field_type, ListTypeNode):
         expr = cst.Subscript(
@@ -142,16 +145,21 @@ def _get_field_type(
             slice=[
                 cst.SubscriptElement(
                     cst.Index(
-                        value=_get_field_type(field_type.type),
+                        value=_get_field_type(
+                            field_type.type, overridden_scalars=overridden_scalars
+                        ),
                     ),
                 )
             ],
         )
     elif isinstance(field_type, NamedTypeNode):
-        expr = _SCALAR_MAP.get(field_type.name.value)
-
-        if expr is None:
-            expr = cst.Name(field_type.name.value)
+        name = field_type.name.value
+        # User-supplied overrides replace the built-in `_SCALAR_MAP` mapping —
+        # the imported binding uses the scalar's GraphQL name.
+        if name in overridden_scalars:
+            expr = cst.Name(name)
+        else:
+            expr = _SCALAR_MAP.get(name) or cst.Name(name)
 
     else:
         raise NotImplementedError(f"Unknown type {field_type}")
@@ -344,6 +352,7 @@ def _get_field(
     imports: set[Import],
     *,
     is_input_field: bool = False,
+    overridden_scalars: frozenset[str] = frozenset(),
 ) -> cst.SimpleStatementLine:
     name = to_snake_case(field.name.value)
     alias: str | None = None
@@ -373,7 +382,11 @@ def _get_field(
             cst.AnnAssign(
                 target=cst.Name(name),
                 annotation=cst.Annotation(
-                    _get_field_type(field.type, wrap_in_maybe=wrap_in_maybe),
+                    _get_field_type(
+                        field.type,
+                        wrap_in_maybe=wrap_in_maybe,
+                        overridden_scalars=overridden_scalars,
+                    ),
                 ),
                 value=_get_field_value(
                     field,
@@ -563,6 +576,8 @@ def _get_class_definition(
     | InputObjectTypeDefinitionNode,
     is_apollo_federation: bool,
     imports: set[Import],
+    *,
+    overridden_scalars: frozenset[str] = frozenset(),
 ) -> Definition:
     decorator = _get_strawberry_decorator(definition, is_apollo_federation, imports)
 
@@ -586,6 +601,7 @@ def _get_class_definition(
                     is_apollo_federation,
                     imports,
                     is_input_field=is_input_type,
+                    overridden_scalars=overridden_scalars,
                 )
                 for field in definition.fields
             ]
@@ -765,9 +781,20 @@ def _get_union_definition(definition: UnionTypeDefinitionNode) -> Definition:
 
 
 def _get_scalar_definition(
-    definition: ScalarTypeDefinitionNode, imports: set[Import]
+    definition: ScalarTypeDefinitionNode,
+    imports: set[Import],
+    scalar_overrides: dict[str, str] | None = None,
 ) -> Definition | None:
     name = definition.name.value
+
+    # User-supplied overrides win over every built-in special-case below.
+    if scalar_overrides and name in scalar_overrides:
+        module, _, target = scalar_overrides[name].partition(":")
+        if target == name:
+            imports.add(Import(module=module, imports=(name,)))
+        else:
+            imports.add(Import(module=module, imports=((target, name),)))
+        return None
 
     if name == "Date":
         imports.add(Import(module="datetime", imports=("date",)))
@@ -786,11 +813,6 @@ def _get_scalar_definition(
         return None
     if name == "JSON":
         imports.add(Import(module="strawberry.scalars", imports=("JSON",)))
-        return None
-    if name == "JSONObject":
-        imports.add(
-            Import(module="strawberry.scalars", imports=(("JSON", "JSONObject"),))
-        )
         return None
 
     description = definition.description.value if definition.description else None
@@ -873,8 +895,10 @@ def _get_scalar_definition(
     )
 
 
-def codegen(schema: str) -> str:
+def codegen(schema: str, *, scalar_overrides: dict[str, str] | None = None) -> str:
     document = parse(schema)
+
+    overridden_scalars = frozenset(scalar_overrides or ())
 
     definitions: dict[str, Definition] = {}
 
@@ -905,7 +929,10 @@ def codegen(schema: str) -> str:
             ),
         ):
             definition = _get_class_definition(
-                graphql_definition, is_apollo_federation, imports
+                graphql_definition,
+                is_apollo_federation,
+                imports,
+                overridden_scalars=overridden_scalars,
             )
 
         elif isinstance(graphql_definition, EnumTypeDefinitionNode):
@@ -930,7 +957,9 @@ def codegen(schema: str) -> str:
 
             definition = _get_union_definition(graphql_definition)
         elif isinstance(graphql_definition, ScalarTypeDefinitionNode):
-            definition = _get_scalar_definition(graphql_definition, imports)
+            definition = _get_scalar_definition(
+                graphql_definition, imports, scalar_overrides
+            )
 
         elif isinstance(graphql_definition, SchemaExtensionNode):
             is_apollo_federation = any(

--- a/strawberry/schema_codegen/__init__.py
+++ b/strawberry/schema_codegen/__init__.py
@@ -58,10 +58,8 @@ _SCALAR_MAP = {
         value=cst.Name("strawberry"),
         attr=cst.Name("ID"),
     ),
-    "JSON": cst.Attribute(
-        value=cst.Name("strawberry"),
-        attr=cst.Name("JSON"),
-    ),
+    "JSON": cst.Name("JSON"),
+    "JSONObject": cst.Name("JSONObject"),
     "UUID": cst.Name("UUID"),
     "Decimal": cst.Name("Decimal"),
     "Date": cst.Name("date"),
@@ -73,7 +71,7 @@ _SCALAR_MAP = {
 @dataclasses.dataclass(frozen=True)
 class Import:
     module: str | None
-    imports: tuple[str]
+    imports: tuple[str | tuple[str, str], ...]
 
     def module_path_to_cst(self, module_path: str) -> cst.Name | cst.Attribute:
         parts = module_path.split(".")
@@ -85,15 +83,24 @@ class Import:
 
         return module_name
 
+    def _to_import_alias(self, name: str | tuple[str, str]) -> cst.ImportAlias:
+        if isinstance(name, tuple):
+            original, alias = name
+            return cst.ImportAlias(
+                name=cst.Name(original),
+                asname=cst.AsName(name=cst.Name(alias)),
+            )
+        return cst.ImportAlias(name=cst.Name(name))
+
     def to_cst(self) -> cst.Import | cst.ImportFrom:
         if self.module is None:
             return cst.Import(
-                names=[cst.ImportAlias(name=cst.Name(name)) for name in self.imports]
+                names=[self._to_import_alias(name) for name in self.imports]
             )
 
         return cst.ImportFrom(
             module=self.module_path_to_cst(self.module),
-            names=[cst.ImportAlias(name=cst.Name(name)) for name in self.imports],
+            names=[self._to_import_alias(name) for name in self.imports],
         )
 
 
@@ -632,6 +639,7 @@ def _get_schema_definition(
     root_mutation_name: str | None,
     root_subscription_name: str | None,
     is_apollo_federation: bool,
+    scalar_map: list[cst.DictElement] | None = None,
 ) -> cst.SimpleStatementLine | None:
     if not any([root_query_name, root_mutation_name, root_subscription_name]):
         return None
@@ -653,6 +661,29 @@ def _get_schema_definition(
 
     if root_subscription_name:
         args.append(_get_arg("subscription", root_subscription_name))
+
+    if scalar_map:
+        config_call = cst.Call(
+            func=cst.Name("StrawberryConfig"),
+            args=[
+                cst.Arg(
+                    keyword=cst.Name("scalar_map"),
+                    value=cst.Dict(elements=scalar_map),
+                    equal=cst.AssignEqual(
+                        cst.SimpleWhitespace(""), cst.SimpleWhitespace("")
+                    ),
+                )
+            ],
+        )
+        args.append(
+            cst.Arg(
+                keyword=cst.Name("config"),
+                value=config_call,
+                equal=cst.AssignEqual(
+                    cst.SimpleWhitespace(""), cst.SimpleWhitespace("")
+                ),
+            )
+        )
 
     # Federation 2 is now always enabled for federation schemas
     if is_apollo_federation:
@@ -690,6 +721,7 @@ class Definition:
     code: cst.CSTNode
     dependencies: list[str]
     name: str
+    scalar_override: cst.DictElement | None = None
 
 
 def _get_union_definition(definition: UnionTypeDefinitionNode) -> Definition:
@@ -753,6 +785,12 @@ def _get_scalar_definition(
         imports.add(Import(module="uuid", imports=("UUID",)))
         return None
     if name == "JSON":
+        imports.add(Import(module="strawberry.scalars", imports=("JSON",)))
+        return None
+    if name == "JSONObject":
+        imports.add(
+            Import(module="strawberry.scalars", imports=(("JSON", "JSONObject"),))
+        )
         return None
 
     description = definition.description.value if definition.description else None
@@ -776,7 +814,8 @@ def _get_scalar_definition(
         ),
     )
 
-    additional_args: list[cst.Arg | None] = [
+    scalar_args: list[cst.Arg | None] = [
+        _get_argument("name", name),
         _get_argument("description", description) if description else None,
         _get_argument("specified_by_url", specified_by_url)
         if specified_by_url
@@ -793,32 +832,45 @@ def _get_scalar_definition(
         ),
     ]
 
+    # Emit `Foo = NewType("Foo", object)` at module scope so the name is a
+    # valid type expression under pyright (NewType is special-cased only on
+    # top-level same-name assignments).
     statement_definition = cst.SimpleStatementLine(
         body=[
             cst.Assign(
                 targets=[cst.AssignTarget(cst.Name(name))],
                 value=cst.Call(
-                    func=cst.Attribute(
-                        value=cst.Name("strawberry"),
-                        attr=cst.Name("scalar"),
-                    ),
+                    func=cst.Name("NewType"),
                     args=[
-                        cst.Arg(
-                            cst.Call(
-                                func=cst.Name("NewType"),
-                                args=[
-                                    cst.Arg(cst.SimpleString(f'"{name}"')),
-                                    cst.Arg(cst.Name("object")),
-                                ],
-                            )
-                        ),
-                        *filter(None, additional_args),
+                        cst.Arg(cst.SimpleString(f'"{name}"')),
+                        cst.Arg(cst.Name("object")),
                     ],
                 ),
             )
         ]
     )
-    return Definition(statement_definition, [], name=definition.name.value)
+
+    # Register the scalar via `scalar_overrides=` on the Schema constructor so
+    # the type expression and the scalar registration are decoupled. Calling
+    # `strawberry.scalar(name=..., ...)` without `cls` returns a
+    # ScalarDefinition and is the type-checker-friendly overload.
+    scalar_override = cst.DictElement(
+        key=cst.Name(name),
+        value=cst.Call(
+            func=cst.Attribute(
+                value=cst.Name("strawberry"),
+                attr=cst.Name("scalar"),
+            ),
+            args=list(filter(None, scalar_args)),
+        ),
+    )
+
+    return Definition(
+        statement_definition,
+        [],
+        name=definition.name.value,
+        scalar_override=scalar_override,
+    )
 
 
 def codegen(schema: str) -> str:
@@ -902,12 +954,22 @@ def codegen(schema: str) -> str:
             "Subscription" if "Subscription" in definitions else None
         )
 
+    scalar_map = [
+        d.scalar_override for d in definitions.values() if d.scalar_override is not None
+    ]
+
     schema_definition = _get_schema_definition(
         root_query_name=root_query_name,
         root_mutation_name=root_mutation_name,
         root_subscription_name=root_subscription_name,
         is_apollo_federation=is_apollo_federation,
+        scalar_map=scalar_map,
     )
+
+    if schema_definition is not None and scalar_map:
+        imports.add(
+            Import(module="strawberry.schema.config", imports=("StrawberryConfig",))
+        )
 
     if schema_definition:
         # Schema must be emitted last; it depends on all other definitions.
@@ -921,7 +983,13 @@ def codegen(schema: str) -> str:
         cst.SimpleStatementLine(body=[future_import.to_cst()]),
         *[
             cst.SimpleStatementLine(body=[import_.to_cst()])
-            for import_ in sorted(imports, key=lambda i: (i.module or "", i.imports))
+            for import_ in sorted(
+                imports,
+                key=lambda i: (
+                    i.module or "",
+                    tuple(n if isinstance(n, str) else n[1] for n in i.imports),
+                ),
+            )
         ],
     ]
 

--- a/strawberry/schema_codegen/__init__.py
+++ b/strawberry/schema_codegen/__init__.py
@@ -639,7 +639,7 @@ def _get_schema_definition(
     root_mutation_name: str | None,
     root_subscription_name: str | None,
     is_apollo_federation: bool,
-    scalar_map: list[cst.DictElement] | None = None,
+    has_scalar_map: bool = False,
 ) -> cst.SimpleStatementLine | None:
     if not any([root_query_name, root_mutation_name, root_subscription_name]):
         return None
@@ -662,13 +662,13 @@ def _get_schema_definition(
     if root_subscription_name:
         args.append(_get_arg("subscription", root_subscription_name))
 
-    if scalar_map:
+    if has_scalar_map:
         config_call = cst.Call(
             func=cst.Name("StrawberryConfig"),
             args=[
                 cst.Arg(
                     keyword=cst.Name("scalar_map"),
-                    value=cst.Dict(elements=scalar_map),
+                    value=cst.Name("scalar_map"),
                     equal=cst.AssignEqual(
                         cst.SimpleWhitespace(""), cst.SimpleWhitespace("")
                     ),
@@ -721,7 +721,7 @@ class Definition:
     code: cst.CSTNode
     dependencies: list[str]
     name: str
-    scalar_override: cst.DictElement | None = None
+    scalar_map_entry: cst.DictElement | None = None
 
 
 def _get_union_definition(definition: UnionTypeDefinitionNode) -> Definition:
@@ -850,11 +850,11 @@ def _get_scalar_definition(
         ]
     )
 
-    # Register the scalar via `scalar_overrides=` on the Schema constructor so
-    # the type expression and the scalar registration are decoupled. Calling
+    # Register the scalar via `scalar_map=` on `StrawberryConfig` so the type
+    # expression and the scalar registration are decoupled. Calling
     # `strawberry.scalar(name=..., ...)` without `cls` returns a
     # ScalarDefinition and is the type-checker-friendly overload.
-    scalar_override = cst.DictElement(
+    scalar_map_entry = cst.DictElement(
         key=cst.Name(name),
         value=cst.Call(
             func=cst.Attribute(
@@ -869,7 +869,7 @@ def _get_scalar_definition(
         statement_definition,
         [],
         name=definition.name.value,
-        scalar_override=scalar_override,
+        scalar_map_entry=scalar_map_entry,
     )
 
 
@@ -954,19 +954,54 @@ def codegen(schema: str) -> str:
             "Subscription" if "Subscription" in definitions else None
         )
 
-    scalar_map = [
-        d.scalar_override for d in definitions.values() if d.scalar_override is not None
+    scalar_map_entries = [
+        (d.name, d.scalar_map_entry)
+        for d in definitions.values()
+        if d.scalar_map_entry is not None
     ]
+
+    if scalar_map_entries:
+        # Annotate as `dict[object, ScalarDefinition]` so pyright can widen the
+        # inferred `dict[type[Foo], ScalarDefinition]` to the
+        # `Mapping[object, ScalarDefinition]` accepted by StrawberryConfig.
+        scalar_map_statement = cst.SimpleStatementLine(
+            body=[
+                cst.AnnAssign(
+                    target=cst.Name("scalar_map"),
+                    annotation=cst.Annotation(
+                        annotation=cst.Subscript(
+                            value=cst.Name("dict"),
+                            slice=[
+                                cst.SubscriptElement(cst.Index(cst.Name("object"))),
+                                cst.SubscriptElement(
+                                    cst.Index(cst.Name("ScalarDefinition"))
+                                ),
+                            ],
+                        )
+                    ),
+                    value=cst.Dict(elements=[entry for _, entry in scalar_map_entries]),
+                )
+            ]
+        )
+        imports.add(
+            Import(module="strawberry.types.scalar", imports=("ScalarDefinition",))
+        )
+        # Depends on each NewType binding so topological sort places it after them.
+        definitions["_scalar_map"] = Definition(
+            scalar_map_statement,
+            [name for name, _ in scalar_map_entries],
+            "scalar_map",
+        )
 
     schema_definition = _get_schema_definition(
         root_query_name=root_query_name,
         root_mutation_name=root_mutation_name,
         root_subscription_name=root_subscription_name,
         is_apollo_federation=is_apollo_federation,
-        scalar_map=scalar_map,
+        has_scalar_map=bool(scalar_map_entries),
     )
 
-    if schema_definition is not None and scalar_map:
+    if schema_definition is not None and scalar_map_entries:
         imports.add(
             Import(module="strawberry.schema.config", imports=("StrawberryConfig",))
         )

--- a/strawberry/schema_codegen/config.py
+++ b/strawberry/schema_codegen/config.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import dataclasses
+import re
+from typing import TYPE_CHECKING
+
+import yaml
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+_SCALAR_TARGET_RE = re.compile(r"^[A-Za-z_][\w.]*:[A-Za-z_]\w*$")
+
+
+@dataclasses.dataclass(frozen=True)
+class CodegenConfig:
+    scalars: dict[str, str] = dataclasses.field(default_factory=dict)
+
+
+def load_config(path: Path) -> CodegenConfig:
+    raw = yaml.safe_load(path.read_text()) or {}
+
+    if not isinstance(raw, dict):
+        raise TypeError(
+            f"Config file {path} must contain a YAML mapping at the top level, "
+            f"got {type(raw).__name__}."
+        )
+
+    scalars_raw = raw.get("scalars", {})
+
+    if not isinstance(scalars_raw, dict):
+        raise TypeError(
+            f"`scalars` in {path} must be a mapping of scalar name to "
+            f'"<module>:<object>", got {type(scalars_raw).__name__}.'
+        )
+
+    scalars: dict[str, str] = {}
+
+    for name, target in scalars_raw.items():
+        if not isinstance(name, str) or not name.isidentifier():
+            raise ValueError(
+                f"Invalid scalar name {name!r} in {path}: must be a valid "
+                f"Python identifier."
+            )
+        if not isinstance(target, str) or not _SCALAR_TARGET_RE.match(target):
+            raise ValueError(
+                f"Invalid target {target!r} for scalar {name!r} in {path}: "
+                f'expected "<module>:<object>" (e.g. "strawberry.scalars:JSON").'
+            )
+        scalars[name] = target
+
+    return CodegenConfig(scalars=scalars)

--- a/strawberry/schema_codegen/config.py
+++ b/strawberry/schema_codegen/config.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-_SCALAR_TARGET_RE = re.compile(r"^[A-Za-z_][\w.]*:[A-Za-z_]\w*$")
+_SCALAR_TARGET_RE = re.compile(r"^[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*:[A-Za-z_]\w*$")
 
 
 @dataclasses.dataclass(frozen=True)
@@ -19,7 +19,10 @@ class CodegenConfig:
 
 
 def load_config(path: Path) -> CodegenConfig:
-    raw = yaml.safe_load(path.read_text()) or {}
+    try:
+        raw = yaml.safe_load(path.read_text()) or {}
+    except yaml.YAMLError as exc:
+        raise ValueError(f"Invalid YAML in config file {path}: {exc}") from exc
 
     if not isinstance(raw, dict):
         raise TypeError(

--- a/tests/cli/test_schema_codegen.py
+++ b/tests/cli/test_schema_codegen.py
@@ -1,8 +1,11 @@
+import re
 from pathlib import Path
 
 import pytest
 from typer import Typer
 from typer.testing import CliRunner
+
+_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*m")
 
 schema = """
 type Query {
@@ -99,6 +102,10 @@ def test_schema_codegen_config_malformed(
         ["schema-codegen", str(schema_file), "--config", str(config_file)],
     )
 
+    # Strip ANSI escapes so the substring match isn't broken by Typer/Rich's
+    # syntax highlighting of the placeholders inside the error message.
+    plain_output = _ANSI_ESCAPE_RE.sub("", result.output)
+
     assert result.exit_code != 0
-    assert "JSONObject" in result.output
-    assert "<module>:<object>" in result.output
+    assert "JSONObject" in plain_output
+    assert "<module>:<object>" in plain_output

--- a/tests/cli/test_schema_codegen.py
+++ b/tests/cli/test_schema_codegen.py
@@ -109,3 +109,21 @@ def test_schema_codegen_config_malformed(
     assert result.exit_code != 0
     assert "JSONObject" in plain_output
     assert "<module>:<object>" in plain_output
+
+
+def test_schema_codegen_config_invalid_yaml(
+    cli_app: Typer, cli_runner: CliRunner, schema_file: Path, tmp_path: Path
+):
+    config_file = tmp_path / "codegen.yaml"
+    # Unbalanced bracket — yaml.safe_load raises yaml.YAMLError.
+    config_file.write_text("scalars: [JSONObject: strawberry.scalars:JSON\n")
+
+    result = cli_runner.invoke(
+        cli_app,
+        ["schema-codegen", str(schema_file), "--config", str(config_file)],
+    )
+
+    plain_output = _ANSI_ESCAPE_RE.sub("", result.output)
+
+    assert result.exit_code != 0
+    assert "Invalid YAML" in plain_output

--- a/tests/cli/test_schema_codegen.py
+++ b/tests/cli/test_schema_codegen.py
@@ -63,3 +63,42 @@ def test_overrides_file_if_exists(
     assert "Code generated at `schema.py`" in result.stdout.strip()
     assert result.exit_code == 0
     assert output_file.read_text().strip() == expected_output
+
+
+def test_schema_codegen_with_config(
+    cli_app: Typer, cli_runner: CliRunner, tmp_path: Path
+):
+    schema_file = tmp_path / "schema.graphql"
+    schema_file.write_text(
+        "scalar JSONObject\n\ntype Query {\n  data: JSONObject!\n}\n"
+    )
+
+    config_file = tmp_path / "codegen.yaml"
+    config_file.write_text("scalars:\n  JSONObject: strawberry.scalars:JSON\n")
+
+    result = cli_runner.invoke(
+        cli_app,
+        ["schema-codegen", str(schema_file), "-c", str(config_file)],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert "from strawberry.scalars import JSON as JSONObject" in result.stdout
+    assert "NewType" not in result.stdout
+    assert "scalar_map" not in result.stdout
+
+
+def test_schema_codegen_config_malformed(
+    cli_app: Typer, cli_runner: CliRunner, schema_file: Path, tmp_path: Path
+):
+    config_file = tmp_path / "codegen.yaml"
+    # Value missing `:` separator — invalid `<module>:<object>` shape.
+    config_file.write_text("scalars:\n  JSONObject: strawberry.scalars.JSON\n")
+
+    result = cli_runner.invoke(
+        cli_app,
+        ["schema-codegen", str(schema_file), "--config", str(config_file)],
+    )
+
+    assert result.exit_code != 0
+    assert "JSONObject" in result.output
+    assert "<module>:<object>" in result.output

--- a/tests/schema_codegen/test_scalar.py
+++ b/tests/schema_codegen/test_scalar.py
@@ -144,7 +144,43 @@ def test_scalar_with_description_and_specified_by_registered_via_scalar_map():
     assert codegen(schema).strip() == expected
 
 
-def test_jsonobject_scalar():
+def test_jsonobject_scalar_without_override():
+    """`JSONObject` is not a built-in — without a config it falls into the
+    generic `scalar_map` path like any other unknown scalar."""
+    schema = """
+    scalar JSONObject
+
+    type Query {
+        data: JSONObject!
+    }
+    """
+
+    expected = textwrap.dedent(
+        """
+        from __future__ import annotations
+        import strawberry
+        from strawberry.schema.config import StrawberryConfig
+        from strawberry.types.scalar import ScalarDefinition
+        from typing import NewType
+
+        JSONObject = NewType("JSONObject", object)
+
+        @strawberry.type
+        class Query:
+            data: JSONObject
+
+        scalar_map: dict[object, ScalarDefinition] = {JSONObject: strawberry.scalar(name="JSONObject", serialize=lambda v: v, parse_value=lambda v: v)}
+
+        schema = strawberry.Schema(query=Query, config=StrawberryConfig(scalar_map=scalar_map))
+        """
+    ).strip()
+
+    assert codegen(schema).strip() == expected
+
+
+def test_scalar_override_with_alias():
+    """Mapping `JSONObject` to `strawberry.scalars:JSON` emits an aliased
+    import and skips the `NewType` / `scalar_map` machinery."""
     schema = """
     scalar JSONObject
 
@@ -167,7 +203,88 @@ def test_jsonobject_scalar():
         """
     ).strip()
 
-    assert codegen(schema).strip() == expected
+    result = codegen(schema, scalar_overrides={"JSONObject": "strawberry.scalars:JSON"})
+    assert result.strip() == expected
+
+
+def test_scalar_override_same_name():
+    """When the override target name matches the scalar name, no `as` alias
+    is emitted."""
+    schema = """
+    scalar MyScalar
+
+    type Query {
+        a: MyScalar!
+    }
+    """
+
+    expected = textwrap.dedent(
+        """
+        from __future__ import annotations
+        import strawberry
+        from my_app.scalars import MyScalar
+
+        @strawberry.type
+        class Query:
+            a: MyScalar
+
+        schema = strawberry.Schema(query=Query)
+        """
+    ).strip()
+
+    result = codegen(schema, scalar_overrides={"MyScalar": "my_app.scalars:MyScalar"})
+    assert result.strip() == expected
+
+
+def test_scalar_override_wins_over_builtin():
+    """Overrides apply to scalars that have built-in handling too — the
+    built-in `from datetime import date` import is suppressed and the field
+    annotation uses the scalar's GraphQL name (`Date`) rather than `date`."""
+    schema = """
+    scalar Date
+
+    type Query {
+        when: Date!
+    }
+    """
+
+    expected = textwrap.dedent(
+        """
+        from __future__ import annotations
+        import strawberry
+        from my_app.scalars import UnixDate as Date
+
+        @strawberry.type
+        class Query:
+            when: Date
+
+        schema = strawberry.Schema(query=Query)
+        """
+    ).strip()
+
+    result = codegen(schema, scalar_overrides={"Date": "my_app.scalars:UnixDate"})
+    assert result.strip() == expected
+
+
+def test_scalar_overrides_do_not_affect_other_scalars():
+    """Overriding one scalar leaves the rest of the codegen unchanged."""
+    schema = """
+    scalar JSONObject
+    scalar LocalDate
+
+    type Query {
+        a: JSONObject!
+        b: LocalDate!
+    }
+    """
+
+    result = codegen(schema, scalar_overrides={"JSONObject": "strawberry.scalars:JSON"})
+
+    assert "from strawberry.scalars import JSON as JSONObject" in result
+    assert 'LocalDate = NewType("LocalDate", object)' in result
+    assert "scalar_map: dict[object, ScalarDefinition] = {LocalDate:" in result
+    # No NewType for the overridden scalar.
+    assert "JSONObject = NewType" not in result
 
 
 def test_multiple_unknown_scalars_aggregated_into_scalar_map():

--- a/tests/schema_codegen/test_scalar.py
+++ b/tests/schema_codegen/test_scalar.py
@@ -14,7 +14,7 @@ def test_scalar():
         import strawberry
         from typing import NewType
 
-        LocalDate = strawberry.scalar(NewType("LocalDate", object), specified_by_url="https://scalars.graphql.org/andimarek/local-date.html", serialize=lambda v: v, parse_value=lambda v: v)
+        LocalDate = NewType("LocalDate", object)
         """
     ).strip()
 
@@ -33,11 +33,117 @@ def test_scalar_with_description():
         import strawberry
         from typing import NewType
 
-        LocalDate = strawberry.scalar(NewType("LocalDate", object), description="A date without a time-zone in the ISO-8601 calendar system, such as 2007-12-03.", serialize=lambda v: v, parse_value=lambda v: v)
+        LocalDate = NewType("LocalDate", object)
         """
     ).strip()
 
     assert codegen(schema).strip() == expected
+
+
+def test_scalar_registered_via_scalar_map():
+    schema = """
+    scalar LocalDate @specifiedBy(url: "https://scalars.graphql.org/andimarek/local-date.html")
+
+    type Query {
+        when: LocalDate!
+    }
+    """
+
+    expected = textwrap.dedent(
+        """
+        from __future__ import annotations
+        import strawberry
+        from strawberry.schema.config import StrawberryConfig
+        from typing import NewType
+
+        LocalDate = NewType("LocalDate", object)
+
+        @strawberry.type
+        class Query:
+            when: LocalDate
+
+        schema = strawberry.Schema(query=Query, config=StrawberryConfig(scalar_map={LocalDate: strawberry.scalar(name="LocalDate", specified_by_url="https://scalars.graphql.org/andimarek/local-date.html", serialize=lambda v: v, parse_value=lambda v: v)}))
+        """
+    ).strip()
+
+    assert codegen(schema).strip() == expected
+
+
+def test_scalar_with_description_registered_via_scalar_map():
+    schema = """
+    "A date without a time-zone in the ISO-8601 calendar system, such as 2007-12-03."
+    scalar LocalDate
+
+    type Query {
+        when: LocalDate!
+    }
+    """
+
+    expected = textwrap.dedent(
+        """
+        from __future__ import annotations
+        import strawberry
+        from strawberry.schema.config import StrawberryConfig
+        from typing import NewType
+
+        LocalDate = NewType("LocalDate", object)
+
+        @strawberry.type
+        class Query:
+            when: LocalDate
+
+        schema = strawberry.Schema(query=Query, config=StrawberryConfig(scalar_map={LocalDate: strawberry.scalar(name="LocalDate", description="A date without a time-zone in the ISO-8601 calendar system, such as 2007-12-03.", serialize=lambda v: v, parse_value=lambda v: v)}))
+        """
+    ).strip()
+
+    assert codegen(schema).strip() == expected
+
+
+def test_jsonobject_scalar():
+    schema = """
+    scalar JSONObject
+
+    type Query {
+        data: JSONObject!
+    }
+    """
+
+    expected = textwrap.dedent(
+        """
+        from __future__ import annotations
+        import strawberry
+        from strawberry.scalars import JSON as JSONObject
+
+        @strawberry.type
+        class Query:
+            data: JSONObject
+
+        schema = strawberry.Schema(query=Query)
+        """
+    ).strip()
+
+    assert codegen(schema).strip() == expected
+
+
+def test_multiple_unknown_scalars_aggregated_into_scalar_map():
+    schema = """
+    scalar Foo
+    scalar Bar
+
+    type Query {
+        a: Foo!
+        b: Bar!
+    }
+    """
+
+    output = codegen(schema)
+
+    assert 'Foo = NewType("Foo", object)' in output
+    assert 'Bar = NewType("Bar", object)' in output
+    assert "from strawberry.schema.config import StrawberryConfig" in output
+    assert "config=StrawberryConfig(scalar_map={" in output
+    assert 'Foo: strawberry.scalar(name="Foo"' in output
+    assert 'Bar: strawberry.scalar(name="Bar"' in output
 
 
 def test_builtin_scalars():
@@ -67,11 +173,12 @@ def test_builtin_scalars():
         from datetime import datetime
         from datetime import time
         from decimal import Decimal
+        from strawberry.scalars import JSON
         from uuid import UUID
 
         @strawberry.type
         class Example:
-            a: strawberry.JSON
+            a: JSON
             b: date
             c: time
             d: datetime

--- a/tests/schema_codegen/test_scalar.py
+++ b/tests/schema_codegen/test_scalar.py
@@ -12,9 +12,12 @@ def test_scalar():
         """
         from __future__ import annotations
         import strawberry
+        from strawberry.types.scalar import ScalarDefinition
         from typing import NewType
 
         LocalDate = NewType("LocalDate", object)
+
+        scalar_map: dict[object, ScalarDefinition] = {LocalDate: strawberry.scalar(name="LocalDate", specified_by_url="https://scalars.graphql.org/andimarek/local-date.html", serialize=lambda v: v, parse_value=lambda v: v)}
         """
     ).strip()
 
@@ -31,9 +34,12 @@ def test_scalar_with_description():
         """
         from __future__ import annotations
         import strawberry
+        from strawberry.types.scalar import ScalarDefinition
         from typing import NewType
 
         LocalDate = NewType("LocalDate", object)
+
+        scalar_map: dict[object, ScalarDefinition] = {LocalDate: strawberry.scalar(name="LocalDate", description="A date without a time-zone in the ISO-8601 calendar system, such as 2007-12-03.", serialize=lambda v: v, parse_value=lambda v: v)}
         """
     ).strip()
 
@@ -54,6 +60,7 @@ def test_scalar_registered_via_scalar_map():
         from __future__ import annotations
         import strawberry
         from strawberry.schema.config import StrawberryConfig
+        from strawberry.types.scalar import ScalarDefinition
         from typing import NewType
 
         LocalDate = NewType("LocalDate", object)
@@ -62,7 +69,9 @@ def test_scalar_registered_via_scalar_map():
         class Query:
             when: LocalDate
 
-        schema = strawberry.Schema(query=Query, config=StrawberryConfig(scalar_map={LocalDate: strawberry.scalar(name="LocalDate", specified_by_url="https://scalars.graphql.org/andimarek/local-date.html", serialize=lambda v: v, parse_value=lambda v: v)}))
+        scalar_map: dict[object, ScalarDefinition] = {LocalDate: strawberry.scalar(name="LocalDate", specified_by_url="https://scalars.graphql.org/andimarek/local-date.html", serialize=lambda v: v, parse_value=lambda v: v)}
+
+        schema = strawberry.Schema(query=Query, config=StrawberryConfig(scalar_map=scalar_map))
         """
     ).strip()
 
@@ -84,6 +93,7 @@ def test_scalar_with_description_registered_via_scalar_map():
         from __future__ import annotations
         import strawberry
         from strawberry.schema.config import StrawberryConfig
+        from strawberry.types.scalar import ScalarDefinition
         from typing import NewType
 
         LocalDate = NewType("LocalDate", object)
@@ -92,7 +102,42 @@ def test_scalar_with_description_registered_via_scalar_map():
         class Query:
             when: LocalDate
 
-        schema = strawberry.Schema(query=Query, config=StrawberryConfig(scalar_map={LocalDate: strawberry.scalar(name="LocalDate", description="A date without a time-zone in the ISO-8601 calendar system, such as 2007-12-03.", serialize=lambda v: v, parse_value=lambda v: v)}))
+        scalar_map: dict[object, ScalarDefinition] = {LocalDate: strawberry.scalar(name="LocalDate", description="A date without a time-zone in the ISO-8601 calendar system, such as 2007-12-03.", serialize=lambda v: v, parse_value=lambda v: v)}
+
+        schema = strawberry.Schema(query=Query, config=StrawberryConfig(scalar_map=scalar_map))
+        """
+    ).strip()
+
+    assert codegen(schema).strip() == expected
+
+
+def test_scalar_with_description_and_specified_by_registered_via_scalar_map():
+    schema = """
+    "A date without a time-zone in the ISO-8601 calendar system, such as 2007-12-03."
+    scalar LocalDate @specifiedBy(url: "https://scalars.graphql.org/andimarek/local-date.html")
+
+    type Query {
+        when: LocalDate!
+    }
+    """
+
+    expected = textwrap.dedent(
+        """
+        from __future__ import annotations
+        import strawberry
+        from strawberry.schema.config import StrawberryConfig
+        from strawberry.types.scalar import ScalarDefinition
+        from typing import NewType
+
+        LocalDate = NewType("LocalDate", object)
+
+        @strawberry.type
+        class Query:
+            when: LocalDate
+
+        scalar_map: dict[object, ScalarDefinition] = {LocalDate: strawberry.scalar(name="LocalDate", description="A date without a time-zone in the ISO-8601 calendar system, such as 2007-12-03.", specified_by_url="https://scalars.graphql.org/andimarek/local-date.html", serialize=lambda v: v, parse_value=lambda v: v)}
+
+        schema = strawberry.Schema(query=Query, config=StrawberryConfig(scalar_map=scalar_map))
         """
     ).strip()
 
@@ -136,14 +181,30 @@ def test_multiple_unknown_scalars_aggregated_into_scalar_map():
     }
     """
 
-    output = codegen(schema)
+    expected = textwrap.dedent(
+        """
+        from __future__ import annotations
+        import strawberry
+        from strawberry.schema.config import StrawberryConfig
+        from strawberry.types.scalar import ScalarDefinition
+        from typing import NewType
 
-    assert 'Foo = NewType("Foo", object)' in output
-    assert 'Bar = NewType("Bar", object)' in output
-    assert "from strawberry.schema.config import StrawberryConfig" in output
-    assert "config=StrawberryConfig(scalar_map={" in output
-    assert 'Foo: strawberry.scalar(name="Foo"' in output
-    assert 'Bar: strawberry.scalar(name="Bar"' in output
+        Foo = NewType("Foo", object)
+
+        Bar = NewType("Bar", object)
+
+        @strawberry.type
+        class Query:
+            a: Foo
+            b: Bar
+
+        scalar_map: dict[object, ScalarDefinition] = {Foo: strawberry.scalar(name="Foo", serialize=lambda v: v, parse_value=lambda v: v), Bar: strawberry.scalar(name="Bar", serialize=lambda v: v, parse_value=lambda v: v)}
+
+        schema = strawberry.Schema(query=Query, config=StrawberryConfig(scalar_map=scalar_map))
+        """
+    ).strip()
+
+    assert codegen(schema).strip() == expected
 
 
 def test_builtin_scalars():


### PR DESCRIPTION
Fix #4378

## Summary

`strawberry schema-codegen` previously produced output that failed pyright's
default ruleset whenever the SDL contained a user-defined custom scalar, and
referenced a non-existent `strawberry.JSON` attribute (raising
`AttributeError` at schema construction). This PR fixes both problems and
adds a `--config / -c` flag for telling codegen how specific scalars should
be emitted.

## Changes

### 1. Pyright-clean output for custom scalars

Replaced the deprecated `Foo = strawberry.scalar(NewType("Foo", object), ...)`
pattern with a module-level `Foo = NewType("Foo", object)` binding registered
through `StrawberryConfig.scalar_map` — the recommended Strawberry API for
custom scalars. The `scalar_map` is emitted as a module-level constant so
descriptions and `@specifiedBy` URLs survive even on scalars-only SDL
fragments.

### 2. Fix the `JSON` registry entry

`_SCALAR_MAP["JSON"]` previously emitted `strawberry.JSON`, which does not
exist. Now emits `from strawberry.scalars import JSON` plus a bare `JSON`
field annotation.

### 3. New: `--config / -c <file>` for scalar overrides

The single section today is `scalars:`, a mapping from a GraphQL scalar name
to a `<module>:<object>` Python target. For each entry, codegen imports the
target instead of generating a `NewType` plus `scalar_map` entry.

```yaml
# codegen.yaml
scalars:
  JSONObject: strawberry.scalars:JSON
  MyDecimal: my_app.scalars:MyDecimal
  Date: my_app.scalars:UnixDate
```

```shell
strawberry schema-codegen schema.graphql -c codegen.yaml
```

`JSONObject` is the canonical example: Strawberry doesn't ship a `JSONObject`
scalar, but several schemas use that name as a synonym for `JSON`. Pointing
it at `strawberry.scalars:JSON` via the config is the recommended way to
wire that convention up — it is intentionally not a built-in. Overrides win
over the built-in scalar mappings, so the same mechanism can redirect
`Date`, `JSON`, `UUID`, etc. to custom implementations.

## Test plan

- [x] `poetry run pytest tests/schema_codegen/ tests/cli/test_schema_codegen.py` — 90/90 pass
- [x] `poetry run mypy --config-file mypy.ini` — clean (239 files)
- [x] `poetry run pyright strawberry/schema_codegen strawberry/cli/commands/schema_codegen.py` — 0 errors
- [x] `poetry run ruff check` + `ruff format --check` — clean
- [x] End-to-end smoke: generated module imports successfully and `strawberry.Schema` builds for both fall-through (`scalar_map`) and override paths

## Summary by Sourcery

Update schema code generation to produce Pyright-clean custom scalar output and support configurable scalar overrides via a YAML-driven CLI flag.

New Features:
- Add YAML-based config support to schema codegen, including a -c/--config CLI option for specifying scalar overrides.
- Allow schema codegen to import custom scalar implementations instead of generating NewType-based placeholders, including support for aliased imports.

Bug Fixes:
- Correct the generated annotation for the JSON scalar to use the actual strawberry.scalars.JSON implementation instead of a non-existent strawberry.JSON attribute.
- Change custom scalar codegen to use top-level NewType bindings plus a scalar_map configuration so generated modules type-check under Pyright.

Enhancements:
- Emit a shared scalar_map constant and wire it into StrawberryConfig when generating schemas with non-built-in scalars, preserving descriptions and specifiedBy URLs across fragments.
- Extend import generation to handle aliased imports and ensure deterministic sorting of imports that may include aliases.
- Document schema-codegen output options, custom scalar handling, and config-file usage in the user guide.
- Add tests covering scalar_map registration, scalar override behavior, malformed config handling, and multiple-unknown-scalar aggregation.

Build:
- Add pyyaml as a CLI dependency for loading schema-codegen configuration files.

Documentation:
- Document writing schema-codegen output to files, the behavior of built-in and custom scalars, and the new YAML config mechanism for scalar overrides.

Tests:
- Expand schema-codegen unit and CLI tests to cover scalar_map generation, override precedence over built-ins, config parsing validation, and the new --config flag behavior.

Chores:
- Add a release note describing the improved Pyright compatibility for custom scalar codegen and the new config-based override mechanism.