### PR TITLE
Don't update headers in GraphiQL

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,11 @@
+---
+release type: patch
+---
+
+This release fixes an issue in the bundled GraphiQL template where editing HTTP
+headers, including `Authorization` headers, wrote those values into the browser
+URL.
+
+GraphiQL still supports loading headers from existing `headers` URL parameters,
+but newly edited headers are no longer added to the URL. Query and variables URL
+sharing is unchanged.

--- a/docs/extensions/disable-introspection.md
+++ b/docs/extensions/disable-introspection.md
@@ -15,11 +15,10 @@ features of the API through GraphQL introspection.
 <Warning>
 
 `DisableIntrospection` does not block non-introspection fields that may expose
-schema information. For example, Apollo Federation schemas expose `_service`
-and its `sdl` field so gateways and routers can compose federated services. If
-you use `strawberry.federation.Schema`, protect federated endpoints from
-untrusted clients with your own authentication, authorization, or network
-controls.
+schema information. For example, Apollo Federation schemas expose `_service` and
+its `sdl` field so gateways and routers can compose federated services. If you
+use `strawberry.federation.Schema`, protect federated endpoints from untrusted
+clients with your own authentication, authorization, or network controls.
 
 </Warning>
 
@@ -51,8 +50,8 @@ _No arguments_
 
 ## Example query:
 
-Running any query including the introspection field `__schema` will result in
-an error. Consider the following query, for example:
+Running any query including the introspection field `__schema` will result in an
+error. Consider the following query, for example:
 
 ```graphql
 query {

--- a/e2e/src/tests/graphiql.spec.ts
+++ b/e2e/src/tests/graphiql.spec.ts
@@ -133,4 +133,35 @@ test.describe("GraphiQL URL Sharing Tests", () => {
 		await expect(headersEditor).toContainText("Authorization");
 		await expect(headersEditor).toContainText("Bearer token123");
 	});
+
+	test("does not update URL when headers are edited", async ({
+		page,
+	}: { page: Page }) => {
+		await page.goto(GRAPHIQL_URL);
+		await waitForGraphiQL(page);
+
+		const headersTab = page.locator('button:has-text("Headers")');
+		await headersTab.click();
+
+		const headersEditor = page.locator(
+			".graphiql-editor-tool .graphiql-editor:not(.hidden) .CodeMirror",
+		);
+		await headersEditor.click();
+		await page.keyboard.type('{"Authorization": "Bearer token123"}', {
+			delay: 50,
+		});
+
+		await expect(page.locator(".graphiql-editor-tool")).toContainText(
+			"Authorization",
+		);
+
+		await expect
+			.poll(() => new URL(page.url()).searchParams.get("headers"))
+			.toBeNull();
+
+		const url = page.url();
+		expect(url).not.toContain("headers=");
+		expect(url).not.toContain("Authorization");
+		expect(url).not.toContain("token123");
+	});
 });

--- a/strawberry/static/graphiql.html
+++ b/strawberry/static/graphiql.html
@@ -191,7 +191,6 @@
 
         function onEditHeaders(newHeaders) {
           setHeaders(newHeaders);
-          updateURL({ headers: newHeaders });
         }
 
         const explorerPlugin = GraphiQLPluginExplorer.explorerPlugin();


### PR DESCRIPTION
<!-- shortcake:start -->
## Stack

- **#4409** (`don-t-update-headers-in-graphiql`) <-- this PR
<!-- shortcake:end -->

## Summary by Sourcery

Prevent GraphiQL from writing edited HTTP headers into the browser URL while keeping query and variables URL sharing intact.

Bug Fixes:
- Stop persisting edited HTTP headers, including Authorization values, into the GraphiQL URL to avoid leaking sensitive data.

Documentation:
- Document the change in GraphiQL header URL handling in the release notes and make minor wording/formatting improvements to the DisableIntrospection documentation.

Chores:
- Add release metadata marking this as a patch release.