### PR TITLE
Match scalar_overrides generic containers by origin (#4433)

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,30 +1,35 @@
 Release type: minor
 
-`scalar_overrides` now matches generic containers by their origin as a
+`scalar_overrides` now matches generic `dict` annotations by their origin as a
 fallback, so registering a bare `dict` covers every `dict[K, V]`
 parameterization instead of needing one entry per variant.
 
-Before, a schema like this only worked if you registered the exact
-annotation (`dict[str, Any]`), and any other shape such as
-`dict[str, Optional[int]]` raised `Unexpected type`:
+Before, registering only the unparameterized origin (`dict`) did not match
+parameterized annotations like `dict[str, int]`. You had to register the exact
+annotation, and any other shape such as `dict[str, list[int]]` raised
+`Unexpected type`:
 
 ```python
+from typing import Any
+
 import strawberry
 from strawberry.scalars import JSON
 
 
 @strawberry.type
 class Query:
-    settings: dict[str, int]
-    metadata: dict[str, list[str]]
+    settings: dict[str, Any]
+    metadata: dict[str, list[int]]
 
 
 schema = strawberry.Schema(
     query=Query,
-    scalar_overrides={dict: JSON},
+    scalar_overrides={dict[str, Any]: JSON},
 )
 ```
 
-Now registering the unparameterized `dict` (or `list`, etc.) covers all
-of its parameterizations. Lookup still tries an exact match first, so
-existing overrides keep working unchanged.
+Now registering the unparameterized `dict` covers all of its parameterizations,
+including resolver and mutation arguments typed with `dict[...]`. This is
+especially useful for `strawberry.experimental.pydantic` models with typed
+dictionary fields. Lookup still tries an exact match first, so existing overrides
+keep working unchanged.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,28 @@
+Release type: minor
+
+`scalar_overrides` now matches generic containers by their origin as a
+fallback, so registering a bare `dict` covers every `dict[K, V]`
+parameterization instead of needing one entry per variant.
+
+Before, a schema like this only worked if you registered the exact
+annotation (`dict[str, Any]`), and any other shape such as
+`dict[str, Optional[int]]` raised `Unexpected type`:
+
+```python
+import strawberry
+from strawberry.scalars import JSON
+
+@strawberry.type
+class Query:
+    settings: dict[str, int]
+    metadata: dict[str, list[str]]
+
+schema = strawberry.Schema(
+    query=Query,
+    scalar_overrides={dict: JSON},
+)
+```
+
+Now registering the unparameterized `dict` (or `list`, etc.) covers all
+of its parameterizations. Lookup still tries an exact match first, so
+existing overrides keep working unchanged.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,10 +12,12 @@ annotation (`dict[str, Any]`), and any other shape such as
 import strawberry
 from strawberry.scalars import JSON
 
+
 @strawberry.type
 class Query:
     settings: dict[str, int]
     metadata: dict[str, list[str]]
+
 
 schema = strawberry.Schema(
     query=Query,

--- a/strawberry/scalars.py
+++ b/strawberry/scalars.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, NewType
+from typing import TYPE_CHECKING, Any, NewType, get_origin
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -29,6 +29,11 @@ def is_scalar(
     scalar_registry: Mapping[object, ScalarWrapper | ScalarDefinition],
 ) -> bool:
     if annotation in scalar_registry:
+        return True
+
+    # Keep scalar checks consistent for schema generation and argument conversion.
+    origin = get_origin(annotation)
+    if origin is not None and origin in scalar_registry:
         return True
 
     return hasattr(annotation, "_scalar_definition")

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -903,6 +903,13 @@ class GraphQLCoreConverter:
         ):  # TODO: Replace with StrawberryScalar
             return self.from_scalar(type_)
 
+        # Fall back to matching a generic container by its origin, so that
+        # registering e.g. ``{dict: JSON}`` covers every ``dict[K, V]``
+        # parameterization instead of requiring one entry per variant.
+        origin = typing.get_origin(type_)
+        if origin is not None and compat.is_scalar(origin, self.scalar_registry):
+            return self.from_scalar(origin)
+
         raise TypeError(f"Unexpected type '{type_}'")
 
     def from_union(self, union: StrawberryUnion) -> GraphQLUnionType:

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -810,6 +810,11 @@ class GraphQLCoreConverter:
 
         scalar_definition: ScalarDefinition
 
+        if scalar not in self.scalar_registry:
+            origin = typing.get_origin(scalar)
+            if origin is not None and origin in self.scalar_registry:
+                scalar = origin
+
         if scalar in self.scalar_registry:
             _scalar_definition = self.scalar_registry[scalar]
             # TODO: check why we need the cast and we are not trying with getattr first
@@ -902,13 +907,6 @@ class GraphQLCoreConverter:
             type_, self.scalar_registry
         ):  # TODO: Replace with StrawberryScalar
             return self.from_scalar(type_)
-
-        # Fall back to matching a generic container by its origin, so that
-        # registering e.g. ``{dict: JSON}`` covers every ``dict[K, V]``
-        # parameterization instead of requiring one entry per variant.
-        origin = typing.get_origin(type_)
-        if origin is not None and compat.is_scalar(origin, self.scalar_registry):
-            return self.from_scalar(origin)
 
         raise TypeError(f"Unexpected type '{type_}'")
 

--- a/tests/schema/test_scalars.py
+++ b/tests/schema/test_scalars.py
@@ -381,15 +381,65 @@ def test_override_generic_container_by_origin():
         ints: dict[str, int]
         nested: dict[str, list[int]]
 
-    schema = strawberry.Schema(Query, scalar_overrides={dict: JSONScalar})
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        def echo(self, value: dict[str, int]) -> dict[str, int]:
+            return value
+
+        @strawberry.mutation
+        def echo_optional(
+            self, value: dict[str, int] | None = None
+        ) -> dict[str, int] | None:
+            return value
+
+        @strawberry.mutation
+        def echo_list(self, value: list[dict[str, int]]) -> list[dict[str, int]]:
+            return value
+
+    schema = strawberry.Schema(
+        Query,
+        mutation=Mutation,
+        scalar_overrides={dict: JSONScalar},
+    )
 
     assert "ints: JSON!" in str(schema)
     assert "nested: JSON!" in str(schema)
 
+    result = schema.execute_sync(
+        "{ ints nested }",
+        root_value=Query(ints={"a": 1}, nested={"b": [2]}),
+    )
+
+    assert not result.errors
+    assert result.data == {"ints": {"a": 1}, "nested": {"b": [2]}}
+
+    result = schema.execute_sync(
+        "mutation($value: JSON!) { echo(value: $value) }",
+        variable_values={"value": {"a": 1}},
+    )
+
+    assert not result.errors
+    assert result.data == {"echo": {"a": 1}}
+
+    result = schema.execute_sync(
+        "mutation($value: JSON) { echoOptional(value: $value) }",
+        variable_values={"value": {"b": 2}},
+    )
+
+    assert not result.errors
+    assert result.data == {"echoOptional": {"b": 2}}
+
+    result = schema.execute_sync(
+        "mutation($value: [JSON!]!) { echoList(value: $value) }",
+        variable_values={"value": [{"c": 3}]},
+    )
+
+    assert not result.errors
+    assert result.data == {"echoList": [{"c": 3}]}
+
 
 def test_override_exact_generic_key_still_matches():
-    # The existing exact-key lookup must keep working: an override registered
-    # for a specific parameterization should only affect that exact type.
     JSONScalar = scalar(
         dict,
         name="JSON",
@@ -404,6 +454,23 @@ def test_override_exact_generic_key_still_matches():
     schema = strawberry.Schema(Query, scalar_overrides={dict[str, Any]: JSONScalar})
 
     assert "settings: JSON!" in str(schema)
+
+
+def test_override_exact_generic_key_does_not_match_other_parameterizations():
+    JSONScalar = scalar(
+        dict,
+        name="JSON",
+        serialize=lambda value: value,
+        parse_value=lambda value: value,
+    )
+
+    @strawberry.type
+    class Query:
+        settings: dict[str, Any]
+        other: dict[str, int]
+
+    with pytest.raises(TypeError, match="Unexpected type 'dict\\[str, int\\]'"):
+        strawberry.Schema(Query, scalar_overrides={dict[str, Any]: JSONScalar})
 
 
 def test_decimal():

--- a/tests/schema/test_scalars.py
+++ b/tests/schema/test_scalars.py
@@ -1,6 +1,7 @@
 from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 from textwrap import dedent
+from typing import Any
 from uuid import UUID
 
 import pytest
@@ -363,6 +364,46 @@ def test_override_unknown_scalars():
 
     assert not result.errors
     assert result.data == {"duration": 10}
+
+
+def test_override_generic_container_by_origin():
+    # Registering the bare ``dict`` should cover every ``dict[K, V]``
+    # parameterization instead of requiring one override entry per variant.
+    JSONScalar = scalar(
+        dict,
+        name="JSON",
+        serialize=lambda value: value,
+        parse_value=lambda value: value,
+    )
+
+    @strawberry.type
+    class Query:
+        ints: dict[str, int]
+        nested: dict[str, list[int]]
+
+    schema = strawberry.Schema(Query, scalar_overrides={dict: JSONScalar})
+
+    assert "ints: JSON!" in str(schema)
+    assert "nested: JSON!" in str(schema)
+
+
+def test_override_exact_generic_key_still_matches():
+    # The existing exact-key lookup must keep working: an override registered
+    # for a specific parameterization should only affect that exact type.
+    JSONScalar = scalar(
+        dict,
+        name="JSON",
+        serialize=lambda value: value,
+        parse_value=lambda value: value,
+    )
+
+    @strawberry.type
+    class Query:
+        settings: dict[str, Any]
+
+    schema = strawberry.Schema(Query, scalar_overrides={dict[str, Any]: JSONScalar})
+
+    assert "settings: JSON!" in str(schema)
 
 
 def test_decimal():


### PR DESCRIPTION
## Description

Fixes #4433.

`scalar_overrides` currently does an exact-key dictionary lookup, so registering `dict[str, Any] -> JSON` does **not** match `dict[str, int]`, `dict[str, Optional[int]]`, or any other parameterization. You end up having to add a new entry every time a different `dict[...]` shape shows up in the schema, which is easy to miss and annoying to maintain (it comes up a lot with `strawberry.experimental.pydantic` types that have `dict[K, V]` fields).

This PR adds an origin fallback in `GraphQLCoreConverter.from_type`: if there's no exact scalar match, it tries `typing.get_origin(type_)`. So registering the bare `dict` once covers every `dict[K, V]`.

```python
@strawberry.type
class Query:
    settings: dict[str, int]
    metadata: dict[str, list[str]]

schema = strawberry.Schema(
    query=Query,
    scalar_overrides={dict: JSON},   # one entry covers both fields now
)
```

## Implementation

The change is in `from_type` (`strawberry/schema/schema_converter.py`):

```python
if compat.is_scalar(type_, self.scalar_registry):
    return self.from_scalar(type_)

# NEW: fall back to the generic container's origin
origin = typing.get_origin(type_)
if origin is not None and compat.is_scalar(origin, self.scalar_registry):
    return self.from_scalar(origin)

raise TypeError(f"Unexpected type '{type_}'")
```

It's intentionally conservative:
- The exact match runs first, so existing overrides behave exactly as before.
- The fallback only kicks in when the user has registered the unparameterized type (`dict`, `list`, ...), so it's opt-in.
- If nothing matches, the same `TypeError` is raised as before.

This is basically the approach suggested in the issue body.

## Tests

Added two tests in `tests/schema/test_scalars.py`:
- `test_override_generic_container_by_origin` – a bare `dict` override covers different `dict[K, V]` fields, including a nested value type.
- `test_override_exact_generic_key_still_matches` – the existing exact-key override still works (backward-compat guard).

Ran the scalar test suite locally (all passing) and checked `ruff` / `ruff format` / `mypy` on the touched files. Also included a `RELEASE.md` (minor) as per CONTRIBUTING.

## Summary by Sourcery

Allow scalar_overrides to match parameterized generic containers by their origin type while preserving existing exact-match behavior.

New Features:
- Support registering scalar_overrides for unparameterized generic containers (e.g., dict) that automatically apply to all their parameterizations.

Bug Fixes:
- Prevent Unexpected type errors when scalar_overrides are defined only for the origin of a generic container but used with parameterized variants.

Documentation:
- Add a minor release note documenting the new scalar_overrides behavior for generic containers.

Tests:
- Add tests to verify generic container overrides apply by origin and that exact generic keys still take precedence.