### PR TITLE
fix: Missing snake case fields from resolver input argument default

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,16 +4,19 @@ Previously attributes which were not camelCase would be removed from field argum
 ```python
 import strawberry
 
+
 @strawberry.input
 class Bar:
     a: str
     b: str
     some_values: list[str] | None = None
 
+
 @strawberry.input(one_of=True)
 class Foo:
     bar: strawberry.Maybe[Bar]
     c: strawberry.Maybe[str]
+
 
 @strawberry.type
 class Query:
@@ -26,6 +29,7 @@ class Query:
             c=None,
         ),
     ) -> str: ...
+
 
 schema = strawberry.Schema(Query)
 ```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,16 +4,19 @@ Previously attributes which were not camelCase would be removed from field argum
 ```python
 import strawberry
 
+
 @strawberry.input
 class Bar:
     a: str
     b: str
     some_values: list[str] | None = None
 
+
 @strawberry.input(one_of=True)
 class Foo:
     bar: strawberry.Maybe[Bar]
     c: strawberry.Maybe[str]
+
 
 @strawberry.type
 class Query:
@@ -26,6 +29,7 @@ class Query:
             c=None,
         ),
     ) -> str: ...
+
 
 schema = strawberry.Schema(Query)
 ```
@@ -50,7 +54,7 @@ type Query {
 }
 ```
 
-After this fix the value will remain:
+After this fix, the value will be reflected in the print statement:
 ```graphql
 directive @oneOf on INPUT_OBJECT
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,71 @@
+Release type: patch
+
+Previously attributes which were not camelCase would be removed from field arguments for queries:
+```python
+import strawberry
+
+@strawberry.input
+class Bar:
+    a: str
+    b: str
+    some_values: list[str] | None = None
+
+@strawberry.input(one_of=True)
+class Foo:
+    bar: strawberry.Maybe[Bar]
+    c: strawberry.Maybe[str]
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    async def foobar(
+        self,
+        info: strawberry.Info,
+        foo: Foo = Foo(
+            bar=strawberry.Some(Bar(a="hi", b="bye", some_values=["my", "world"])),
+            c=None,
+        ),
+    ) -> str: ...
+
+schema = strawberry.Schema(Query)
+```
+
+Once printed the output would look like the following with the some_values removed.
+```graphql
+directive @oneOf on INPUT_OBJECT
+
+input Bar {
+  a: String!
+  b: String!
+  someValues: [String!] = null
+}
+
+input Foo @oneOf {
+  bar: Bar
+  c: String
+}
+
+type Query {
+  foobar(foo: Foo! = {bar: {a: "hi", b: "bye"}}): String!
+}
+```
+
+After this fix the value will remain:
+```graphql
+directive @oneOf on INPUT_OBJECT
+
+input Bar {
+  a: String!
+  b: String!
+  someValues: [String!] = null
+}
+
+input Foo @oneOf {
+  bar: Bar
+  c: String
+}
+
+type Query {
+  foobar(foo: Foo! = {bar: {a: "hi", b: "bye", someValues: ["my", "world"]}}): String!
+}
+```

--- a/strawberry/printer/ast_from_value.py
+++ b/strawberry/printer/ast_from_value.py
@@ -17,7 +17,7 @@ from graphql.language import (
     ObjectValueNode,
     StringValueNode,
 )
-from graphql.pyutils import Undefined, inspect, is_iterable, camel_to_snake
+from graphql.pyutils import Undefined, camel_to_snake, inspect, is_iterable
 from graphql.type import (
     GraphQLID,
     is_enum_type,
@@ -83,22 +83,21 @@ def ast_from_leaf_type(serialized: object, type_: GraphQLInputType | None) -> Va
         f"Cannot convert value to AST: {inspect(serialized)}."
     )  # pragma: no cover
 
+
 def field_in_object(field_name: str, value: dict) -> bool:
     if field_name in value:
         return True
 
-    if camel_to_snake(field_name) in value:
-        return True
-
-    return False
+    return camel_to_snake(field_name) in value
 
 
-def look_up_field(field_name: str, value: dict) -> str | None:
+def look_up_field(field_name: str, value: Mapping[str, Any]) -> Any:
     if field_name in value:
         return value[field_name]
 
-    if camel_to_snake(field_name) in value:
-        return value[camel_to_snake(field_name)]
+    snake_cased = camel_to_snake(field_name)
+    if snake_cased in value:
+        return value[snake_cased]
 
     return None
 

--- a/strawberry/printer/ast_from_value.py
+++ b/strawberry/printer/ast_from_value.py
@@ -17,7 +17,7 @@ from graphql.language import (
     ObjectValueNode,
     StringValueNode,
 )
-from graphql.pyutils import Undefined, inspect, is_iterable, camel_to_snake
+from graphql.pyutils import Undefined, camel_to_snake, inspect, is_iterable
 from graphql.type import (
     GraphQLID,
     is_enum_type,
@@ -82,6 +82,7 @@ def ast_from_leaf_type(serialized: object, type_: GraphQLInputType | None) -> Va
     raise TypeError(
         f"Cannot convert value to AST: {inspect(serialized)}."
     )  # pragma: no cover
+
 
 def field_in_object(field_name: str, value: dict) -> bool:
     if field_name in value:

--- a/strawberry/printer/ast_from_value.py
+++ b/strawberry/printer/ast_from_value.py
@@ -143,9 +143,9 @@ def ast_from_value(value: Any, type_: GraphQLInputType) -> ValueNode | None:
 
         type_ = cast("GraphQLInputObjectType", type_)
         field_items = (
-            (field_name, ast_from_value(look_up_field(field_name, value), field.type))
+            (field_name, ast_from_value(field_value, field.type))
             for field_name, field in type_.fields.items()
-            if field_in_object(field_name, value)
+            if (field_value := look_up_field(field_name, value))
         )
         field_nodes = tuple(
             ObjectFieldNode(name=NameNode(value=field_name), value=field_value)

--- a/strawberry/printer/ast_from_value.py
+++ b/strawberry/printer/ast_from_value.py
@@ -84,13 +84,6 @@ def ast_from_leaf_type(serialized: object, type_: GraphQLInputType | None) -> Va
     )  # pragma: no cover
 
 
-def field_in_object(field_name: str, value: dict) -> bool:
-    if field_name in value:
-        return True
-
-    return camel_to_snake(field_name) in value
-
-
 def look_up_field(field_name: str, value: Mapping[str, Any]) -> Any:
     if field_name in value:
         return value[field_name]

--- a/strawberry/printer/ast_from_value.py
+++ b/strawberry/printer/ast_from_value.py
@@ -17,7 +17,7 @@ from graphql.language import (
     ObjectValueNode,
     StringValueNode,
 )
-from graphql.pyutils import Undefined, inspect, is_iterable
+from graphql.pyutils import Undefined, inspect, is_iterable, camel_to_snake
 from graphql.type import (
     GraphQLID,
     is_enum_type,
@@ -83,6 +83,25 @@ def ast_from_leaf_type(serialized: object, type_: GraphQLInputType | None) -> Va
         f"Cannot convert value to AST: {inspect(serialized)}."
     )  # pragma: no cover
 
+def field_in_object(field_name: str, value: dict) -> bool:
+    if field_name in value:
+        return True
+
+    if camel_to_snake(field_name) in value:
+        return True
+
+    return False
+
+
+def look_up_field(field_name: str, value: dict) -> str | None:
+    if field_name in value:
+        return value[field_name]
+
+    if camel_to_snake(field_name) in value:
+        return value[camel_to_snake(field_name)]
+
+    return None
+
 
 def ast_from_value(value: Any, type_: GraphQLInputType) -> ValueNode | None:
     # custom ast_from_value that allows to also serialize custom scalar that aren't
@@ -125,9 +144,9 @@ def ast_from_value(value: Any, type_: GraphQLInputType) -> ValueNode | None:
 
         type_ = cast("GraphQLInputObjectType", type_)
         field_items = (
-            (field_name, ast_from_value(value[field_name], field.type))
+            (field_name, ast_from_value(look_up_field(field_name, value), field.type))
             for field_name, field in type_.fields.items()
-            if field_name in value
+            if field_in_object(field_name, value)
         )
         field_nodes = tuple(
             ObjectFieldNode(name=NameNode(value=field_name), value=field_value)

--- a/tests/schema/test_print.py
+++ b/tests/schema/test_print.py
@@ -1,0 +1,93 @@
+import strawberry
+
+
+def test_print_with_snake_case_values():
+
+    @strawberry.input
+    class Bar:
+        a: str
+        b: str
+        some_values: list[str] | None = None
+
+    @strawberry.input(one_of=True)
+    class Foo:
+        bar: strawberry.Maybe[Bar]
+        c: strawberry.Maybe[str]
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        async def foobar(
+            self,
+            info: strawberry.Info,
+            foo: Foo = Foo(
+                bar=strawberry.Some(Bar(a="hi", b="bye", some_values=["my", "world"])),
+                c=None,
+            ),
+        ) -> str: ...
+
+    schema = strawberry.Schema(Query)
+
+    assert schema.as_str() == \
+"""directive @oneOf on INPUT_OBJECT
+
+input Bar {
+  a: String!
+  b: String!
+  someValues: [String!] = null
+}
+
+input Foo @oneOf {
+  bar: Bar
+  c: String
+}
+
+type Query {
+  foobar(foo: Foo! = {bar: {a: "hi", b: "bye", someValues: ["my", "world"]}}): String!
+}"""
+
+
+def test_print_with_camel_case_values():
+
+    @strawberry.input
+    class Bar:
+        a: str
+        b: str
+        someValues: list[str] | None = None
+
+    @strawberry.input(one_of=True)
+    class Foo:
+        bar: strawberry.Maybe[Bar]
+        c: strawberry.Maybe[str]
+
+    @strawberry.type
+    class Query:
+        @strawberry.field()
+        async def foobar(
+            self,
+            info: strawberry.Info,
+            foo: Foo = Foo(
+                bar=strawberry.Some(Bar(a="hi", b="bye", someValues=["my", "world"])),
+                c=None,
+            ),
+        ) -> str: ...
+
+    schema = strawberry.Schema(Query)
+
+    assert schema.as_str() == \
+"""directive @oneOf on INPUT_OBJECT
+
+input Bar {
+  a: String!
+  b: String!
+  someValues: [String!] = null
+}
+
+input Foo @oneOf {
+  bar: Bar
+  c: String
+}
+
+type Query {
+  foobar(foo: Foo! = {bar: {a: "hi", b: "bye", someValues: ["my", "world"]}}): String!
+}"""

--- a/tests/schema/test_print.py
+++ b/tests/schema/test_print.py
@@ -28,8 +28,9 @@ def test_print_with_snake_case_values():
 
     schema = strawberry.Schema(Query)
 
-    assert schema.as_str() == \
-"""directive @oneOf on INPUT_OBJECT
+    assert (
+        schema.as_str()
+        == """directive @oneOf on INPUT_OBJECT
 
 input Bar {
   a: String!
@@ -45,6 +46,7 @@ input Foo @oneOf {
 type Query {
   foobar(foo: Foo! = {bar: {a: "hi", b: "bye", someValues: ["my", "world"]}}): String!
 }"""
+    )
 
 
 def test_print_with_camel_case_values():
@@ -74,8 +76,9 @@ def test_print_with_camel_case_values():
 
     schema = strawberry.Schema(Query)
 
-    assert schema.as_str() == \
-"""directive @oneOf on INPUT_OBJECT
+    assert (
+        schema.as_str()
+        == """directive @oneOf on INPUT_OBJECT
 
 input Bar {
   a: String!
@@ -91,3 +94,4 @@ input Foo @oneOf {
 type Query {
   foobar(foo: Foo! = {bar: {a: "hi", b: "bye", someValues: ["my", "world"]}}): String!
 }"""
+    )

--- a/tests/schema/test_print.py
+++ b/tests/schema/test_print.py
@@ -55,7 +55,7 @@ def test_print_with_camel_case_values():
     class Bar:
         a: str
         b: str
-        someValues: list[str] | None = None
+        someValues: list[str] | None = None  # noqa: N815
 
     @strawberry.input(one_of=True)
     class Foo:


### PR DESCRIPTION
I added two functions to provide look up based on the field value and a check to see if it said field exists on the end value. This is in response to this ticket opened finding an issue with the printing functionality [here](https://github.com/strawberry-graphql/strawberry/issues/4387).

## Description

Due to how the underlying rendering of the strawberry graphql object is via the naming convention of camelCase, the printing of objects that had camelcase originally caused misses on resulting ast node constructions which in turn caused a failure to include that field in the resulting ast. This change adds a check and a lookup on the possibility that the underlying field format was either originally snake_case or camelCase. 

TBH I'm not too happy with this change as I feel it masks some underlying issues with the hard push to camelCase, but for the time being I'm creating this PR to instigate some conversation on the topic for possible fixes, or if this change is acceptable see through to completion the merging of this PR.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

Fix #4387 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Ensure schema printing preserves default argument values for both snake_case and camelCase input fields.

Bug Fixes:
- Fix omission of snake_case-derived fields from printed default values for input object arguments.

Enhancements:
- Add helper functions to resolve input object fields regardless of snake_case or camelCase naming when generating AST nodes.

Documentation:
- Add release notes documenting the fix for missing snake_case fields in printed default values.

Tests:
- Add regression tests covering schema printing with both snake_case and camelCase input value attributes in default arguments.