### PR TITLE
Add offset argument to relay connections

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+Release type: minor
+
+`relay.ListConnection` now supports an `offset` argument in addition to
+`before`, `after`, `first`, and `last`. This lets clients skip a known number of
+items without first converting that offset into a cursor, while keeping
+`pageInfo` consistent with the skipped range.

--- a/docs/guides/relay.md
+++ b/docs/guides/relay.md
@@ -138,6 +138,7 @@ type Query {
     after: String = null
     first: Int = null
     last: Int = null
+    offset: Int = null
   ): FruitConnection!
 }
 ```
@@ -335,9 +336,10 @@ By default the connection will automatically insert some arguments for it to be
 able to paginate the results. Those are:
 
 - `before`: Returns the items in the list that come before the specified cursor
-- `after`: Returns the items in the list that come after the " "specified cursor
+- `after`: Returns the items in the list that come after the specified cursor
 - `first`: Returns the first n items from the list
-- `last`: Returns the items in the list that come after the " "specified cursor
+- `last`: Returns the last n items from the list
+- `offset`: Skips the first n items from the list
 
 You can still define extra arguments to be used by your own resolver or custom
 pagination logic. For example, suppose we want to return the pagination of all
@@ -367,6 +369,7 @@ type Query {
     after: String = null
     first: Int = null
     last: Int = null
+    offset: Int = null
   ): FruitConnection!
 }
 ```

--- a/strawberry/relay/fields.py
+++ b/strawberry/relay/fields.py
@@ -256,10 +256,14 @@ class ConnectionExtension(FieldExtension):
                 python_name="last",
                 graphql_name=None,
                 type_annotation=StrawberryAnnotation(Optional[int]),  # noqa: UP045
-                description=(
-                    "Returns the items in the list that come after the "
-                    "specified cursor."
-                ),
+                description="Returns the last n items from the list.",
+                default=None,
+            ),
+            StrawberryArgument(
+                python_name="offset",
+                graphql_name=None,
+                type_annotation=StrawberryAnnotation(Optional[int]),  # noqa: UP045
+                description="Skips the first n items in the list.",
                 default=None,
             ),
         ]
@@ -323,6 +327,7 @@ class ConnectionExtension(FieldExtension):
         after: str | None = None,
         first: int | None = None,
         last: int | None = None,
+        offset: int | None = None,
         **kwargs: Any,
     ) -> Any:
         assert self.connection_type is not None
@@ -333,6 +338,7 @@ class ConnectionExtension(FieldExtension):
             after=after,
             first=first,
             last=last,
+            offset=offset,
             max_results=self.max_results,
         )
 
@@ -346,6 +352,7 @@ class ConnectionExtension(FieldExtension):
         after: str | None = None,
         first: int | None = None,
         last: int | None = None,
+        offset: int | None = None,
         **kwargs: Any,
     ) -> Any:
         assert self.connection_type is not None
@@ -362,6 +369,7 @@ class ConnectionExtension(FieldExtension):
             after=after,
             first=first,
             last=last,
+            offset=offset,
             max_results=self.max_results,
         )
 

--- a/strawberry/relay/types.py
+++ b/strawberry/relay/types.py
@@ -716,6 +716,7 @@ class Connection(Generic[NodeType]):
         after: str | None = None,
         first: int | None = None,
         last: int | None = None,
+        offset: int | None = None,
         max_results: int | None = None,
         **kwargs: Any,
     ) -> AwaitableOrValue[Self]:
@@ -730,7 +731,8 @@ class Connection(Generic[NodeType]):
             before: Returns the items in the list that come before the specified cursor.
             after: Returns the items in the list that come after the specified cursor.
             first: Returns the first n items from the list.
-            last: Returns the items in the list that come after the specified cursor.
+            last: Returns the last n items from the list.
+            offset: Skips the first n items in the list.
             max_results: The maximum number of results to resolve.
             kwargs: Additional arguments passed to the resolver.
 
@@ -768,6 +770,7 @@ class ListConnection(Connection[NodeType]):
         after: str | None = None,
         first: int | None = None,
         last: int | None = None,
+        offset: int | None = None,
         max_results: int | None = None,
         **kwargs: Any,
     ) -> AwaitableOrValue[Self]:
@@ -781,7 +784,8 @@ class ListConnection(Connection[NodeType]):
             before: Returns the items in the list that come before the specified cursor.
             after: Returns the items in the list that come after the specified cursor.
             first: Returns the first n items from the list.
-            last: Returns the items in the list that come after the specified cursor.
+            last: Returns the last n items from the list.
+            offset: Skips the first n items in the list.
             max_results: The maximum number of results to resolve.
             kwargs: Additional arguments passed to the resolver.
 
@@ -808,6 +812,7 @@ class ListConnection(Connection[NodeType]):
             after=after,
             first=first,
             last=last,
+            offset=offset,
             max_results=max_results,
             prefix=edge_class.CURSOR_PREFIX,
         )
@@ -865,7 +870,7 @@ class ListConnection(Connection[NodeType]):
                     original_len = len(edges)
                     edges = edges[-last:]
                     has_next_page = False
-                    has_previous_page = len(edges) != original_len
+                    has_previous_page = has_previous_page or len(edges) != original_len
                 else:
                     has_next_page = False
 
@@ -929,7 +934,7 @@ class ListConnection(Connection[NodeType]):
             original_len = len(edges)
             edges = edges[-last:]
             has_next_page = False
-            has_previous_page = len(edges) != original_len
+            has_previous_page = has_previous_page or len(edges) != original_len
         else:
             has_next_page = False
 

--- a/strawberry/relay/utils.py
+++ b/strawberry/relay/utils.py
@@ -119,6 +119,7 @@ class SliceMetadata:
         after: str | None = None,
         first: int | None = None,
         last: int | None = None,
+        offset: int | None = None,
         max_results: int | None = None,
         prefix: str | None = None,
     ) -> Self:
@@ -142,6 +143,11 @@ class SliceMetadata:
                 raise TypeError("Argument 'after' contains a non-existing value.")
 
             start = int(after_parsed) + 1
+        if isinstance(offset, int):
+            if offset < 0:
+                raise ValueError("Argument 'offset' must be a non-negative integer.")
+
+            start += offset
         if before:
             before_type, before_parsed = from_base64(before)
             if before_type != prefix:
@@ -158,6 +164,12 @@ class SliceMetadata:
                 )
 
             if end is not None:
+                if isinstance(offset, int) and offset > 0:
+                    raise ValueError(
+                        "Argument 'offset' cannot be used with both "
+                        "'before' and 'first'."
+                    )
+
                 start = max(0, end - 1)
 
             end = start + first

--- a/tests/relay/snapshots/schema.gql
+++ b/tests/relay/snapshots/schema.gql
@@ -125,8 +125,11 @@ type Query {
     """Returns the first n items from the list."""
     first: Int = null
 
-    """Returns the items in the list that come after the specified cursor."""
+    """Returns the last n items from the list."""
     last: Int = null
+
+    """Skips the first n items in the list."""
+    offset: Int = null
   ): FruitConnection!
   fruitsLazy(
     """Returns the items in the list that come before the specified cursor."""
@@ -138,8 +141,11 @@ type Query {
     """Returns the first n items from the list."""
     first: Int = null
 
-    """Returns the items in the list that come after the specified cursor."""
+    """Returns the last n items from the list."""
     last: Int = null
+
+    """Skips the first n items in the list."""
+    offset: Int = null
   ): FruitConnection!
   fruitsAlias(
     """Returns the items in the list that come before the specified cursor."""
@@ -151,8 +157,11 @@ type Query {
     """Returns the first n items from the list."""
     first: Int = null
 
-    """Returns the items in the list that come after the specified cursor."""
+    """Returns the last n items from the list."""
     last: Int = null
+
+    """Skips the first n items in the list."""
+    offset: Int = null
   ): FruitConnection!
   fruitsAliasLazy(
     """Returns the items in the list that come before the specified cursor."""
@@ -164,8 +173,11 @@ type Query {
     """Returns the first n items from the list."""
     first: Int = null
 
-    """Returns the items in the list that come after the specified cursor."""
+    """Returns the last n items from the list."""
     last: Int = null
+
+    """Skips the first n items in the list."""
+    offset: Int = null
   ): FruitConnection!
   fruitsAsync(
     """Returns the items in the list that come before the specified cursor."""
@@ -177,8 +189,11 @@ type Query {
     """Returns the first n items from the list."""
     first: Int = null
 
-    """Returns the items in the list that come after the specified cursor."""
+    """Returns the last n items from the list."""
     last: Int = null
+
+    """Skips the first n items in the list."""
+    offset: Int = null
   ): FruitAsyncConnection!
   fruitsCustomPagination(
     """Returns the items in the list that come before the specified cursor."""
@@ -190,8 +205,11 @@ type Query {
     """Returns the first n items from the list."""
     first: Int = null
 
-    """Returns the items in the list that come after the specified cursor."""
+    """Returns the last n items from the list."""
     last: Int = null
+
+    """Skips the first n items in the list."""
+    offset: Int = null
   ): FruitCustomPaginationConnection!
   fruitsConcreteResolver(
     nameEndswith: String = null
@@ -205,8 +223,11 @@ type Query {
     """Returns the first n items from the list."""
     first: Int = null
 
-    """Returns the items in the list that come after the specified cursor."""
+    """Returns the last n items from the list."""
     last: Int = null
+
+    """Skips the first n items in the list."""
+    offset: Int = null
   ): FruitConnection!
   fruitsCustomResolver(
     nameEndswith: String = null
@@ -220,8 +241,11 @@ type Query {
     """Returns the first n items from the list."""
     first: Int = null
 
-    """Returns the items in the list that come after the specified cursor."""
+    """Returns the last n items from the list."""
     last: Int = null
+
+    """Skips the first n items in the list."""
+    offset: Int = null
   ): FruitConnection!
   fruitsCustomResolverLazy(
     nameEndswith: String = null
@@ -235,8 +259,11 @@ type Query {
     """Returns the first n items from the list."""
     first: Int = null
 
-    """Returns the items in the list that come after the specified cursor."""
+    """Returns the last n items from the list."""
     last: Int = null
+
+    """Skips the first n items in the list."""
+    offset: Int = null
   ): FruitConnection!
   fruitsCustomResolverIterator(
     nameEndswith: String = null
@@ -250,8 +277,11 @@ type Query {
     """Returns the first n items from the list."""
     first: Int = null
 
-    """Returns the items in the list that come after the specified cursor."""
+    """Returns the last n items from the list."""
     last: Int = null
+
+    """Skips the first n items in the list."""
+    offset: Int = null
   ): FruitConnection!
   fruitsCustomResolverIterable(
     nameEndswith: String = null
@@ -265,8 +295,11 @@ type Query {
     """Returns the first n items from the list."""
     first: Int = null
 
-    """Returns the items in the list that come after the specified cursor."""
+    """Returns the last n items from the list."""
     last: Int = null
+
+    """Skips the first n items in the list."""
+    offset: Int = null
   ): FruitConnection!
   fruitsCustomResolverGenerator(
     nameEndswith: String = null
@@ -280,8 +313,11 @@ type Query {
     """Returns the first n items from the list."""
     first: Int = null
 
-    """Returns the items in the list that come after the specified cursor."""
+    """Returns the last n items from the list."""
     last: Int = null
+
+    """Skips the first n items in the list."""
+    offset: Int = null
   ): FruitConnection!
   fruitsCustomResolverAsyncIterable(
     nameEndswith: String = null
@@ -295,8 +331,11 @@ type Query {
     """Returns the first n items from the list."""
     first: Int = null
 
-    """Returns the items in the list that come after the specified cursor."""
+    """Returns the last n items from the list."""
     last: Int = null
+
+    """Skips the first n items in the list."""
+    offset: Int = null
   ): FruitConnection!
   fruitsCustomResolverAsyncIterator(
     nameEndswith: String = null
@@ -310,8 +349,11 @@ type Query {
     """Returns the first n items from the list."""
     first: Int = null
 
-    """Returns the items in the list that come after the specified cursor."""
+    """Returns the last n items from the list."""
     last: Int = null
+
+    """Skips the first n items in the list."""
+    offset: Int = null
   ): FruitConnection!
   fruitsCustomResolverAsyncGenerator(
     nameEndswith: String = null
@@ -325,8 +367,11 @@ type Query {
     """Returns the first n items from the list."""
     first: Int = null
 
-    """Returns the items in the list that come after the specified cursor."""
+    """Returns the last n items from the list."""
     last: Int = null
+
+    """Skips the first n items in the list."""
+    offset: Int = null
   ): FruitConnection!
   fruitAlikeConnectionCustomResolver(
     nameEndswith: String = null
@@ -340,8 +385,11 @@ type Query {
     """Returns the first n items from the list."""
     first: Int = null
 
-    """Returns the items in the list that come after the specified cursor."""
+    """Returns the last n items from the list."""
     last: Int = null
+
+    """Skips the first n items in the list."""
+    offset: Int = null
   ): FruitAlikeConnection!
   someFruits(
     """Returns the items in the list that come before the specified cursor."""
@@ -353,7 +401,10 @@ type Query {
     """Returns the first n items from the list."""
     first: Int = null
 
-    """Returns the items in the list that come after the specified cursor."""
+    """Returns the last n items from the list."""
     last: Int = null
+
+    """Skips the first n items in the list."""
+    offset: Int = null
   ): FruitConnection!
 }

--- a/tests/relay/snapshots/schema_future_annotations.gql
+++ b/tests/relay/snapshots/schema_future_annotations.gql
@@ -125,8 +125,11 @@ type Query {
     """Returns the first n items from the list."""
     first: Int = null
 
-    """Returns the items in the list that come after the specified cursor."""
+    """Returns the last n items from the list."""
     last: Int = null
+
+    """Skips the first n items in the list."""
+    offset: Int = null
   ): FruitConnection!
   fruitsLazy(
     """Returns the items in the list that come before the specified cursor."""
@@ -138,8 +141,11 @@ type Query {
     """Returns the first n items from the list."""
     first: Int = null
 
-    """Returns the items in the list that come after the specified cursor."""
+    """Returns the last n items from the list."""
     last: Int = null
+
+    """Skips the first n items in the list."""
+    offset: Int = null
   ): FruitConnection!
   fruitsAsync(
     """Returns the items in the list that come before the specified cursor."""
@@ -151,8 +157,11 @@ type Query {
     """Returns the first n items from the list."""
     first: Int = null
 
-    """Returns the items in the list that come after the specified cursor."""
+    """Returns the last n items from the list."""
     last: Int = null
+
+    """Skips the first n items in the list."""
+    offset: Int = null
   ): FruitAsyncConnection!
   fruitsCustomPagination(
     """Returns the items in the list that come before the specified cursor."""
@@ -164,8 +173,11 @@ type Query {
     """Returns the first n items from the list."""
     first: Int = null
 
-    """Returns the items in the list that come after the specified cursor."""
+    """Returns the last n items from the list."""
     last: Int = null
+
+    """Skips the first n items in the list."""
+    offset: Int = null
   ): FruitCustomPaginationConnection!
   fruitsConcreteResolver(
     nameEndswith: String = null
@@ -179,8 +191,11 @@ type Query {
     """Returns the first n items from the list."""
     first: Int = null
 
-    """Returns the items in the list that come after the specified cursor."""
+    """Returns the last n items from the list."""
     last: Int = null
+
+    """Skips the first n items in the list."""
+    offset: Int = null
   ): FruitConnection!
   fruitsCustomResolver(
     nameEndswith: String = null
@@ -194,8 +209,11 @@ type Query {
     """Returns the first n items from the list."""
     first: Int = null
 
-    """Returns the items in the list that come after the specified cursor."""
+    """Returns the last n items from the list."""
     last: Int = null
+
+    """Skips the first n items in the list."""
+    offset: Int = null
   ): FruitConnection!
   fruitsCustomResolverLazy(
     nameEndswith: String = null
@@ -209,8 +227,11 @@ type Query {
     """Returns the first n items from the list."""
     first: Int = null
 
-    """Returns the items in the list that come after the specified cursor."""
+    """Returns the last n items from the list."""
     last: Int = null
+
+    """Skips the first n items in the list."""
+    offset: Int = null
   ): FruitConnection!
   fruitsCustomResolverIterator(
     nameEndswith: String = null
@@ -224,8 +245,11 @@ type Query {
     """Returns the first n items from the list."""
     first: Int = null
 
-    """Returns the items in the list that come after the specified cursor."""
+    """Returns the last n items from the list."""
     last: Int = null
+
+    """Skips the first n items in the list."""
+    offset: Int = null
   ): FruitConnection!
   fruitsCustomResolverIterable(
     nameEndswith: String = null
@@ -239,8 +263,11 @@ type Query {
     """Returns the first n items from the list."""
     first: Int = null
 
-    """Returns the items in the list that come after the specified cursor."""
+    """Returns the last n items from the list."""
     last: Int = null
+
+    """Skips the first n items in the list."""
+    offset: Int = null
   ): FruitConnection!
   fruitsCustomResolverGenerator(
     nameEndswith: String = null
@@ -254,8 +281,11 @@ type Query {
     """Returns the first n items from the list."""
     first: Int = null
 
-    """Returns the items in the list that come after the specified cursor."""
+    """Returns the last n items from the list."""
     last: Int = null
+
+    """Skips the first n items in the list."""
+    offset: Int = null
   ): FruitConnection!
   fruitsCustomResolverAsyncIterable(
     nameEndswith: String = null
@@ -269,8 +299,11 @@ type Query {
     """Returns the first n items from the list."""
     first: Int = null
 
-    """Returns the items in the list that come after the specified cursor."""
+    """Returns the last n items from the list."""
     last: Int = null
+
+    """Skips the first n items in the list."""
+    offset: Int = null
   ): FruitConnection!
   fruitsCustomResolverAsyncIterator(
     nameEndswith: String = null
@@ -284,8 +317,11 @@ type Query {
     """Returns the first n items from the list."""
     first: Int = null
 
-    """Returns the items in the list that come after the specified cursor."""
+    """Returns the last n items from the list."""
     last: Int = null
+
+    """Skips the first n items in the list."""
+    offset: Int = null
   ): FruitConnection!
   fruitsCustomResolverAsyncGenerator(
     nameEndswith: String = null
@@ -299,8 +335,11 @@ type Query {
     """Returns the first n items from the list."""
     first: Int = null
 
-    """Returns the items in the list that come after the specified cursor."""
+    """Returns the last n items from the list."""
     last: Int = null
+
+    """Skips the first n items in the list."""
+    offset: Int = null
   ): FruitConnection!
   fruitAlikeConnectionCustomResolver(
     nameEndswith: String = null
@@ -314,8 +353,11 @@ type Query {
     """Returns the first n items from the list."""
     first: Int = null
 
-    """Returns the items in the list that come after the specified cursor."""
+    """Returns the last n items from the list."""
     last: Int = null
+
+    """Skips the first n items in the list."""
+    offset: Int = null
   ): FruitAlikeConnection!
   someFruits(
     """Returns the items in the list that come before the specified cursor."""
@@ -327,7 +369,10 @@ type Query {
     """Returns the first n items from the list."""
     first: Int = null
 
-    """Returns the items in the list that come after the specified cursor."""
+    """Returns the last n items from the list."""
     last: Int = null
+
+    """Skips the first n items in the list."""
+    offset: Int = null
   ): FruitConnection!
 }

--- a/tests/relay/test_custom_edge.py
+++ b/tests/relay/test_custom_edge.py
@@ -101,8 +101,11 @@ def test_schema_with_custom_edge_class(schema: Schema):
             """Returns the first n items from the list."""
             first: Int = null
 
-            """Returns the items in the list that come after the specified cursor."""
+            """Returns the last n items from the list."""
             last: Int = null
+
+            """Skips the first n items in the list."""
+            offset: Int = null
           ): FruitConnection!
         }
         '''

--- a/tests/relay/test_fields.py
+++ b/tests/relay/test_fields.py
@@ -1545,8 +1545,11 @@ def test_parameters(mocker: MockerFixture):
         """Returns the first n items from the list."""
         first: Int = null
 
-        """Returns the items in the list that come after the specified cursor."""
+        """Returns the last n items from the list."""
         last: Int = null
+
+        """Skips the first n items in the list."""
+        offset: Int = null
       ): FruitConnection!
       fruitCustomField(
         foo: String!
@@ -1560,8 +1563,11 @@ def test_parameters(mocker: MockerFixture):
         """Returns the first n items from the list."""
         first: Int = null
 
-        """Returns the items in the list that come after the specified cursor."""
+        """Returns the last n items from the list."""
         last: Int = null
+
+        """Skips the first n items in the list."""
+        offset: Int = null
       ): FruitConnection!
     }
     '''

--- a/tests/relay/test_schema.py
+++ b/tests/relay/test_schema.py
@@ -95,8 +95,11 @@ def test_node_id_annotation():
             """Returns the first n items from the list."""
             first: Int = null
 
-            """Returns the items in the list that come after the specified cursor."""
+            """Returns the last n items from the list."""
             last: Int = null
+
+            """Skips the first n items in the list."""
+            offset: Int = null
           ): FruitConnection!
         }
         '''
@@ -119,6 +122,122 @@ def test_node_id_annotation():
     assert result.data == {
         "fruits": {
             "edges": [{"node": {"id": to_base64("Fruit", i)}} for i in range(10)]
+        }
+    }
+
+
+def test_connection_with_offset_argument():
+    @strawberry.type
+    class Fruit(relay.Node):
+        code: relay.NodeID[int]
+
+    @strawberry.type
+    class Query:
+        @relay.connection(relay.ListConnection[Fruit])
+        def fruits(self) -> list[Fruit]:
+            return [Fruit(code=i) for i in range(5)]
+
+    schema = strawberry.Schema(query=Query)
+    result = schema.execute_sync(
+        """
+        query {
+          fruits(first: 2, offset: 2) {
+            pageInfo {
+              hasPreviousPage
+              hasNextPage
+              startCursor
+              endCursor
+            }
+            edges {
+              cursor
+              node {
+                id
+              }
+            }
+          }
+        }
+        """
+    )
+
+    assert result.errors is None
+    assert result.data == {
+        "fruits": {
+            "pageInfo": {
+                "hasPreviousPage": True,
+                "hasNextPage": True,
+                "startCursor": to_base64("arrayconnection", 2),
+                "endCursor": to_base64("arrayconnection", 3),
+            },
+            "edges": [
+                {
+                    "cursor": to_base64("arrayconnection", 2),
+                    "node": {"id": to_base64("Fruit", 2)},
+                },
+                {
+                    "cursor": to_base64("arrayconnection", 3),
+                    "node": {"id": to_base64("Fruit", 3)},
+                },
+            ],
+        }
+    }
+
+
+def test_connection_with_last_and_offset_argument():
+    @strawberry.type
+    class Fruit(relay.Node):
+        code: relay.NodeID[int]
+
+    @strawberry.type
+    class Query:
+        @relay.connection(relay.ListConnection[Fruit])
+        def fruits(self) -> list[Fruit]:
+            return [Fruit(code=i) for i in range(5)]
+
+    schema = strawberry.Schema(query=Query)
+    result = schema.execute_sync(
+        """
+        query {
+          fruits(last: 3, offset: 2) {
+            pageInfo {
+              hasPreviousPage
+              hasNextPage
+              startCursor
+              endCursor
+            }
+            edges {
+              cursor
+              node {
+                id
+              }
+            }
+          }
+        }
+        """
+    )
+
+    assert result.errors is None
+    assert result.data == {
+        "fruits": {
+            "pageInfo": {
+                "hasPreviousPage": True,
+                "hasNextPage": False,
+                "startCursor": to_base64("arrayconnection", 2),
+                "endCursor": to_base64("arrayconnection", 4),
+            },
+            "edges": [
+                {
+                    "cursor": to_base64("arrayconnection", 2),
+                    "node": {"id": to_base64("Fruit", 2)},
+                },
+                {
+                    "cursor": to_base64("arrayconnection", 3),
+                    "node": {"id": to_base64("Fruit", 3)},
+                },
+                {
+                    "cursor": to_base64("arrayconnection", 4),
+                    "node": {"id": to_base64("Fruit", 4)},
+                },
+            ],
         }
     }
 
@@ -195,8 +314,11 @@ def test_node_id_annotation_in_superclass():
             """Returns the first n items from the list."""
             first: Int = null
 
-            """Returns the items in the list that come after the specified cursor."""
+            """Returns the last n items from the list."""
             last: Int = null
+
+            """Skips the first n items in the list."""
+            offset: Int = null
           ): FruitConnection!
         }
         '''
@@ -296,8 +418,11 @@ def test_node_id_annotation_in_superclass_and_subclass():
             """Returns the first n items from the list."""
             first: Int = null
 
-            """Returns the items in the list that come after the specified cursor."""
+            """Returns the last n items from the list."""
             last: Int = null
+
+            """Skips the first n items in the list."""
+            offset: Int = null
           ): FruitConnection!
         }
         '''

--- a/tests/relay/test_utils.py
+++ b/tests/relay/test_utils.py
@@ -79,12 +79,14 @@ def test_to_base64_with_invalid_type(value: Any):
         "after",
         "first",
         "last",
+        "offset",
         "max_results",
         "expected",
         "expected_overfetch",
     ),
     [
         (
+            None,
             None,
             None,
             None,
@@ -98,6 +100,7 @@ def test_to_base64_with_invalid_type(value: Any):
             None,
             None,
             None,
+            None,
             200,
             SliceMetadata(start=0, end=200, expected=200),
             201,
@@ -107,6 +110,7 @@ def test_to_base64_with_invalid_type(value: Any):
             None,
             10,
             None,
+            None,
             100,
             SliceMetadata(start=0, end=10, expected=10),
             11,
@@ -116,6 +120,7 @@ def test_to_base64_with_invalid_type(value: Any):
             None,
             None,
             10,
+            None,
             100,
             SliceMetadata(start=0, end=sys.maxsize, expected=None),
             sys.maxsize,
@@ -125,6 +130,7 @@ def test_to_base64_with_invalid_type(value: Any):
             None,
             None,
             None,
+            None,
             100,
             SliceMetadata(start=0, end=10, expected=10),
             11,
@@ -132,6 +138,7 @@ def test_to_base64_with_invalid_type(value: Any):
         (
             None,
             10,
+            None,
             None,
             None,
             100,
@@ -143,6 +150,7 @@ def test_to_base64_with_invalid_type(value: Any):
             None,
             10,
             None,
+            None,
             100,
             SliceMetadata(start=14, end=24, expected=10),
             25,
@@ -152,9 +160,40 @@ def test_to_base64_with_invalid_type(value: Any):
             15,
             None,
             10,
+            None,
             100,
             SliceMetadata(start=16, end=sys.maxsize, expected=None),
             sys.maxsize,
+        ),
+        (
+            None,
+            None,
+            None,
+            None,
+            2,
+            100,
+            SliceMetadata(start=2, end=102, expected=100),
+            103,
+        ),
+        (
+            None,
+            None,
+            2,
+            None,
+            1,
+            100,
+            SliceMetadata(start=1, end=3, expected=2),
+            4,
+        ),
+        (
+            None,
+            10,
+            None,
+            None,
+            2,
+            100,
+            SliceMetadata(start=13, end=113, expected=100),
+            114,
         ),
     ],
 )
@@ -163,6 +202,7 @@ def test_get_slice_metadata(
     after: str | None,
     first: int | None,
     last: int | None,
+    offset: int | None,
     max_results: int,
     expected: SliceMetadata,
     expected_overfetch: int,
@@ -175,6 +215,28 @@ def test_get_slice_metadata(
         after=after and to_base64(PREFIX, after),
         first=first,
         last=last,
+        offset=offset,
     )
     assert slice_metadata == expected
     assert slice_metadata.overfetch == expected_overfetch
+
+
+def test_get_slice_metadata_with_negative_offset():
+    info = mock.Mock()
+    info.schema.config = StrawberryConfig(relay_max_results=100)
+
+    with pytest.raises(ValueError, match="Argument 'offset'"):
+        SliceMetadata.from_arguments(info, offset=-1)
+
+
+def test_get_slice_metadata_rejects_offset_with_before_and_first():
+    info = mock.Mock()
+    info.schema.config = StrawberryConfig(relay_max_results=100)
+
+    with pytest.raises(ValueError, match="Argument 'offset'"):
+        SliceMetadata.from_arguments(
+            info,
+            before=to_base64(PREFIX, 5),
+            first=2,
+            offset=1,
+        )


### PR DESCRIPTION
## Summary

- add an `offset` argument to relay connection fields
- apply `offset` in `SliceMetadata` so `ListConnection` skips the requested number of items and keeps `pageInfo` accurate
- update relay docs, release note, schema snapshots, and regression coverage

Fixes #3053

## Tests

- `uv run pytest tests/relay -q`
- `uv run pytest -q`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `git diff --check`

## Summary by Sourcery

Add support for an offset argument on Relay list connections to allow skipping items before applying cursor-based pagination.

New Features:
- Introduce an offset argument on Relay connection fields and ListConnection resolvers to skip a specified number of items before pagination.

Enhancements:
- Integrate offset into SliceMetadata calculation so pagination ranges and pageInfo remain accurate when skipping items.
- Validate offset as a non-negative integer and propagate it through connection resolution utilities.

Documentation:
- Update Relay documentation and schema examples to describe the new offset argument and its behavior.

Tests:
- Extend Relay connection, slice metadata, and custom edge tests and schema snapshots to cover the new offset behavior and validation.

Chores:
- Add a release note announcing offset support for relay.ListConnection.