### PR TITLE
Isolate extension state per request to fix concurrency leaks

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,23 @@
+Release type: patch
+
+Fixes a concurrency bug where extension state could leak between
+requests running in parallel.
+
+Two cases were affected:
+
+- Custom extensions that read `self.execution_context` (e.g. inside
+  `get_results`) and were passed as instances to `extensions=[…]` —
+  concurrent requests could observe each other's `ExecutionContext`.
+- The built-in `ApolloTracingExtension`, `DatadogTracingExtension`,
+  and `OpenTelemetryExtension` (plus their `*Sync` variants) — when
+  passed as instances, concurrent requests' tracing data could be
+  mixed.
+
+Both are now isolated per request, so passing tracing extensions as
+instances is safe.
+
+If you write custom extensions, note that reading
+`self.execution_context` outside an extension lifecycle hook
+(`on_operation`, `on_validate`, `on_parse`, `on_execute`, `resolve`,
+`get_results`) now raises `RuntimeError` instead of returning a stale
+value.

--- a/docs/guides/custom-extensions.md
+++ b/docs/guides/custom-extensions.md
@@ -291,3 +291,20 @@ class MyExtension(SchemaExtension):
         yield
         self.execution_context.context["db"].close()
 ```
+
+`execution_context` is backed by a
+[context variable](https://docs.python.org/3/library/contextvars.html), so
+concurrent requests sharing the same extension instance each see their own
+request's context. Reading `self.execution_context` outside an extension
+lifecycle hook (`on_operation`, `on_validate`, `on_parse`, `on_execute`,
+`resolve`, `get_results`) raises `RuntimeError`.
+
+### Request isolation
+
+If your extension needs to store request-scoped state, prefer holding it on
+`self.execution_context.extensions_results` or in a
+[`contextvars.ContextVar`](https://docs.python.org/3/library/contextvars.html)
+rather than on `self` directly. Plain `self` attributes are only safe when the
+extension is passed as a class (so the schema instantiates one per request); if
+you pass an extension as an instance, two concurrent requests share the same
+object and any mutable attribute on `self` will race.

--- a/strawberry/extensions/base_extension.py
+++ b/strawberry/extensions/base_extension.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextvars
 from collections.abc import Callable
 from enum import Enum
 from typing import TYPE_CHECKING, Any
@@ -19,14 +20,49 @@ class LifecycleStep(Enum):
     RESOLVE = "resolve"
 
 
-class SchemaExtension:
-    execution_context: ExecutionContext
+# The currently-running request's ``ExecutionContext``. Set by the schema at
+# the start of every ``execute`` / ``execute_sync`` / ``subscribe`` call and
+# read via :attr:`SchemaExtension.execution_context`. Using a context variable
+# keeps a single shared extension instance safe under concurrent execution
+# (asyncio.gather, threaded ``execute_sync``) — each task/thread observes its
+# own request's context. See issue #4369.
+execution_context_var: contextvars.ContextVar[ExecutionContext | None] = (
+    contextvars.ContextVar("strawberry.extension.execution_context", default=None)
+)
 
+
+class SchemaExtension:
     # to support extensions that still use the old signature
     # we have an optional argument here for ease of initialization.
     def __init__(
         self, *, execution_context: ExecutionContext | None = None
     ) -> None: ...
+
+    @property
+    def execution_context(self) -> ExecutionContext:
+        """The currently-running request's :class:`ExecutionContext`.
+
+        Backed by a context variable, so concurrent requests sharing this
+        extension instance each see their own context. Accessing this outside
+        an extension lifecycle hook raises ``RuntimeError``.
+        """
+        ec = execution_context_var.get()
+        if ec is None:
+            raise RuntimeError(
+                "ExecutionContext is only available inside an extension "
+                "lifecycle hook (on_operation, on_validate, on_parse, "
+                "on_execute, resolve, get_results)."
+            )
+        return ec
+
+    @execution_context.setter
+    def execution_context(self, value: ExecutionContext) -> None:
+        # Backwards-compat setter for code that does
+        # ``self.execution_context = ec`` (notably older third-party
+        # extensions). Updates the context variable so reads see the new value
+        # within the current task/thread.
+        execution_context_var.set(value)
+
     def on_operation(  # type: ignore
         self,
     ) -> AsyncIteratorOrIterator[None]:  # pragma: no cover
@@ -79,4 +115,10 @@ HOOK_METHODS: set[str] = {
     SchemaExtension.on_execute.__name__,
 }
 
-__all__ = ["HOOK_METHODS", "Hook", "LifecycleStep", "SchemaExtension"]
+__all__ = [
+    "HOOK_METHODS",
+    "Hook",
+    "LifecycleStep",
+    "SchemaExtension",
+    "execution_context_var",
+]

--- a/strawberry/extensions/context.py
+++ b/strawberry/extensions/context.py
@@ -11,12 +11,15 @@ from typing import (
 )
 
 from strawberry.extensions import SchemaExtension
+from strawberry.extensions.base_extension import execution_context_var
 
 if TYPE_CHECKING:
+    import contextvars
     from collections.abc import AsyncIterator, Callable, Iterator
     from types import TracebackType
 
     from strawberry.extensions.base_extension import Hook
+    from strawberry.types import ExecutionContext
     from strawberry.utils.await_maybe import AwaitableOrValue
 
 
@@ -31,16 +34,35 @@ class WrappedHook(NamedTuple):
 
 
 class ExtensionContextManagerBase:
+    """Run extension lifecycle hooks and yield the bound ExecutionContext.
+
+    Runs a single class of hooks (named by ``HOOK_NAME``) and yields the
+    per-request ``ExecutionContext`` so callers can write
+    ``with cm as execution_context:``. Subclasses just provide
+    ``HOOK_NAME``. The only one that does extra work is
+    :class:`OperationContextManager`, which additionally binds the
+    per-request
+    :data:`strawberry.extensions.base_extension.execution_context_var`
+    so concurrent requests sharing one extension instance each see their
+    own context.
+    """
+
     __slots__ = (
         "async_exit_stack",
         "default_hook",
+        "execution_context",
         "exit_stack",
         "hooks",
     )
 
     HOOK_NAME: str
 
-    def __init__(self, extensions: list[SchemaExtension]) -> None:
+    def __init__(
+        self,
+        extensions: list[SchemaExtension],
+        execution_context: ExecutionContext,
+    ) -> None:
+        self.execution_context = execution_context
         self.hooks: list[WrappedHook] = []
         self.default_hook: Hook = getattr(SchemaExtension, self.HOOK_NAME)
         for extension in extensions:
@@ -100,7 +122,7 @@ class ExtensionContextManagerBase:
 
         return WrappedHook(extension=extension, hook=iterator, is_async=False)
 
-    def __enter__(self) -> None:
+    def __enter__(self) -> ExecutionContext:
         self.exit_stack = contextlib.ExitStack()
 
         self.exit_stack.__enter__()
@@ -112,6 +134,7 @@ class ExtensionContextManagerBase:
                     "failed to complete synchronously."
                 )
             self.exit_stack.enter_context(hook.hook())  # type: ignore
+        return self.execution_context
 
     def __exit__(
         self,
@@ -121,7 +144,7 @@ class ExtensionContextManagerBase:
     ) -> None:
         self.exit_stack.__exit__(exc_type, exc_val, exc_tb)
 
-    async def __aenter__(self) -> None:
+    async def __aenter__(self) -> ExecutionContext:
         self.async_exit_stack = contextlib.AsyncExitStack()
 
         await self.async_exit_stack.__aenter__()
@@ -131,6 +154,7 @@ class ExtensionContextManagerBase:
                 await self.async_exit_stack.enter_async_context(hook.hook())  # type: ignore
             else:
                 self.async_exit_stack.enter_context(hook.hook())  # type: ignore
+        return self.execution_context
 
     async def __aexit__(
         self,
@@ -142,7 +166,63 @@ class ExtensionContextManagerBase:
 
 
 class OperationContextManager(ExtensionContextManagerBase):
+    """Top-level extension context manager for a GraphQL operation.
+
+    In addition to running the ``on_operation`` lifecycle hooks and
+    yielding the ``ExecutionContext`` (inherited behaviour), it binds
+    that context to the per-request
+    :data:`strawberry.extensions.base_extension.execution_context_var`
+    so concurrent requests sharing a single extension instance each
+    see their own context (asyncio.gather, threaded ``execute_sync``).
+    """
+
+    __slots__ = ("_token",)
+
     HOOK_NAME = SchemaExtension.on_operation.__name__
+
+    def __enter__(self) -> ExecutionContext:
+        self._token: contextvars.Token | None = execution_context_var.set(
+            self.execution_context
+        )
+        try:
+            return super().__enter__()
+        except BaseException:
+            execution_context_var.reset(self._token)
+            self._token = None
+            raise
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        try:
+            super().__exit__(exc_type, exc_val, exc_tb)
+        finally:
+            if self._token is not None:
+                execution_context_var.reset(self._token)
+
+    async def __aenter__(self) -> ExecutionContext:
+        self._token = execution_context_var.set(self.execution_context)
+        try:
+            return await super().__aenter__()
+        except BaseException:
+            execution_context_var.reset(self._token)
+            self._token = None
+            raise
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        try:
+            await super().__aexit__(exc_type, exc_val, exc_tb)
+        finally:
+            if self._token is not None:
+                execution_context_var.reset(self._token)
 
 
 class ValidationContextManager(ExtensionContextManagerBase):

--- a/strawberry/extensions/runner.py
+++ b/strawberry/extensions/runner.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import inspect
 from typing import TYPE_CHECKING, Any
 
+from strawberry.extensions.base_extension import execution_context_var
 from strawberry.extensions.context import (
     ExecutingContextManager,
     OperationContextManager,
@@ -29,32 +30,50 @@ class SchemaExtensionsRunner:
         self.extensions = extensions or []
 
     def operation(self) -> OperationContextManager:
-        return OperationContextManager(self.extensions)
+        return OperationContextManager(self.extensions, self.execution_context)
 
     def validation(self) -> ValidationContextManager:
-        return ValidationContextManager(self.extensions)
+        return ValidationContextManager(self.extensions, self.execution_context)
 
     def parsing(self) -> ParsingContextManager:
-        return ParsingContextManager(self.extensions)
+        return ParsingContextManager(self.extensions, self.execution_context)
 
     def executing(self) -> ExecutingContextManager:
-        return ExecutingContextManager(self.extensions)
+        return ExecutingContextManager(self.extensions, self.execution_context)
 
-    def get_extensions_results_sync(self) -> dict[str, Any]:
-        data: dict[str, Any] = {}
-        for extension in self.extensions:
-            if inspect.iscoroutinefunction(extension.get_results):
-                msg = "Cannot use async extension hook during sync execution"
-                raise RuntimeError(msg)
-            data.update(extension.get_results())  # type: ignore
+    def get_extensions_results_sync(self, ctx: ExecutionContext) -> dict[str, Any]:
+        # ``get_results`` may be invoked after ``OperationContextManager`` has
+        # already exited and reset the per-request ContextVar (e.g. for the
+        # success path of ``execute_sync``, where the call sits *outside* the
+        # ``with`` block so ``on_operation`` post-yield code can mutate the
+        # result first). Bind the ContextVar locally so extensions can still
+        # read ``self.execution_context`` regardless of the call site.
+        token = execution_context_var.set(ctx)
+        try:
+            data: dict[str, Any] = {}
+            for extension in self.extensions:
+                if inspect.iscoroutinefunction(extension.get_results):
+                    msg = "Cannot use async extension hook during sync execution"
+                    raise RuntimeError(msg)
+                data.update(extension.get_results())  # type: ignore
+
+            data.update(ctx.extensions_results)
+        finally:
+            execution_context_var.reset(token)
 
         return data
 
     async def get_extensions_results(self, ctx: ExecutionContext) -> dict[str, Any]:
-        data: dict[str, Any] = {}
+        # See ``get_extensions_results_sync`` for why we bind the ContextVar.
+        token = execution_context_var.set(ctx)
+        try:
+            data: dict[str, Any] = {}
 
-        for extension in self.extensions:
-            data.update(await await_maybe(extension.get_results()))
+            for extension in self.extensions:
+                data.update(await await_maybe(extension.get_results()))
 
-        data.update(ctx.extensions_results)
+            data.update(ctx.extensions_results)
+        finally:
+            execution_context_var.reset(token)
+
         return data

--- a/strawberry/extensions/tracing/apollo.py
+++ b/strawberry/extensions/tracing/apollo.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextvars
 import dataclasses
 import time
 from datetime import datetime, timezone
@@ -17,9 +18,6 @@ if TYPE_CHECKING:
     from graphql import GraphQLResolveInfo
 
 DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
-
-if TYPE_CHECKING:
-    from strawberry.types.execution import ExecutionContext
 
 
 @dataclasses.dataclass
@@ -81,66 +79,131 @@ class ApolloTracingStats:
         }
 
 
+@dataclasses.dataclass
+class _ApolloTracingState:
+    """Per-request tracing state.
+
+    Held in a context variable so that a single ``ApolloTracingExtension``
+    instance shared across concurrent requests gives each request its own
+    timing buffer and resolver stats.
+    """
+
+    resolver_stats: list[ApolloResolverStats]
+    start_timestamp: int
+    end_timestamp: int
+    start_time: datetime
+    end_time: datetime
+    start_parsing: int
+    end_parsing: int
+    start_validation: int
+    end_validation: int
+
+
+_apollo_state_var: contextvars.ContextVar[_ApolloTracingState | None] = (
+    contextvars.ContextVar("strawberry.tracing.apollo", default=None)
+)
+
+
+def _get_state() -> _ApolloTracingState:
+    state = _apollo_state_var.get()
+    if state is None:
+        raise RuntimeError(
+            "ApolloTracingExtension state is not initialised: this method "
+            "must be called inside the on_operation lifecycle hook."
+        )
+    return state
+
+
 class ApolloTracingExtension(SchemaExtension):
-    def __init__(self, execution_context: ExecutionContext) -> None:
-        self._resolver_stats: list[ApolloResolverStats] = []
-        self.execution_context = execution_context
-        now = self.now()
-        self.start_timestamp: int = now
-        self.end_timestamp: int = now
-        self.start_time: datetime = datetime.now(timezone.utc)
-        self.end_time: datetime = self.start_time
-        self._start_parsing: int = now
-        self._end_parsing: int = now
-        self._start_validation: int = now
-        self._end_validation: int = now
-
-    def on_operation(self) -> Generator[None, None, None]:
-        self._resolver_stats = []
-        self.start_timestamp = self.now()
-        self.start_time = datetime.now(timezone.utc)
-        try:
-            yield
-        finally:
-            self.end_timestamp = self.now()
-            self.end_time = datetime.now(timezone.utc)
-
-    def on_parse(self) -> Generator[None, None, None]:
-        self._start_parsing = self.now()
-        try:
-            yield
-        finally:
-            self._end_parsing = self.now()
-
-    def on_validate(self) -> Generator[None, None, None]:
-        self._start_validation = self.now()
-        try:
-            yield
-        finally:
-            self._end_validation = self.now()
-
     def now(self) -> int:
         return time.perf_counter_ns()
 
+    def on_operation(self) -> Generator[None, None, None]:
+        now = self.now()
+        start_time = datetime.now(timezone.utc)
+        state = _ApolloTracingState(
+            resolver_stats=[],
+            start_timestamp=now,
+            end_timestamp=now,
+            start_time=start_time,
+            end_time=start_time,
+            start_parsing=now,
+            end_parsing=now,
+            start_validation=now,
+            end_validation=now,
+        )
+        token = _apollo_state_var.set(state)
+        try:
+            yield
+        finally:
+            state.end_timestamp = self.now()
+            state.end_time = datetime.now(timezone.utc)
+            # Publish the per-request tracing payload onto the
+            # ``ExecutionContext`` before clearing state, so the extensions
+            # runner can pick it up after this hook exits without needing
+            # to read the ContextVar again.
+            stats = self.stats
+            assert stats is not None
+            self.execution_context.extensions_results["tracing"] = stats.to_json()
+            _apollo_state_var.reset(token)
+
+    def on_parse(self) -> Generator[None, None, None]:
+        state = _get_state()
+        state.start_parsing = self.now()
+        try:
+            yield
+        finally:
+            state.end_parsing = self.now()
+
+    def on_validate(self) -> Generator[None, None, None]:
+        state = _get_state()
+        state.start_validation = self.now()
+        try:
+            yield
+        finally:
+            state.end_validation = self.now()
+
     @property
-    def stats(self) -> ApolloTracingStats:
+    def stats(self) -> ApolloTracingStats | None:
+        """Snapshot of the current request's tracing stats.
+
+        Returns ``None`` when accessed outside an active ``on_operation``
+        — i.e. once the per-request state ContextVar has been reset.
+        """
+        state = _apollo_state_var.get()
+        if state is None:
+            return None
         return ApolloTracingStats(
-            start_time=self.start_time,
-            end_time=self.end_time,
-            duration=self.end_timestamp - self.start_timestamp,
-            execution=ApolloExecutionStats(self._resolver_stats),
+            start_time=state.start_time,
+            end_time=state.end_time,
+            duration=state.end_timestamp - state.start_timestamp,
+            execution=ApolloExecutionStats(state.resolver_stats),
             validation=ApolloStepStats(
-                start_offset=self._start_validation - self.start_timestamp,
-                duration=self._end_validation - self._start_validation,
+                start_offset=state.start_validation - state.start_timestamp,
+                duration=state.end_validation - state.start_validation,
             ),
             parsing=ApolloStepStats(
-                start_offset=self._start_parsing - self.start_timestamp,
-                duration=self._end_parsing - self._start_parsing,
+                start_offset=state.start_parsing - state.start_timestamp,
+                duration=state.end_parsing - state.start_parsing,
             ),
         )
 
     def get_results(self) -> dict[str, dict[str, Any]]:
-        return {"tracing": self.stats.to_json()}
+        """Return the tracing payload for the current request.
+
+        Called by ``SchemaExtensionsRunner`` either *during* the operation
+        (e.g. on an early-return triggered by a parse error) or *after*
+        it. While the operation is still active the state is in the
+        ContextVar, so the payload is built from there. Once
+        ``on_operation``'s ``finally`` has reset the token, the payload
+        has already been published onto
+        ``execution_context.extensions_results`` and returning ``{}``
+        lets the runner pick that up.
+        """
+        stats = self.stats
+        if stats is None:
+            return {}
+        return {"tracing": stats.to_json()}
 
     async def resolve(
         self,
@@ -158,6 +221,7 @@ class ApolloTracingExtension(SchemaExtension):
 
             return result
 
+        state = _get_state()
         start_timestamp = self.now()
 
         resolver_stats = ApolloResolverStats(
@@ -165,7 +229,7 @@ class ApolloTracingExtension(SchemaExtension):
             field_name=info.field_name,
             parent_type=info.parent_type,
             return_type=info.return_type,
-            start_offset=start_timestamp - self.start_timestamp,
+            start_offset=start_timestamp - state.start_timestamp,
         )
 
         try:
@@ -178,7 +242,7 @@ class ApolloTracingExtension(SchemaExtension):
         finally:
             end_timestamp = self.now()
             resolver_stats.duration = end_timestamp - start_timestamp
-            self._resolver_stats.append(resolver_stats)
+            state.resolver_stats.append(resolver_stats)
 
 
 class ApolloTracingExtensionSync(ApolloTracingExtension):
@@ -193,6 +257,7 @@ class ApolloTracingExtensionSync(ApolloTracingExtension):
         if should_skip_tracing(_next, info):
             return _next(root, info, *args, **kwargs)
 
+        state = _get_state()
         start_timestamp = self.now()
 
         resolver_stats = ApolloResolverStats(
@@ -200,7 +265,7 @@ class ApolloTracingExtensionSync(ApolloTracingExtension):
             field_name=info.field_name,
             parent_type=info.parent_type,
             return_type=info.return_type,
-            start_offset=start_timestamp - self.start_timestamp,
+            start_offset=start_timestamp - state.start_timestamp,
         )
 
         try:
@@ -208,7 +273,7 @@ class ApolloTracingExtensionSync(ApolloTracingExtension):
         finally:
             end_timestamp = self.now()
             resolver_stats.duration = end_timestamp - start_timestamp
-            self._resolver_stats.append(resolver_stats)
+            state.resolver_stats.append(resolver_stats)
 
 
 __all__ = ["ApolloTracingExtension", "ApolloTracingExtensionSync"]

--- a/strawberry/extensions/tracing/datadog.py
+++ b/strawberry/extensions/tracing/datadog.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import contextvars
+import dataclasses
 import hashlib
-from functools import cached_property
 from inspect import isawaitable
 from typing import TYPE_CHECKING, Any
 
@@ -23,29 +24,62 @@ if TYPE_CHECKING:
 
     from graphql import GraphQLResolveInfo
 
-    from strawberry.types.execution import ExecutionContext
+
+@dataclasses.dataclass
+class _DatadogTracingState:
+    """Per-request Datadog tracing state.
+
+    Held in a context variable so a shared extension instance is safe under
+    concurrent execution.
+    """
+
+    operation_name: str | None = None
+    resource_name: str | None = None
+    request_span: Span | None = None
+    validation_span: Span | None = None
+    parsing_span: Span | None = None
+
+
+_datadog_state_var: contextvars.ContextVar[_DatadogTracingState | None] = (
+    contextvars.ContextVar("strawberry.tracing.datadog", default=None)
+)
+
+
+def _get_state() -> _DatadogTracingState:
+    state = _datadog_state_var.get()
+    if state is None:
+        raise RuntimeError(
+            "DatadogTracingExtension state is not initialised: this method "
+            "must be called inside the on_operation lifecycle hook."
+        )
+    return state
 
 
 class DatadogTracingExtension(SchemaExtension):
-    def __init__(
-        self,
-        *,
-        execution_context: ExecutionContext | None = None,
-    ) -> None:
-        if execution_context:
-            self.execution_context = execution_context
-
-    @cached_property
+    @property
     def _resource_name(self) -> str:
+        """Datadog resource name for the current request, computed lazily.
+
+        Cached on the per-request state so multiple accesses don't re-hash.
+        Override this in a subclass to customise the resource label.
+        """
+        state = _get_state()
+        if state.resource_name is not None:
+            return state.resource_name
+
         if self.execution_context.query is None:
-            return "query_missing"
+            state.resource_name = "query_missing"
+            return state.resource_name
 
         query_hash = self.hash_query(self.execution_context.query)
 
         if self.execution_context.operation_name:
-            return f"{self.execution_context.operation_name}:{query_hash}"
-
-        return query_hash
+            state.resource_name = (
+                f"{self.execution_context.operation_name}:{query_hash}"
+            )
+        else:
+            state.resource_name = query_hash
+        return state.resource_name
 
     def create_span(
         self,
@@ -78,53 +112,63 @@ class DatadogTracingExtension(SchemaExtension):
         return hashlib.md5(query.encode("utf-8")).hexdigest()  # noqa: S324
 
     def on_operation(self) -> Iterator[None]:
-        self._operation_name = self.execution_context.operation_name
-        span_name = (
-            f"{self._operation_name}" if self._operation_name else "Anonymous Query"
-        )
+        state = _DatadogTracingState()
+        token = _datadog_state_var.set(state)
+        try:
+            state.operation_name = self.execution_context.operation_name
+            span_name = (
+                f"{state.operation_name}" if state.operation_name else "Anonymous Query"
+            )
 
-        self.request_span = self.create_span(
-            LifecycleStep.OPERATION,
-            span_name,
-            resource=self._resource_name,
-            service="strawberry",
-        )
-        self.request_span.set_tag("graphql.operation_name", self._operation_name)
+            request_span = self.create_span(
+                LifecycleStep.OPERATION,
+                span_name,
+                resource=self._resource_name,
+                service="strawberry",
+            )
+            state.request_span = request_span
+            request_span.set_tag("graphql.operation_name", state.operation_name)
 
-        query = self.execution_context.query
+            query = self.execution_context.query
 
-        if query is not None:
-            query = query.strip()
-            operation_type = "query"
+            if query is not None:
+                query = query.strip()
+                operation_type = "query"
 
-            if query.startswith("mutation"):
-                operation_type = "mutation"
-            elif query.startswith("subscription"):  # pragma: no cover
-                operation_type = "subscription"
-        else:
-            operation_type = "query_missing"
+                if query.startswith("mutation"):
+                    operation_type = "mutation"
+                elif query.startswith("subscription"):  # pragma: no cover
+                    operation_type = "subscription"
+            else:
+                operation_type = "query_missing"
 
-        self.request_span.set_tag("graphql.operation_type", operation_type)
+            request_span.set_tag("graphql.operation_type", operation_type)
 
-        yield
-
-        self.request_span.finish()
+            yield
+        finally:
+            if state.request_span is not None:
+                state.request_span.finish()
+            _datadog_state_var.reset(token)
 
     def on_validate(self) -> Generator[None, None, None]:
-        self.validation_span = self.create_span(
+        state = _get_state()
+        validation_span = self.create_span(
             lifecycle_step=LifecycleStep.VALIDATION,
             name="Validation",
         )
+        state.validation_span = validation_span
         yield
-        self.validation_span.finish()
+        validation_span.finish()
 
     def on_parse(self) -> Generator[None, None, None]:
-        self.parsing_span = self.create_span(
+        state = _get_state()
+        parsing_span = self.create_span(
             lifecycle_step=LifecycleStep.PARSE,
             name="Parsing",
         )
+        state.parsing_span = parsing_span
         yield
-        self.parsing_span.finish()
+        parsing_span.finish()
 
     async def resolve(
         self,

--- a/strawberry/extensions/tracing/opentelemetry.py
+++ b/strawberry/extensions/tracing/opentelemetry.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import contextvars
+import dataclasses
 from collections.abc import Callable
 from copy import deepcopy
 from inspect import isawaitable
@@ -30,9 +32,36 @@ DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 ArgFilter = Callable[[dict[str, Any], "GraphQLResolveInfo"], dict[str, Any]]
 
 
+@dataclasses.dataclass
+class _OpenTelemetryTracingState:
+    """Per-request OpenTelemetry tracing state.
+
+    Held in a context variable so a shared extension instance is safe under
+    concurrent execution. Stores the active spans (operation, validation,
+    parsing) and the operation name used to label them.
+    """
+
+    operation_name: str | None = None
+    span_holder: dict[LifecycleStep, Span] = dataclasses.field(default_factory=dict)
+
+
+_opentelemetry_state_var: contextvars.ContextVar[_OpenTelemetryTracingState | None] = (
+    contextvars.ContextVar("strawberry.tracing.opentelemetry", default=None)
+)
+
+
+def _get_state() -> _OpenTelemetryTracingState:
+    state = _opentelemetry_state_var.get()
+    if state is None:
+        raise RuntimeError(
+            "OpenTelemetryExtension state is not initialised: this method "
+            "must be called inside the on_operation lifecycle hook."
+        )
+    return state
+
+
 class OpenTelemetryExtension(SchemaExtension):
     _arg_filter: ArgFilter | None
-    _span_holder: dict[LifecycleStep, Span]
     _tracer: Tracer
 
     def __init__(
@@ -44,56 +73,60 @@ class OpenTelemetryExtension(SchemaExtension):
     ) -> None:
         self._arg_filter = arg_filter
         self._tracer = trace.get_tracer("strawberry", tracer_provider=tracer_provider)
-        self._span_holder = {}
-        if execution_context:
-            self.execution_context = execution_context
 
     def on_operation(self) -> Generator[None, None, None]:
-        self._operation_name = self.execution_context.operation_name
-        span_name = (
-            f"GraphQL Query: {self._operation_name}"
-            if self._operation_name
-            else "GraphQL Query"
-        )
-
-        self._span_holder[LifecycleStep.OPERATION] = self._tracer.start_span(
-            span_name, kind=SpanKind.SERVER
-        )
-        self._span_holder[LifecycleStep.OPERATION].set_attribute("component", "graphql")
-
-        if self.execution_context.query:
-            self._span_holder[LifecycleStep.OPERATION].set_attribute(
-                "query", self.execution_context.query
+        state = _OpenTelemetryTracingState()
+        token = _opentelemetry_state_var.set(state)
+        try:
+            state.operation_name = self.execution_context.operation_name
+            span_name = (
+                f"GraphQL Query: {state.operation_name}"
+                if state.operation_name
+                else "GraphQL Query"
             )
 
-        yield
-        # If the client doesn't provide an operation name then GraphQL will
-        # execute the first operation in the query string. This might be a named
-        # operation but we don't know until the parsing stage has finished. If
-        # that's the case we want to update the span name so that we have a more
-        # useful name in our trace.
-        if not self._operation_name and self.execution_context.operation_name:
-            span_name = f"GraphQL Query: {self.execution_context.operation_name}"
-            self._span_holder[LifecycleStep.OPERATION].update_name(span_name)
-        self._span_holder[LifecycleStep.OPERATION].end()
+            operation_span = self._tracer.start_span(span_name, kind=SpanKind.SERVER)
+            state.span_holder[LifecycleStep.OPERATION] = operation_span
+            operation_span.set_attribute("component", "graphql")
+
+            if self.execution_context.query:
+                operation_span.set_attribute("query", self.execution_context.query)
+
+            yield
+
+            # If the client doesn't provide an operation name then GraphQL will
+            # execute the first operation in the query string. This might be a named
+            # operation but we don't know until the parsing stage has finished. If
+            # that's the case we want to update the span name so that we have a more
+            # useful name in our trace.
+            if not state.operation_name and self.execution_context.operation_name:
+                span_name = f"GraphQL Query: {self.execution_context.operation_name}"
+                operation_span.update_name(span_name)
+        finally:
+            span = state.span_holder.get(LifecycleStep.OPERATION)
+            if span is not None:
+                span.end()
+            _opentelemetry_state_var.reset(token)
 
     def on_validate(self) -> Generator[None, None, None]:
-        ctx = trace.set_span_in_context(self._span_holder[LifecycleStep.OPERATION])
-        self._span_holder[LifecycleStep.VALIDATION] = self._tracer.start_span(
+        state = _get_state()
+        ctx = trace.set_span_in_context(state.span_holder[LifecycleStep.OPERATION])
+        validation_span = self._tracer.start_span(
             "GraphQL Validation",
             context=ctx,
         )
+        state.span_holder[LifecycleStep.VALIDATION] = validation_span
         yield
-        self._span_holder[LifecycleStep.VALIDATION].end()
+        validation_span.end()
 
     def on_parse(self) -> Generator[None, None, None]:
-        ctx = trace.set_span_in_context(self._span_holder[LifecycleStep.OPERATION])
-        self._span_holder[LifecycleStep.PARSE] = self._tracer.start_span(
-            "GraphQL Parsing", context=ctx
-        )
+        state = _get_state()
+        ctx = trace.set_span_in_context(state.span_holder[LifecycleStep.OPERATION])
+        parsing_span = self._tracer.start_span("GraphQL Parsing", context=ctx)
+        state.span_holder[LifecycleStep.PARSE] = parsing_span
 
         yield
-        self._span_holder[LifecycleStep.PARSE].end()
+        parsing_span.end()
 
     def filter_resolver_args(
         self, args: dict[str, Any], info: GraphQLResolveInfo
@@ -165,10 +198,11 @@ class OpenTelemetryExtension(SchemaExtension):
 
             return result
 
+        state = _get_state()
         with self._tracer.start_as_current_span(
             f"GraphQL Resolving: {info.field_name}",
             context=trace.set_span_in_context(
-                self._span_holder[LifecycleStep.OPERATION]
+                state.span_holder[LifecycleStep.OPERATION]
             ),
         ) as span:
             self.add_tags(span, info, kwargs)
@@ -192,10 +226,11 @@ class OpenTelemetryExtensionSync(OpenTelemetryExtension):
         if should_skip_tracing(_next, info):
             return _next(root, info, *args, **kwargs)
 
+        state = _get_state()
         with self._tracer.start_as_current_span(
             f"GraphQL Resolving: {info.field_name}",
             context=trace.set_span_in_context(
-                self._span_holder[LifecycleStep.OPERATION]
+                state.span_holder[LifecycleStep.OPERATION]
             ),
         ) as span:
             self.add_tags(span, info, kwargs)

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import warnings
 from asyncio import ensure_future
 from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable, Iterable
-from functools import cached_property, lru_cache
+from functools import lru_cache
 from inspect import isawaitable
 from typing import (
     TYPE_CHECKING,
@@ -380,14 +380,12 @@ class Schema(BaseSchema):
             for ext in extensions
         ]
 
-    @cached_property
+    @property
     def _sync_extensions(self) -> list[SchemaExtension]:
         return self.get_extensions(sync=True)
 
     @property
     def _async_extensions(self) -> list[SchemaExtension]:
-        # Fresh instances per access: concurrent async requests must not share
-        # extension state. See _sync_extensions for the cached counterpart.
         return self.get_extensions(sync=False)
 
     def create_extensions_runner(
@@ -586,10 +584,6 @@ class Schema(BaseSchema):
             operation_extensions=operation_extensions,
         )
         extensions = self._async_extensions
-        # TODO (#3571): remove this when we implement execution context as parameter.
-        for extension in extensions:
-            extension.execution_context = execution_context
-
         extensions_runner = self.create_extensions_runner(execution_context, extensions)
         # uncached: each async request needs its own middleware to avoid
         # concurrent requests overwriting each other's execution_context
@@ -609,7 +603,7 @@ class Schema(BaseSchema):
         custom_context_kwargs = self._get_custom_context_kwargs(operation_extensions)
 
         try:
-            async with extensions_runner.operation():
+            async with extensions_runner.operation() as execution_context:
                 # Note: In graphql-core the schema would be validated here but in
                 # Strawberry we are validating it at initialisation time instead
 
@@ -667,7 +661,12 @@ class Schema(BaseSchema):
                 PreExecutionError(data=None, errors=[_coerce_error(exc)]),
                 extensions_runner,
             )
-        # return results after all the operation completed.
+        # Success path: returns *after* the operation context exits so that
+        # ``on_operation`` post-yield code (which can mutate
+        # ``execution_context.result``) runs before the response is built.
+        # ``SchemaExtensionsRunner.get_extensions_results`` re-binds the
+        # per-request ContextVar so extensions can still read
+        # ``self.execution_context`` from inside ``get_results``.
         return await self._handle_execution_result(
             execution_context, result, extensions_runner, skip_process_errors=True
         )
@@ -695,12 +694,10 @@ class Schema(BaseSchema):
             operation_extensions=operation_extensions,
         )
         extensions = self._sync_extensions
-        # TODO (#3571): remove this when we implement execution context as parameter.
-        for extension in extensions:
-            extension.execution_context = execution_context
-
         extensions_runner = self.create_extensions_runner(execution_context, extensions)
-        middleware_manager = self._get_middleware_manager(extensions)
+        # Uncached: extensions are fresh per request, so the middleware
+        # manager wrapping them must be too.
+        middleware_manager = self._get_middleware_manager(extensions, cached=False)
 
         execute_function = execute
 
@@ -717,7 +714,7 @@ class Schema(BaseSchema):
         )
 
         try:
-            with extensions_runner.operation():
+            with extensions_runner.operation() as execution_context:
                 # Note: In graphql-core the schema would be validated here but in
                 # Strawberry we are validating it at initialisation time instead
                 if not execution_context.query:
@@ -737,7 +734,9 @@ class Schema(BaseSchema):
                         return ExecutionResult(
                             data=None,
                             errors=[error],
-                            extensions=extensions_runner.get_extensions_results_sync(),
+                            extensions=extensions_runner.get_extensions_results_sync(
+                                execution_context
+                            ),
                         )
 
                 try:
@@ -754,12 +753,15 @@ class Schema(BaseSchema):
                     _run_validation(execution_context)
                     if execution_context.pre_execution_errors:
                         self._process_errors(
-                            execution_context.pre_execution_errors, execution_context
+                            execution_context.pre_execution_errors,
+                            execution_context,
                         )
                         return ExecutionResult(
                             data=None,
                             errors=execution_context.pre_execution_errors,
-                            extensions=extensions_runner.get_extensions_results_sync(),
+                            extensions=extensions_runner.get_extensions_results_sync(
+                                execution_context
+                            ),
                         )
 
                 with extensions_runner.executing():
@@ -778,7 +780,9 @@ class Schema(BaseSchema):
                         )
 
                         if isawaitable(result):
-                            result = cast("Awaitable[GraphQLExecutionResult]", result)  # type: ignore[redundant-cast]
+                            result = cast(  # type: ignore[redundant-cast]
+                                "Awaitable[GraphQLExecutionResult]", result
+                            )
                             ensure_future(result).cancel()
                             raise RuntimeError(  # noqa: TRY301
                                 "GraphQL execution failed to complete synchronously."
@@ -809,12 +813,20 @@ class Schema(BaseSchema):
             return ExecutionResult(
                 data=None,
                 errors=errors,
-                extensions=extensions_runner.get_extensions_results_sync(),
+                extensions=extensions_runner.get_extensions_results_sync(
+                    execution_context
+                ),
             )
+        # Success path: return *after* the operation context exits so
+        # ``on_operation`` post-yield code (e.g. ``MaskErrors`` mutating
+        # ``execution_context.result.errors``) runs before the response
+        # is built. ``SchemaExtensionsRunner.get_extensions_results_sync``
+        # re-binds the per-request ContextVar so extensions can still read
+        # ``self.execution_context`` from inside ``get_results``.
         return ExecutionResult(
             data=execution_context.result.data,
             errors=execution_context.result.errors,
-            extensions=extensions_runner.get_extensions_results_sync(),
+            extensions=extensions_runner.get_extensions_results_sync(execution_context),
         )
 
     async def _subscribe(
@@ -918,17 +930,13 @@ class Schema(BaseSchema):
             operation_name=operation_name,
         )
         extensions = self._async_extensions
-        # TODO (#3571): remove this when we implement execution context as parameter.
-        for extension in extensions:
-            extension.execution_context = execution_context
-
         return self._subscribe(
             execution_context,
             extensions_runner=self.create_extensions_runner(
                 execution_context, extensions
             ),
-            # uncached: subscriptions are long-lived and concurrent, so each
-            # needs isolated middleware to keep its own execution_context
+            # Uncached: subscriptions are long-lived and concurrent; each
+            # needs its own middleware referencing fresh extensions.
             middleware_manager=self._get_middleware_manager(extensions, cached=False),
             execution_context_class=self.execution_context_class,
             operation_extensions=operation_extensions,

--- a/strawberry/subscriptions/protocols/graphql_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_ws/handlers.py
@@ -184,6 +184,7 @@ class BaseGraphQLWSHandler(Generic[Context, RootValue]):
         operation_name: str | None,
         variables: dict[str, object] | None,
     ) -> None:
+        result_source: AsyncGenerator | None = None
         try:
             result_source = await self.schema.subscribe(
                 query=query,
@@ -224,17 +225,32 @@ class BaseGraphQLWSHandler(Generic[Context, RootValue]):
             )
         except asyncio.CancelledError:
             await self.send_message(CompleteMessage(type="complete", id=operation_id))
+        finally:
+            # Close the generator from inside this task so its ``__aexit__``
+            # (which resets the per-request ``execution_context_var`` token)
+            # runs in the same :class:`contextvars.Context` that drove
+            # iteration. ``aclose`` is a no-op once the generator finished.
+            if result_source is not None:
+                with suppress(RuntimeError):
+                    await result_source.aclose()
+            # Drop our own registry entries so ``max_subscriptions_per_connection``
+            # accounting and memory don't drift on long-lived connections.
+            # Idempotent against ``cleanup_operation`` racing on the same id.
+            self.subscriptions.pop(operation_id, None)
+            self.tasks.pop(operation_id, None)
 
     async def cleanup_operation(self, operation_id: str) -> None:
-        if operation_id in self.subscriptions:
-            with suppress(RuntimeError):
-                await self.subscriptions[operation_id].aclose()
-            del self.subscriptions[operation_id]
-
-        self.tasks[operation_id].cancel()
-        with suppress(BaseException):
-            await self.tasks[operation_id]
-        del self.tasks[operation_id]
+        # Idempotent: a ``stop`` for an unknown id (or for one already cleaned
+        # up by ``handle_async_results``' finally) is a no-op.
+        task = self.tasks.pop(operation_id, None)
+        self.subscriptions.pop(operation_id, None)
+        if task is None:
+            return
+        # Cancel and await so the task's ``finally`` closes the subscription
+        # generator in its own context (see ``handle_async_results``).
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
 
     async def cleanup(self) -> None:
         for operation_id in list(self.tasks.keys()):

--- a/tests/extensions/tracing/test_opentelemetry.py
+++ b/tests/extensions/tracing/test_opentelemetry.py
@@ -1,31 +1,48 @@
 from unittest.mock import Mock
 
-from opentelemetry.trace import Span, TracerProvider
+import pytest
+from opentelemetry.trace import TracerProvider
 
-from strawberry.extensions import LifecycleStep
 from strawberry.extensions.tracing.opentelemetry import (
     OpenTelemetryExtension,
     OpenTelemetryExtensionSync,
+    _opentelemetry_state_var,
 )
 
 
-def test_span_holder_initialization():
+def test_no_per_request_state_on_instance():
+    """Per-request span state lives in a context variable, not on the
+    instance — so a freshly-built extension has none of it, and concurrent
+    requests sharing one instance don't see each other's spans."""
     extension = OpenTelemetryExtension()
-    assert extension._span_holder == {}
-    extension._span_holder[LifecycleStep.OPERATION] = Mock(spec=Span)
-    extension = OpenTelemetryExtension()
-    assert extension._span_holder == {}
+    assert not hasattr(extension, "_span_holder")
+    assert _opentelemetry_state_var.get() is None
+
+
+def test_no_per_request_state_on_instance_sync():
+    extension = OpenTelemetryExtensionSync()
+    assert not hasattr(extension, "_span_holder")
+    assert _opentelemetry_state_var.get() is None
+
+
+def test_tracer_provider_is_used():
     tracer_provider = Mock(spec=TracerProvider)
-    extension = OpenTelemetryExtension(tracer_provider=tracer_provider)
+    OpenTelemetryExtension(tracer_provider=tracer_provider)
     assert tracer_provider.get_tracer.called
 
 
-def test_span_holder_initialization_sync():
-    extension = OpenTelemetryExtensionSync()
-    assert extension._span_holder == {}
-    extension._span_holder[LifecycleStep.OPERATION] = Mock(spec=Span)
-    extension = OpenTelemetryExtensionSync()
-    assert extension._span_holder == {}
-    tracer_provider = Mock(spec=TracerProvider)
-    extension = OpenTelemetryExtension(tracer_provider=tracer_provider)
-    assert tracer_provider.get_tracer.called
+def test_on_validate_outside_operation_raises():
+    """``_get_state`` must raise when ``on_validate`` is invoked without
+    a preceding ``on_operation`` initialising the state ContextVar."""
+    extension = OpenTelemetryExtension()
+    gen = extension.on_validate()
+    with pytest.raises(RuntimeError, match="on_operation"):
+        next(gen)
+
+
+def test_on_parse_outside_operation_raises():
+    """Same contract for ``on_parse``."""
+    extension = OpenTelemetryExtension()
+    gen = extension.on_parse()
+    with pytest.raises(RuntimeError, match="on_operation"):
+        next(gen)

--- a/tests/schema/extensions/test_isolation.py
+++ b/tests/schema/extensions/test_isolation.py
@@ -1,0 +1,310 @@
+"""Regression tests for issue #4369: extension state must not leak between
+concurrent requests, regardless of whether the extension is passed to
+``strawberry.Schema`` as a class or as an instance, and regardless of
+whether the request is run via ``execute`` (async) or ``execute_sync``
+(threaded)."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import AsyncGenerator
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import pytest
+
+import strawberry
+from strawberry.extensions import SchemaExtension
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def hello(self) -> str:
+        time.sleep(0.05)
+        return "world"
+
+    @strawberry.field
+    async def hello_async(self) -> str:
+        await asyncio.sleep(0.05)
+        return "world"
+
+
+@strawberry.type
+class Subscription:
+    @strawberry.subscription
+    async def tick(self) -> AsyncGenerator[int, None]:
+        for i in range(3):
+            await asyncio.sleep(0.01)
+            yield i
+
+
+class QueryEchoExtension(SchemaExtension):
+    """Echoes the running request's query into the extensions payload.
+
+    Reads ``self.execution_context.query`` — the exact attribute the
+    reporter showed leaking between concurrent requests.
+    """
+
+    def get_results(self) -> dict[str, Any]:
+        return {"query": str(self.execution_context.query)}
+
+
+def _build_schema(extensions: list) -> strawberry.Schema:
+    return strawberry.Schema(query=Query, extensions=extensions)
+
+
+def _run_sync_concurrent(schema: strawberry.Schema) -> list:
+    queries = ["{ hello }", "{ test: hello }"]
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [executor.submit(schema.execute_sync, q) for q in queries]
+        return [f.result() for f in futures]
+
+
+async def _run_async_concurrent(schema: strawberry.Schema) -> list:
+    return list(
+        await asyncio.gather(
+            schema.execute("{ helloAsync }"),
+            schema.execute("{ test: helloAsync }"),
+        )
+    )
+
+
+def _assert_no_leak(results: list, queries: list[str]) -> None:
+    """Each result's echoed query must match its own request, not the other."""
+    assert len(results) == len(queries)
+    for result, expected_query in zip(results, queries, strict=True):
+        assert result.errors is None, result.errors
+        assert result.extensions is not None
+        assert result.extensions["query"] == expected_query, (
+            f"extension state leaked: expected {expected_query!r}, "
+            f"got {result.extensions['query']!r}"
+        )
+
+
+def test_sync_concurrent_instance_passed():
+    """Reporter's exact sync repro: instance-passed extension must not leak."""
+    schema = _build_schema([QueryEchoExtension()])
+    results = _run_sync_concurrent(schema)
+    _assert_no_leak(results, ["{ hello }", "{ test: hello }"])
+
+
+def test_sync_concurrent_class_passed():
+    """Sync, class-passed: also must not leak (PR #4256 only fixed async)."""
+    schema = _build_schema([QueryEchoExtension])
+    results = _run_sync_concurrent(schema)
+    _assert_no_leak(results, ["{ hello }", "{ test: hello }"])
+
+
+@pytest.mark.asyncio
+async def test_async_concurrent_instance_passed():
+    """Reporter's exact async repro: instance-passed extension must not leak."""
+    schema = _build_schema([QueryEchoExtension()])
+    results = await _run_async_concurrent(schema)
+    _assert_no_leak(results, ["{ helloAsync }", "{ test: helloAsync }"])
+
+
+@pytest.mark.asyncio
+async def test_async_concurrent_class_passed():
+    schema = _build_schema([QueryEchoExtension])
+    results = await _run_async_concurrent(schema)
+    _assert_no_leak(results, ["{ helloAsync }", "{ test: helloAsync }"])
+
+
+def test_instance_passed_extension_is_shared_but_context_isolated():
+    """Instance-passed extensions are reused across requests (no copying);
+    isolation comes from the ContextVar-backed ``execution_context``."""
+    captured_instances: list[SchemaExtension] = []
+    captured_queries: list[str] = []
+
+    class RecorderExtension(SchemaExtension):
+        def on_operation(self):
+            captured_instances.append(self)
+            captured_queries.append(str(self.execution_context.query))
+            yield
+
+    @strawberry.type
+    class TinyQuery:
+        @strawberry.field
+        def x(self) -> str:
+            return ""
+
+    extension = RecorderExtension()
+    schema = strawberry.Schema(query=TinyQuery, extensions=[extension])
+
+    schema.execute_sync("{ x }")
+    schema.execute_sync("query Two { x }")
+
+    assert captured_instances == [extension, extension], (
+        "the same instance must be reused across requests"
+    )
+    assert captured_queries == ["{ x }", "query Two { x }"]
+
+
+def test_execution_context_outside_hook_raises():
+    """Reading ``execution_context`` outside an extension lifecycle hook
+    should raise rather than silently return a stale value."""
+
+    class MyExtension(SchemaExtension):
+        pass
+
+    extension = MyExtension()
+    with pytest.raises(RuntimeError, match="ExecutionContext"):
+        _ = extension.execution_context
+
+
+@pytest.mark.asyncio
+async def test_apollo_tracing_concurrent_instance_passed():
+    """ApolloTracingExtension instance shared across concurrent requests must
+    produce a separate tracing payload per request."""
+    from strawberry.extensions.tracing.apollo import ApolloTracingExtension
+
+    @strawberry.type
+    class TracingQuery:
+        @strawberry.field
+        async def slow(self) -> str:
+            await asyncio.sleep(0.05)
+            return "ok"
+
+    schema = strawberry.Schema(
+        query=TracingQuery, extensions=[ApolloTracingExtension()]
+    )
+
+    results = await asyncio.gather(
+        schema.execute("{ slow }"),
+        schema.execute("{ slow }"),
+        schema.execute("{ slow }"),
+    )
+
+    for result in results:
+        assert result.errors is None
+        assert result.extensions is not None
+        tracing = result.extensions["tracing"]
+        # Each request must produce its own resolver list: one entry for the
+        # single ``slow`` field. If the instance leaked state between
+        # requests, the lists would have accumulated 2 or 3 resolvers.
+        assert len(tracing["execution"]["resolvers"]) == 1
+        assert tracing["execution"]["resolvers"][0]["field_name"] == "slow"
+
+
+def test_apollo_tracing_concurrent_threaded_instance_passed():
+    """Same regression for the threaded sync path."""
+    from strawberry.extensions.tracing.apollo import ApolloTracingExtensionSync
+
+    @strawberry.type
+    class TracingQuery:
+        @strawberry.field
+        def slow(self) -> str:
+            time.sleep(0.05)
+            return "ok"
+
+    schema = strawberry.Schema(
+        query=TracingQuery, extensions=[ApolloTracingExtensionSync()]
+    )
+
+    queries = ["{ slow }"] * 4
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        futures = [executor.submit(schema.execute_sync, q) for q in queries]
+        results = [f.result() for f in futures]
+
+    for result in results:
+        assert result.errors is None
+        assert result.extensions is not None
+        tracing = result.extensions["tracing"]
+        assert len(tracing["execution"]["resolvers"]) == 1
+        assert tracing["execution"]["resolvers"][0]["field_name"] == "slow"
+
+
+@pytest.mark.asyncio
+async def test_subscribe_resets_execution_context_var():
+    """After a subscription is fully consumed, the per-request
+    ``ExecutionContext`` ContextVar must be reset — otherwise reading
+    ``extension.execution_context`` in the caller's task would silently
+    return the stale subscription context instead of raising."""
+    extension = SchemaExtension()
+    schema = strawberry.Schema(
+        query=Query, subscription=Subscription, extensions=[extension]
+    )
+
+    async for _ in await schema.subscribe("subscription { tick }"):
+        pass
+
+    with pytest.raises(RuntimeError, match="ExecutionContext"):
+        _ = extension.execution_context
+
+
+@pytest.mark.asyncio
+async def test_subscribe_concurrent_instance_passed():
+    """Two concurrent subscriptions sharing the same extension instance
+    must each see their own ``execution_context``."""
+    captured: list[tuple[int, str]] = []
+
+    class RecorderExtension(SchemaExtension):
+        async def on_operation(self):
+            captured.append((id(self), str(self.execution_context.query)))
+            yield
+
+    schema = strawberry.Schema(
+        query=Query,
+        subscription=Subscription,
+        extensions=[RecorderExtension()],
+    )
+
+    queries = ["subscription { tick }", "subscription Two { tick }"]
+
+    async def consume(q: str) -> None:
+        async for _ in await schema.subscribe(q):
+            pass
+
+    await asyncio.gather(*(consume(q) for q in queries))
+
+    assert sorted(q for _, q in captured) == sorted(queries)
+
+
+@pytest.mark.asyncio
+async def test_subscribe_aclosed_resets_context_var():
+    """Resetting must happen even if the consumer breaks out of the
+    iteration early (the generator's ``aclose`` runs the ``finally``)."""
+    extension = SchemaExtension()
+    schema = strawberry.Schema(
+        query=Query, subscription=Subscription, extensions=[extension]
+    )
+
+    agen = await schema.subscribe("subscription { tick }")
+    async for _ in agen:
+        await agen.aclose()
+        break
+
+    with pytest.raises(RuntimeError, match="ExecutionContext"):
+        _ = extension.execution_context
+
+
+@pytest.mark.asyncio
+async def test_apollo_tracing_nested_execution_does_not_leak():
+    """A resolver that triggers a nested ``schema.execute()`` must not
+    overwrite the outer request's tracing state — the state ContextVar
+    is now reset when ``on_operation`` exits, so the outer request's
+    payload still describes its own resolvers."""
+    from strawberry.extensions.tracing.apollo import ApolloTracingExtension
+
+    inner_schema = strawberry.Schema(query=Query)
+
+    @strawberry.type
+    class OuterQuery:
+        @strawberry.field
+        async def outer(self) -> str:
+            inner_result = await inner_schema.execute("{ helloAsync }")
+            assert inner_result.errors is None
+            return "outer-done"
+
+    schema = strawberry.Schema(query=OuterQuery, extensions=[ApolloTracingExtension()])
+    result = await schema.execute("{ outer }")
+    assert result.errors is None
+    assert result.extensions is not None
+    tracing = result.extensions["tracing"]
+    # The outer payload should describe exactly one resolver: ``outer``.
+    # If the inner ``schema.execute`` had leaked into the outer state,
+    # this list would contain the inner request's ``helloAsync`` too.
+    assert len(tracing["execution"]["resolvers"]) == 1
+    assert tracing["execution"]["resolvers"][0]["field_name"] == "outer"


### PR DESCRIPTION
## Summary

- Replace the per-extension `execution_context` instance attribute with a `contextvars.ContextVar`. Concurrent requests sharing an extension instance now each see their own request's context.
- Move the per-request mutable state of `ApolloTracingExtension`, `DatadogTracingExtension`, and `OpenTelemetryExtension` (and their `*Sync` variants) into per-extension `ContextVar`s, so passing them as instances to `extensions=[…]` is safe under `asyncio.gather` and threaded `execute_sync`.
- Reading `self.execution_context` outside a lifecycle hook now raises `RuntimeError` instead of returning a stale value.

Fix #4369

## Test plan

- [x] `poetry run pytest tests/schema/extensions/ tests/extensions/`
- [x] `poetry run pytest tests/schema/`
- [x] `poetry run mypy --config-file mypy.ini` on changed files
- [x] `poetry run ruff check strawberry/`
- [x] New regression suite at `tests/schema/extensions/test_isolation.py` covers the reporter's exact repro (sync threaded + async gathered, instance- and class-passed) plus concurrent `ApolloTracingExtension` instance under both paths.

## Summary by Sourcery

Isolate per-request execution and tracing state for GraphQL extensions using context variables to prevent concurrency leaks, and add regression tests and documentation for the new behavior.

Bug Fixes:
- Prevent leakage of ExecutionContext and tracing state between concurrent async and threaded executions when extensions are passed as instances.
- Fix Apollo, Datadog, and OpenTelemetry tracing extensions so concurrent requests no longer share resolver stats or span objects.

Enhancements:
- Back SchemaExtension.execution_context with a ContextVar and make access outside lifecycle hooks fail fast with RuntimeError.
- Refine extension context manager and runner plumbing so execution contexts are bound and reset correctly for execute, execute_sync, and subscribe flows.
- Adjust GraphQL WS subscription cleanup to close result generators in the originating task context to keep context variables consistent.

Documentation:
- Document ContextVar-backed execution_context and guidance for storing request-scoped state in custom extensions.

Tests:
- Add a regression suite ensuring extension state is isolated across concurrent async, sync, and subscription executions, including built-in tracing extensions and nested executions.