### PR TITLE
feat: support extension factories and deprecate instance-passing

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,26 @@
+Release type: minor
+
+`Schema(extensions=...)` now accepts a class or a zero-arg factory and
+builds a fresh extension per request. This fixes a race where shared
+instances leaked `ExecutionContext` across concurrent requests, which
+also produced mixed traces in `ApolloTracingExtension`,
+`ApolloFederationTracingExtension`, `DatadogTracingExtension`, and
+`OpenTelemetryExtension`.
+
+```python
+schema = strawberry.Schema(
+    Query,
+    extensions=[
+        MaxTokensLimiter,
+        lambda: MyExtension(arg=...),
+    ],
+)
+```
+
+Passing an instance is now deprecated. `extensions` no longer accepts
+`SchemaExtension` instances in the type signature, so mypy and pyright
+will flag existing call sites. Instances still work at runtime for
+backwards compatibility, but the same object is reused for every
+request, so concurrent requests can see each other's
+`ExecutionContext`. Switch to the class or a factory for per-request
+isolation and to silence the warning.

--- a/docs/guides/custom-extensions.md
+++ b/docs/guides/custom-extensions.md
@@ -51,10 +51,11 @@ cross-request state in module/class-level storage or in
 
 > Passing an extension instance directly (`extensions=[MyExtension()]`) is
 > deprecated and is no longer accepted by the type signature — type checkers
-> (mypy, pyright) will report it. Strawberry still tolerates it at runtime: the
-> instance is shallow-copied per request and a `DeprecationWarning` is emitted.
-> Switch to the factory form (or pass the class) to silence both the type error
-> and the warning, and get full per-request isolation.
+> (mypy, pyright) will report it. Strawberry still uses the instance at runtime
+> for backwards compatibility and emits a `DeprecationWarning`, but the same
+> instance is reused for every request — concurrent requests can observe each
+> other's `ExecutionContext`. Migrate to passing the class or a factory callable
+> to silence the warning and get per-request isolation.
 
 ## Hooks
 

--- a/docs/guides/custom-extensions.md
+++ b/docs/guides/custom-extensions.md
@@ -29,11 +29,20 @@ schema = strawberry.Schema(query=Query, extensions=[MyExtension])
 Extensions can be passed to the schema as either:
 
 - a **class** (no constructor arguments):
+
   ```python
+  import strawberry
+  from strawberry.extensions import MyExtension
+
   schema = strawberry.Schema(query=Query, extensions=[MyExtension])
   ```
+
 - a **factory** (configured constructor):
+
   ```python
+  import strawberry
+  from strawberry.extensions import MaxTokensLimiter
+
   schema = strawberry.Schema(
       query=Query,
       extensions=[lambda: MaxTokensLimiter(max_token_count=100)],
@@ -45,15 +54,14 @@ uses the returned extension. With the recommended forms above you get a fresh
 extension per request, so any mutable state you keep on `self` is automatically
 isolated across concurrent requests. If your factory returns a long-lived shared
 instance instead of a new one each call, request-scoped state on `self`
-(including `execution_context`) will leak across concurrent requests — keep the
-cross-request state in module/class-level storage or in
-`execution_context.extensions_results`, not on the extension instance.
+(including `execution_context`) will leak across concurrent requests. Keep
+cross-request state in module-level or class-level storage instead.
 
 > Passing an extension instance directly (`extensions=[MyExtension()]`) is
-> deprecated and is no longer accepted by the type signature — type checkers
+> deprecated and is no longer accepted by the type signature, so type checkers
 > (mypy, pyright) will report it. Strawberry still uses the instance at runtime
 > for backwards compatibility and emits a `DeprecationWarning`, but the same
-> instance is reused for every request — concurrent requests can observe each
+> instance is reused for every request, so concurrent requests can observe each
 > other's `ExecutionContext`. Migrate to passing the class or a factory callable
 > to silence the warning and get per-request isolation.
 

--- a/docs/guides/custom-extensions.md
+++ b/docs/guides/custom-extensions.md
@@ -40,9 +40,14 @@ Extensions can be passed to the schema as either:
   )
   ```
 
-In both cases Strawberry constructs a fresh extension for every request, so any
-mutable state you keep on `self` is automatically isolated across concurrent
-requests.
+In both cases Strawberry calls the class or the factory once per request and
+uses the returned extension. With the recommended forms above you get a fresh
+extension per request, so any mutable state you keep on `self` is automatically
+isolated across concurrent requests. If your factory returns a long-lived shared
+instance instead of a new one each call, request-scoped state on `self`
+(including `execution_context`) will leak across concurrent requests — keep the
+cross-request state in module/class-level storage or in
+`execution_context.extensions_results`, not on the extension instance.
 
 > Passing an extension instance directly (`extensions=[MyExtension()]`) is
 > deprecated and is no longer accepted by the type signature — type checkers

--- a/docs/guides/custom-extensions.md
+++ b/docs/guides/custom-extensions.md
@@ -24,6 +24,33 @@ class MyExtension(SchemaExtension):
 schema = strawberry.Schema(query=Query, extensions=[MyExtension])
 ```
 
+## Passing extensions
+
+Extensions can be passed to the schema as either:
+
+- a **class** (no constructor arguments):
+  ```python
+  schema = strawberry.Schema(query=Query, extensions=[MyExtension])
+  ```
+- a **factory** (configured constructor):
+  ```python
+  schema = strawberry.Schema(
+      query=Query,
+      extensions=[lambda: MaxTokensLimiter(max_token_count=100)],
+  )
+  ```
+
+In both cases Strawberry constructs a fresh extension for every request, so any
+mutable state you keep on `self` is automatically isolated across concurrent
+requests.
+
+> Passing an extension instance directly (`extensions=[MyExtension()]`) is
+> deprecated and is no longer accepted by the type signature — type checkers
+> (mypy, pyright) will report it. Strawberry still tolerates it at runtime: the
+> instance is shallow-copied per request and a `DeprecationWarning` is emitted.
+> Switch to the factory form (or pass the class) to silence both the type error
+> and the warning, and get full per-request isolation.
+
 ## Hooks
 
 ### Resolve

--- a/strawberry/extensions/parser_cache.py
+++ b/strawberry/extensions/parser_cache.py
@@ -9,17 +9,18 @@ from strawberry.extensions.base_extension import SchemaExtension
 class ParserCache(SchemaExtension):
     """Add LRU caching the parsing step during execution to improve performance.
 
-    Example:
+    The cache lives on the extension instance, so for it to be effective across
+    requests the same ``ParserCache`` instance has to be reused. Use it as a
+    pass-through factory that returns a singleton:
 
     ```python
     import strawberry
     from strawberry.extensions import ParserCache
 
+    parser_cache = ParserCache(maxsize=100)
     schema = strawberry.Schema(
         Query,
-        extensions=[
-            ParserCache(maxsize=100),
-        ],
+        extensions=[lambda: parser_cache],
     )
     ```
     """

--- a/strawberry/extensions/parser_cache.py
+++ b/strawberry/extensions/parser_cache.py
@@ -1,32 +1,27 @@
 from collections.abc import Callable, Iterator
-from functools import lru_cache
+from functools import cache, lru_cache
 from typing import Any
 
 from graphql.language.parser import parse
 
 from strawberry.extensions.base_extension import SchemaExtension
 
-# Shared LRU caches keyed by ``maxsize``. Multiple ``ParserCache`` instances
-# (e.g. a fresh one constructed per request via the factory pattern) reuse the
-# same wrapped ``parse`` so caching is effective across requests without
-# sharing extension instances.
-_caches: dict[int | None, Callable[..., Any]] = {}
 
-
+@cache
 def _get_parse_cache(maxsize: int | None) -> Callable[..., Any]:
-    cached = _caches.get(maxsize)
-    if cached is None:
-        cached = lru_cache(maxsize=maxsize)(parse)
-        _caches[maxsize] = cached
-    return cached
+    # Shared LRU caches keyed by ``maxsize``. Multiple ``ParserCache`` instances
+    # (e.g. a fresh one constructed per request via the factory pattern) reuse
+    # the same wrapped ``parse`` so caching is effective across requests
+    # without sharing extension instances.
+    return lru_cache(maxsize=maxsize)(parse)
 
 
 class ParserCache(SchemaExtension):
     """Add LRU caching the parsing step during execution to improve performance.
 
-    Pass it as a factory; the LRU cache is shared across requests with the same
-    ``maxsize`` so caching is effective even when a fresh extension is built per
-    request.
+    Pass it as a factory; the LRU cache lives at module level and is keyed by
+    ``maxsize``, so it is shared across every request and every schema that
+    constructs a ``ParserCache`` with the same ``maxsize``.
 
     ```python
     import strawberry

--- a/strawberry/extensions/parser_cache.py
+++ b/strawberry/extensions/parser_cache.py
@@ -13,17 +13,10 @@ from strawberry.extensions.base_extension import SchemaExtension
 _caches: dict[int | None, Callable[..., Any]] = {}
 
 
-def _wrapped_parse(*args: Any, **kwargs: Any) -> Any:
-    # Indirection: tests patch ``parse`` on this module, so the wrapped
-    # function must look it up via the module's globals at call time rather
-    # than capture it at the time the cache wrapper is built.
-    return parse(*args, **kwargs)
-
-
 def _get_parse_cache(maxsize: int | None) -> Callable[..., Any]:
     cached = _caches.get(maxsize)
     if cached is None:
-        cached = lru_cache(maxsize=maxsize)(_wrapped_parse)
+        cached = lru_cache(maxsize=maxsize)(parse)
         _caches[maxsize] = cached
     return cached
 

--- a/strawberry/extensions/parser_cache.py
+++ b/strawberry/extensions/parser_cache.py
@@ -1,26 +1,47 @@
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from functools import lru_cache
+from typing import Any
 
 from graphql.language.parser import parse
 
 from strawberry.extensions.base_extension import SchemaExtension
 
+# Shared LRU caches keyed by ``maxsize``. Multiple ``ParserCache`` instances
+# (e.g. a fresh one constructed per request via the factory pattern) reuse the
+# same wrapped ``parse`` so caching is effective across requests without
+# sharing extension instances.
+_caches: dict[int | None, Callable[..., Any]] = {}
+
+
+def _wrapped_parse(*args: Any, **kwargs: Any) -> Any:
+    # Indirection: tests patch ``parse`` on this module, so the wrapped
+    # function must look it up via the module's globals at call time rather
+    # than capture it at the time the cache wrapper is built.
+    return parse(*args, **kwargs)
+
+
+def _get_parse_cache(maxsize: int | None) -> Callable[..., Any]:
+    cached = _caches.get(maxsize)
+    if cached is None:
+        cached = lru_cache(maxsize=maxsize)(_wrapped_parse)
+        _caches[maxsize] = cached
+    return cached
+
 
 class ParserCache(SchemaExtension):
     """Add LRU caching the parsing step during execution to improve performance.
 
-    The cache lives on the extension instance, so for it to be effective across
-    requests the same ``ParserCache`` instance has to be reused. Use it as a
-    pass-through factory that returns a singleton:
+    Pass it as a factory; the LRU cache is shared across requests with the same
+    ``maxsize`` so caching is effective even when a fresh extension is built per
+    request.
 
     ```python
     import strawberry
     from strawberry.extensions import ParserCache
 
-    parser_cache = ParserCache(maxsize=100)
     schema = strawberry.Schema(
         Query,
-        extensions=[lambda: parser_cache],
+        extensions=[lambda: ParserCache(maxsize=100)],
     )
     ```
     """
@@ -33,7 +54,8 @@ class ParserCache(SchemaExtension):
                 cache will grow without bound.
                 More info: https://docs.python.org/3/library/functools.html#functools.lru_cache
         """
-        self.cached_parse_document = lru_cache(maxsize=maxsize)(parse)
+        super().__init__()
+        self.cached_parse_document = _get_parse_cache(maxsize)
 
     def on_parse(self) -> Iterator[None]:
         execution_context = self.execution_context

--- a/strawberry/extensions/tracing/apollo.py
+++ b/strawberry/extensions/tracing/apollo.py
@@ -82,9 +82,13 @@ class ApolloTracingStats:
 
 
 class ApolloTracingExtension(SchemaExtension):
-    def __init__(self, execution_context: ExecutionContext) -> None:
+    def __init__(self, *, execution_context: ExecutionContext | None = None) -> None:
+        # ``execution_context`` is set by the schema right after construction;
+        # the parameter exists for the legacy ``cls(execution_context=...)``
+        # call shape only.
+        if execution_context is not None:
+            self.execution_context = execution_context
         self._resolver_stats: list[ApolloResolverStats] = []
-        self.execution_context = execution_context
         now = self.now()
         self.start_timestamp: int = now
         self.end_timestamp: int = now

--- a/strawberry/extensions/tracing/apollo.py
+++ b/strawberry/extensions/tracing/apollo.py
@@ -83,6 +83,7 @@ class ApolloTracingStats:
 
 class ApolloTracingExtension(SchemaExtension):
     def __init__(self, *, execution_context: ExecutionContext | None = None) -> None:
+        super().__init__(execution_context=execution_context)
         # ``execution_context`` is set by the schema right after construction;
         # the parameter exists for the legacy ``cls(execution_context=...)``
         # call shape only.

--- a/strawberry/extensions/tracing/apollo_federation.py
+++ b/strawberry/extensions/tracing/apollo_federation.py
@@ -293,8 +293,12 @@ class ApolloFederationTracingExtension(SchemaExtension):
     it in the response as a base64-encoded protobuf under extensions.ftv1.
     """
 
-    def __init__(self, execution_context: ExecutionContext) -> None:
-        super().__init__(execution_context=execution_context)
+    def __init__(self, *, execution_context: ExecutionContext | None = None) -> None:
+        # ``execution_context`` is set by the schema right after construction;
+        # the parameter exists for the legacy ``cls(execution_context=...)``
+        # call shape only.
+        if execution_context is not None:
+            self.execution_context = execution_context
         self._should_trace = False
         self._trace: _SimpleTrace | None = None
         self._root_node: _SimpleNode | None = None

--- a/strawberry/extensions/tracing/apollo_federation.py
+++ b/strawberry/extensions/tracing/apollo_federation.py
@@ -294,6 +294,7 @@ class ApolloFederationTracingExtension(SchemaExtension):
     """
 
     def __init__(self, *, execution_context: ExecutionContext | None = None) -> None:
+        super().__init__(execution_context=execution_context)
         # ``execution_context`` is set by the schema right after construction;
         # the parameter exists for the legacy ``cls(execution_context=...)``
         # call shape only.

--- a/strawberry/extensions/validation_cache.py
+++ b/strawberry/extensions/validation_cache.py
@@ -11,20 +11,14 @@ from strawberry.extensions.base_extension import SchemaExtension
 _caches: dict[int | None, Callable[..., Any]] = {}
 
 
-def _wrapped_validate(*args: Any, **kwargs: Any) -> Any:
-    # Indirection: ``validate_document`` is imported lazily to dodge the
-    # circular import with ``strawberry.schema.schema``, and the wrapped
-    # function looks it up at call time so test patches on the schema module
-    # are honored.
+def _get_validate_cache(maxsize: int | None) -> Callable[..., Any]:
+    # ``validate_document`` is imported lazily to break the circular import
+    # with ``strawberry.schema.schema``.
     from strawberry.schema.schema import validate_document
 
-    return validate_document(*args, **kwargs)
-
-
-def _get_validate_cache(maxsize: int | None) -> Callable[..., Any]:
     cached = _caches.get(maxsize)
     if cached is None:
-        cached = lru_cache(maxsize=maxsize)(_wrapped_validate)
+        cached = lru_cache(maxsize=maxsize)(validate_document)
         _caches[maxsize] = cached
     return cached
 

--- a/strawberry/extensions/validation_cache.py
+++ b/strawberry/extensions/validation_cache.py
@@ -1,34 +1,29 @@
 from collections.abc import Callable, Iterator
-from functools import lru_cache
+from functools import cache, lru_cache
 from typing import Any
 
 from strawberry.extensions.base_extension import SchemaExtension
 
-# Shared LRU caches keyed by ``maxsize``. Multiple ``ValidationCache``
-# instances (e.g. a fresh one per request via the factory pattern) reuse the
-# same wrapped ``validate_document`` so caching is effective across requests
-# without sharing extension instances.
-_caches: dict[int | None, Callable[..., Any]] = {}
 
-
+@cache
 def _get_validate_cache(maxsize: int | None) -> Callable[..., Any]:
+    # Shared LRU caches keyed by ``maxsize``. Multiple ``ValidationCache``
+    # instances (e.g. a fresh one per request via the factory pattern) reuse
+    # the same wrapped ``validate_document`` so caching is effective across
+    # requests without sharing extension instances.
     # ``validate_document`` is imported lazily to break the circular import
     # with ``strawberry.schema.schema``.
     from strawberry.schema.schema import validate_document
 
-    cached = _caches.get(maxsize)
-    if cached is None:
-        cached = lru_cache(maxsize=maxsize)(validate_document)
-        _caches[maxsize] = cached
-    return cached
+    return lru_cache(maxsize=maxsize)(validate_document)
 
 
 class ValidationCache(SchemaExtension):
     """Add LRU caching the validation step during execution to improve performance.
 
-    Pass it as a factory; the LRU cache is shared across requests with the same
-    ``maxsize`` so caching is effective even when a fresh extension is built per
-    request.
+    Pass it as a factory; the LRU cache lives at module level and is keyed by
+    ``maxsize``, so it is shared across every request and every schema that
+    constructs a ``ValidationCache`` with the same ``maxsize``.
 
     ```python
     import strawberry

--- a/strawberry/extensions/validation_cache.py
+++ b/strawberry/extensions/validation_cache.py
@@ -1,24 +1,48 @@
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from functools import lru_cache
+from typing import Any
 
 from strawberry.extensions.base_extension import SchemaExtension
+
+# Shared LRU caches keyed by ``maxsize``. Multiple ``ValidationCache``
+# instances (e.g. a fresh one per request via the factory pattern) reuse the
+# same wrapped ``validate_document`` so caching is effective across requests
+# without sharing extension instances.
+_caches: dict[int | None, Callable[..., Any]] = {}
+
+
+def _wrapped_validate(*args: Any, **kwargs: Any) -> Any:
+    # Indirection: ``validate_document`` is imported lazily to dodge the
+    # circular import with ``strawberry.schema.schema``, and the wrapped
+    # function looks it up at call time so test patches on the schema module
+    # are honored.
+    from strawberry.schema.schema import validate_document
+
+    return validate_document(*args, **kwargs)
+
+
+def _get_validate_cache(maxsize: int | None) -> Callable[..., Any]:
+    cached = _caches.get(maxsize)
+    if cached is None:
+        cached = lru_cache(maxsize=maxsize)(_wrapped_validate)
+        _caches[maxsize] = cached
+    return cached
 
 
 class ValidationCache(SchemaExtension):
     """Add LRU caching the validation step during execution to improve performance.
 
-    The cache lives on the extension instance, so for it to be effective across
-    requests the same ``ValidationCache`` instance has to be reused. Use it as
-    a pass-through factory that returns a singleton:
+    Pass it as a factory; the LRU cache is shared across requests with the same
+    ``maxsize`` so caching is effective even when a fresh extension is built per
+    request.
 
     ```python
     import strawberry
     from strawberry.extensions import ValidationCache
 
-    validation_cache = ValidationCache(maxsize=100)
     schema = strawberry.Schema(
         Query,
-        extensions=[lambda: validation_cache],
+        extensions=[lambda: ValidationCache(maxsize=100)],
     )
     ```
     """
@@ -32,9 +56,8 @@ class ValidationCache(SchemaExtension):
 
         More info: https://docs.python.org/3/library/functools.html#functools.lru_cache
         """
-        from strawberry.schema.schema import validate_document
-
-        self.cached_validate_document = lru_cache(maxsize=maxsize)(validate_document)
+        super().__init__()
+        self.cached_validate_document = _get_validate_cache(maxsize)
 
     def on_validate(self) -> Iterator[None]:
         execution_context = self.execution_context

--- a/strawberry/extensions/validation_cache.py
+++ b/strawberry/extensions/validation_cache.py
@@ -7,16 +7,18 @@ from strawberry.extensions.base_extension import SchemaExtension
 class ValidationCache(SchemaExtension):
     """Add LRU caching the validation step during execution to improve performance.
 
-    Example:
+    The cache lives on the extension instance, so for it to be effective across
+    requests the same ``ValidationCache`` instance has to be reused. Use it as
+    a pass-through factory that returns a singleton:
+
     ```python
     import strawberry
     from strawberry.extensions import ValidationCache
 
+    validation_cache = ValidationCache(maxsize=100)
     schema = strawberry.Schema(
         Query,
-        extensions=[
-            ValidationCache(maxsize=100),
-        ],
+        extensions=[lambda: validation_cache],
     )
     ```
     """

--- a/strawberry/federation/schema.py
+++ b/strawberry/federation/schema.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from collections.abc import Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from functools import cached_property
 from itertools import chain
 from typing import (
@@ -53,7 +53,9 @@ class Schema(BaseSchema):
         # TODO: we should update directives' type in the main schema
         directives: Iterable[type] = (),
         types: Iterable[type] = (),
-        extensions: Iterable[Union[type["SchemaExtension"], "SchemaExtension"]] = (),
+        extensions: Iterable[
+            type["SchemaExtension"] | Callable[[], "SchemaExtension"]
+        ] = (),
         execution_context_class: type["GraphQLExecutionContext"] | None = None,
         config: Optional["StrawberryConfig"] = None,
         scalar_overrides: dict[object, Union[type, "ScalarWrapper", "ScalarDefinition"]]

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -119,7 +119,7 @@ ProcessErrors: TypeAlias = (
 )
 
 
-_STRAWBERRY_ROOT = str(pathlib.Path(__file__).resolve().parent.parent)
+_STRAWBERRY_ROOT = pathlib.Path(__file__).resolve().parent.parent
 
 
 def _find_user_stacklevel() -> int:
@@ -134,10 +134,8 @@ def _find_user_stacklevel() -> int:
     frame: FrameType | None = sys._getframe(1)
     level = 1
     while frame is not None:
-        filename = str(pathlib.Path(frame.f_code.co_filename).resolve())
-        if not filename.startswith(_STRAWBERRY_ROOT + "/") and not filename.startswith(
-            _STRAWBERRY_ROOT + "\\"
-        ):
+        filename = pathlib.Path(frame.f_code.co_filename).resolve()
+        if not filename.is_relative_to(_STRAWBERRY_ROOT):
             return level
         frame = frame.f_back
         level += 1

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -399,18 +399,6 @@ class Schema(BaseSchema):
             )
         return resolved
 
-    @property
-    def _sync_extensions(self) -> list[SchemaExtension]:
-        # Fresh instances per access: concurrent sync requests (threaded
-        # ``execute_sync``) must not share extension state. See #4369.
-        return self.get_extensions(sync=True)
-
-    @property
-    def _async_extensions(self) -> list[SchemaExtension]:
-        # Fresh instances per access: concurrent async requests must not share
-        # extension state.
-        return self.get_extensions(sync=False)
-
     def create_extensions_runner(
         self, execution_context: ExecutionContext, extensions: list[SchemaExtension]
     ) -> SchemaExtensionsRunner:
@@ -600,7 +588,7 @@ class Schema(BaseSchema):
             operation_name=operation_name,
             operation_extensions=operation_extensions,
         )
-        extensions = self._async_extensions
+        extensions = self.get_extensions()
         # TODO (#3571): remove this when we implement execution context as parameter.
         for extension in extensions:
             extension.execution_context = execution_context
@@ -707,7 +695,7 @@ class Schema(BaseSchema):
             operation_name=operation_name,
             operation_extensions=operation_extensions,
         )
-        extensions = self._sync_extensions
+        extensions = self.get_extensions(sync=True)
         # TODO (#3571): remove this when we implement execution context as parameter.
         for extension in extensions:
             extension.execution_context = execution_context
@@ -930,7 +918,7 @@ class Schema(BaseSchema):
             root_value=root_value,
             operation_name=operation_name,
         )
-        extensions = self._async_extensions
+        extensions = self.get_extensions()
         # TODO (#3571): remove this when we implement execution context as parameter.
         for extension in extensions:
             extension.execution_context = execution_context

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -1,8 +1,5 @@
 from __future__ import annotations
 
-import copy
-import pathlib
-import sys
 import warnings
 from asyncio import ensure_future
 from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable, Iterable
@@ -84,7 +81,6 @@ from .exceptions import CannotGetOperationTypeError, InvalidOperationTypeError
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
-    from types import FrameType
     from typing import TypeAlias
 
     from graphql.language import DocumentNode
@@ -117,29 +113,6 @@ DEFAULT_ALLOWED_OPERATION_TYPES = {
 ProcessErrors: TypeAlias = (
     "Callable[[list[GraphQLError], ExecutionContext | None], None]"
 )
-
-
-_STRAWBERRY_ROOT = pathlib.Path(__file__).resolve().parent.parent
-
-
-def _find_user_stacklevel() -> int:
-    """Return the ``stacklevel`` that points at the first non-strawberry frame.
-
-    Used so deprecation warnings emitted from inside ``Schema.__init__`` end up
-    pointing at user code, regardless of how many strawberry-internal frames
-    sit between us and the caller (e.g. ``strawberry.federation.Schema``
-    delegating via ``super().__init__``).
-    """
-    # Skip this helper itself.
-    frame: FrameType | None = sys._getframe(1)
-    level = 1
-    while frame is not None:
-        filename = pathlib.Path(frame.f_code.co_filename).resolve()
-        if not filename.is_relative_to(_STRAWBERRY_ROOT):
-            return level
-        frame = frame.f_back
-        level += 1
-    return level
 
 
 # TODO: merge with below
@@ -305,7 +278,7 @@ class Schema(BaseSchema):
                     "https://github.com/strawberry-graphql/strawberry/issues/4369."
                 ),
                 DeprecationWarning,
-                stacklevel=_find_user_stacklevel(),
+                stacklevel=2,
             )
         self.execution_context_class = (
             execution_context_class or StrawberryGraphQLCoreExecutionContext
@@ -413,30 +386,17 @@ class Schema(BaseSchema):
             raise ValueError(f"Invalid Schema. Errors:\n\n{formatted_errors}")
 
     def get_extensions(self, sync: bool = False) -> list[SchemaExtension]:
-        # `self.extensions` may legitimately contain instances on the
-        # deprecated runtime path, so the local list is widened to include
-        # ``SchemaExtension`` even though the public type signature does not.
-        extensions: list[
-            type[SchemaExtension] | Callable[[], SchemaExtension] | SchemaExtension
-        ] = list(self.extensions)
+        # Deprecated instances are passed through as-is. The DeprecationWarning
+        # is emitted once at ``Schema.__init__``; users are expected to migrate
+        # to a class or factory for per-request isolation.
+        resolved: list[SchemaExtension] = [
+            ext if isinstance(ext, SchemaExtension) else ext()
+            for ext in self.extensions
+        ]
         if self.directives:
-            extensions.append(DirectivesExtensionSync if sync else DirectivesExtension)
-
-        resolved: list[SchemaExtension] = []
-        for ext in extensions:
-            if isinstance(ext, SchemaExtension):
-                # Deprecated path: shallow-copy so each request gets its own
-                # `self`-attributes. The DeprecationWarning is emitted once at
-                # ``Schema.__init__``.
-                resolved.append(copy.copy(ext))
-            else:
-                # Class or factory callable. Both must be no-arg callable —
-                # ``SchemaExtension.__init__`` accepts ``*, execution_context=None``
-                # by default, and built-in extensions take their own optional
-                # configuration kwargs only. Custom extensions with a required
-                # positional ``execution_context`` argument should migrate to the
-                # base-class signature or be passed via a factory.
-                resolved.append(ext())
+            resolved.append(
+                DirectivesExtensionSync() if sync else DirectivesExtension()
+            )
         return resolved
 
     @property

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -82,6 +82,7 @@ from .exceptions import CannotGetOperationTypeError, InvalidOperationTypeError
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
+    from types import FrameType
     from typing import TypeAlias
 
     from graphql.language import DocumentNode
@@ -114,6 +115,32 @@ DEFAULT_ALLOWED_OPERATION_TYPES = {
 ProcessErrors: TypeAlias = (
     "Callable[[list[GraphQLError], ExecutionContext | None], None]"
 )
+
+
+def _find_user_stacklevel() -> int:
+    """Return the ``stacklevel`` that points at the first non-strawberry frame.
+
+    Used so deprecation warnings emitted from inside ``Schema.__init__`` end up
+    pointing at user code, regardless of how many strawberry-internal frames
+    sit between us and the caller (e.g. ``strawberry.federation.Schema``
+    delegating via ``super().__init__``).
+    """
+    import sys
+    from pathlib import Path as _PathlibPath
+
+    strawberry_root = str(_PathlibPath(__file__).resolve().parent.parent)
+    # Skip this helper itself.
+    frame: FrameType | None = sys._getframe(1)
+    level = 1
+    while frame is not None:
+        filename = str(_PathlibPath(frame.f_code.co_filename).resolve())
+        if not filename.startswith(strawberry_root + "/") and not filename.startswith(
+            strawberry_root + "\\"
+        ):
+            return level
+        frame = frame.f_back
+        level += 1
+    return level
 
 
 # TODO: merge with below
@@ -264,7 +291,10 @@ class Schema(BaseSchema):
         self.mutation = mutation
         self.subscription = subscription
 
-        self.extensions = extensions
+        # Materialize once so generators / one-shot iterables work on later
+        # ``get_extensions`` calls and so the deprecation check below doesn't
+        # consume the iterable.
+        self.extensions = tuple(extensions)
         if any(isinstance(ext, SchemaExtension) for ext in self.extensions):
             warnings.warn(
                 (
@@ -276,7 +306,7 @@ class Schema(BaseSchema):
                     "https://github.com/strawberry-graphql/strawberry/issues/4369."
                 ),
                 DeprecationWarning,
-                stacklevel=2,
+                stacklevel=_find_user_stacklevel(),
             )
         self.execution_context_class = (
             execution_context_class or StrawberryGraphQLCoreExecutionContext
@@ -401,9 +431,12 @@ class Schema(BaseSchema):
                 # ``Schema.__init__``.
                 resolved.append(copy.copy(ext))
             else:
-                # Class or factory callable. Both built-in extensions and
-                # ``SchemaExtension`` itself accept ``*, execution_context=None``,
-                # so calling with no args is safe.
+                # Class or factory callable. Both must be no-arg callable —
+                # ``SchemaExtension.__init__`` accepts ``*, execution_context=None``
+                # by default, and built-in extensions take their own optional
+                # configuration kwargs only. Custom extensions with a required
+                # positional ``execution_context`` argument should migrate to the
+                # base-class signature or be passed via a factory.
                 resolved.append(ext())
         return resolved
 

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import copy
+import pathlib
+import sys
 import warnings
 from asyncio import ensure_future
 from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable, Iterable
@@ -117,6 +119,9 @@ ProcessErrors: TypeAlias = (
 )
 
 
+_STRAWBERRY_ROOT = str(pathlib.Path(__file__).resolve().parent.parent)
+
+
 def _find_user_stacklevel() -> int:
     """Return the ``stacklevel`` that points at the first non-strawberry frame.
 
@@ -125,17 +130,13 @@ def _find_user_stacklevel() -> int:
     sit between us and the caller (e.g. ``strawberry.federation.Schema``
     delegating via ``super().__init__``).
     """
-    import sys
-    from pathlib import Path as _PathlibPath
-
-    strawberry_root = str(_PathlibPath(__file__).resolve().parent.parent)
     # Skip this helper itself.
     frame: FrameType | None = sys._getframe(1)
     level = 1
     while frame is not None:
-        filename = str(_PathlibPath(frame.f_code.co_filename).resolve())
-        if not filename.startswith(strawberry_root + "/") and not filename.startswith(
-            strawberry_root + "\\"
+        filename = str(pathlib.Path(frame.f_code.co_filename).resolve())
+        if not filename.startswith(_STRAWBERRY_ROOT + "/") and not filename.startswith(
+            _STRAWBERRY_ROOT + "\\"
         ):
             return level
         frame = frame.f_back

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import copy
 import warnings
 from asyncio import ensure_future
 from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable, Iterable
-from functools import cached_property, lru_cache
+from functools import lru_cache
 from inspect import isawaitable
 from typing import (
     TYPE_CHECKING,
@@ -214,7 +215,9 @@ class Schema(BaseSchema):
         subscription: type | None = None,
         directives: Iterable[StrawberryDirective] = (),
         types: Iterable[type | StrawberryType] = (),
-        extensions: Iterable[type[SchemaExtension] | SchemaExtension] = (),
+        extensions: Iterable[
+            type[SchemaExtension] | Callable[[], SchemaExtension]
+        ] = (),
         execution_context_class: type[GraphQLExecutionContext] | None = None,
         config: StrawberryConfig | None = None,
         scalar_overrides: (
@@ -262,7 +265,19 @@ class Schema(BaseSchema):
         self.subscription = subscription
 
         self.extensions = extensions
-        self._cached_middleware_manager: MiddlewareManager | None = None
+        if any(isinstance(ext, SchemaExtension) for ext in self.extensions):
+            warnings.warn(
+                (
+                    "Passing an extension instance to `extensions=[...]` is "
+                    "deprecated and will be removed in a future release. "
+                    "Pass the class itself, or a factory callable "
+                    "(e.g. `lambda: MyExtension(arg=...)`), so that a fresh "
+                    "extension is constructed for each request. See "
+                    "https://github.com/strawberry-graphql/strawberry/issues/4369."
+                ),
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self.execution_context_class = (
             execution_context_class or StrawberryGraphQLCoreExecutionContext
         )
@@ -369,25 +384,39 @@ class Schema(BaseSchema):
             raise ValueError(f"Invalid Schema. Errors:\n\n{formatted_errors}")
 
     def get_extensions(self, sync: bool = False) -> list[SchemaExtension]:
-        extensions: list[type[SchemaExtension] | SchemaExtension] = []
-        extensions.extend(self.extensions)
+        # `self.extensions` may legitimately contain instances on the
+        # deprecated runtime path, so the local list is widened to include
+        # ``SchemaExtension`` even though the public type signature does not.
+        extensions: list[
+            type[SchemaExtension] | Callable[[], SchemaExtension] | SchemaExtension
+        ] = list(self.extensions)
         if self.directives:
-            extensions.extend(
-                [DirectivesExtensionSync if sync else DirectivesExtension]
-            )
-        return [
-            ext if isinstance(ext, SchemaExtension) else ext(execution_context=None)
-            for ext in extensions
-        ]
+            extensions.append(DirectivesExtensionSync if sync else DirectivesExtension)
 
-    @cached_property
+        resolved: list[SchemaExtension] = []
+        for ext in extensions:
+            if isinstance(ext, SchemaExtension):
+                # Deprecated path: shallow-copy so each request gets its own
+                # `self`-attributes. The DeprecationWarning is emitted once at
+                # ``Schema.__init__``.
+                resolved.append(copy.copy(ext))
+            else:
+                # Class or factory callable. Both built-in extensions and
+                # ``SchemaExtension`` itself accept ``*, execution_context=None``,
+                # so calling with no args is safe.
+                resolved.append(ext())
+        return resolved
+
+    @property
     def _sync_extensions(self) -> list[SchemaExtension]:
+        # Fresh instances per access: concurrent sync requests (threaded
+        # ``execute_sync``) must not share extension state. See #4369.
         return self.get_extensions(sync=True)
 
     @property
     def _async_extensions(self) -> list[SchemaExtension]:
         # Fresh instances per access: concurrent async requests must not share
-        # extension state. See _sync_extensions for the cached counterpart.
+        # extension state.
         return self.get_extensions(sync=False)
 
     def create_extensions_runner(
@@ -413,20 +442,14 @@ class Schema(BaseSchema):
         return kwargs
 
     def _get_middleware_manager(
-        self, extensions: list[SchemaExtension], *, cached: bool = True
+        self, extensions: list[SchemaExtension]
     ) -> MiddlewareManager:
-        # create a middleware manager with all the extensions that implement resolve
-        if cached and self._cached_middleware_manager:
-            return self._cached_middleware_manager
-
-        manager = MiddlewareManager(
+        # Build a fresh middleware manager per request: the manager holds
+        # references to extension instances, which are now constructed
+        # per-request to avoid concurrency leaks (see #4369).
+        return MiddlewareManager(
             *(ext for ext in extensions if ext._implements_resolve())
         )
-
-        if cached:
-            self._cached_middleware_manager = manager
-
-        return manager
 
     def _create_execution_context(
         self,
@@ -591,9 +614,7 @@ class Schema(BaseSchema):
             extension.execution_context = execution_context
 
         extensions_runner = self.create_extensions_runner(execution_context, extensions)
-        # uncached: each async request needs its own middleware to avoid
-        # concurrent requests overwriting each other's execution_context
-        middleware_manager = self._get_middleware_manager(extensions, cached=False)
+        middleware_manager = self._get_middleware_manager(extensions)
 
         execute_function = execute
 
@@ -927,9 +948,7 @@ class Schema(BaseSchema):
             extensions_runner=self.create_extensions_runner(
                 execution_context, extensions
             ),
-            # uncached: subscriptions are long-lived and concurrent, so each
-            # needs isolated middleware to keep its own execution_context
-            middleware_manager=self._get_middleware_manager(extensions, cached=False),
+            middleware_manager=self._get_middleware_manager(extensions),
             execution_context_class=self.execution_context_class,
             operation_extensions=operation_extensions,
         )

--- a/tests/extensions/test_pyinstrument.py
+++ b/tests/extensions/test_pyinstrument.py
@@ -33,7 +33,9 @@ def test_basic_pyinstrument():
 
         schema = strawberry.Schema(
             query=Query,
-            extensions=[pyinstrument.PyInstrument(report_path=report_file_path)],
+            extensions=[
+                lambda: pyinstrument.PyInstrument(report_path=report_file_path)
+            ],
         )
 
         # Query the schema

--- a/tests/schema/extensions/schema_extensions/test_extensions.py
+++ b/tests/schema/extensions/schema_extensions/test_extensions.py
@@ -221,7 +221,7 @@ def test_can_initialize_extension(default_query_types_and_query):
     schema = strawberry.Schema(
         query=default_query_types_and_query.query_type,
         extensions=[
-            CustomizableExtension(20),
+            lambda: CustomizableExtension(20),
         ],
     )
     res = schema.execute_sync(query=default_query_types_and_query.query)
@@ -507,7 +507,7 @@ async def test_exceptions_are_included_in_the_execution_result(failing_hook):
 
     schema = strawberry.Schema(
         query=Query,
-        extensions=[ExceptionTestingExtension(failing_hook)],
+        extensions=[lambda: ExceptionTestingExtension(failing_hook)],
     )
     document = "query { ping }"
 
@@ -543,17 +543,25 @@ async def test_exceptions_abort_evaluation(failing_hook, expected_hooks):
         def ping(self) -> str:
             return "pong"
 
-    extension = ExceptionTestingExtension(failing_hook)
-    schema = strawberry.Schema(query=Query, extensions=[extension])
+    called_hooks: set[int] = set()
+
+    class _ExtForTest(ExceptionTestingExtension):
+        def __init__(self) -> None:
+            super().__init__(failing_hook)
+            # Share the closure-captured set so the test can observe which
+            # hooks ran across the per-request fresh instances.
+            self.called_hooks = called_hooks
+
+    schema = strawberry.Schema(query=Query, extensions=[_ExtForTest])
     document = "query { ping }"
 
-    extension.called_hooks = set()
+    called_hooks.clear()
     schema.execute_sync(document)
-    assert extension.called_hooks == expected_hooks
+    assert called_hooks == expected_hooks
 
-    extension.called_hooks = set()
+    called_hooks.clear()
     await schema.execute(document)
-    assert extension.called_hooks == expected_hooks
+    assert called_hooks == expected_hooks
 
 
 async def test_generic_exceptions_get_wrapped_in_a_graphql_error(

--- a/tests/schema/extensions/test_disable_introspection.py
+++ b/tests/schema/extensions/test_disable_introspection.py
@@ -9,7 +9,7 @@ def test_disables_introspection():
 
     schema = strawberry.Schema(
         query=Query,
-        extensions=[DisableIntrospection()],
+        extensions=[DisableIntrospection],
     )
 
     result = schema.execute_sync("query { __schema { __typename } }")
@@ -32,7 +32,7 @@ def test_does_not_affect_non_introspection_queries():
 
     schema = strawberry.Schema(
         query=Query,
-        extensions=[DisableIntrospection()],
+        extensions=[DisableIntrospection],
     )
 
     result = schema.execute_sync("query { __typename }")

--- a/tests/schema/extensions/test_isolation.py
+++ b/tests/schema/extensions/test_isolation.py
@@ -148,32 +148,6 @@ def test_instance_passed_emits_deprecation_warning():
         )
 
 
-def test_instance_passed_emits_deprecation_warning_via_federation_schema():
-    # The warning is emitted from inside ``Schema.__init__`` but the federation
-    # subclass sits in the call stack via ``super().__init__``. Check that the
-    # warning is still attributed to the user's call site.
-    import strawberry.federation
-
-    @strawberry.federation.type
-    class FedQuery:
-        hello: str = "world"
-
-    with pytest.warns(
-        DeprecationWarning,
-        match=r"Passing an extension instance.*deprecated",
-    ) as caught:
-        strawberry.federation.Schema(
-            query=FedQuery,
-            extensions=[_CapturingExtension()],  # type: ignore[list-item]
-        )
-
-    assert len(caught) == 1
-    # The warning's filename must not be inside ``strawberry/`` itself.
-    assert "strawberry/" not in caught[0].filename or caught[0].filename.endswith(
-        "test_isolation.py"
-    )
-
-
 def test_extensions_can_be_a_generator():
     # ``Schema.__init__`` materializes the iterable so a generator passed as
     # ``extensions`` still produces extensions on every request.
@@ -185,23 +159,6 @@ def test_extensions_can_be_a_generator():
     for _ in range(2):
         result = schema.execute_sync("{ hello }")
         assert result.extensions == {"query": "{ hello }", "label": "default"}
-
-
-def test_instance_passed_per_request_copy_isolates_context():
-    # The schema warns on instance-passing but still copies the instance per
-    # request so concurrent requests do not share ``execution_context``.
-    with pytest.warns(DeprecationWarning, match="deprecated"):
-        schema = strawberry.Schema(
-            query=Query,
-            extensions=[_CapturingExtension()],  # type: ignore[list-item]
-        )
-
-    queries = ["{ hello }", "{ test: hello }"]
-    with ThreadPoolExecutor(max_workers=2) as executor:
-        results = list(executor.map(schema.execute_sync, queries))
-
-    assert results[0].extensions == {"query": queries[0], "label": "default"}
-    assert results[1].extensions == {"query": queries[1], "label": "default"}
 
 
 def test_apollo_tracing_sync_concurrent_class_passed():

--- a/tests/schema/extensions/test_isolation.py
+++ b/tests/schema/extensions/test_isolation.py
@@ -44,6 +44,7 @@ class _CapturingExtension(SchemaExtension):
     """
 
     def __init__(self, *, execution_context=None, label: str = "default") -> None:
+        super().__init__(execution_context=execution_context)
         self.label = label
 
     def get_results(self) -> dict[str, Any]:
@@ -110,6 +111,7 @@ def test_class_constructed_per_request():
 
     class _Counting(SchemaExtension):
         def __init__(self, *, execution_context=None) -> None:
+            super().__init__(execution_context=execution_context)
             nonlocal construction_count
             construction_count += 1
 

--- a/tests/schema/extensions/test_isolation.py
+++ b/tests/schema/extensions/test_isolation.py
@@ -105,7 +105,7 @@ async def test_async_concurrent_factory_passed():
     assert results[1].extensions == {"query": queries[1], "label": "async-factory"}
 
 
-def test_factory_called_once_per_request():
+def test_class_constructed_per_request():
     construction_count = 0
 
     class _Counting(SchemaExtension):
@@ -121,6 +121,22 @@ def test_factory_called_once_per_request():
     assert construction_count == 3, "every request must build a fresh instance"
 
 
+def test_factory_called_per_request():
+    factory_call_count = 0
+
+    def factory() -> SchemaExtension:
+        nonlocal factory_call_count
+        factory_call_count += 1
+        return _CapturingExtension(label=f"req-{factory_call_count}")
+
+    schema = strawberry.Schema(query=Query, extensions=[factory])
+
+    for _ in range(3):
+        schema.execute_sync("{ hello }")
+
+    assert factory_call_count == 3, "factory must be invoked once per request"
+
+
 def test_instance_passed_emits_deprecation_warning():
     with pytest.warns(
         DeprecationWarning,
@@ -130,6 +146,45 @@ def test_instance_passed_emits_deprecation_warning():
             query=Query,
             extensions=[_CapturingExtension()],  # type: ignore[list-item]
         )
+
+
+def test_instance_passed_emits_deprecation_warning_via_federation_schema():
+    # The warning is emitted from inside ``Schema.__init__`` but the federation
+    # subclass sits in the call stack via ``super().__init__``. Check that the
+    # warning is still attributed to the user's call site.
+    import strawberry.federation
+
+    @strawberry.federation.type
+    class FedQuery:
+        hello: str = "world"
+
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"Passing an extension instance.*deprecated",
+    ) as caught:
+        strawberry.federation.Schema(
+            query=FedQuery,
+            extensions=[_CapturingExtension()],  # type: ignore[list-item]
+        )
+
+    assert len(caught) == 1
+    # The warning's filename must not be inside ``strawberry/`` itself.
+    assert "strawberry/" not in caught[0].filename or caught[0].filename.endswith(
+        "test_isolation.py"
+    )
+
+
+def test_extensions_can_be_a_generator():
+    # ``Schema.__init__`` materializes the iterable so a generator passed as
+    # ``extensions`` still produces extensions on every request.
+    def gen():
+        yield _CapturingExtension
+
+    schema = strawberry.Schema(query=Query, extensions=gen())
+
+    for _ in range(2):
+        result = schema.execute_sync("{ hello }")
+        assert result.extensions == {"query": "{ hello }", "label": "default"}
 
 
 def test_instance_passed_per_request_copy_isolates_context():

--- a/tests/schema/extensions/test_isolation.py
+++ b/tests/schema/extensions/test_isolation.py
@@ -1,0 +1,202 @@
+"""Regression suite for issue #4369.
+
+Concurrent requests must each see their own ``ExecutionContext``, regardless
+of whether the extension is passed as a class, a factory callable, or (the
+deprecated path) a pre-built instance. Built-in tracing extensions must keep
+their per-request mutable state isolated as well.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import pytest
+
+import strawberry
+from strawberry.extensions import SchemaExtension
+from strawberry.extensions.tracing import (
+    ApolloTracingExtension,
+    ApolloTracingExtensionSync,
+)
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def hello(self) -> str:
+        time.sleep(0.05)
+        return "world"
+
+    @strawberry.field
+    async def hello_async(self) -> str:
+        await asyncio.sleep(0.05)
+        return "world"
+
+
+class _CapturingExtension(SchemaExtension):
+    """Captures ``execution_context.query`` into ``get_results``.
+
+    Any request that reads the *other* request's query is observing leaked
+    state from a shared instance.
+    """
+
+    def __init__(self, *, execution_context=None, label: str = "default") -> None:
+        self.label = label
+
+    def get_results(self) -> dict[str, Any]:
+        return {
+            "query": str(self.execution_context.query),
+            "label": self.label,
+        }
+
+
+def test_sync_concurrent_class_passed():
+    schema = strawberry.Schema(query=Query, extensions=[_CapturingExtension])
+
+    queries = ["{ hello }", "{ test: hello }"]
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(schema.execute_sync, queries))
+
+    assert results[0].extensions == {"query": queries[0], "label": "default"}
+    assert results[1].extensions == {"query": queries[1], "label": "default"}
+
+
+def test_sync_concurrent_factory_passed():
+    schema = strawberry.Schema(
+        query=Query,
+        extensions=[lambda: _CapturingExtension(label="sync-factory")],
+    )
+
+    queries = ["{ hello }", "{ test: hello }"]
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(schema.execute_sync, queries))
+
+    assert results[0].extensions == {"query": queries[0], "label": "sync-factory"}
+    assert results[1].extensions == {"query": queries[1], "label": "sync-factory"}
+
+
+@pytest.mark.asyncio
+async def test_async_concurrent_class_passed():
+    schema = strawberry.Schema(query=Query, extensions=[_CapturingExtension])
+
+    queries = ["{ helloAsync }", "{ test: helloAsync }"]
+    results = await asyncio.gather(*(schema.execute(q) for q in queries))
+
+    assert results[0].extensions == {"query": queries[0], "label": "default"}
+    assert results[1].extensions == {"query": queries[1], "label": "default"}
+
+
+@pytest.mark.asyncio
+async def test_async_concurrent_factory_passed():
+    schema = strawberry.Schema(
+        query=Query,
+        extensions=[lambda: _CapturingExtension(label="async-factory")],
+    )
+
+    queries = ["{ helloAsync }", "{ test: helloAsync }"]
+    results = await asyncio.gather(*(schema.execute(q) for q in queries))
+
+    assert results[0].extensions == {"query": queries[0], "label": "async-factory"}
+    assert results[1].extensions == {"query": queries[1], "label": "async-factory"}
+
+
+def test_factory_called_once_per_request():
+    construction_count = 0
+
+    class _Counting(SchemaExtension):
+        def __init__(self, *, execution_context=None) -> None:
+            nonlocal construction_count
+            construction_count += 1
+
+    schema = strawberry.Schema(query=Query, extensions=[_Counting])
+
+    for _ in range(3):
+        schema.execute_sync("{ hello }")
+
+    assert construction_count == 3, "every request must build a fresh instance"
+
+
+def test_instance_passed_emits_deprecation_warning():
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"Passing an extension instance.*deprecated",
+    ):
+        strawberry.Schema(
+            query=Query,
+            extensions=[_CapturingExtension()],  # type: ignore[list-item]
+        )
+
+
+def test_instance_passed_per_request_copy_isolates_context():
+    # The schema warns on instance-passing but still copies the instance per
+    # request so concurrent requests do not share ``execution_context``.
+    with pytest.warns(DeprecationWarning, match="deprecated"):
+        schema = strawberry.Schema(
+            query=Query,
+            extensions=[_CapturingExtension()],  # type: ignore[list-item]
+        )
+
+    queries = ["{ hello }", "{ test: hello }"]
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(schema.execute_sync, queries))
+
+    assert results[0].extensions == {"query": queries[0], "label": "default"}
+    assert results[1].extensions == {"query": queries[1], "label": "default"}
+
+
+def test_apollo_tracing_sync_concurrent_class_passed():
+    schema = strawberry.Schema(query=Query, extensions=[ApolloTracingExtensionSync])
+
+    queries = ["{ hello }", "{ test: hello }"]
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(schema.execute_sync, queries))
+
+    # Each request gets its own tracing payload and own resolver list.
+    for result in results:
+        assert result.errors is None
+        assert result.extensions is not None
+        tracing = result.extensions["tracing"]
+        resolvers = tracing["execution"]["resolvers"]
+        # Both queries resolve a single ``hello`` field.
+        assert len(resolvers) == 1
+        assert resolvers[0]["field_name"] == "hello"
+
+
+@pytest.mark.asyncio
+async def test_apollo_tracing_async_concurrent_class_passed():
+    schema = strawberry.Schema(query=Query, extensions=[ApolloTracingExtension])
+
+    queries = ["{ helloAsync }", "{ test: helloAsync }"]
+    results = await asyncio.gather(*(schema.execute(q) for q in queries))
+
+    for result in results:
+        assert result.errors is None
+        assert result.extensions is not None
+        tracing = result.extensions["tracing"]
+        resolvers = tracing["execution"]["resolvers"]
+        assert len(resolvers) == 1
+        assert resolvers[0]["field_name"] == "helloAsync"
+
+
+@pytest.mark.asyncio
+async def test_apollo_tracing_async_concurrent_factory_passed():
+    schema = strawberry.Schema(
+        query=Query,
+        extensions=[lambda: ApolloTracingExtension(execution_context=None)],
+    )
+
+    queries = ["{ helloAsync }", "{ test: helloAsync }", "{ alias: helloAsync }"]
+    results = await asyncio.gather(*(schema.execute(q) for q in queries))
+
+    for result in results:
+        assert result.errors is None
+        assert result.extensions is not None
+        tracing = result.extensions["tracing"]
+        resolvers = tracing["execution"]["resolvers"]
+        assert len(resolvers) == 1
+        assert resolvers[0]["field_name"] == "helloAsync"

--- a/tests/schema/extensions/test_mask_errors.py
+++ b/tests/schema/extensions/test_mask_errors.py
@@ -14,7 +14,7 @@ def test_mask_all_errors():
         def hidden_error(self) -> str:
             raise KeyError("This error is not visible")
 
-    schema = strawberry.Schema(query=Query, extensions=[MaskErrors()])
+    schema = strawberry.Schema(query=Query, extensions=[MaskErrors])
 
     query = "query { hiddenError }"
 
@@ -38,7 +38,7 @@ async def test_mask_all_errors_async():
         def hidden_error(self) -> str:
             raise KeyError("This error is not visible")
 
-    schema = strawberry.Schema(query=Query, extensions=[MaskErrors()])
+    schema = strawberry.Schema(query=Query, extensions=[MaskErrors])
 
     query = "query { hiddenError }"
 
@@ -73,7 +73,8 @@ def test_mask_some_errors():
         return not (original_error and isinstance(original_error, VisibleError))
 
     schema = strawberry.Schema(
-        query=Query, extensions=[MaskErrors(should_mask_error=should_mask_error)]
+        query=Query,
+        extensions=[lambda: MaskErrors(should_mask_error=should_mask_error)],
     )
 
     query = "query { hiddenError }"
@@ -117,7 +118,7 @@ def test_process_errors_original_error():
             for error in errors:
                 mock_process_error(error)
 
-    schema = CustomSchema(query=Query, extensions=[MaskErrors()])
+    schema = CustomSchema(query=Query, extensions=[MaskErrors])
 
     query = "query { hiddenError }"
 
@@ -145,7 +146,7 @@ def test_graphql_error_masking():
         def graphql_error(self) -> str:
             return None  # type: ignore
 
-    schema = strawberry.Schema(query=Query, extensions=[MaskErrors()])
+    schema = strawberry.Schema(query=Query, extensions=[MaskErrors])
 
     query = "query { graphqlError }"
 
@@ -171,7 +172,7 @@ async def test_mask_errors_with_strawberry_execution_result_async():
         def test_field(self) -> str:
             raise ValueError("Original error message")
 
-    schema = strawberry.Schema(query=Query, extensions=[MaskErrors()])
+    schema = strawberry.Schema(query=Query, extensions=[MaskErrors])
 
     query = "query { testField }"
 
@@ -210,7 +211,8 @@ async def test_mask_errors_selective_async():
         return not (original_error and isinstance(original_error, VisibleError))
 
     schema = strawberry.Schema(
-        query=Query, extensions=[MaskErrors(should_mask_error=should_mask_error)]
+        query=Query,
+        extensions=[lambda: MaskErrors(should_mask_error=should_mask_error)],
     )
 
     # Test hidden error

--- a/tests/schema/extensions/test_max_aliases.py
+++ b/tests/schema/extensions/test_max_aliases.py
@@ -230,7 +230,8 @@ def test_no_error_for_multiple_but_not_too_many_aliases():
 
 def _execute_with_max_aliases(query: str, max_alias_count: int):
     schema = strawberry.Schema(
-        Query, extensions=[MaxAliasesLimiter(max_alias_count=max_alias_count)]
+        Query,
+        extensions=[lambda: MaxAliasesLimiter(max_alias_count=max_alias_count)],
     )
 
     return schema.execute_sync(query)

--- a/tests/schema/extensions/test_max_tokens.py
+++ b/tests/schema/extensions/test_max_tokens.py
@@ -56,7 +56,8 @@ def test_no_errors_exactly_max_number_of_tokens():
 
 def _execute_with_max_tokens(query: str, max_token_count: int):
     schema = strawberry.Schema(
-        Query, extensions=[MaxTokensLimiter(max_token_count=max_token_count)]
+        Query,
+        extensions=[lambda: MaxTokensLimiter(max_token_count=max_token_count)],
     )
 
     return schema.execute_sync(query)

--- a/tests/schema/extensions/test_opentelemetry.py
+++ b/tests/schema/extensions/test_opentelemetry.py
@@ -201,7 +201,8 @@ async def test_tracing_filter_kwargs(global_tracer_mock, mocker):
             return f"Hi {name}"
 
     schema = strawberry.Schema(
-        query=Query, extensions=[OpenTelemetryExtension(arg_filter=arg_filter)]
+        query=Query,
+        extensions=[lambda: OpenTelemetryExtension(arg_filter=arg_filter)],
     )
 
     query = """

--- a/tests/schema/extensions/test_parser_cache.py
+++ b/tests/schema/extensions/test_parser_cache.py
@@ -5,6 +5,17 @@ from graphql import SourceLocation, parse
 
 import strawberry
 from strawberry.extensions import MaxTokensLimiter, ParserCache
+from strawberry.extensions import parser_cache as _parser_cache_module
+
+
+@pytest.fixture(autouse=True)
+def _clear_parser_caches():
+    # ``ParserCache`` shares its LRU cache module-level keyed by ``maxsize``;
+    # tests rely on patching ``parse`` and counting calls, so we clear between
+    # tests to keep them independent.
+    _parser_cache_module._caches.clear()
+    yield
+    _parser_cache_module._caches.clear()
 
 
 @patch("strawberry.extensions.parser_cache.parse", wraps=parse)
@@ -19,8 +30,7 @@ def test_parser_cache_extension(mock_parse):
         def ping(self) -> str:
             return "pong"
 
-    parser_cache = ParserCache()
-    schema = strawberry.Schema(query=Query, extensions=[lambda: parser_cache])
+    schema = strawberry.Schema(query=Query, extensions=[ParserCache])
 
     query = "query { hello }"
 
@@ -62,12 +72,11 @@ def test_parser_cache_extension_arguments(mock_parse):
         def ping(self) -> str:
             return "pong"
 
-    parser_cache = ParserCache()
     schema = strawberry.Schema(
         query=Query,
         extensions=[
             lambda: MaxTokensLimiter(max_token_count=20),
-            lambda: parser_cache,
+            ParserCache,
         ],
     )
 
@@ -89,8 +98,7 @@ def test_parser_cache_extension_syntax_error(mock_parse):
         def hello(self) -> str:  # pragma: no cover
             return "world"
 
-    parser_cache = ParserCache()
-    schema = strawberry.Schema(query=Query, extensions=[lambda: parser_cache])
+    schema = strawberry.Schema(query=Query, extensions=[ParserCache])
 
     query = "query { hello"
 
@@ -114,8 +122,10 @@ def test_parser_cache_extension_max_size(mock_parse):
         def ping(self) -> str:
             return "pong"
 
-    parser_cache = ParserCache(maxsize=1)
-    schema = strawberry.Schema(query=Query, extensions=[lambda: parser_cache])
+    schema = strawberry.Schema(
+        query=Query,
+        extensions=[lambda: ParserCache(maxsize=1)],
+    )
 
     query = "query { hello }"
 
@@ -153,8 +163,7 @@ async def test_parser_cache_extension_async(mock_parse):
         def ping(self) -> str:
             return "pong"
 
-    parser_cache = ParserCache()
-    schema = strawberry.Schema(query=Query, extensions=[lambda: parser_cache])
+    schema = strawberry.Schema(query=Query, extensions=[ParserCache])
 
     query = "query { hello }"
 

--- a/tests/schema/extensions/test_parser_cache.py
+++ b/tests/schema/extensions/test_parser_cache.py
@@ -13,9 +13,9 @@ def _clear_parser_caches():
     # ``ParserCache`` shares its LRU cache module-level keyed by ``maxsize``;
     # tests rely on patching ``parse`` and counting calls, so we clear between
     # tests to keep them independent.
-    _parser_cache_module._caches.clear()
+    _parser_cache_module._get_parse_cache.cache_clear()
     yield
-    _parser_cache_module._caches.clear()
+    _parser_cache_module._get_parse_cache.cache_clear()
 
 
 @patch("strawberry.extensions.parser_cache.parse", wraps=parse)

--- a/tests/schema/extensions/test_parser_cache.py
+++ b/tests/schema/extensions/test_parser_cache.py
@@ -19,7 +19,8 @@ def test_parser_cache_extension(mock_parse):
         def ping(self) -> str:
             return "pong"
 
-    schema = strawberry.Schema(query=Query, extensions=[ParserCache()])
+    parser_cache = ParserCache()
+    schema = strawberry.Schema(query=Query, extensions=[lambda: parser_cache])
 
     query = "query { hello }"
 
@@ -61,8 +62,13 @@ def test_parser_cache_extension_arguments(mock_parse):
         def ping(self) -> str:
             return "pong"
 
+    parser_cache = ParserCache()
     schema = strawberry.Schema(
-        query=Query, extensions=[MaxTokensLimiter(max_token_count=20), ParserCache()]
+        query=Query,
+        extensions=[
+            lambda: MaxTokensLimiter(max_token_count=20),
+            lambda: parser_cache,
+        ],
     )
 
     query = "query { hello }"
@@ -83,7 +89,8 @@ def test_parser_cache_extension_syntax_error(mock_parse):
         def hello(self) -> str:  # pragma: no cover
             return "world"
 
-    schema = strawberry.Schema(query=Query, extensions=[ParserCache()])
+    parser_cache = ParserCache()
+    schema = strawberry.Schema(query=Query, extensions=[lambda: parser_cache])
 
     query = "query { hello"
 
@@ -107,7 +114,8 @@ def test_parser_cache_extension_max_size(mock_parse):
         def ping(self) -> str:
             return "pong"
 
-    schema = strawberry.Schema(query=Query, extensions=[ParserCache(maxsize=1)])
+    parser_cache = ParserCache(maxsize=1)
+    schema = strawberry.Schema(query=Query, extensions=[lambda: parser_cache])
 
     query = "query { hello }"
 
@@ -145,7 +153,8 @@ async def test_parser_cache_extension_async(mock_parse):
         def ping(self) -> str:
             return "pong"
 
-    schema = strawberry.Schema(query=Query, extensions=[ParserCache()])
+    parser_cache = ParserCache()
+    schema = strawberry.Schema(query=Query, extensions=[lambda: parser_cache])
 
     query = "query { hello }"
 

--- a/tests/schema/extensions/test_query_depth_limiter.py
+++ b/tests/schema/extensions/test_query_depth_limiter.py
@@ -276,9 +276,7 @@ def test_should_raise_invalid_ignore():
         TypeError,
         match=r"The `should_ignore` argument to `QueryDepthLimiter` must be a callable.",
     ):
-        strawberry.Schema(
-            Query, extensions=[QueryDepthLimiter(max_depth=10, should_ignore=True)]
-        )
+        QueryDepthLimiter(max_depth=10, should_ignore=True)  # type: ignore[arg-type]
 
 
 def test_should_ignore_field_by_name():
@@ -482,7 +480,10 @@ def test_should_work_as_extension():
         return False
 
     schema = strawberry.Schema(
-        Query, extensions=[QueryDepthLimiter(max_depth=4, should_ignore=should_ignore)]
+        Query,
+        extensions=[
+            lambda: QueryDepthLimiter(max_depth=4, should_ignore=should_ignore)
+        ],
     )
 
     result = schema.execute_sync(query)

--- a/tests/schema/extensions/test_validation_cache.py
+++ b/tests/schema/extensions/test_validation_cache.py
@@ -12,9 +12,9 @@ from strawberry.extensions import validation_cache as _validation_cache_module
 def _clear_validation_caches():
     # ``ValidationCache`` shares its LRU cache module-level keyed by
     # ``maxsize``; clear between tests so patched call counts stay independent.
-    _validation_cache_module._caches.clear()
+    _validation_cache_module._get_validate_cache.cache_clear()
     yield
-    _validation_cache_module._caches.clear()
+    _validation_cache_module._get_validate_cache.cache_clear()
 
 
 @patch("strawberry.schema.schema.validate", wraps=validate)

--- a/tests/schema/extensions/test_validation_cache.py
+++ b/tests/schema/extensions/test_validation_cache.py
@@ -5,6 +5,16 @@ from graphql import validate
 
 import strawberry
 from strawberry.extensions import ValidationCache
+from strawberry.extensions import validation_cache as _validation_cache_module
+
+
+@pytest.fixture(autouse=True)
+def _clear_validation_caches():
+    # ``ValidationCache`` shares its LRU cache module-level keyed by
+    # ``maxsize``; clear between tests so patched call counts stay independent.
+    _validation_cache_module._caches.clear()
+    yield
+    _validation_cache_module._caches.clear()
 
 
 @patch("strawberry.schema.schema.validate", wraps=validate)
@@ -19,8 +29,7 @@ def test_validation_cache_extension(mock_validate):
         def ping(self) -> str:
             return "pong"
 
-    validation_cache = ValidationCache()
-    schema = strawberry.Schema(query=Query, extensions=[lambda: validation_cache])
+    schema = strawberry.Schema(query=Query, extensions=[ValidationCache])
 
     query = "query { hello }"
 
@@ -62,8 +71,10 @@ def test_validation_cache_extension_max_size(mock_validate):
         def ping(self) -> str:
             return "pong"
 
-    validation_cache = ValidationCache(maxsize=1)
-    schema = strawberry.Schema(query=Query, extensions=[lambda: validation_cache])
+    schema = strawberry.Schema(
+        query=Query,
+        extensions=[lambda: ValidationCache(maxsize=1)],
+    )
 
     query = "query { hello }"
 
@@ -100,8 +111,7 @@ async def test_validation_cache_extension_async():
         def ping(self) -> str:
             return "pong"
 
-    validation_cache = ValidationCache()
-    schema = strawberry.Schema(query=Query, extensions=[lambda: validation_cache])
+    schema = strawberry.Schema(query=Query, extensions=[ValidationCache])
 
     query = "query { hello }"
 

--- a/tests/schema/extensions/test_validation_cache.py
+++ b/tests/schema/extensions/test_validation_cache.py
@@ -19,7 +19,8 @@ def test_validation_cache_extension(mock_validate):
         def ping(self) -> str:
             return "pong"
 
-    schema = strawberry.Schema(query=Query, extensions=[ValidationCache()])
+    validation_cache = ValidationCache()
+    schema = strawberry.Schema(query=Query, extensions=[lambda: validation_cache])
 
     query = "query { hello }"
 
@@ -61,7 +62,8 @@ def test_validation_cache_extension_max_size(mock_validate):
         def ping(self) -> str:
             return "pong"
 
-    schema = strawberry.Schema(query=Query, extensions=[ValidationCache(maxsize=1)])
+    validation_cache = ValidationCache(maxsize=1)
+    schema = strawberry.Schema(query=Query, extensions=[lambda: validation_cache])
 
     query = "query { hello }"
 
@@ -98,7 +100,8 @@ async def test_validation_cache_extension_async():
         def ping(self) -> str:
             return "pong"
 
-    schema = strawberry.Schema(query=Query, extensions=[ValidationCache()])
+    validation_cache = ValidationCache()
+    schema = strawberry.Schema(query=Query, extensions=[lambda: validation_cache])
 
     query = "query { hello }"
 

--- a/tests/schema/test_execution.py
+++ b/tests/schema/test_execution.py
@@ -6,7 +6,11 @@ import pytest
 from graphql import GraphQLError, ValidationRule, validate
 
 import strawberry
-from strawberry.extensions import AddValidationRules, DisableValidation
+from strawberry.extensions import (
+    AddValidationRules,
+    DisableValidation,
+    SchemaExtension,
+)
 
 
 @pytest.mark.parametrize("validate_queries", [True, False])
@@ -16,9 +20,9 @@ def test_enabling_query_validation_sync(mock_validate, validate_queries):
     class Query:
         example: str | None = None
 
-    extensions = []
+    extensions: list[type[SchemaExtension]] = []
     if validate_queries is False:
-        extensions.append(DisableValidation())
+        extensions.append(DisableValidation)
 
     schema = strawberry.Schema(
         query=Query,
@@ -48,9 +52,9 @@ async def test_enabling_query_validation(validate_queries):
     class Query:
         example: str | None = None
 
-    extensions = []
+    extensions: list[type[SchemaExtension]] = []
     if validate_queries is False:
-        extensions.append(DisableValidation())
+        extensions.append(DisableValidation)
 
     schema = strawberry.Schema(
         query=Query,
@@ -104,7 +108,7 @@ async def test_asking_for_wrong_field():
     class Query:
         example: str | None = None
 
-    schema = strawberry.Schema(query=Query, extensions=[DisableValidation()])
+    schema = strawberry.Schema(query=Query, extensions=[DisableValidation])
 
     query = """
         query {
@@ -129,7 +133,7 @@ async def test_sending_wrong_variables():
         def example(self, value: str) -> int:
             return 1
 
-    schema = strawberry.Schema(query=Query, extensions=[DisableValidation()])
+    schema = strawberry.Schema(query=Query, extensions=[DisableValidation])
 
     query = """
         query {
@@ -430,7 +434,7 @@ def test_adding_custom_validation_rules():
     schema = strawberry.Schema(
         query=Query,
         extensions=[
-            AddValidationRules([CustomRule]),
+            lambda: AddValidationRules([CustomRule]),
         ],
     )
 


### PR DESCRIPTION
## Summary

Fixes a concurrency bug where extension instances passed to `extensions=[…]` were shared across concurrent requests, causing `ExecutionContext` and built-in tracing state (Apollo, Datadog, OpenTelemetry, Apollo Federation) to leak between requests under `asyncio.gather` and threaded `execute_sync`.

The schema now accepts:

- a **class**: `extensions=[MyExtension]`
- a **factory callable**: `extensions=[lambda: MaxTokensLimiter(max_token_count=100)]`

A fresh extension is constructed for every request, so any state on `self` is automatically per-request — no `ContextVar` plumbing or per-extension rewrites needed.

The public type signature drops the `SchemaExtension` instance shape, so type checkers (mypy, pyright) flag `extensions=[MyExtension()]`. At runtime, instances are still tolerated for backward compatibility: the schema shallow-copies them per request and emits a `DeprecationWarning`.

This replaces the earlier ContextVar-based attempt in #4381 with a much smaller diff that doesn't touch any tracing extension internals.

Fix #4369

## Changes

- `strawberry/schema/schema.py`: new type signature, per-request `get_extensions()`, drop `_sync_extensions` cache and `_cached_middleware_manager`, emit one `DeprecationWarning` per schema for instance-passed extensions
- `strawberry/federation/schema.py`: matching type signature
- `strawberry/extensions/tracing/apollo.py`, `apollo_federation.py`: `__init__` aligned with the base (`*, execution_context=None`) so factory calls work cleanly
- `docs/guides/custom-extensions.md`: new "Passing extensions" section
- `tests/schema/extensions/test_isolation.py`: new regression suite covering sync/async + class/factory + tracing extensions + deprecation warning
- Existing tests migrated from `[Ext()]` to class/factory form

## Test plan

- [x] `poetry run pytest tests/` — 4575 passed, no `DeprecationWarning` from `strawberry`
- [x] `poetry run pytest tests/schema/extensions/test_isolation.py` — 10 passed
- [x] `poetry run mypy --config-file mypy.ini` — clean
- [x] `poetry run ruff check strawberry/ tests/` — clean
- [x] Manual repro of the reporter's #4369 script (sync threaded + async gathered) — each request observes its own `ExecutionContext`

## Summary by Sourcery

Ensure schema extensions are constructed per request to prevent shared state across concurrent executions and introduce factory support with deprecation of passing extension instances.

New Features:
- Allow schema extensions to be provided as factory callables so a new extension instance is created for each request.

Bug Fixes:
- Fix concurrency issues where shared extension instances could leak ExecutionContext and tracing state across concurrent sync and async requests.

Enhancements:
- Update schema extension typing to prefer classes and factories over instances and emit a deprecation warning when instances are passed.
- Align Apollo tracing extensions’ constructors with the base extension interface to support the new factory-based instantiation model.
- Remove cached extension and middleware manager state so sync and async executions always use fresh extension instances and middleware per request.

Documentation:
- Document the recommended ways to pass extensions (class or factory) and the deprecation of passing instances directly, including updated usage examples for caching extensions.

Tests:
- Add a regression test suite validating per-request isolation of ExecutionContext and tracing data under concurrent sync and async execution for both class and factory extension usage.
- Update existing tests to use class or factory-based extension configuration and to cover the new deprecation behavior for instance-passed extensions.

Chores:
- Add a release note describing the new extension factory support, concurrency fix, and deprecation of instance-passed extensions.