### PR TITLE
Fix input default printing for explicit nulls

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,11 @@
+---
+release type: patch
+---
+
+This release fixes schema printing for input object defaults that explicitly set
+nullable fields to `null`.
+
+Strawberry now preserves explicit `None` values in printed nested input
+defaults, including fields set with `strawberry.Some(None)` and fields renamed
+with `strawberry.field(name=...)`, while still omitting fields that were not
+explicitly set.

--- a/strawberry/printer/ast_from_value.py
+++ b/strawberry/printer/ast_from_value.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 import re
 from collections.abc import Mapping
 from math import isfinite
@@ -17,7 +18,7 @@ from graphql.language import (
     ObjectValueNode,
     StringValueNode,
 )
-from graphql.pyutils import Undefined, camel_to_snake, inspect, is_iterable
+from graphql.pyutils import Undefined, inspect, is_iterable
 from graphql.type import (
     GraphQLID,
     is_enum_type,
@@ -28,7 +29,7 @@ from graphql.type import (
 )
 
 import strawberry
-from strawberry.types.base import has_object_definition
+from strawberry.types.base import StrawberryMaybe, has_object_definition
 
 if TYPE_CHECKING:
     from graphql.language import ValueNode
@@ -38,6 +39,8 @@ if TYPE_CHECKING:
         GraphQLList,
         GraphQLNonNull,
     )
+
+    from strawberry.types.field import StrawberryField
 
 __all__ = ["ast_from_value"]
 
@@ -84,24 +87,112 @@ def ast_from_leaf_type(serialized: object, type_: GraphQLInputType | None) -> Va
     )  # pragma: no cover
 
 
-def look_up_field(field_name: str, value: Mapping[str, Any]) -> Any:
+def get_strawberry_field(field: Any) -> StrawberryField | None:
+    if not (extensions := field.extensions):
+        return None
+
+    return extensions.get("strawberry-definition")
+
+
+def get_field_python_name(field: Any) -> str | None:
+    if (out_name := getattr(field, "out_name", None)) is not None:
+        return out_name
+
+    if (strawberry_field := get_strawberry_field(field)) is None:
+        return None
+
+    return strawberry_field.python_name
+
+
+def get_field_value(
+    field_name: str,
+    field_python_name: str | None,
+    value: Mapping[str, Any],
+) -> Any:
     if field_name in value:
         return value[field_name]
 
-    snake_cased = camel_to_snake(field_name)
-    if snake_cased in value:
-        return value[snake_cased]
+    if field_python_name is not None and field_python_name in value:
+        return value[field_python_name]
 
-    return None
+    return Undefined
 
 
-def ast_from_value(value: Any, type_: GraphQLInputType) -> ValueNode | None:
+def object_to_shallow_dict(value: Any) -> dict[str, Any]:
+    type_definition = (
+        value.__strawberry_definition__ if has_object_definition(value) else None
+    )
+    result = {}
+
+    for field in dataclasses.fields(value):
+        field_value = getattr(value, field.name)
+        if field_value is strawberry.UNSET:
+            continue
+
+        if (
+            field_value is None
+            and type_definition is not None
+            and (strawberry_field := type_definition.get_field(field.name)) is not None
+            and isinstance(strawberry_field.type, StrawberryMaybe)
+        ):
+            continue
+
+        if isinstance(field_value, strawberry.Some):
+            field_value = field_value.value
+
+        result[field.name] = field_value
+
+    return result
+
+
+def should_print_null_field(
+    field_python_name: str | None,
+    value: Any,
+    skip_default_null_fields: bool,
+) -> bool:
+    if not skip_default_null_fields:
+        return True
+
+    if not dataclasses.is_dataclass(value) or isinstance(value, type):
+        return False
+
+    if field_python_name is None:
+        return False
+
+    type_definition = (
+        value.__strawberry_definition__ if has_object_definition(value) else None
+    )
+    if isinstance(
+        field_value := getattr(value, field_python_name, Undefined),
+        strawberry.Some,
+    ):
+        return True
+
+    if field_value is not None:
+        return False
+
+    return any(
+        getattr(value, field.name) is strawberry.UNSET
+        for field in dataclasses.fields(value)
+        if type_definition is None or type_definition.get_field(field.name) is not None
+    )
+
+
+def ast_from_value(
+    value: Any,
+    type_: GraphQLInputType,
+    skip_default_null_fields: bool = False,
+) -> ValueNode | None:
     # custom ast_from_value that allows to also serialize custom scalar that aren't
     # basic types, namely JSON scalar types
 
     if is_non_null_type(type_):
         type_ = cast("GraphQLNonNull", type_)
-        ast_value = ast_from_value(value, type_.of_type)
+        ast_value = ast_from_value(
+            value,
+            type_.of_type,
+            skip_default_null_fields,
+        )
         if isinstance(ast_value, NullValueNode):
             return None
         return ast_value
@@ -120,32 +211,53 @@ def ast_from_value(value: Any, type_: GraphQLInputType) -> ValueNode | None:
         type_ = cast("GraphQLList", type_)
         item_type = type_.of_type
         if is_iterable(value):
-            maybe_value_nodes = (ast_from_value(item, item_type) for item in value)
+            maybe_value_nodes = (
+                ast_from_value(item, item_type, skip_default_null_fields)
+                for item in value
+            )
             value_nodes = tuple(node for node in maybe_value_nodes if node)
             return ListValueNode(values=value_nodes)
-        return ast_from_value(value, item_type)
+        return ast_from_value(value, item_type, skip_default_null_fields)
 
     # Populate the fields of the input object by creating ASTs from each value in the
     # Python dict according to the fields in the input type.
     if is_input_object_type(type_):
+        object_value = value
         if has_object_definition(value):
-            value = strawberry.asdict(value)
+            value = object_to_shallow_dict(value)
+            skip_default_null_fields = True
 
         if value is None or not isinstance(value, Mapping):
             return None
 
         type_ = cast("GraphQLInputObjectType", type_)
-        field_items = (
-            (field_name, ast_from_value(field_value, field.type))
-            for field_name, field in type_.fields.items()
-            if (field_value := look_up_field(field_name, value))
-        )
-        field_nodes = tuple(
-            ObjectFieldNode(name=NameNode(value=field_name), value=field_value)
-            for field_name, field_value in field_items
-            if field_value
-        )
-        return ObjectValueNode(fields=field_nodes)
+        field_nodes = []
+        for field_name, field in type_.fields.items():
+            field_python_name = get_field_python_name(field)
+            if (
+                field_value := get_field_value(field_name, field_python_name, value)
+            ) is Undefined:
+                continue
+
+            if field_value is None and not should_print_null_field(
+                field_python_name,
+                object_value,
+                skip_default_null_fields,
+            ):
+                continue
+
+            if (
+                ast_value := ast_from_value(
+                    field_value,
+                    field.type,
+                    skip_default_null_fields,
+                )
+            ) is not None:
+                field_nodes.append(
+                    ObjectFieldNode(name=NameNode(value=field_name), value=ast_value)
+                )
+
+        return ObjectValueNode(fields=tuple(field_nodes))
 
     if is_leaf_type(type_):
         # Since value is an internally represented value, it must be serialized to an

--- a/strawberry/printer/printer.py
+++ b/strawberry/printer/printer.py
@@ -10,7 +10,7 @@ from typing import (
     overload,
 )
 
-from graphql import GraphQLObjectType, GraphQLSchema, is_union_type
+from graphql import GraphQLInputField, GraphQLObjectType, GraphQLSchema, is_union_type
 from graphql.language.printer import print_ast
 from graphql.type import (
     is_enum_type,
@@ -428,8 +428,12 @@ def _print_interface(type_: Any, schema: BaseSchema, *, extras: PrintExtras) -> 
     )
 
 
-def print_input_value(name: str, arg: GraphQLArgument) -> str:
-    default_ast = ast_from_value(arg.default_value, arg.type)
+def print_input_value(name: str, arg: GraphQLArgument | GraphQLInputField) -> str:
+    default_ast = ast_from_value(
+        arg.default_value,
+        arg.type,
+        isinstance(arg, GraphQLInputField),
+    )
     arg_decl = f"{name}: {arg.type}"
     if default_ast:
         arg_decl += f" = {print_ast(default_ast)}"

--- a/tests/schema/test_print.py
+++ b/tests/schema/test_print.py
@@ -1,8 +1,10 @@
+import pytest
+
 import strawberry
+from strawberry.utils import IS_GQL_32
 
 
-def test_print_with_snake_case_values():
-
+def _get_snake_case_schema_str() -> str:
     @strawberry.input
     class Bar:
         a: str
@@ -27,9 +29,13 @@ def test_print_with_snake_case_values():
         ) -> str: ...
 
     schema = strawberry.Schema(Query)
+    return schema.as_str()
 
+
+@pytest.mark.skipif(not IS_GQL_32, reason="formatting is different in gql 3.3")
+def test_print_with_snake_case_values_gql_32():
     assert (
-        schema.as_str()
+        _get_snake_case_schema_str()
         == """directive @oneOf on INPUT_OBJECT
 
 input Bar {
@@ -49,8 +55,30 @@ type Query {
     )
 
 
-def test_print_with_camel_case_values():
+@pytest.mark.skipif(IS_GQL_32, reason="formatting is different in gql 3.2")
+def test_print_with_snake_case_values_gql_33():
+    assert (
+        _get_snake_case_schema_str()
+        == """directive @oneOf on INPUT_OBJECT
 
+input Bar {
+  a: String!
+  b: String!
+  someValues: [String!] = null
+}
+
+input Foo @oneOf {
+  bar: Bar
+  c: String
+}
+
+type Query {
+  foobar(foo: Foo! = { bar: { a: "hi", b: "bye", someValues: ["my", "world"] } }): String!
+}"""
+    )
+
+
+def _get_camel_case_schema_str() -> str:
     @strawberry.input
     class Bar:
         a: str
@@ -75,9 +103,13 @@ def test_print_with_camel_case_values():
         ) -> str: ...
 
     schema = strawberry.Schema(Query)
+    return schema.as_str()
 
+
+@pytest.mark.skipif(not IS_GQL_32, reason="formatting is different in gql 3.3")
+def test_print_with_camel_case_values_gql_32():
     assert (
-        schema.as_str()
+        _get_camel_case_schema_str()
         == """directive @oneOf on INPUT_OBJECT
 
 input Bar {
@@ -93,5 +125,28 @@ input Foo @oneOf {
 
 type Query {
   foobar(foo: Foo! = {bar: {a: "hi", b: "bye", someValues: ["my", "world"]}}): String!
+}"""
+    )
+
+
+@pytest.mark.skipif(IS_GQL_32, reason="formatting is different in gql 3.2")
+def test_print_with_camel_case_values_gql_33():
+    assert (
+        _get_camel_case_schema_str()
+        == """directive @oneOf on INPUT_OBJECT
+
+input Bar {
+  a: String!
+  b: String!
+  someValues: [String!] = null
+}
+
+input Foo @oneOf {
+  bar: Bar
+  c: String
+}
+
+type Query {
+  foobar(foo: Foo! = { bar: { a: "hi", b: "bye", someValues: ["my", "world"] } }): String!
 }"""
     )

--- a/tests/test_printer/test_basic.py
+++ b/tests/test_printer/test_basic.py
@@ -1,11 +1,14 @@
 import textwrap
 from uuid import UUID
 
+import pytest
+
 import strawberry
 from strawberry import UNSET, Maybe, Some
 from strawberry.printer import print_schema
 from strawberry.scalars import JSON
 from strawberry.schema.config import StrawberryConfig
+from strawberry.utils import IS_GQL_32
 from tests.conftest import skip_if_gql_32
 
 
@@ -451,6 +454,69 @@ def test_input_with_maybe_some_none_default():
 
         input QueryInput {
           filter: FilterInput! = { name: null }
+        }
+    """).strip()
+
+    assert sdl == expected
+
+
+def _get_renamed_maybe_some_none_default_sdl() -> str:
+    @strawberry.input
+    class FilterInput:
+        in_: Maybe[str | None] = strawberry.field(name="in", default=Some(None))
+
+    @strawberry.input
+    class QueryInput:
+        filter: FilterInput = strawberry.field(
+            default_factory=lambda: FilterInput(in_=Some(None))
+        )
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def search(self, filter: QueryInput) -> str:
+            return "ok"
+
+    schema = strawberry.Schema(query=Query)
+    return print_schema(schema).strip()
+
+
+@pytest.mark.skipif(not IS_GQL_32, reason="formatting is different in gql 3.3")
+def test_input_with_renamed_maybe_some_none_default_gql_32():
+    sdl = _get_renamed_maybe_some_none_default_sdl()
+
+    expected = textwrap.dedent("""
+        input FilterInput {
+          in: String
+        }
+
+        type Query {
+          search(filter: QueryInput!): String!
+        }
+
+        input QueryInput {
+          filter: FilterInput! = {in: null}
+        }
+    """).strip()
+
+    assert sdl == expected
+
+
+@skip_if_gql_32("formatting is different in gql 3.2")
+def test_input_with_renamed_maybe_some_none_default_gql_33():
+    sdl = _get_renamed_maybe_some_none_default_sdl()
+
+    expected = textwrap.dedent("""
+        input FilterInput {
+          in: String
+        }
+
+        type Query {
+          search(filter: QueryInput!): String!
+        }
+
+        input QueryInput {
+          filter: FilterInput! = { in: null }
         }
     """).strip()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Tests:
- Split schema printing tests into version-specific cases gated by graphql-core 3.2/3.3 checks to validate the expected schema string formatting for both versions.