### PR TITLE
chore: run only the assigned nox session per matrix job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
           enable-cache: true
 
       - run: uv sync
-      - run: uv run nox -r -t tests -s "${{ matrix.session.session }}"
+      - run: uv run nox -r -s "${{ matrix.session.session }}"
       - name: Rename coverage data
         if: ${{ always() }}
         run: |


### PR DESCRIPTION
## Summary

Test CI jobs were taking ~34 minutes each across **all** test categories (regular tests, pydantic, django, integrations, CLI, type checkers) — the uniformity of the wall-clock was the tell. Reading the log of any individual job (e.g. [`🔬 CLI tests on 3.12`](https://github.com/strawberry-graphql/strawberry/actions/runs/24954631292/job/73070647165), 34m 39s) shows it serially running **every** session in the `tests` tag, not just its own:

```
nox > Running session Tests-3.14(gql_core='3.2.6')
nox > Session Tests-3.14(gql_core='3.2.6') was successful in 50 seconds.
nox > Running session Tests-3.14(gql_core='3.3.0a12')
… ~60 more sessions …
nox > Running session CLI tests-3.12
nox > Session CLI tests-3.12 was successful in 14 seconds.   ← the only session this job should run
```

The cause is the workflow run step:

```yaml
- run: uv run nox -r -t tests -s "${{ matrix.session.session }}"
```

When `-t <tag>` and `-s <name>` are passed together, nox unions them (run all sessions matching either filter) rather than intersecting. `-t tests` matches every session, so `-s` becomes a no-op and each of the ~62 matrix jobs runs all ~62 sessions. ~62× more compute than intended.

The matrix-generation step (`nox --json -t tests -l`) correctly uses `-t tests` to enumerate sessions and is left untouched. Only the run step needs the tag dropped.

This was introduced in #4082 (poetry → uv migration); Windows uses `pytest` directly and is unaffected (~4 min total).

## Expected impact

Each job drops from ~34 min to roughly its actual session time (14 s – ~80 s), so the unit-tests workflow returns to a few minutes wall-clock.

## Test plan

- [ ] Open this PR and watch the next CI run
- [ ] For any single matrix job, the "Run uv run nox..." step should complete in well under a minute
- [ ] `grep "nox > Running session" \$LOG | wc -l` should print `1` for any job, not ~62
- [ ] Total run wall-clock should drop from ~35 min to a few minutes
- [ ] Coverage upload still works: each job uploads exactly one `.coverage.<session>` and the `coverage` job combines them