### PR TITLE
Feat: Support for TypedDicts

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,29 @@
+Release type: patch
+
+Add native support for `typing.TypedDict` GraphQL object and input types via
+the new `@strawberry.typed_dict` and `@strawberry.typed_dict_input` decorators.
+
+TypedDicts can now be used to define GraphQL schemas backed directly by Python
+dictionaries, including support for nested TypedDicts, `Required`,
+`NotRequired`, `total=False`, and `typing.Annotated` metadata.
+
+Example:
+
+```python
+from typing import TypedDict
+
+import strawberry
+
+
+@strawberry.typed_dict
+class User(TypedDict):
+    id: int
+    name: str
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def get_user(self) -> User:
+        return {"id": 1, "name": "Alice"}
+```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,4 @@
-Release type: patch
+Release type: minor
 
 Add native support for `typing.TypedDict` GraphQL object and input types via
 the new `@strawberry.typed_dict` and `@strawberry.typed_dict_input` decorators.

--- a/docs/types/input-types.md
+++ b/docs/types/input-types.md
@@ -89,6 +89,47 @@ completely absent (common in update operations), you can use `strawberry.Maybe`.
 See the [Maybe documentation](./maybe.md) for comprehensive examples and usage
 patterns.
 
+## Using TypedDicts for Inputs
+
+If you prefer your resolvers to receive standard Python dictionaries rather than
+Strawberry input class instances, you can use the `@strawberry.typed_dict_input`
+decorator.
+
+<CodeGrid>
+
+```python
+import strawberry
+from typing import TypedDict
+
+
+@strawberry.typed_dict_input
+class Point2DInput(TypedDict):
+    x: float
+    y: float
+
+
+@strawberry.type
+class Mutation:
+    @strawberry.mutation
+    def store_point(self, data: Point2DInput) -> bool:
+        # data is a standard dictionary: {"x": 1.0, "y": 2.0}
+        print(data["x"])
+        return True
+```
+
+```graphql
+input Point2DInput {
+  x: Float!
+  y: Float!
+}
+
+type Mutation {
+  storePoint(data: Point2DInput!): Boolean!
+}
+```
+
+</CodeGrid>
+
 ## API
 
 `@strawberry.input(name: str = None, description: str = None)`

--- a/docs/types/object-types.md
+++ b/docs/types/object-types.md
@@ -90,6 +90,45 @@ type Book {
 
 </CodeGrid>
 
+## Using TypedDicts
+
+If you prefer your resolvers to return standard Python dictionaries instead of
+Strawberry object classes, you can use the `@strawberry.typed_dict` decorator to
+define your object types using `typing.TypedDict`.
+
+<CodeGrid>
+
+```python
+import strawberry
+from typing import TypedDict
+
+
+@strawberry.typed_dict
+class CharacterDict(TypedDict):
+    name: str
+    age: int
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def character(self) -> CharacterDict:
+        return {"name": "Luke", "age": 19}
+```
+
+```graphql
+type CharacterDict {
+  name: String!
+  age: Int!
+}
+
+type Query {
+  character: CharacterDict!
+}
+```
+
+</CodeGrid>
+
 ## API
 
 `@strawberry.type(name: str = None, description: str = None)`

--- a/docs/types/typed-dicts.md
+++ b/docs/types/typed-dicts.md
@@ -1,0 +1,274 @@
+---
+title: TypedDicts
+---
+
+# TypedDicts
+
+While Strawberry typically uses Python classes to define GraphQL types, you
+might prefer working with standard Python dictionaries, especially when
+integrating with external APIs, databases, or legacy codebases that already
+return dictionaries.
+
+Strawberry provides native support for converting Python's `typing.TypedDict`
+into GraphQL Object Types and Input Types using the `@strawberry.typed_dict` and
+`@strawberry.typed_dict_input` decorators.
+
+## Output Types
+
+To define a GraphQL Object Type that resolves from a dictionary, use the
+`@strawberry.typed_dict` decorator.
+
+<CodeGrid>
+
+```python
+import strawberry
+from typing import TypedDict
+
+
+@strawberry.typed_dict
+class UserDict(TypedDict):
+    id: int
+    name: str
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def get_user(self) -> UserDict:
+        # We can return a standard dictionary directly!
+        return {"id": 1, "name": "Alice"}
+```
+
+```graphql
+type UserDict {
+  id: Int!
+  name: String!
+}
+
+type Query {
+  getUser: UserDict!
+}
+```
+
+</CodeGrid>
+
+## Input Types
+
+Similarly, you can define GraphQL Input Types using
+`@strawberry.typed_dict_input`. This allows your mutation resolvers to receive
+standard dictionaries instead of instantiated objects.
+
+<CodeGrid>
+
+```python
+import strawberry
+from typing import TypedDict
+
+
+@strawberry.typed_dict_input
+class CreateUserInput(TypedDict):
+    name: str
+    age: int
+
+
+@strawberry.type
+class Mutation:
+    @strawberry.mutation
+    def create_user(self, data: CreateUserInput) -> bool:
+        # data is a dictionary: {"name": "Bob", "age": 30}
+        print(f"Creating user: {data['name']}")
+        return True
+```
+
+```graphql
+input CreateUserInput {
+  name: String!
+  age: Int!
+}
+
+type Mutation {
+  createUser(data: CreateUserInput!): Boolean!
+}
+```
+
+</CodeGrid>
+
+## Nullability and Required Keys
+
+GraphQL nullability, whether a field has a `!`, is determined by whether a key
+is explicitly required to exist in the dictionary. Strawberry fully supports
+Python's advanced TypedDict nullability rules, including `total=False`,
+`Required`, and `NotRequired`.
+
+### `total=False`
+
+By default, all keys in a `TypedDict` are required. If you set `total=False`,
+all keys become optional and therefore nullable in GraphQL.
+
+<CodeGrid>
+
+```python
+import strawberry
+from typing import TypedDict
+
+
+@strawberry.typed_dict
+class PartialUser(TypedDict, total=False):
+    name: str
+    email: str
+```
+
+```graphql
+type PartialUser {
+  name: String
+  email: String
+}
+```
+
+</CodeGrid>
+
+### Mixing `Required` and `NotRequired`
+
+You can fine-tune exactly which keys are required using `Required` and
+`NotRequired` (available in `typing` in Python 3.11+, or `typing_extensions` in
+older versions).
+
+<CodeGrid>
+
+```python
+import sys
+
+import strawberry
+
+# For Python < 3.11, use typing_extensions.
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, Required, TypedDict
+else:
+    from typing import TypedDict
+
+    from typing_extensions import NotRequired, Required
+
+
+@strawberry.typed_dict
+class UpdateUserDict(TypedDict, total=False):
+    # 'id' MUST be provided, even though total=False
+    id: Required[int]
+
+    # 'name' is optional
+    name: NotRequired[str]
+```
+
+```graphql
+type UpdateUserDict {
+  id: Int!
+  name: String
+}
+```
+
+</CodeGrid>
+
+<Note>
+
+`Optional[str]` means the key must exist in the dictionary, but its value can be
+`None`. `NotRequired[str]` means the key can be completely missing from the
+dictionary. Strawberry respects this distinction internally, though both compile
+to a nullable `String` in the final GraphQL schema.
+
+</Note>
+
+## Metadata and Directives
+
+Because `TypedDict` does not support Strawberry's standard `strawberry.field()`
+assignment, for example `name: str = strawberry.field(...)`, you must use
+`typing.Annotated` to attach GraphQL descriptions and directives to the fields.
+
+<CodeGrid>
+
+```python
+import strawberry
+from typing import Annotated, TypedDict
+
+
+@strawberry.typed_dict
+class BookDict(TypedDict):
+    # You can pass a string directly for a description...
+    id: Annotated[int, "The unique ISBN of the book"]
+
+    # ...or use strawberry.field() to attach directives
+    title: Annotated[
+        str,
+        strawberry.field(description="The book title"),
+    ]
+```
+
+```graphql
+type BookDict {
+  """
+  The unique ISBN of the book
+  """
+  id: Int!
+
+  """
+  The book title
+  """
+  title: String!
+}
+```
+
+</CodeGrid>
+
+## Optional Runtime Validation
+
+When returning a standard Strawberry Object Type, missing fields will often
+trigger immediate errors during instantiation. However, Strawberry does not
+automatically validate TypedDict contents at runtime. Because dictionaries are
+evaluated lazily during GraphQL execution, a missing required key will result in
+a cryptic `KeyError` late in the request lifecycle.
+
+To prevent this, Strawberry provides a `validate_typed_dict` utility to eagerly
+validate required keys before returning data from a resolver. You can use it
+inside your resolvers to guarantee the dictionary matches the GraphQL contract
+before returning it.
+
+```python
+from typing import TypedDict
+
+import strawberry
+
+from strawberry.typed_dict import TypedDictValidationError, validate_typed_dict
+
+
+@strawberry.typed_dict
+class Point2D(TypedDict):
+    x: int
+    y: int
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def get_point(self) -> Point2D:
+        data = {"x": 10}  # No y
+
+        # This will raise a TypedDictValidationError
+        validate_typed_dict(data, Point2D)
+
+        return data
+```
+
+## API Reference
+
+### `@strawberry.typed_dict` / `@strawberry.typed_dict_input`
+
+- `name` (`str`): Override the GraphQL name. Defaults to the CamelCase class
+  name.
+- `description` (`str`): Set a GraphQL description for the type.
+- `directives` (`Iterable[object]`): An iterable of GraphQL directives to apply to
+  the type.
+
+### `validate_typed_dict`
+
+- `validate_typed_dict(data: dict, typed_dict_cls: Type)`: Evaluates the
+  provided dictionary against the requirements of the given Strawberry-decorated
+  `TypedDict` and raises a `TypedDictValidationError` if any required keys are
+  missing.

--- a/docs/types/typed-dicts.md
+++ b/docs/types/typed-dicts.md
@@ -263,8 +263,8 @@ class Query:
 - `name` (`str`): Override the GraphQL name. Defaults to the CamelCase class
   name.
 - `description` (`str`): Set a GraphQL description for the type.
-- `directives` (`Iterable[object]`): An iterable of GraphQL directives to apply to
-  the type.
+- `directives` (`Iterable[object]`): An iterable of GraphQL directives to apply
+  to the type.
 
 ### `validate_typed_dict`
 

--- a/strawberry/__init__.py
+++ b/strawberry/__init__.py
@@ -4,6 +4,8 @@ Strawberry is a Python library for GraphQL that aims to stay close to the GraphQ
 specification and allow for a more natural way of defining GraphQL schemas.
 """
 
+from strawberry.typed_dict import typed_dict, typed_dict_input
+
 from . import experimental, federation, relay
 from .directive import directive, directive_field
 from .parent import Parent
@@ -59,5 +61,7 @@ __all__ = [
     "schema_directive",
     "subscription",
     "type",
+    "typed_dict",
+    "typed_dict_input",
     "union",
 ]

--- a/strawberry/typed_dict.py
+++ b/strawberry/typed_dict.py
@@ -35,7 +35,12 @@ except ImportError:  # pragma: no cover
 
     def is_typeddict(tp: type[Any]) -> bool:
         """Fallback check for TypedDict across standard library and extensions."""
-        return isinstance(tp, type) and hasattr(tp, "__total__")
+        return (
+            isinstance(tp, type)
+            and hasattr(tp, "__total__")
+            and hasattr(tp, "__required_keys__")
+            and hasattr(tp, "__optional_keys__")
+        )
 
 
 _REQUIRED_TYPES: tuple[object, ...] = ()
@@ -388,7 +393,7 @@ def _apply_typed_dict(
     definition = _create_typed_dict_definition(
         cls, name, description, directives, is_input
     )
-    cls.__strawberry_definition__ = definition  # type: ignore[attr-defined]
+    cls.__strawberry_definition__ = definition
     return cls
 
 

--- a/strawberry/typed_dict.py
+++ b/strawberry/typed_dict.py
@@ -1,0 +1,529 @@
+"""Native support for TypedDict in Strawberry GraphQL.
+
+This module provides decorators to natively convert Python's `typing.TypedDict`
+into Strawberry GraphQL output and input types. It features robust support for
+Python's nuanced nullability rules, metadata extraction via `typing.Annotated`,
+and runtime validation utilities.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import sys
+import types
+import typing
+import warnings
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Optional,
+    overload,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Sequence
+
+from strawberry.annotation import StrawberryAnnotation
+from strawberry.types.base import StrawberryObjectDefinition, has_object_definition
+from strawberry.types.field import StrawberryField
+from strawberry.types.fields.resolver import StrawberryResolver
+from strawberry.types.unset import UNSET
+
+try:
+    from typing_extensions import is_typeddict
+except ImportError:  # pragma: no cover
+
+    def is_typeddict(tp: type[Any]) -> bool:
+        """Fallback check for TypedDict across standard library and extensions."""
+        return isinstance(tp, type) and hasattr(tp, "__total__")
+
+
+_REQUIRED_TYPES: tuple[object, ...] = ()
+_NOT_REQUIRED_TYPES: tuple[object, ...] = ()
+
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, Required
+
+    _REQUIRED_TYPES += (Required,)
+    _NOT_REQUIRED_TYPES += (NotRequired,)
+
+try:
+    from typing_extensions import NotRequired as _ExtNotRequired
+    from typing_extensions import Required as _ExtRequired
+
+    _REQUIRED_TYPES += (_ExtRequired,)
+    _NOT_REQUIRED_TYPES += (_ExtNotRequired,)
+except ImportError:
+    pass
+
+
+class TypedDictRegistry:
+    """Caches generated Strawberry definitions for TypedDict classes."""
+
+    def __init__(self) -> None:
+        self._definitions_by_key: dict[
+            tuple[type[Any], bool, str | None],
+            StrawberryObjectDefinition,
+        ] = {}
+
+    def get(
+        self,
+        cls: type[Any],
+        *,
+        is_input: bool,
+        name: str | None,
+    ) -> StrawberryObjectDefinition | None:
+        return self._definitions_by_key.get((cls, is_input, name))
+
+    def set(
+        self,
+        cls: type[Any],
+        *,
+        is_input: bool,
+        name: str | None,
+        definition: StrawberryObjectDefinition,
+    ) -> None:
+        self._definitions_by_key[(cls, is_input, name)] = definition
+
+
+_typed_dict_registry = TypedDictRegistry()
+
+
+class TypedDictValidationError(Exception):
+    """Exception raised when a dictionary fails runtime TypedDict validation."""
+
+
+def validate_typed_dict(
+    data: dict[str, Any],
+    typed_dict_cls: type[Any],
+) -> None:
+    """Validates at runtime that a dictionary conforms to its TypedDict definition.
+
+    Ensures no required keys are missing. This is useful because Strawberry
+    normally defers key lookups until execution, which could result in a KeyError.
+
+    Args:
+        data (dict): The dictionary returned by the resolver.
+        typed_dict_cls (Type[Any]): The TypedDict class it claims to represent.
+
+    Raises:
+        TypedDictValidationError: If required keys are missing or the type is invalid.
+    """
+    if not isinstance(data, dict):
+        raise TypedDictValidationError(
+            f"Expected a dictionary, got {type(data).__name__}"
+        )
+
+    definition = getattr(typed_dict_cls, "__strawberry_definition__", None)
+    if not definition:
+        return
+
+    # Extract required keys from Strawberry definitions
+    required_keys = {
+        f.python_name
+        for f in definition.fields
+        if f.metadata.get("typed_dict_required", False)
+    }
+
+    missing_keys = required_keys - data.keys()
+    if missing_keys:
+        raise TypedDictValidationError(
+            f"Missing required keys for {typed_dict_cls.__name__}: {', '.join(sorted(missing_keys))}"
+        )
+
+
+@dataclasses.dataclass(frozen=True)
+class NormalizedTypedDictAnnotation:
+    annotation: Any
+    required: bool
+    description: str | None
+    directives: list[Any]
+
+
+def _is_optional(annotation: Any) -> bool:
+    origin = typing.get_origin(annotation)
+
+    if origin in (typing.Union, types.UnionType):
+        return type(None) in typing.get_args(annotation)
+
+    return False
+
+
+def _normalize_typed_dict_annotation(
+    annotation: Any,
+    *,
+    required_by_default: bool,
+) -> NormalizedTypedDictAnnotation:
+    required = required_by_default
+    description = None
+    directives: list[Any] = []
+
+    while True:
+        origin = typing.get_origin(annotation)
+
+        if origin is typing.Annotated:
+            args = typing.get_args(annotation)
+
+            annotation = args[0]
+
+            for meta in args[1:]:
+                if isinstance(meta, str):
+                    description = meta
+
+                elif isinstance(meta, StrawberryField):
+                    if meta.description:
+                        description = meta.description
+
+                    if meta.directives:
+                        directives.extend(meta.directives)
+
+            continue
+
+        if origin in _REQUIRED_TYPES:
+            required = True
+            annotation = typing.get_args(annotation)[0]
+            continue
+
+        if origin in _NOT_REQUIRED_TYPES:
+            required = False
+            annotation = typing.get_args(annotation)[0]
+            continue
+
+        break
+
+    return NormalizedTypedDictAnnotation(
+        annotation=annotation,
+        required=required,
+        description=description,
+        directives=directives,
+    )
+
+
+def _synthesize_nested_typed_dicts(
+    annotation: Any,
+    *,
+    is_input: bool,
+) -> None:
+    origin = typing.get_origin(annotation)
+
+    if is_typeddict(annotation):
+        if not has_object_definition(annotation):
+            _apply_typed_dict(
+                annotation,
+                name=None,
+                description=None,
+                directives=(),
+                is_input=is_input,
+            )
+        return
+
+    if origin is None:
+        return
+
+    for arg in typing.get_args(annotation):
+        if arg is type(None):
+            continue
+
+        _synthesize_nested_typed_dicts(
+            arg,
+            is_input=is_input,
+        )
+
+
+def _make_key_resolver(key: str, required: bool) -> StrawberryResolver:
+    """Generates a dynamic field resolver for a TypedDict key.
+
+    Unlike standard classes which use `getattr(obj, key)`, TypedDicts
+    are resolved at runtime using dictionary subscripting `obj[key]`.
+    """
+    if required:
+
+        def resolver(self: Any) -> Any:
+            return self[key]
+    else:
+
+        def resolver(self: Any) -> Any:
+            return self.get(key, None)
+
+    return StrawberryResolver(resolver)
+
+
+def _create_typed_dict_definition(
+    typed_dict_cls: type[Any],
+    name: str | None,
+    description: str | None,
+    directives: Sequence[object],
+    is_input: bool,
+) -> StrawberryObjectDefinition:
+    """Dynamically generates a StrawberryObjectDefinition from a TypedDict class."""
+    existing = _typed_dict_registry.get(
+        typed_dict_cls,
+        is_input=is_input,
+        name=name,
+    )
+
+    if existing is not None:
+        return existing
+
+    definition = StrawberryObjectDefinition(
+        name=name or typed_dict_cls.__name__,
+        is_input=is_input,
+        is_interface=False,
+        origin=typed_dict_cls,
+        description=description,
+        interfaces=[],
+        extend=False,
+        directives=directives,
+        is_type_of=None,
+        resolve_type=None,
+        fields=[],
+    )
+    _typed_dict_registry.set(
+        typed_dict_cls,
+        is_input=is_input,
+        name=name,
+        definition=definition,
+    )
+
+    total = getattr(typed_dict_cls, "__total__", True)
+    module = sys.modules.get(typed_dict_cls.__module__)
+    namespace = module.__dict__ if module else {}
+
+    # Extract hints preserving wrappers (Required / NotRequired)
+    try:
+        try:
+            from typing_extensions import get_type_hints as get_type_hints_ext
+        except ImportError:
+            from typing import get_type_hints as get_type_hints_ext
+
+        hints_with_extras = get_type_hints_ext(
+            typed_dict_cls, globalns=namespace, include_extras=True
+        )
+    except (TypeError, NameError):
+        hints_with_extras = getattr(typed_dict_cls, "__annotations__", {})
+
+    fields: list[StrawberryField] = []
+
+    for field_name, raw_hint in hints_with_extras.items():
+        if field_name.startswith("_"):
+            continue
+
+        normalized = _normalize_typed_dict_annotation(
+            raw_hint,
+            required_by_default=total,
+        )
+
+        base_type = normalized.annotation
+        is_req = normalized.required
+
+        _synthesize_nested_typed_dicts(
+            base_type,
+            is_input=is_input,
+        )
+
+        graphql_type = base_type
+
+        if not is_req and not _is_optional(graphql_type):
+            graphql_type = Optional[graphql_type]  # noqa: UP045
+
+        resolver = _make_key_resolver(field_name, is_req)
+
+        type_annotation = StrawberryAnnotation(
+            annotation=graphql_type,
+            namespace=namespace,
+        )
+
+        field = StrawberryField(
+            python_name=field_name,
+            graphql_name=None,
+            type_annotation=type_annotation,
+            origin=typed_dict_cls,
+            description=normalized.description,
+            directives=normalized.directives,
+            default=dataclasses.MISSING,
+            metadata={
+                "typed_dict_required": is_req,
+            },
+        )
+
+        field.base_resolver = resolver
+        field.default_value = UNSET
+
+        fields.append(field)
+
+    definition.fields = fields
+    return definition
+
+
+def _apply_typed_dict(
+    cls: type[Any] | None,
+    name: str | None,
+    description: str | None,
+    directives: Sequence[object],
+    is_input: bool,
+) -> Any:
+    if cls is None:
+        return lambda cls_: _apply_typed_dict(
+            cls_, name, description, directives, is_input
+        )
+
+    if not is_typeddict(cls):
+        raise TypeError(
+            f"@strawberry.typed_dict can only be applied to TypedDict classes, got {cls!r}"
+        )
+
+    existing = _typed_dict_registry.get(
+        cls,
+        is_input=is_input,
+        name=name,
+    )
+
+    if existing is not None:
+        warnings.warn(
+            f"TypedDict {cls.__name__} is already registered",
+            stacklevel=2,
+        )
+        return cls
+
+    definition = _create_typed_dict_definition(
+        cls, name, description, directives, is_input
+    )
+    cls.__strawberry_definition__ = definition  # type: ignore[attr-defined]
+    return cls
+
+
+@overload
+def typed_dict(
+    cls: type[Any],
+    *,
+    name: str | None = None,
+    description: str | None = None,
+    directives: Iterable[object] = (),
+) -> type[Any]: ...
+
+
+@overload
+def typed_dict(
+    cls: None = None,
+    *,
+    name: str | None = None,
+    description: str | None = None,
+    directives: Iterable[object] = (),
+) -> Callable[[type[Any]], type[Any]]: ...
+
+
+def typed_dict(
+    cls: type[Any] | None = None,
+    *,
+    name: str | None = None,
+    description: str | None = None,
+    directives: Iterable[object] = (),
+) -> Any:
+    """Annotates a TypedDict as a Strawberry GraphQL output type.
+
+    Args:
+        cls: The TypedDict class to annotate.
+        name: The GraphQL name of the type.
+        description: The GraphQL description of the type.
+        directives: The directives to attach to the type.
+
+    Returns:
+        The decorated TypedDict class.
+
+    Example:
+
+    ```python
+    from typing import TypedDict
+    import strawberry
+
+
+    @strawberry.typed_dict
+    class User(TypedDict):
+        id: int
+        name: str
+    ```
+
+    The above code will generate the following GraphQL schema:
+
+    ```graphql
+    type User {
+        id: Int!
+        name: String!
+    }
+    ```
+    """
+    return _apply_typed_dict(
+        cls,
+        name,
+        description,
+        tuple(directives),
+        is_input=False,
+    )
+
+
+@overload
+def typed_dict_input(
+    cls: type[Any],
+    *,
+    name: str | None = None,
+    description: str | None = None,
+    directives: Iterable[object] = (),
+) -> type[Any]: ...
+
+
+@overload
+def typed_dict_input(
+    cls: None = None,
+    *,
+    name: str | None = None,
+    description: str | None = None,
+    directives: Iterable[object] = (),
+) -> Callable[[type[Any]], type[Any]]: ...
+
+
+def typed_dict_input(
+    cls: type[Any] | None = None,
+    *,
+    name: str | None = None,
+    description: str | None = None,
+    directives: Iterable[object] = (),
+) -> Any:
+    """Annotates a TypedDict as a Strawberry GraphQL input type.
+
+    Args:
+        cls: The TypedDict class to annotate.
+        name: The GraphQL name of the input type.
+        description: The GraphQL description of the input type.
+        directives: The directives to attach to the input type.
+
+    Returns:
+        The decorated TypedDict class.
+
+    Example:
+
+    ```python
+    from typing import TypedDict
+    import strawberry
+
+
+    @strawberry.typed_dict_input
+    class CreateUserInput(TypedDict):
+        name: str
+        age: int
+    ```
+    """
+    return _apply_typed_dict(
+        cls,
+        name,
+        description,
+        tuple(directives),
+        is_input=True,
+    )
+
+
+__all__ = [
+    "TypedDictValidationError",
+    "typed_dict",
+    "typed_dict_input",
+    "validate_typed_dict",
+]

--- a/strawberry/typed_dict.py
+++ b/strawberry/typed_dict.py
@@ -33,7 +33,7 @@ try:
     from typing_extensions import is_typeddict
 except ImportError:  # pragma: no cover
 
-    def is_typeddict(tp: type[Any]) -> bool:
+    def is_typeddict(tp: object) -> bool:
         """Fallback check for TypedDict across standard library and extensions."""
         return (
             isinstance(tp, type)

--- a/strawberry/types/base.py
+++ b/strawberry/types/base.py
@@ -282,6 +282,9 @@ class StrawberryObjectDefinition(StrawberryType):
     directives: Sequence[object] | None
     is_type_of: Callable[[Any, GraphQLResolveInfo], bool] | None
     resolve_type: Callable[[Any, GraphQLResolveInfo, GraphQLAbstractType], str] | None
+    _is_typed_dict: bool = dataclasses.field(
+        default=False, init=False, repr=False, compare=False, hash=False
+    )
 
     fields: list[StrawberryField]
 

--- a/strawberry/types/base.py
+++ b/strawberry/types/base.py
@@ -282,7 +282,7 @@ class StrawberryObjectDefinition(StrawberryType):
     directives: Sequence[object] | None
     is_type_of: Callable[[Any, GraphQLResolveInfo], bool] | None
     resolve_type: Callable[[Any, GraphQLResolveInfo, GraphQLAbstractType], str] | None
-    _is_typed_dict: bool = dataclasses.field(
+    _is_typeddict: bool = dataclasses.field(
         default=False, init=False, repr=False, compare=False, hash=False
     )
 

--- a/tests/schema/test_typed_dict.py
+++ b/tests/schema/test_typed_dict.py
@@ -1,0 +1,397 @@
+"""
+Tests for TypedDict support (output, input, nullability, nesting, and validation).
+"""
+
+from __future__ import annotations
+
+import textwrap
+from typing import Annotated, Optional, TypedDict
+from typing_extensions import NotRequired, Required
+
+import pytest
+
+import strawberry
+from strawberry.schema_directive import Location
+from strawberry.typed_dict import TypedDictValidationError, validate_typed_dict
+
+
+@strawberry.typed_dict
+class Point2D(TypedDict):
+    x: int
+    y: int
+
+
+@strawberry.typed_dict_input
+class CreateUserInput(TypedDict):
+    name: str
+    age: int
+
+
+@strawberry.typed_dict
+class UserDictTotalFalse(TypedDict, total=False):
+    name: str
+    email: str
+
+
+@strawberry.typed_dict
+class UserDictRequired(TypedDict, total=False):
+    id: Required[int]
+    name: str
+    email: NotRequired[str]
+
+
+@strawberry.typed_dict
+class UserDictOptional(TypedDict, total=False):
+    id: Required[int]
+    name: str
+
+
+@strawberry.typed_dict
+class AddressDict(TypedDict):
+    city: str
+    zipcode: str
+
+
+@strawberry.typed_dict
+class UserDictNested(TypedDict):
+    name: str
+    address: AddressDict
+
+
+@strawberry.typed_dict
+class Item(TypedDict):
+    sku: str
+    qty: int
+
+
+@strawberry.typed_dict
+class ExamplePrivateFields(TypedDict):
+    visible: str
+    _internal: str
+
+
+@strawberry.typed_dict_input
+class OptionalInput(TypedDict, total=False):
+    required_field: Required[str]
+    optional_field: NotRequired[int]
+
+
+def test_basic_output_typed_dict():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def get_point(self) -> Point2D:
+            return {"x": 10, "y": 20}
+
+    schema = strawberry.Schema(query=Query)
+
+    query = "{ getPoint { x y } }"
+    result = schema.execute_sync(query)
+
+    assert not result.errors
+    assert result.data["getPoint"] == {"x": 10, "y": 20}
+
+
+def test_basic_input_typed_dict():
+    @strawberry.type
+    class Query:
+        _dummy: str = "unused"  # at least one field needed
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        def create_user(self, data: CreateUserInput) -> str:
+            return f"Created {data['name']} (age {data['age']})"
+
+    schema = strawberry.Schema(query=Query, mutation=Mutation)
+
+    mutation = """
+        mutation {
+            createUser(data: {name: "John", age: 30})
+        }
+    """
+    result = schema.execute_sync(mutation)
+    assert not result.errors
+    assert result.data["createUser"] == "Created John (age 30)"
+
+
+def test_total_false_makes_fields_nullable():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def user(self) -> UserDictTotalFalse:
+            return {"name": "Alice"}
+
+    schema = strawberry.Schema(query=Query)
+
+    expected = textwrap.dedent("""\
+        type Query {
+          user: UserDictTotalFalse!
+        }
+
+        type UserDictTotalFalse {
+          name: String
+          email: String
+        }
+    """).strip()
+
+    assert str(schema) == expected
+
+
+def test_required_and_not_required_fields():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def user(self) -> UserDictRequired:
+            return {"id": 1, "name": "Bob"}
+
+    schema = strawberry.Schema(query=Query)
+
+    expected = textwrap.dedent("""\
+        type Query {
+          user: UserDictRequired!
+        }
+
+        type UserDictRequired {
+          id: Int!
+          name: String
+          email: String
+        }
+    """).strip()
+
+    assert str(schema) == expected
+
+
+def test_missing_optional_key_resolves_to_null():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def user(self) -> UserDictOptional:
+            return {"id": 42}
+
+    schema = strawberry.Schema(query=Query)
+
+    query = "{ user { id name } }"
+    result = schema.execute_sync(query)
+
+    assert not result.errors
+    assert result.data["user"] == {"id": 42, "name": None}
+
+
+def test_nested_typed_dict():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def user(self) -> UserDictNested:
+            return {
+                "name": "Carol",
+                "address": {"city": "Springfield", "zipcode": "12345"},
+            }
+
+    schema = strawberry.Schema(query=Query)
+
+    query = "{ user { name address { city zipcode } } }"
+    result = schema.execute_sync(query)
+
+    assert not result.errors
+    assert result.data["user"] == {
+        "name": "Carol",
+        "address": {"city": "Springfield", "zipcode": "12345"},
+    }
+
+
+def test_list_of_typed_dict():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def inventory(self) -> list[Item]:
+            return [
+                {"sku": "A1", "qty": 10},
+                {"sku": "B2", "qty": 0},
+            ]
+
+    schema = strawberry.Schema(query=Query)
+
+    query = "{ inventory { sku qty } }"
+    result = schema.execute_sync(query)
+
+    assert not result.errors
+    assert result.data["inventory"] == [
+        {"sku": "A1", "qty": 10},
+        {"sku": "B2", "qty": 0},
+    ]
+
+
+def test_input_typed_dict_missing_optional_field():
+    @strawberry.type
+    class Query:
+        _dummy: str = "unused"
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        def process(self, data: OptionalInput) -> str:
+            req = data["required_field"]
+            opt = data.get("optional_field", "missing")
+            return f"req={req}, opt={opt}"
+
+    schema = strawberry.Schema(query=Query, mutation=Mutation)
+
+    mutation = """
+        mutation {
+            process(data: {requiredField: "hello"})
+        }
+    """
+    result = schema.execute_sync(mutation)
+    assert not result.errors
+    assert result.data["process"] == "req=hello, opt=missing"
+
+
+# Schema directive used for annotated metadata tests
+@strawberry.schema_directive(locations=[Location.FIELD_DEFINITION])
+class ExampleDirective:
+    value: str
+
+
+@strawberry.typed_dict
+class AnnotatedUser(TypedDict):
+    id: Annotated[int, "The unique identifier"]
+    name: Annotated[
+        str,
+        strawberry.field(
+            description="The user name", directives=[ExampleDirective(value="test")]
+        ),
+    ]
+
+
+def test_annotated_metadata():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def fetch_annotated(self) -> AnnotatedUser:
+            return {"id": 1, "name": "Test"}
+
+    schema = strawberry.Schema(query=Query)
+
+    expected = textwrap.dedent('''\
+        type AnnotatedUser {
+          """The unique identifier"""
+          id: Int!
+
+          """The user name"""
+          name: String! @exampleDirective(value: "test")
+        }
+    ''').strip()
+
+    assert expected in str(schema)
+
+
+def test_validate_typed_dict_success():
+    @strawberry.typed_dict
+    class ValidDict(TypedDict):
+        req: str
+        opt: NotRequired[str]
+        opt_type: Optional[int]
+
+    validate_typed_dict(
+        {
+            "req": "hello",
+            "opt": "world",
+            "opt_type": 5,
+        },
+        ValidDict,
+    )
+
+    validate_typed_dict(
+        {
+            "req": "hello",
+            "opt_type": None,
+        },
+        ValidDict,
+    )
+
+    validate_typed_dict(
+        {
+            "req": "hello",
+            "opt_type": 1,
+        },
+        ValidDict,
+    )
+
+
+def test_validate_typed_dict_failure():
+    @strawberry.typed_dict
+    class MissingRequiredFieldDict(TypedDict):
+        req1: str
+        req2: int
+
+    with pytest.raises(
+        TypedDictValidationError,
+        match="Missing required keys for MissingRequiredFieldDict: req2",
+    ):
+        validate_typed_dict(
+            {"req1": "hello"},
+            MissingRequiredFieldDict,
+        )
+
+
+def test_optional_value_does_not_make_key_optional():
+    @strawberry.typed_dict
+    class OptionalValueRequiredKeyDict(TypedDict):
+        value: Optional[int]
+
+    with pytest.raises(
+        TypedDictValidationError,
+        match="Missing required keys for OptionalValueRequiredKeyDict: value",
+    ):
+        validate_typed_dict({}, OptionalValueRequiredKeyDict)
+
+
+def test_private_fields_are_ignored():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def example(self) -> ExamplePrivateFields:
+            return {
+                "visible": "hello",
+                "_internal": "secret",
+            }
+
+    schema = strawberry.Schema(query=Query)
+
+    expected = textwrap.dedent("""\
+        type ExamplePrivateFields {
+          visible: String!
+        }
+
+        type Query {
+          example: ExamplePrivateFields!
+        }
+    """).strip()
+
+    assert str(schema) == expected
+
+
+def test_pep604_optional_union():
+    @strawberry.typed_dict
+    class Example(TypedDict):
+        value: int | None
+
+    validate_typed_dict(
+        {"value": None},
+        Example,
+    )
+
+    with pytest.raises(
+        TypedDictValidationError,
+        match="Missing required keys for Example: value",
+    ):
+        validate_typed_dict({}, Example)
+
+
+def test_raises_error_on_non_typed_dict():
+    with pytest.raises(TypeError, match="can only be applied to TypedDict classes"):
+
+        @strawberry.typed_dict
+        class NormalClass:
+            name: str


### PR DESCRIPTION
Add native support for `typing.TypedDict` GraphQL object and input types via the new `@strawberry.typed_dict` and `@strawberry.typed_dict_input` decorators.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
TypedDicts can now be used to define GraphQL schemas backed directly by Python dictionaries, including support for nested TypedDicts, `Required`, `NotRequired`, `total=False`, and `typing.Annotated` metadata.

Example:

```python
from typing import TypedDict

import strawberry


@strawberry.typed_dict
class User(TypedDict):
    id: int
    name: str


@strawberry.type
class Query:
    @strawberry.field
    def get_user(self) -> User:
        return {"id": 1, "name": "Alice"}
```

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

* #2187

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Add native support for using typing.TypedDict to define Strawberry GraphQL object and input types backed by plain Python dictionaries.

New Features:
- Introduce @strawberry.typed_dict and @strawberry.typed_dict_input decorators to map TypedDicts to GraphQL object and input types.
- Add runtime validation utilities for TypedDict-backed data, including TypedDictValidationError and validate_typed_dict.
- Support nested TypedDicts, Required/NotRequired keys, total=False, Optional/PEP 604 unions, and metadata via typing.Annotated when generating GraphQL schemas.

Enhancements:
- Expose typed_dict and typed_dict_input from the main strawberry package and extend Strawberry object definitions to track TypedDict-backed types.

Documentation:
- Document TypedDict support, including usage for object and input types, nullability and required keys, metadata/directives, and runtime validation, with new examples in the type docs and a dedicated TypedDicts guide.

Tests:
- Add comprehensive tests covering TypedDict output and input handling, nullability semantics, nesting, lists, metadata via Annotated, validation behavior, and error cases for invalid usage.