### PR TITLE
fix fragment issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,4 +75,3 @@ jobs:
         env:
           TYPEFULLY_API_KEY: ${{ secrets.TYPEFULLY_API_KEY }}
           TYPEFULLY_SOCIAL_SET_ID: ${{ secrets.TYPEFULLY_SOCIAL_SET_ID }}
-

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,12 @@
+---
+release type: patch
+---
+
+This release fixes validation of fragment spreads in `QueryDepthLimiter` and
+`MaxAliasesLimiter`.
+
+`QueryDepthLimiter` now tracks visited fragments while calculating operation depth,
+preventing circular fragment references from causing unbounded recursion.
+
+`MaxAliasesLimiter` now expands fragment spreads when counting aliases, so aliases
+declared inside fragments are counted each time the fragment is used.

--- a/strawberry/extensions/max_aliases.py
+++ b/strawberry/extensions/max_aliases.py
@@ -1,8 +1,12 @@
+from collections.abc import Mapping
+
 from graphql import (
-    ExecutableDefinitionNode,
     FieldNode,
+    FragmentDefinitionNode,
+    FragmentSpreadNode,
     GraphQLError,
     InlineFragmentNode,
+    OperationDefinitionNode,
     ValidationContext,
     ValidationRule,
 )
@@ -43,13 +47,18 @@ def create_validator(max_alias_count: int) -> type[ValidationRule]:
     class MaxAliasesValidator(ValidationRule):
         def __init__(self, validation_context: ValidationContext) -> None:
             document = validation_context.document
+            fragments = {
+                definition.name.value: definition
+                for definition in document.definitions
+                if isinstance(definition, FragmentDefinitionNode)
+            }
             def_that_can_contain_alias = (
                 def_
                 for def_ in document.definitions
-                if isinstance(def_, (ExecutableDefinitionNode))
+                if isinstance(def_, OperationDefinitionNode)
             )
             total_aliases = sum(
-                count_fields_with_alias(def_node)
+                count_fields_with_alias(def_node, fragments)
                 for def_node in def_that_can_contain_alias
             )
             if total_aliases > max_alias_count:
@@ -62,10 +71,17 @@ def create_validator(max_alias_count: int) -> type[ValidationRule]:
 
 
 def count_fields_with_alias(
-    selection_set_owner: ExecutableDefinitionNode | FieldNode | InlineFragmentNode,
+    selection_set_owner: (
+        OperationDefinitionNode | FragmentDefinitionNode | FieldNode | InlineFragmentNode
+    ),
+    fragments: Mapping[str, FragmentDefinitionNode] | None = None,
+    visited_fragments: set[str] | None = None,
 ) -> int:
     if selection_set_owner.selection_set is None:
         return 0
+
+    if visited_fragments is None:
+        visited_fragments = set()
 
     result = 0
 
@@ -76,7 +92,20 @@ def count_fields_with_alias(
             isinstance(selection, (FieldNode, InlineFragmentNode))
             and selection.selection_set
         ):
-            result += count_fields_with_alias(selection)
+            result += count_fields_with_alias(
+                selection, fragments, visited_fragments
+            )
+        if isinstance(selection, FragmentSpreadNode) and fragments:
+            fragment_name = selection.name.value
+            fragment = fragments.get(fragment_name)
+            if fragment is None or fragment_name in visited_fragments:
+                continue
+
+            result += count_fields_with_alias(
+                fragment,
+                fragments,
+                visited_fragments | {fragment_name},
+            )
 
     return result
 

--- a/strawberry/extensions/max_aliases.py
+++ b/strawberry/extensions/max_aliases.py
@@ -72,16 +72,19 @@ def create_validator(max_alias_count: int) -> type[ValidationRule]:
 
 def count_fields_with_alias(
     selection_set_owner: (
-        OperationDefinitionNode | FragmentDefinitionNode | FieldNode | InlineFragmentNode
+        OperationDefinitionNode
+        | FragmentDefinitionNode
+        | FieldNode
+        | InlineFragmentNode
     ),
     fragments: Mapping[str, FragmentDefinitionNode] | None = None,
-    visited_fragments: set[str] | None = None,
+    visited_fragments: frozenset[str] | None = None,
 ) -> int:
     if selection_set_owner.selection_set is None:
         return 0
 
     if visited_fragments is None:
-        visited_fragments = set()
+        visited_fragments = frozenset()
 
     result = 0
 
@@ -92,9 +95,7 @@ def count_fields_with_alias(
             isinstance(selection, (FieldNode, InlineFragmentNode))
             and selection.selection_set
         ):
-            result += count_fields_with_alias(
-                selection, fragments, visited_fragments
-            )
+            result += count_fields_with_alias(selection, fragments, visited_fragments)
         if isinstance(selection, FragmentSpreadNode) and fragments:
             fragment_name = selection.name.value
             fragment = fragments.get(fragment_name)

--- a/strawberry/extensions/query_depth_limiter.py
+++ b/strawberry/extensions/query_depth_limiter.py
@@ -223,7 +223,11 @@ def determine_depth(
     context: ValidationContext,
     operation_name: str,
     should_ignore: ShouldIgnoreType | None,
+    visited_fragments: frozenset[str] | None = None,
 ) -> int:
+    if visited_fragments is None:
+        visited_fragments = frozenset()
+
     if depth_so_far > max_depth:
         context.report_error(
             GraphQLError(
@@ -261,18 +265,24 @@ def determine_depth(
                 context=context,
                 operation_name=operation_name,
                 should_ignore=should_ignore,
+                visited_fragments=visited_fragments,
             )
             for selection in node.selection_set.selections
         )
     if isinstance(node, FragmentSpreadNode):
+        fragment_name = node.name.value
+        if fragment_name in visited_fragments:
+            return 0
+
         return determine_depth(
-            node=fragments[node.name.value],
+            node=fragments[fragment_name],
             fragments=fragments,
             depth_so_far=depth_so_far,
             max_depth=max_depth,
             context=context,
             operation_name=operation_name,
             should_ignore=should_ignore,
+            visited_fragments=visited_fragments | {fragment_name},
         )
     if isinstance(
         node, (InlineFragmentNode, FragmentDefinitionNode, OperationDefinitionNode)
@@ -286,6 +296,7 @@ def determine_depth(
                 context=context,
                 operation_name=operation_name,
                 should_ignore=should_ignore,
+                visited_fragments=visited_fragments,
             )
             for selection in node.selection_set.selections
         )

--- a/tests/schema/extensions/test_max_aliases.py
+++ b/tests/schema/extensions/test_max_aliases.py
@@ -131,6 +131,54 @@ def test_alias_in_fragment():
     assert result.errors[0].message == "2 aliases found. Allowed: 1"
 
 
+def test_repeated_fragment_spreads_count_expanded_aliases():
+    query = """
+    fragment humanInfo on Human {
+      email_address: email
+      full_name: name
+    }
+    query read {
+      matt: user(name: "matt") {
+        ...humanInfo
+      }
+      jane: user(name: "jane") {
+        ...humanInfo
+      }
+    }
+    """
+
+    result = _execute_with_max_aliases(query, 4)
+
+    assert result.errors is not None
+    assert len(result.errors) == 1
+    assert result.errors[0].message == "6 aliases found. Allowed: 4"
+
+
+def test_circular_fragment_spreads_do_not_recurse_forever():
+    query = """
+    fragment A on Human {
+      email_address: email
+      ...B
+    }
+    fragment B on Human {
+      ...A
+    }
+    query read {
+      user(name: "matt") {
+        ...A
+      }
+    }
+    """
+
+    result = _execute_with_max_aliases(query, 10)
+
+    assert result.errors is not None
+    assert any(
+        error.message == "Cannot spread fragment 'A' within itself via 'B'."
+        for error in result.errors
+    )
+
+
 def test_2_top_level_1_nested():
     query = """{
       matt: user(name: "matt") {

--- a/tests/schema/extensions/test_query_depth_limiter.py
+++ b/tests/schema/extensions/test_query_depth_limiter.py
@@ -213,6 +213,29 @@ def test_should_count_with_fragments():
     assert result == expected
 
 
+def test_circular_fragments_do_not_recurse_forever():
+    query = """
+    fragment A on Human {
+      ...B
+    }
+    fragment B on Human {
+      ...A
+    }
+    query Crash {
+      user {
+        ...A
+      }
+    }
+    """
+
+    errors, _result = run_query(query, 10)
+
+    assert any(
+        error.message == "Cannot spread fragment 'A' within itself via 'B'."
+        for error in errors
+    )
+
+
 def test_should_ignore_the_introspection_query():
     errors, result = run_query(get_introspection_query(), 10)
     assert not errors

--- a/tests/schema/extensions/test_query_depth_limiter.py
+++ b/tests/schema/extensions/test_query_depth_limiter.py
@@ -84,7 +84,10 @@ schema = strawberry.Schema(Query)
 
 
 def run_query(
-    query: str, max_depth: int, should_ignore: ShouldIgnoreType = None
+    query: str,
+    max_depth: int,
+    should_ignore: ShouldIgnoreType = None,
+    include_specified_rules: bool = True,
 ) -> tuple[list[GraphQLError], dict[str, int] | None]:
     document = parse(query)
 
@@ -95,11 +98,16 @@ def run_query(
         result = query_depths
 
     validation_rule = create_validator(max_depth, should_ignore, callback)
+    rules = (
+        (*specified_rules, validation_rule)
+        if include_specified_rules
+        else (validation_rule,)
+    )
 
     errors = validate(
         schema._schema,
         document,
-        rules=(*specified_rules, validation_rule),
+        rules=rules,
     )
 
     return errors, result
@@ -228,12 +236,10 @@ def test_circular_fragments_do_not_recurse_forever():
     }
     """
 
-    errors, _result = run_query(query, 10)
+    errors, result = run_query(query, 10, include_specified_rules=False)
 
-    assert any(
-        error.message == "Cannot spread fragment 'A' within itself via 'B'."
-        for error in errors
-    )
+    assert not errors
+    assert result == {"Crash": 1}
 
 
 def test_should_ignore_the_introspection_query():


### PR DESCRIPTION
- **Check if fragment was visited already in query depth limiter**
- **Fix fragment spread and max aliases**

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Fix GraphQL validation around fragments to correctly account for aliases and prevent infinite recursion in depth limiting.

Bug Fixes:
- Ensure max-alias validation counts aliases from fragment spreads across operations.
- Prevent circular fragment references from causing unbounded recursion in the query depth limiter.

Tests:
- Add coverage for alias counting with repeated fragment spreads.
- Add coverage to verify circular fragments are safely handled and reported by the depth limiter.