### PR TITLE
ci: address zizmor code-scanning alerts in workflows

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -9,13 +9,20 @@ on:
       - "e2e/**"
       - ".github/workflows/e2e-tests.yml"
 
+permissions:
+  contents: read
+
 jobs:
   e2e-tests:
     name: 🎭 Run E2E Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2

--- a/.github/workflows/federation-compatibility.yml
+++ b/.github/workflows/federation-compatibility.yml
@@ -17,13 +17,20 @@ on:
       - "uv.lock"
       - ".github/workflows/federation-compatibility.yml"
 
+permissions:
+  contents: read
+
 jobs:
   federation-tests:
     name: Federation tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -1,6 +1,9 @@
 name: 🆙 Release file check
 
 on:
+  # zizmor: ignore[dangerous-triggers] required so autopub can comment on
+  # fork PRs; sparse-checkout below limits the PR working tree to RELEASE.md
+  # and pyproject.toml, which autopub `check` parses as data only.
   pull_request_target:
     types: [synchronize, reopened, opened, ready_for_review]
     branches:
@@ -23,6 +26,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: "refs/pull/${{ github.event.number }}/merge"
+          persist-credentials: false
           sparse-checkout: |
             RELEASE.md
             pyproject.toml

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -12,6 +12,9 @@ on:
       - "strawberry/**"
       - "pyproject.toml"
 
+permissions:
+  contents: read
+
 jobs:
   check-release:
     name: Release check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          token: ${{ secrets.BOT_TOKEN }}
+          persist-credentials: false
 
       - name: Check for release
         id: check
@@ -47,7 +47,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          token: ${{ secrets.BOT_TOKEN }}
+          persist-credentials: false
 
       - name: Prepare release
         uses: autopub/autopub-action@5fdc82e84c048a82303de6b5c5a9d027665e73cf # v1.1.1


### PR DESCRIPTION
## Summary

Resolves 8 zizmor code-scanning alerts across 4 workflow files: 1 `dangerous-triggers`, 5 `artipacked` (credential persistence), 2 `excessive-permissions`.

## Changes

- `release-check.yml`: inline `# zizmor: ignore[dangerous-triggers]` with the rationale in the comment. `pull_request_target` is needed so autopub can comment on fork PRs, and the sparse-checkout limits the PR working tree to `RELEASE.md` and `pyproject.toml`, both parsed as data by `autopub check`. Also adds `persist-credentials: false`.
- `release.yml`: drops `token:` from both checkouts and adds `persist-credentials: false`. The publish job's git push keeps working because `autopub.plugins.github.GithubPlugin.pre_publish` runs `git remote set-url origin https://$BOT_TOKEN@github.com/<repo>` before any push, using the `github-token: ${{ secrets.BOT_TOKEN }}` already passed to the publish step. The GitHub release is still created with BOT_TOKEN (authored as botberry).
- `federation-compatibility.yml`: adds workflow- and job-level `permissions: contents: read` plus `persist-credentials: false` on checkout.
- `e2e-tests.yml`: same treatment as `federation-compatibility.yml`.

## Verification

- `uvx zizmor .github/workflows/` reports no findings on the four files.
- All four workflows parse as valid YAML.
- Next release run exercises autopub's `git push` and GitHub release creation under the new auth flow; if that breaks, revert the publish-job checkout first.

## Summary by Sourcery

Tighten security of GitHub Actions workflows in response to code-scanning findings.

Enhancements:
- Add least-privilege contents: read permissions at workflow and job level for federation and E2E test workflows.
- Disable credential persistence in checkout steps across release, federation-compatibility, e2e-tests, and release-check workflows.
- Document the rationale for using pull_request_target in the release-check workflow while constraining the checked-out files.