### PR TITLE
Add workflow for requiring tests before merging to main branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,13 +9,6 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-    paths:
-      - "strawberry/**"
-      - "tests/**"
-      - "noxfile.py"
-      - "pyproject.toml"
-      - "uv.lock"
-      - ".github/workflows/test.yml"
 
 permissions:
   contents: read
@@ -210,3 +203,23 @@ jobs:
           path: .coverage.windows
           include-hidden-files: true
           if-no-files-found: ignore
+
+  required-ci:
+    name: Required CI
+    if: ${{ always() }}
+    needs:
+      - generate-jobs-tests
+      - unit-tests
+      - unit-tests-on-windows
+      - coverage
+      - benchmarks
+      - lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check required jobs
+        env:
+          NEEDS: ${{ toJson(needs) }}
+        run: |
+          echo "$NEEDS" | jq -r 'to_entries[] | "\(.key)=\(.value.result)"'
+          echo "$NEEDS" | jq -e 'to_entries | all(.value.result == "success")'


### PR DESCRIPTION
<!-- shortcake:start -->
## Stack

- **#4462** (`2026-06-17-add-workflow-for-requiring-tests-before-merging-to`) <-- this PR
<!-- shortcake:end -->

## Summary by Sourcery

Enforce that all test and quality-check jobs succeed before merging to the main branch by centralizing them behind a required CI job.

CI:
- Trigger the test workflow for all pull requests targeting main by removing path-based filters.
- Introduce a terminal "required CI" job that depends on all key testing, coverage, benchmark, and lint jobs and fails if any of them do not succeed.