### PR TITLE
Make `ReservedParameterSpecification` protocol in types/fields/resolver.py satisfy `Hashable` interface

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+The `types.field.resolver.ReservedParameterSpecification` protocol now requires classes to have `__hash__` as well,
+because instances of those classes are to be used as dictionary keys.

--- a/strawberry/types/fields/resolver.py
+++ b/strawberry/types/fields/resolver.py
@@ -63,6 +63,7 @@ class ReservedParameterSpecification(Protocol):
         resolver: StrawberryResolver[Any],
     ) -> inspect.Parameter | None:
         """Finds the reserved parameter from ``parameters``."""
+    def __hash__(self) -> int: ...
 
 
 class ReservedName(NamedTuple):

--- a/strawberry/types/fields/resolver.py
+++ b/strawberry/types/fields/resolver.py
@@ -63,6 +63,7 @@ class ReservedParameterSpecification(Protocol):
         resolver: StrawberryResolver[Any],
     ) -> inspect.Parameter | None:
         """Finds the reserved parameter from ``parameters``."""
+
     def __hash__(self) -> int: ...
 
 


### PR DESCRIPTION
## Description

Because instances of classes conforming to the above protocol are used as dictionary keys, they must be hashable.

Parent: [python/typeshed#15754](https://github.com/python/typeshed/pull/15754).

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Bug Fixes:
- Make ReservedParameterSpecification protocol explicitly hashable so it can be safely used as a dictionary key.