### PR TITLE
fix: support input object instances as default argument values

### DIFF
--- a/strawberry/types/arguments.py
+++ b/strawberry/types/arguments.py
@@ -244,6 +244,12 @@ def convert_argument(
         return convert_argument(value, enum_definition, scalar_registry, config)
 
     if has_object_definition(type_):
+        # If the value is already an instance of the expected input type
+        # (e.g., from a default value), return it directly instead of trying
+        # to treat it as a mapping and re-convert it.
+        if isinstance(value, type_):
+            return value
+
         kwargs = {}
 
         type_definition = type_.__strawberry_definition__


### PR DESCRIPTION
Default values for input object arguments in field resolvers raised
TypeError when the argument was omitted in the query.

The convert_argument() function assumed the value was always a dict/Mapping
when it had an object definition, but graphql-core passes Python instances
directly for default values.

Fix: add isinstance check to return the value directly when it is already
an instance of the expected input type.

Fixes #4070

## Summary by Sourcery

Bug Fixes:
- Prevent TypeError when GraphQL input object arguments use Python instances as default values by returning existing instances directly during argument conversion.