### PR TITLE
Feat: Add TypedDict support for @strawberry.type and @strawberry.input

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,31 @@
+Release type: minor
+
+Add native support for `typing.TypedDict` GraphQL object and input types via
+the existing `@strawberry.type` and `@strawberry.input` decorators.
+
+TypedDicts can now be used to define GraphQL schemas backed directly by Python
+dictionaries, including support for nested TypedDicts, `Required`,
+`NotRequired`, `total=False`, and `typing.Annotated` metadata. TypedDicts can
+also participate in Strawberry unions, with runtime resolution based on
+TypedDict shape.
+
+Example:
+
+```python
+from typing import TypedDict
+
+import strawberry
+
+
+@strawberry.type
+class User(TypedDict):
+    id: int
+    name: str
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def get_user(self) -> User:
+        return {"id": 1, "name": "Alice"}
+```

--- a/docs/types/typed-dicts.md
+++ b/docs/types/typed-dicts.md
@@ -1,0 +1,356 @@
+---
+title: TypedDicts
+---
+
+# TypedDicts
+
+While Strawberry typically uses Python classes to define GraphQL types, you
+might prefer working with standard Python dictionaries, especially when
+integrating with external APIs, databases, or legacy codebases that already
+return dictionaries.
+
+Strawberry provides native support for converting Python's `typing.TypedDict`
+definitions into GraphQL Object Types and Input Types. To use this, decorate a
+`TypedDict` with `@strawberry.type` or `@strawberry.input` to expose it in your
+schema while continuing to work with standard Python dictionaries at runtime.
+
+Also note that a `TypedDict` used in nested positions should not be shared
+between input and output definitions. If the same structure is needed in both
+positions, define separate TypedDict classes for the input and output
+representations.
+
+## Output Types
+
+To define a GraphQL Object Type that resolves from a dictionary, decorate a
+`TypedDict` with `@strawberry.type`.
+
+<CodeGrid>
+
+```python
+import strawberry
+from typing import TypedDict
+
+
+@strawberry.type
+class UserDict(TypedDict):
+    id: int
+    name: str
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def get_user(self) -> UserDict:
+        # We can return a standard dictionary directly!
+        return {"id": 1, "name": "Alice"}
+```
+
+```graphql
+type UserDict {
+  id: Int!
+  name: String!
+}
+
+type Query {
+  getUser: UserDict!
+}
+```
+
+</CodeGrid>
+
+## Input Types
+
+Similarly, you can define GraphQL Input Types by decorating a `TypedDict` with
+`@strawberry.input`. This allows your mutation resolvers to receive standard
+dictionaries instead of instantiated objects.
+
+<CodeGrid>
+
+```python
+import strawberry
+from typing import TypedDict
+
+
+@strawberry.input
+class CreateUserInput(TypedDict):
+    name: str
+    age: int
+
+
+@strawberry.type
+class Mutation:
+    @strawberry.mutation
+    def create_user(self, data: CreateUserInput) -> bool:
+        # data is a dictionary: {"name": "Bob", "age": 30}
+        print(f"Creating user: {data['name']}")
+        return True
+```
+
+```graphql
+input CreateUserInput {
+  name: String!
+  age: Int!
+}
+
+type Mutation {
+  createUser(data: CreateUserInput!): Boolean!
+}
+```
+
+</CodeGrid>
+
+## Nullability and Required Keys
+
+GraphQL nullability, whether a field has a `!`, is determined by whether a key
+is explicitly required to exist in the dictionary. Strawberry fully supports
+Python's advanced TypedDict nullability rules, including `total=False`,
+`Required`, and `NotRequired`.
+
+### `total=False`
+
+By default, all keys in a `TypedDict` are required. If you set `total=False`,
+all keys become optional and therefore nullable in GraphQL.
+
+<CodeGrid>
+
+```python
+import strawberry
+from typing import TypedDict
+
+
+@strawberry.type
+class PartialUser(TypedDict, total=False):
+    name: str
+    email: str
+```
+
+```graphql
+type PartialUser {
+  name: String
+  email: String
+}
+```
+
+</CodeGrid>
+
+### Mixing `Required` and `NotRequired`
+
+You can fine-tune exactly which keys are required using `Required` and
+`NotRequired` (available in `typing` in Python 3.11+, or `typing_extensions` in
+older versions).
+
+<CodeGrid>
+
+```python
+import sys
+
+import strawberry
+
+# For Python < 3.11, use typing_extensions.
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, Required, TypedDict
+else:
+    from typing import TypedDict
+
+    from typing_extensions import NotRequired, Required
+
+
+@strawberry.type
+class UpdateUserDict(TypedDict, total=False):
+    # 'id' MUST be provided, even though total=False
+    id: Required[int]
+
+    # 'name' is optional
+    name: NotRequired[str]
+```
+
+```graphql
+type UpdateUserDict {
+  id: Int!
+  name: String
+}
+```
+
+</CodeGrid>
+
+<Note>
+
+`Optional[str]` means the key must exist in the dictionary, but its value can be
+`None`. `NotRequired[str]` means the key can be completely missing from the
+dictionary. Strawberry respects this distinction internally, though both compile
+to a nullable `String` in the final GraphQL schema.
+
+</Note>
+
+## Metadata and Directives
+
+Because `TypedDict` does not support Strawberry's standard `strawberry.field()`
+assignment, for example `name: str = strawberry.field(...)`, you must use
+`typing.Annotated` to attach GraphQL descriptions and directives to the fields.
+
+<CodeGrid>
+
+```python
+import strawberry
+from typing import Annotated, TypedDict
+
+
+@strawberry.type
+class BookDict(TypedDict):
+    # You can pass a string directly for a description...
+    id: Annotated[int, "The unique ISBN of the book"]
+
+    # ...or use strawberry.field() to attach directives
+    title: Annotated[
+        str,
+        strawberry.field(description="The book title"),
+    ]
+```
+
+```graphql
+type BookDict {
+  """
+  The unique ISBN of the book
+  """
+  id: Int!
+
+  """
+  The book title
+  """
+  title: String!
+}
+```
+
+</CodeGrid>
+
+## Runtime Validation
+
+When returning a standard Strawberry Object Type, missing fields will often
+trigger immediate errors during instantiation. However, because dictionaries are
+evaluated lazily during GraphQL execution, a missing required key will result in
+a cryptic `KeyError` late in the request lifecycle.
+
+To prevent this, Strawberry provides a `validate_typed_dict` utility. You can
+use it inside your resolvers to guarantee the dictionary matches the GraphQL
+contract before returning it.
+
+```python
+from typing import TypedDict
+
+import strawberry
+
+from strawberry.types.typed_dict import TypedDictValidationError, validate_typed_dict
+
+
+@strawberry.type
+class Point2D(TypedDict):
+    x: int
+    y: int
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def get_point(self) -> Point2D:
+        data = {"x": 10}  # No y
+
+        # This will raise a TypedDictValidationError
+        validate_typed_dict(data, Point2D)
+
+        return data
+```
+
+## TypedDicts in Unions
+
+TypedDict-based GraphQL types can be used as members of Strawberry unions.
+
+When a resolver returns a plain dictionary, Strawberry uses the TypedDict's
+required keys to determine whether the value matches a union member.
+
+If multiple union members match the same dictionary shape, the selected type
+depends on union resolution order. For unambiguous results, ensure union members
+can be distinguished by their required fields.
+
+```python
+@strawberry.type
+class BasicUserDict(TypedDict):
+    id: int
+
+
+@strawberry.type
+class AdminUserDict(TypedDict):
+    id: int
+    permissions: list[str]
+
+
+UserAccountUnion = Annotated[
+    BasicUserDict | AdminUserDict,
+    strawberry.union("UserAccount"),
+]
+```
+
+### Union Resolution Caveats
+
+Because TypedDict union resolution is based on required keys rather than runtime
+type identity, ambiguity can occur when one TypedDict's required keys are a
+subset of another's.
+
+For example, this dictionary:
+
+```python
+{
+    "id": 1,
+    "permissions": ["*"],
+}
+```
+
+matches both of the aforementioned TypedDict examples:
+
+```python
+class BasicUserDict(TypedDict):
+    id: int
+
+
+class AdminUserDict(TypedDict):
+    id: int
+    permissions: list[str]
+```
+
+It matches `AdminUserDict` because it has `id` and `permissions`, but it also
+matches `BasicUserDict` because it satisfies the requirement of having an `id`.
+
+In this scenario, Strawberry cannot intrinsically know which type you intended,
+and will resolve to the first match it evaluates.
+
+For predictable union resolution, prefer union members whose required keys do
+not overlap ambiguously, or return values with explicit runtime type
+information.
+
+## API Reference
+
+### `@strawberry.type`
+
+Can be applied directly to a TypedDict to create a GraphQL object type.
+
+- `name` (`str`): Override the GraphQL name. Defaults to the CamelCase class
+  name.
+- `description` (`str`): Set a GraphQL description for the type.
+- `directives` (`Iterable[object]`): A list of GraphQL directives to apply to
+  the type.
+
+### `@strawberry.input`
+
+Can be applied directly to a TypedDict to create a GraphQL input type.
+
+- `name` (`str`): Override the GraphQL name. Defaults to the CamelCase class
+  name.
+- `description` (`str`): Set a GraphQL description for the type.
+- `directives` (`Iterable[object]`): A list of GraphQL directives to apply to
+  the type.
+
+### `validate_typed_dict`
+
+- `validate_typed_dict(data: dict, typed_dict_cls: Type)`: Evaluates the
+  provided dictionary against the requirements of the given Strawberry-decorated
+  `TypedDict` and raises a `TypedDictValidationError` if any required keys are
+  missing.

--- a/strawberry/annotation.py
+++ b/strawberry/annotation.py
@@ -17,7 +17,7 @@ from typing import (
     get_args,
     get_origin,
 )
-from typing_extensions import Self
+from typing_extensions import Self, is_typeddict
 
 from strawberry.streamable import StrawberryStreamable
 from strawberry.types.base import (
@@ -196,6 +196,8 @@ class StrawberryAnnotation:
             return self.create_union(evaled_type, args)
         if is_type_var(evaled_type) or evaled_type is Self:
             return self.create_type_var(cast("TypeVar", evaled_type))
+        if self._is_typed_dict(evaled_type):
+            return evaled_type
         if self._is_strawberry_type(evaled_type):
             # Simply return objects that are already StrawberryTypes
             return evaled_type
@@ -446,6 +448,10 @@ class StrawberryAnnotation:
         from strawberry.types.union import StrawberryUnion
 
         return any(isinstance(arg, StrawberryUnion) for arg in args)
+
+    @classmethod
+    def _is_typed_dict(cls, annotation: Any) -> bool:
+        return is_typeddict(annotation)
 
     @classmethod
     def _strip_async_type(cls, annotation: type[Any]) -> type:

--- a/strawberry/types/object_type.py
+++ b/strawberry/types/object_type.py
@@ -292,8 +292,6 @@ def type(
 
             if field and isinstance(field, StrawberryField) and field.type_annotation:
                 original_type_annotations[field_name] = field.type_annotation.annotation
-        if is_input:
-            _inject_default_for_maybe_annotations(cls, annotations)
 
         if is_typeddict(cls):
             definition = create_typed_dict_definition(
@@ -305,6 +303,9 @@ def type(
             )
             cls.__strawberry_definition__ = definition
             return cls
+
+        if is_input:
+            _inject_default_for_maybe_annotations(cls, annotations)
 
         wrapped = _wrap_dataclass(cls)
 

--- a/strawberry/types/object_type.py
+++ b/strawberry/types/object_type.py
@@ -9,7 +9,7 @@ from typing import (
     TypeVar,
     overload,
 )
-from typing_extensions import dataclass_transform, get_annotations
+from typing_extensions import dataclass_transform, get_annotations, is_typeddict
 
 from strawberry.exceptions import (
     InvalidSuperclassInterfaceError,
@@ -19,6 +19,7 @@ from strawberry.exceptions import (
 )
 from strawberry.types.base import get_object_definition
 from strawberry.types.maybe import Some, _annotation_is_maybe
+from strawberry.types.typed_dict import create_typed_dict_definition
 from strawberry.types.unset import UNSET
 from strawberry.utils.str_converters import to_camel_case
 
@@ -293,6 +294,18 @@ def type(
                 original_type_annotations[field_name] = field.type_annotation.annotation
         if is_input:
             _inject_default_for_maybe_annotations(cls, annotations)
+
+        if is_typeddict(cls):
+            definition = create_typed_dict_definition(
+                cls,
+                name=name,
+                description=description,
+                directives=directives,
+                is_input=is_input,
+            )
+            cls.__strawberry_definition__ = definition
+            return cls
+
         wrapped = _wrap_dataclass(cls)
 
         return _process_type(  # type: ignore

--- a/strawberry/types/typed_dict.py
+++ b/strawberry/types/typed_dict.py
@@ -15,6 +15,7 @@ import typing
 from typing import (
     TYPE_CHECKING,
     Any,
+    Optional,
 )
 from typing_extensions import (
     NotRequired,
@@ -292,7 +293,7 @@ def create_typed_dict_definition(
         graphql_type = base_type
 
         if not is_req and not _is_optional(graphql_type):
-            graphql_type = graphql_type | None
+            graphql_type = Optional[graphql_type]  # noqa: UP045
 
         resolver = _make_key_resolver(field_name, is_req)
 

--- a/strawberry/types/typed_dict.py
+++ b/strawberry/types/typed_dict.py
@@ -1,0 +1,344 @@
+"""Native support for TypedDict in Strawberry GraphQL.
+
+This module provides decorators to natively convert Python's `typing.TypedDict`
+into Strawberry GraphQL output and input types. It features robust support for
+Python's nuanced nullability rules, metadata extraction via `typing.Annotated`,
+and runtime validation utilities.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import sys
+import types
+import typing
+from typing import (
+    TYPE_CHECKING,
+    Any,
+)
+from typing_extensions import (
+    NotRequired,
+    Required,
+    get_type_hints,
+    is_typeddict,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+from strawberry.annotation import StrawberryAnnotation
+from strawberry.types.base import StrawberryObjectDefinition, has_object_definition
+from strawberry.types.field import StrawberryField
+from strawberry.types.fields.resolver import StrawberryResolver
+from strawberry.types.unset import UNSET
+
+_REQUIRED_TYPES: tuple[object, ...] = ()
+_NOT_REQUIRED_TYPES: tuple[object, ...] = ()
+
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, Required
+
+    _REQUIRED_TYPES += (Required,)
+    _NOT_REQUIRED_TYPES += (NotRequired,)
+
+try:
+    from typing_extensions import NotRequired as _ExtNotRequired
+    from typing_extensions import Required as _ExtRequired
+
+    _REQUIRED_TYPES += (_ExtRequired,)
+    _NOT_REQUIRED_TYPES += (_ExtNotRequired,)
+except ImportError:
+    pass
+
+
+class TypedDictValidationError(Exception):
+    """Exception raised when a dictionary fails runtime TypedDict validation."""
+
+
+def validate_typed_dict(
+    data: dict[str, Any],
+    typed_dict_cls: type[Any],
+) -> None:
+    """Validates at runtime that a dictionary conforms to its TypedDict definition.
+
+    Ensures no required keys are missing. This is useful because Strawberry
+    normally defers key lookups until execution, which could result in a KeyError.
+
+    Args:
+        data (dict): The dictionary returned by the resolver.
+        typed_dict_cls (Type[Any]): The TypedDict class it claims to represent.
+
+    Raises:
+        TypedDictValidationError: If required keys are missing, the type is invalid
+        or the TypedDict is undecorated.
+    """
+    if not isinstance(data, dict):
+        raise TypedDictValidationError(
+            f"Expected a dictionary, got {type(data).__name__}"
+        )
+
+    definition = getattr(typed_dict_cls, "__strawberry_definition__", None)
+    if not definition:
+        raise TypedDictValidationError(
+            f"{typed_dict_cls.__name__} is not a Strawberry TypedDict"
+        )
+
+    # Extract required keys from Strawberry definitions
+    required_keys = {
+        f.python_name
+        for f in definition.fields
+        if f.metadata.get("typed_dict_required", False)
+    }
+
+    missing_keys = required_keys - data.keys()
+    if missing_keys:
+        raise TypedDictValidationError(
+            f"Missing required keys for {typed_dict_cls.__name__}: {', '.join(sorted(missing_keys))}"
+        )
+
+
+@dataclasses.dataclass(frozen=True)
+class NormalizedTypedDictAnnotation:
+    annotation: Any
+    required: bool
+    description: str | None
+    strawberry_field: StrawberryField | None
+
+
+def _normalize_typed_dict_annotation(
+    annotation: Any,
+    *,
+    required_by_default: bool,
+) -> NormalizedTypedDictAnnotation:
+    required = required_by_default
+    description = None
+    strawberry_field: StrawberryField | None = None
+
+    while True:
+        origin = typing.get_origin(annotation)
+
+        if origin is typing.Annotated:
+            args = typing.get_args(annotation)
+
+            annotation = args[0]
+
+            for meta in args[1:]:
+                if isinstance(meta, str):
+                    description = meta
+
+                elif isinstance(meta, StrawberryField):
+                    strawberry_field = meta
+
+                    if meta.description:
+                        description = meta.description
+
+            continue
+
+        if origin in _REQUIRED_TYPES:
+            required = True
+            annotation = typing.get_args(annotation)[0]
+            continue
+
+        if origin in _NOT_REQUIRED_TYPES:
+            required = False
+            annotation = typing.get_args(annotation)[0]
+            continue
+
+        break
+
+    return NormalizedTypedDictAnnotation(
+        annotation=annotation,
+        required=required,
+        description=description,
+        strawberry_field=strawberry_field,
+    )
+
+
+def _is_optional(annotation: Any) -> bool:
+    origin = typing.get_origin(annotation)
+
+    if origin in (typing.Union, types.UnionType):
+        return type(None) in typing.get_args(annotation)
+
+    return False
+
+
+def _synthesize_nested_typed_dicts(
+    annotation: Any,
+    *,
+    is_input: bool,
+) -> None:
+    origin = typing.get_origin(annotation)
+
+    if is_typeddict(annotation):
+        if not has_object_definition(annotation):
+            definition = create_typed_dict_definition(
+                annotation,
+                name=None,
+                description=None,
+                directives=(),
+                is_input=is_input,
+            )
+
+            annotation.__strawberry_definition__ = definition
+
+        return
+
+    if origin is None:
+        return
+
+    for arg in typing.get_args(annotation):
+        if arg is type(None):
+            continue
+
+        _synthesize_nested_typed_dicts(
+            arg,
+            is_input=is_input,
+        )
+
+
+def _make_key_resolver(key: str, required: bool) -> StrawberryResolver:
+    """Generates a dynamic field resolver for a TypedDict key.
+
+    Unlike standard classes which use `getattr(obj, key)`, TypedDicts
+    are resolved at runtime using dictionary subscripting `obj[key]`.
+    """
+    if required:
+
+        def resolver(self: Any) -> Any:
+            return self[key]
+    else:
+
+        def resolver(self: Any) -> Any:
+            return self.get(key, None)
+
+    return StrawberryResolver(resolver)
+
+
+def create_typed_dict_definition(
+    typed_dict_cls: type[Any],
+    name: str | None,
+    description: str | None,
+    directives: Sequence[object] | None = (),
+    *,
+    is_input: bool,
+) -> StrawberryObjectDefinition:
+    """Dynamically generates a StrawberryObjectDefinition from a TypedDict class."""
+    existing = getattr(
+        typed_dict_cls,
+        "__strawberry_definition__",
+        None,
+    )
+
+    if existing is not None:
+        return existing
+
+    required_keys: frozenset[str] = getattr(
+        typed_dict_cls,
+        "__required_keys__",
+        frozenset(),
+    )
+
+    def default_is_type_of(obj: Any, _info: Any) -> bool:
+        return isinstance(obj, dict) and required_keys.issubset(obj)
+
+    definition = StrawberryObjectDefinition(
+        name=name or typed_dict_cls.__name__,
+        is_input=is_input,
+        is_interface=False,
+        origin=typed_dict_cls,
+        description=description,
+        interfaces=[],
+        extend=False,
+        directives=directives or (),
+        is_type_of=default_is_type_of,
+        resolve_type=None,
+        fields=[],
+    )
+
+    total = getattr(typed_dict_cls, "__total__", True)
+    module = sys.modules.get(typed_dict_cls.__module__)
+    namespace = module.__dict__ if module else {}
+
+    # Extract hints preserving wrappers (Required / NotRequired)
+    try:
+        hints_with_extras = get_type_hints(
+            typed_dict_cls,
+            globalns=namespace,
+            include_extras=True,
+        )
+    except (TypeError, NameError):
+        hints_with_extras = getattr(typed_dict_cls, "__annotations__", {})
+
+    fields: list[StrawberryField] = []
+
+    for field_name, raw_hint in hints_with_extras.items():
+        if field_name.startswith("_"):
+            continue
+
+        normalized = _normalize_typed_dict_annotation(
+            raw_hint,
+            required_by_default=total,
+        )
+
+        base_type = normalized.annotation
+        is_req = normalized.required
+
+        _synthesize_nested_typed_dicts(
+            base_type,
+            is_input=is_input,
+        )
+
+        graphql_type = base_type
+
+        if not is_req and not _is_optional(graphql_type):
+            graphql_type = graphql_type | None
+
+        resolver = _make_key_resolver(field_name, is_req)
+
+        type_annotation = StrawberryAnnotation(
+            annotation=graphql_type,
+            namespace=namespace,
+        )
+
+        extra_field = normalized.strawberry_field
+
+        field = StrawberryField(
+            python_name=field_name,
+            graphql_name=(
+                normalized.strawberry_field.graphql_name
+                if normalized.strawberry_field
+                else None
+            ),
+            type_annotation=type_annotation,
+            origin=typed_dict_cls,
+            description=normalized.description,
+            directives=(extra_field.directives if extra_field else ()),
+            permission_classes=(extra_field.permission_classes if extra_field else []),
+            deprecation_reason=(
+                extra_field.deprecation_reason if extra_field else None
+            ),
+            extensions=(extra_field.extensions if extra_field else []),
+            default=dataclasses.MISSING,
+            metadata={
+                "typed_dict_required": is_req,
+            },
+        )
+
+        field.base_resolver = resolver
+        field.default_value = UNSET
+
+        fields.append(field)
+
+    definition.fields = fields
+
+    typed_dict_cls.__strawberry_definition__ = definition
+
+    return definition
+
+
+__all__ = [
+    "TypedDictValidationError",
+    "create_typed_dict_definition",
+    "validate_typed_dict",
+]

--- a/tests/schema/test_typed_dict.py
+++ b/tests/schema/test_typed_dict.py
@@ -1,0 +1,553 @@
+"""
+Tests for native TypedDict support using standard @strawberry.type and @strawberry.input
+decorators (output, input, nullability, nesting, and validation).
+"""
+
+from __future__ import annotations
+
+import textwrap
+from typing import Annotated, Optional, TypedDict
+from typing_extensions import NotRequired, Required
+from typing_extensions import TypedDict as ExtTypedDict
+
+import pytest
+
+import strawberry
+from strawberry.schema_directive import Location
+from strawberry.types.typed_dict import TypedDictValidationError, validate_typed_dict
+
+
+@strawberry.type
+class Point2D(TypedDict):
+    x: int
+    y: int
+
+
+@strawberry.input
+class CreateUserInput(TypedDict):
+    name: str
+    age: int
+
+
+@strawberry.type
+class UserDictTotalFalse(TypedDict, total=False):
+    name: str
+    email: str
+
+
+@strawberry.type
+class UserDictRequired(TypedDict, total=False):
+    id: Required[int]
+    name: str
+    email: NotRequired[str]
+
+
+@strawberry.type
+class UserDictOptional(TypedDict, total=False):
+    id: Required[int]
+    name: str
+
+
+@strawberry.type
+class AddressDict(TypedDict):
+    city: str
+    zipcode: str
+
+
+@strawberry.type
+class UserDictNested(TypedDict):
+    name: str
+    address: AddressDict
+
+
+@strawberry.type
+class Item(TypedDict):
+    sku: str
+    qty: int
+
+
+@strawberry.type
+class ExamplePrivateFields(TypedDict):
+    visible: str
+    _internal: str
+
+
+@strawberry.input
+class OptionalInput(TypedDict, total=False):
+    required_field: Required[str]
+    optional_field: NotRequired[int]
+
+
+def test_basic_output_typed_dict():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def get_point(self) -> Point2D:
+            return {"x": 10, "y": 20}
+
+    schema = strawberry.Schema(query=Query)
+
+    query = "{ getPoint { x y } }"
+    result = schema.execute_sync(query)
+
+    assert not result.errors
+    assert result.data["getPoint"] == {"x": 10, "y": 20}
+
+
+def test_basic_input_typed_dict():
+    @strawberry.type
+    class Query:
+        _dummy: str = "unused"  # at least one field needed
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        def create_user(self, data: CreateUserInput) -> str:
+            return f"Created {data['name']} (age {data['age']})"
+
+    schema = strawberry.Schema(query=Query, mutation=Mutation)
+
+    mutation = """
+        mutation {
+            createUser(data: {name: "John", age: 30})
+        }
+    """
+    result = schema.execute_sync(mutation)
+    assert not result.errors
+    assert result.data["createUser"] == "Created John (age 30)"
+
+
+def test_total_false_makes_fields_nullable():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def user(self) -> UserDictTotalFalse:
+            return {"name": "Alice"}
+
+    schema = strawberry.Schema(query=Query)
+
+    expected = textwrap.dedent("""\
+        type Query {
+          user: UserDictTotalFalse!
+        }
+
+        type UserDictTotalFalse {
+          name: String
+          email: String
+        }
+    """).strip()
+
+    assert str(schema) == expected
+
+
+def test_required_and_not_required_fields():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def user(self) -> UserDictRequired:
+            return {"id": 1, "name": "Bob"}
+
+    schema = strawberry.Schema(query=Query)
+
+    expected = textwrap.dedent("""\
+        type Query {
+          user: UserDictRequired!
+        }
+
+        type UserDictRequired {
+          id: Int!
+          name: String
+          email: String
+        }
+    """).strip()
+
+    assert str(schema) == expected
+
+
+def test_missing_optional_key_resolves_to_null():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def user(self) -> UserDictOptional:
+            return {"id": 42}
+
+    schema = strawberry.Schema(query=Query)
+
+    query = "{ user { id name } }"
+    result = schema.execute_sync(query)
+
+    assert not result.errors
+    assert result.data["user"] == {"id": 42, "name": None}
+
+
+def test_nested_typed_dict():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def user(self) -> UserDictNested:
+            return {
+                "name": "Carol",
+                "address": {"city": "Springfield", "zipcode": "12345"},
+            }
+
+    schema = strawberry.Schema(query=Query)
+
+    query = "{ user { name address { city zipcode } } }"
+    result = schema.execute_sync(query)
+
+    assert not result.errors
+    assert result.data["user"] == {
+        "name": "Carol",
+        "address": {"city": "Springfield", "zipcode": "12345"},
+    }
+
+
+def test_list_of_typed_dict():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def inventory(self) -> list[Item]:
+            return [
+                {"sku": "A1", "qty": 10},
+                {"sku": "B2", "qty": 0},
+            ]
+
+    schema = strawberry.Schema(query=Query)
+
+    query = "{ inventory { sku qty } }"
+    result = schema.execute_sync(query)
+
+    assert not result.errors
+    assert result.data["inventory"] == [
+        {"sku": "A1", "qty": 10},
+        {"sku": "B2", "qty": 0},
+    ]
+
+
+def test_input_typed_dict_missing_optional_field():
+    @strawberry.type
+    class Query:
+        _dummy: str = "unused"
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        def process(self, data: OptionalInput) -> str:
+            req = data["required_field"]
+            opt = data.get("optional_field", "missing")
+            return f"req={req}, opt={opt}"
+
+    schema = strawberry.Schema(query=Query, mutation=Mutation)
+
+    mutation = """
+        mutation {
+            process(data: {requiredField: "hello"})
+        }
+    """
+    result = schema.execute_sync(mutation)
+    assert not result.errors
+    assert result.data["process"] == "req=hello, opt=missing"
+
+
+# Schema directive used for annotated metadata tests
+@strawberry.schema_directive(locations=[Location.FIELD_DEFINITION])
+class ExampleDirective:
+    value: str
+
+
+@strawberry.type
+class AnnotatedUser(TypedDict):
+    id: Annotated[int, "The unique identifier"]
+    name: Annotated[
+        str,
+        strawberry.field(
+            description="The user name", directives=[ExampleDirective(value="test")]
+        ),
+    ]
+
+
+def test_annotated_metadata():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def fetch_annotated(self) -> AnnotatedUser:
+            return {"id": 1, "name": "Test"}
+
+    schema = strawberry.Schema(query=Query)
+
+    expected = textwrap.dedent('''\
+        type AnnotatedUser {
+          """The unique identifier"""
+          id: Int!
+
+          """The user name"""
+          name: String! @exampleDirective(value: "test")
+        }
+    ''').strip()
+
+    assert expected in str(schema)
+
+
+def test_validate_typed_dict_success():
+    @strawberry.type
+    class ValidDict(TypedDict):
+        req: str
+        opt: NotRequired[str]
+        opt_type: Optional[int]
+
+    validate_typed_dict(
+        {
+            "req": "hello",
+            "opt": "world",
+            "opt_type": 5,
+        },
+        ValidDict,
+    )
+
+    validate_typed_dict(
+        {
+            "req": "hello",
+            "opt_type": None,
+        },
+        ValidDict,
+    )
+
+    validate_typed_dict(
+        {
+            "req": "hello",
+            "opt_type": 1,
+        },
+        ValidDict,
+    )
+
+
+def test_validate_typed_dict_failure():
+    @strawberry.type
+    class MissingRequiredFieldDict(TypedDict):
+        req1: str
+        req2: int
+
+    with pytest.raises(
+        TypedDictValidationError,
+        match="Missing required keys for MissingRequiredFieldDict: req2",
+    ):
+        validate_typed_dict(
+            {"req1": "hello"},
+            MissingRequiredFieldDict,
+        )
+
+
+def test_optional_value_does_not_make_key_optional():
+    @strawberry.type
+    class OptionalValueRequiredKeyDict(TypedDict):
+        value: Optional[int]
+
+    with pytest.raises(
+        TypedDictValidationError,
+        match="Missing required keys for OptionalValueRequiredKeyDict: value",
+    ):
+        validate_typed_dict({}, OptionalValueRequiredKeyDict)
+
+
+def test_private_fields_are_ignored():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def example(self) -> ExamplePrivateFields:
+            return {
+                "visible": "hello",
+                "_internal": "secret",
+            }
+
+    schema = strawberry.Schema(query=Query)
+
+    expected = textwrap.dedent("""\
+        type ExamplePrivateFields {
+          visible: String!
+        }
+
+        type Query {
+          example: ExamplePrivateFields!
+        }
+    """).strip()
+
+    assert str(schema) == expected
+
+
+def test_pep604_optional_union():
+    @strawberry.type
+    class Example(TypedDict):
+        value: int | None
+
+    validate_typed_dict(
+        {"value": None},
+        Example,
+    )
+
+    with pytest.raises(
+        TypedDictValidationError,
+        match="Missing required keys for Example: value",
+    ):
+        validate_typed_dict({}, Example)
+
+
+@pytest.mark.parametrize("typed_dict_class", [TypedDict, ExtTypedDict])
+def test_typed_dict_accepts_strawberry_definition(typed_dict_class):
+    class MyDict(typed_dict_class):
+        name: str
+
+    try:
+        MyDict.__strawberry_definition__ = "mock_definition"
+    except AttributeError:
+        pytest.fail(
+            f"Failed to set __strawberry_definition__ on a TypedDict "
+            f"created by {typed_dict_class.__module__}"
+        )
+
+    assert MyDict.__strawberry_definition__ == "mock_definition"
+
+
+@strawberry.type
+class BasicUserDict(TypedDict):
+    id: int
+
+
+@strawberry.type
+class AdminUserDict(TypedDict):
+    id: int
+    permissions: list[str]
+
+
+UserAccountUnion = Annotated[
+    BasicUserDict | AdminUserDict,
+    strawberry.union("Account"),
+]
+
+
+def test_typed_dict_union_runtime_resolution_user():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def account(self) -> UserAccountUnion:
+            return {
+                "id": 1,
+            }
+
+    schema = strawberry.Schema(query=Query)
+
+    result = schema.execute_sync(
+        """
+        {
+          account {
+            __typename
+
+            ... on BasicUserDict {
+              id
+            }
+          }
+        }
+        """
+    )
+
+    assert not result.errors
+
+    assert result.data == {
+        "account": {
+            "__typename": "BasicUserDict",
+            "id": 1,
+        }
+    }
+
+
+def test_typed_dict_union_resolution_uses_first_matching_type():
+    """TypedDict union resolution currently uses the first matching type.
+
+    Both BasicUserDict and AdminUserDict match this payload because
+    BasicUserDict's required keys are a subset of the returned dictionary.
+    The union resolver returns the first matching member.
+    """
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def account(self) -> UserAccountUnion:
+            return {
+                "id": 1,
+                "permissions": ["*"],
+            }
+
+    schema = strawberry.Schema(query=Query)
+
+    result = schema.execute_sync(
+        """
+        {
+          account {
+            __typename
+          }
+        }
+        """
+    )
+
+    assert not result.errors
+
+    assert result.data == {
+        "account": {
+            "__typename": "BasicUserDict",
+        }
+    }
+
+
+def test_validate_typed_dict_does_not_recurse_into_nested_typed_dicts():
+    @strawberry.type
+    class Child(TypedDict):
+        value: str
+
+    @strawberry.type
+    class Parent(TypedDict):
+        child: Child
+
+    validate_typed_dict(
+        {"child": {}},
+        Parent,
+    )
+
+
+def test_validate_typed_dict_rejects_non_strawberry_typed_dict():
+    class PlainDict(TypedDict):
+        name: str
+
+    with pytest.raises(
+        TypedDictValidationError,
+        match="PlainDict is not a Strawberry TypedDict",
+    ):
+        validate_typed_dict({}, PlainDict)
+
+
+@strawberry.type
+class RenamedFieldDict(TypedDict):
+    name: Annotated[
+        str,
+        strawberry.field(name="fullName"),
+    ]
+
+
+def test_annotated_field_name_override():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def user(self) -> RenamedFieldDict:
+            return {"name": "Alice"}
+
+    schema = strawberry.Schema(query=Query)
+
+    expected = textwrap.dedent("""\
+        type Query {
+          user: RenamedFieldDict!
+        }
+
+        type RenamedFieldDict {
+          fullName: String!
+        }
+    """).strip()
+
+    assert str(schema) == expected


### PR DESCRIPTION
Add native support for `typing.TypedDict` GraphQL object and input types via the existing `@strawberry.type` and `@strawberry.input` decorators.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

While Strawberry typically uses Python classes to define GraphQL types, you might prefer working with standard Python dictionaries, especially when integrating with external APIs, databases, or legacy codebases that already return dictionaries.

TypedDicts can now be used to define GraphQL schemas backed directly by Python dictionaries, including support for nested TypedDicts, `Required`, `NotRequired`, `total=False`, and `typing.Annotated` metadata. TypedDicts can also participate in Strawberry unions, with runtime resolution based on TypedDict shape.

Example:

```python
from typing import TypedDict

import strawberry


@strawberry.type
class User(TypedDict):
    id: int
    name: str


@strawberry.type
class Query:
    @strawberry.field
    def get_user(self) -> User:
        return {"id": 1, "name": "Alice"}
```

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

* #2187

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Add native TypedDict-based GraphQL object and input type support and integrate it into Strawberry’s type system.

New Features:
- Allow decorating typing.TypedDict definitions with @strawberry.type and @strawberry.input to generate GraphQL object and input types backed by plain dictionaries.
- Support nested TypedDicts, advanced key requiredness semantics (total=False, Required, NotRequired), Optional/PEP 604 unions, and Annotated metadata for descriptions, directives, and field renames.
- Enable TypedDict-based types to participate in Strawberry unions with runtime resolution based on required key shape.
- Provide a validate_typed_dict utility and TypedDictValidationError exception to perform runtime validation of resolver dictionaries against their TypedDict contracts.

Enhancements:
- Extend annotation resolution to recognize TypedDicts as first-class Strawberry types and synthesize definitions for nested TypedDict annotations automatically.

Documentation:
- Add comprehensive documentation for using TypedDicts as GraphQL object/input types, including nullability rules, metadata via Annotated, runtime validation, and union behavior.

Tests:
- Add an extensive TypedDict test suite covering input/output behavior, nullability, nesting, validation rules, private field handling, Annotated metadata, and union resolution behavior.

Chores:
- Declare this change as a minor release in RELEASE.md, describing the new TypedDict support and example usage.