### PR TITLE
Fix example in strawberry.argument docstring

### DIFF
--- a/strawberry/types/arguments.py
+++ b/strawberry/types/arguments.py
@@ -335,7 +335,7 @@ def argument(
         def example(
             self,
             info: strawberry.Info,
-            value: Annotated[int, strawberry.argument(description="The value")]
+            value: Annotated[int, strawberry.argument(description="The value")],
         ) -> int:
             return value
     ```

--- a/strawberry/types/arguments.py
+++ b/strawberry/types/arguments.py
@@ -325,6 +325,7 @@ def argument(
 
     Example:
     ```python
+    from typing import Annotated
     import strawberry
 
 
@@ -332,7 +333,9 @@ def argument(
     class Query:
         @strawberry.field
         def example(
-            self, info, value: int = strawberry.argument(description="The value")
+            self,
+            info: strawberry.Info,
+            value: Annotated[int, strawberry.argument(description="The value")]
         ) -> int:
             return value
     ```


### PR DESCRIPTION
## Description

The docstring for `strawberry.argument` has the following [example](https://github.com/strawberry-graphql/strawberry/blob/d15c2d45e4bf8434fb22e332600ffdef3ec04624/strawberry/types/arguments.py#L326-L338):

```
import strawberry


@strawberry.type
class Query:
    @strawberry.field
    def example(
        self, info, value: int = strawberry.argument(description="The value")
    ) -> int:
        return value
```

When trying to print the SDL for a schema with this type, the following error is raised:

```
>>> schema = strawberry.Schema(query=Query)
>>> schema.as_str()
Traceback (most recent call last):
  File "/Users/.../.venv/lib/python3.13/site-packages/graphql/type/scalars.py", line 56, in serialize_int
    num = int(output_value)  # raises ValueError if not an integer
TypeError: int() argument must be a string, a bytes-like object or a real number, not 'StrawberryArgumentAnnotation'
```

The problem is that the `StrawberryArgumentAnnotation` instance returned by `strawberry.argument` is interpreted as default for the argument. And then it fails because an integer is expected.

This PR fixes the example, so that `typing.Annotated` is used.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Documentation:
- Fix the strawberry.argument docstring example to use typing.Annotated and a typed info parameter so the example reflects the correct usage.