### PR TITLE
fix: resolve module-level lazy alias under future annotations

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,19 @@
+Release type: patch
+
+Fix `UnresolvedFieldTypeError` when using `from __future__ import annotations` together with a module-level `Annotated[..., strawberry.lazy(...)]` alias. The aliased form now resolves the same as inlining `Annotated[...]` on the field.
+
+```python
+from __future__ import annotations
+from typing import TYPE_CHECKING, Annotated
+import strawberry
+
+if TYPE_CHECKING:
+    from .user import User
+
+LazyUser = Annotated["User", strawberry.lazy(".user")]
+
+
+@strawberry.type
+class Post:
+    user: LazyUser  # previously failed
+```

--- a/strawberry/utils/typing.py
+++ b/strawberry/utils/typing.py
@@ -289,6 +289,22 @@ def eval_type(
 
         type_ = _eval_type(type_, globalns, localns, **extra)
 
+        # The forward ref may have resolved to a module-level alias such as
+        # `Annotated[ForwardRef("User"), StrawberryLazyReference(...)]`. The
+        # inner ForwardRef won't be resolved by `_eval_type` because its
+        # target only exists under `TYPE_CHECKING`; use the lazy reference
+        # to convert it into a LazyType, preserving the Annotated wrapper.
+        if (
+            get_origin(type_) is Annotated
+            and (args := get_args(type_))
+            and isinstance(args[0], ForwardRef)
+        ):
+            for arg in args[1:]:
+                if isinstance(arg, StrawberryLazyReference):
+                    return Annotated[(arg.resolve_forward_ref(args[0]), *args[1:])]
+
+        return type_
+
     origin = get_origin(type_)
     if origin is not None:
         args = get_args(type_)

--- a/strawberry/utils/typing.py
+++ b/strawberry/utils/typing.py
@@ -287,7 +287,7 @@ def eval_type(
         if sys.version_info >= (3, 13):
             extra = {"type_params": None}
 
-        return _eval_type(type_, globalns, localns, **extra)
+        type_ = _eval_type(type_, globalns, localns, **extra)
 
     origin = get_origin(type_)
     if origin is not None:

--- a/tests/types/test_lazy_types_future_annotations.py
+++ b/tests/types/test_lazy_types_future_annotations.py
@@ -10,6 +10,13 @@ if TYPE_CHECKING:
     from tests.schema.test_lazy.type_c import TypeC
 
 
+# Module-level Annotated alias. With `from __future__ import annotations`,
+# field annotations are strings, so a field typed as `LazyTypeC` is resolved
+# by name through the module globals. The alias must live here (not inside
+# the test) for that lookup to find it.
+LazyTypeC = Annotated["TypeC", strawberry.lazy("tests.schema.test_lazy.type_c")]
+
+
 def test_optional_lazy_type_using_or_operator():
 
     global SomeType, AnotherType
@@ -169,3 +176,69 @@ def test_or_none_lazy_type_with_type_checking_guard():
         assert str(schema).strip() == textwrap.dedent(expected).strip()
     finally:
         del OrNoneLazyType
+
+
+def test_module_level_lazy_alias():
+    """Module-level Annotated alias resolves under `from __future__ import annotations`."""
+    global AliasedLazyType
+
+    try:
+
+        @strawberry.type
+        class AliasedLazyType:
+            child: LazyTypeC
+
+        @strawberry.type
+        class Query:
+            my_type: AliasedLazyType
+
+        schema = strawberry.Schema(query=Query)
+        expected = """\
+        type AliasedLazyType {
+          child: TypeC!
+        }
+
+        type Query {
+          myType: AliasedLazyType!
+        }
+
+        type TypeC {
+          name: String!
+        }
+        """
+        assert str(schema).strip() == textwrap.dedent(expected).strip()
+    finally:
+        del AliasedLazyType
+
+
+def test_module_level_lazy_alias_in_list():
+    """Module-level Annotated alias wrapped in `list[...]` resolves correctly."""
+    global AliasedListLazyType
+
+    try:
+
+        @strawberry.type
+        class AliasedListLazyType:
+            children: list[LazyTypeC]
+
+        @strawberry.type
+        class Query:
+            my_type: AliasedListLazyType
+
+        schema = strawberry.Schema(query=Query)
+        expected = """\
+        type AliasedListLazyType {
+          children: [TypeC!]!
+        }
+
+        type Query {
+          myType: AliasedListLazyType!
+        }
+
+        type TypeC {
+          name: String!
+        }
+        """
+        assert str(schema).strip() == textwrap.dedent(expected).strip()
+    finally:
+        del AliasedListLazyType


### PR DESCRIPTION
Fix `UnresolvedFieldTypeError` triggered by combining `from __future__ import annotations` with a module-level `Annotated[..., strawberry.lazy(...)]` alias. Inlining `Annotated[...]` directly on the field already worked; the aliased form did not.

In `eval_type`, `_eval_type` resolves `ForwardRef('LazyUser')` to its bound value `Annotated[ForwardRef('User'), StrawberryLazyReference(...)]`, but the inner `ForwardRef('User')` stays unresolved because `User` is only imported under `TYPE_CHECKING`. The fix calls `StrawberryLazyReference.resolve_forward_ref` right after `_eval_type` to convert it to a `LazyType`, keeping the `Annotated` wrapper intact.

Regression tests cover the bare alias and a `list[Alias]` variant. One existing test inlined `Annotated` under future annotations, another used a module-level alias without future annotations; neither combined the two.

Fix #3568

## Summary by Sourcery

Fix resolution of module-level lazy Annotated aliases when using future annotations so that aliased lazy types behave like inlined annotations.

Bug Fixes:
- Resolve UnresolvedFieldTypeError when a module-level Annotated[..., strawberry.lazy(...)] alias is used under from __future__ import annotations.
- Ensure lazy Annotated aliases inside list[...] are correctly resolved to their underlying types under future annotations.

Documentation:
- Add release notes describing the fix for lazy Annotated aliases with future annotations.

Tests:
- Add regression tests for module-level lazy Annotated aliases and their list-wrapped variants under from __future__ import annotations.