### PR TITLE
feat: add lexicographic_sort_schema config option

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,19 @@
+Release type: minor
+
+Add a new `lexicographic_sort_schema` option to `StrawberryConfig`. When enabled,
+the schema's types, fields and arguments are sorted alphabetically, affecting both
+the introspection result and the exported SDL. This makes it easier to find
+related fields (for example `userById`, `userByName`) in the GraphiQL UI and in
+exported `schema.graphql` files.
+
+```python
+import strawberry
+from strawberry.schema.config import StrawberryConfig
+
+schema = strawberry.Schema(
+    query=Query,
+    config=StrawberryConfig(lexicographic_sort_schema=True),
+)
+```
+
+It defaults to `False`, preserving the existing definition order.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
 Release type: minor
 
-Add a new `lexicographic_sort_schema` option to `StrawberryConfig`. When enabled,
+Add a new `sort_schema` option to `StrawberryConfig`. When enabled,
 the schema's types, fields and arguments are sorted alphabetically, affecting both
 the introspection result and the exported SDL. This makes it easier to find
 related fields (for example `userById`, `userByName`) in the GraphiQL UI and in
@@ -12,7 +12,7 @@ from strawberry.schema.config import StrawberryConfig
 
 schema = strawberry.Schema(
     query=Query,
-    config=StrawberryConfig(lexicographic_sort_schema=True),
+    config=StrawberryConfig(sort_schema=True),
 )
 ```
 

--- a/docs/types/schema-configurations.md
+++ b/docs/types/schema-configurations.md
@@ -106,6 +106,43 @@ schema = strawberry.Schema(
 )
 ```
 
+### lexicographic_sort_schema
+
+By default Strawberry preserves the order in which fields and types are defined.
+This can make the introspection UI and the exported `schema.graphql` file harder
+to read, since related fields (for example `userById`, `userByName`) are not
+grouped together.
+
+Setting `lexicographic_sort_schema` to `True` sorts all types, fields and
+arguments alphabetically, affecting both the introspection result and the
+exported SDL.
+
+```python
+schema = strawberry.Schema(
+    query=Query, config=StrawberryConfig(lexicographic_sort_schema=True)
+)
+```
+
+With sorting enabled a schema like:
+
+```graphql
+type Query {
+  userByName(name: String!): User!
+  allUsers: [User!]!
+  userById(id: Int!): User!
+}
+```
+
+becomes:
+
+```graphql
+type Query {
+  allUsers: [User!]!
+  userById(id: Int!): User!
+  userByName(name: String!): User!
+}
+```
+
 ### info_class
 
 By default Strawberry will create an object of type `strawberry.Info` when the

--- a/docs/types/schema-configurations.md
+++ b/docs/types/schema-configurations.md
@@ -113,14 +113,11 @@ This can make the introspection UI and the exported `schema.graphql` file harder
 to read, since related fields (for example `userById`, `userByName`) are not
 grouped together.
 
-Setting `sort_schema` to `True` sorts all types, fields and
-arguments alphabetically, affecting both the introspection result and the
-exported SDL.
+Setting `sort_schema` to `True` sorts all types, fields and arguments
+alphabetically, affecting both the introspection result and the exported SDL.
 
 ```python
-schema = strawberry.Schema(
-    query=Query, config=StrawberryConfig(sort_schema=True)
-)
+schema = strawberry.Schema(query=Query, config=StrawberryConfig(sort_schema=True))
 ```
 
 With sorting enabled a schema like:

--- a/docs/types/schema-configurations.md
+++ b/docs/types/schema-configurations.md
@@ -106,20 +106,20 @@ schema = strawberry.Schema(
 )
 ```
 
-### lexicographic_sort_schema
+### sort_schema
 
 By default Strawberry preserves the order in which fields and types are defined.
 This can make the introspection UI and the exported `schema.graphql` file harder
 to read, since related fields (for example `userById`, `userByName`) are not
 grouped together.
 
-Setting `lexicographic_sort_schema` to `True` sorts all types, fields and
+Setting `sort_schema` to `True` sorts all types, fields and
 arguments alphabetically, affecting both the introspection result and the
 exported SDL.
 
 ```python
 schema = strawberry.Schema(
-    query=Query, config=StrawberryConfig(lexicographic_sort_schema=True)
+    query=Query, config=StrawberryConfig(sort_schema=True)
 )
 ```
 

--- a/strawberry/schema/config.py
+++ b/strawberry/schema/config.py
@@ -34,6 +34,10 @@ class StrawberryConfig:
             any type (including NewType) to be used as a GraphQL scalar with
             proper type checking support.
         batching_config: Configuration for operation batching.
+        lexicographic_sort_schema: Whether to sort the schema's types, fields and
+            arguments lexicographically. This affects both the introspection
+            result and the exported SDL, making it easier to find related
+            fields. Defaults to False, which preserves definition order.
     """
 
     auto_camel_case: InitVar[bool] = None  # pyright: reportGeneralTypeIssues=false
@@ -47,6 +51,7 @@ class StrawberryConfig:
     _unsafe_disable_same_type_validation: bool = False
     scalar_map: Mapping[object, ScalarDefinition] = field(default_factory=dict)
     batching_config: BatchingConfig | None = None
+    lexicographic_sort_schema: bool = False
 
     def __post_init__(
         self,

--- a/strawberry/schema/config.py
+++ b/strawberry/schema/config.py
@@ -34,7 +34,7 @@ class StrawberryConfig:
             any type (including NewType) to be used as a GraphQL scalar with
             proper type checking support.
         batching_config: Configuration for operation batching.
-        lexicographic_sort_schema: Whether to sort the schema's types, fields and
+        sort_schema: Whether to sort the schema's types, fields and
             arguments lexicographically. This affects both the introspection
             result and the exported SDL, making it easier to find related
             fields. Defaults to False, which preserves definition order.
@@ -51,7 +51,7 @@ class StrawberryConfig:
     _unsafe_disable_same_type_validation: bool = False
     scalar_map: Mapping[object, ScalarDefinition] = field(default_factory=dict)
     batching_config: BatchingConfig | None = None
-    lexicographic_sort_schema: bool = False
+    sort_schema: bool = False
 
     def __post_init__(
         self,

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -29,6 +29,7 @@ from graphql import (
     GraphQLSchema,
     OperationDefinitionNode,
     get_introspection_query,
+    lexicographic_sort_schema,
     parse,
     validate_schema,
 )
@@ -370,6 +371,9 @@ class Schema(BaseSchema):
                 raise error.__cause__ from None
 
             raise
+
+        if self.config.lexicographic_sort_schema:
+            self._schema = lexicographic_sort_schema(self._schema)
 
         # attach our schema to the GraphQL schema instance
         self._schema._strawberry_schema = self  # type: ignore

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -372,7 +372,7 @@ class Schema(BaseSchema):
 
             raise
 
-        if self.config.lexicographic_sort_schema:
+        if self.config.sort_schema:
             self._schema = lexicographic_sort_schema(self._schema)
 
         # attach our schema to the GraphQL schema instance

--- a/tests/schema/test_config.py
+++ b/tests/schema/test_config.py
@@ -1,5 +1,8 @@
+import textwrap
+
 import pytest
 
+import strawberry
 from strawberry.schema.config import StrawberryConfig
 from strawberry.types.info import Info
 
@@ -37,3 +40,82 @@ def test_config_post_init_info_class_is_not_subclass():
         StrawberryConfig(info_class=object)
 
     assert str(exc_info.value) == "`info_class` must be a subclass of strawberry.Info"
+
+
+def test_lexicographic_sort_schema_defaults_to_false():
+    assert StrawberryConfig().lexicographic_sort_schema is False
+
+
+def test_lexicographic_sort_schema_preserves_definition_order_by_default():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def zebra(self) -> int: ...
+
+        @strawberry.field
+        def apple(self) -> int: ...
+
+    schema = strawberry.Schema(query=Query)
+
+    expected = """\
+    type Query {
+      zebra: Int!
+      apple: Int!
+    }"""
+
+    assert str(schema) == textwrap.dedent(expected).strip()
+
+
+def test_lexicographic_sort_schema_sorts_fields_and_types():
+    @strawberry.type
+    class User:
+        name: str
+        age: int
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def user_by_name(self, name: str) -> User: ...
+
+        @strawberry.field
+        def all_users(self) -> list[User]: ...
+
+        @strawberry.field
+        def user_by_id(self, id: int) -> User: ...
+
+    schema = strawberry.Schema(
+        query=Query,
+        config=StrawberryConfig(lexicographic_sort_schema=True),
+    )
+
+    expected = """\
+    type Query {
+      allUsers: [User!]!
+      userById(id: Int!): User!
+      userByName(name: String!): User!
+    }
+
+    type User {
+      age: Int!
+      name: String!
+    }"""
+
+    assert str(schema) == textwrap.dedent(expected).strip()
+
+
+def test_lexicographic_sort_schema_still_executes():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def hello(self, name: str) -> str:
+            return f"Hi {name}"
+
+    schema = strawberry.Schema(
+        query=Query,
+        config=StrawberryConfig(lexicographic_sort_schema=True),
+    )
+
+    result = schema.execute_sync('{ hello(name: "Patrick") }')
+
+    assert not result.errors
+    assert result.data == {"hello": "Hi Patrick"}

--- a/tests/schema/test_config.py
+++ b/tests/schema/test_config.py
@@ -42,11 +42,11 @@ def test_config_post_init_info_class_is_not_subclass():
     assert str(exc_info.value) == "`info_class` must be a subclass of strawberry.Info"
 
 
-def test_lexicographic_sort_schema_defaults_to_false():
-    assert StrawberryConfig().lexicographic_sort_schema is False
+def test_sort_schema_defaults_to_false():
+    assert StrawberryConfig().sort_schema is False
 
 
-def test_lexicographic_sort_schema_preserves_definition_order_by_default():
+def test_sort_schema_preserves_definition_order_by_default():
     @strawberry.type
     class Query:
         @strawberry.field
@@ -66,7 +66,7 @@ def test_lexicographic_sort_schema_preserves_definition_order_by_default():
     assert str(schema) == textwrap.dedent(expected).strip()
 
 
-def test_lexicographic_sort_schema_sorts_fields_and_types():
+def test_sort_schema_sorts_fields_and_types():
     @strawberry.type
     class User:
         name: str
@@ -85,7 +85,7 @@ def test_lexicographic_sort_schema_sorts_fields_and_types():
 
     schema = strawberry.Schema(
         query=Query,
-        config=StrawberryConfig(lexicographic_sort_schema=True),
+        config=StrawberryConfig(sort_schema=True),
     )
 
     expected = """\
@@ -103,7 +103,7 @@ def test_lexicographic_sort_schema_sorts_fields_and_types():
     assert str(schema) == textwrap.dedent(expected).strip()
 
 
-def test_lexicographic_sort_schema_still_executes():
+def test_sort_schema_still_executes():
     @strawberry.type
     class Query:
         @strawberry.field
@@ -112,7 +112,7 @@ def test_lexicographic_sort_schema_still_executes():
 
     schema = strawberry.Schema(
         query=Query,
-        config=StrawberryConfig(lexicographic_sort_schema=True),
+        config=StrawberryConfig(sort_schema=True),
     )
 
     result = schema.execute_sync('{ hello(name: "Patrick") }')


### PR DESCRIPTION
## Summary by Sourcery

Add optional lexicographic schema sorting while preserving definition order by default.

New Features:
- Add a `sort_schema` configuration option that alphabetically orders schema types, fields, and arguments in introspection and exported SDL.

Documentation:
- Document the `sort_schema` option, its default behavior, and its effect on generated SDL.

Tests:
- Add coverage for the default definition order, lexicographic sorting, and schema execution with sorting enabled.