### PR TITLE
Extract HTTP stream transports

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,5 @@
 ---
-release type: patch
+release type: minor
 ---
 
 This release adds a shared internal HTTP stream transport for multipart

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,15 @@
+---
+release type: patch
+---
+
+This release adds a shared internal HTTP stream transport for multipart
+subscription responses.
+
+Application behavior for multipart subscriptions is largely unchanged. The
+shared transport now owns multipart response headers, heartbeat frames,
+completion frames, batching errors, and sync-mode errors, keeping Strawberry's
+built-in HTTP integrations on the same streaming contract.
+
+The one behavioral change is that each multipart part's `Content-Length` is now
+computed from the UTF-8 byte length of the payload instead of its character
+count, fixing the header for responses containing non-ASCII data.

--- a/strawberry/aiohttp/views.py
+++ b/strawberry/aiohttp/views.py
@@ -171,7 +171,7 @@ class GraphQLView(
         request: web.Request,
         stream: Callable[[], AsyncGenerator[str, None]],
         sub_response: web.Response,
-        headers: dict[str, str],
+        headers: Mapping[str, str],
     ) -> web.StreamResponse:
         response = web.StreamResponse(
             status=sub_response.status,

--- a/strawberry/asgi/__init__.py
+++ b/strawberry/asgi/__init__.py
@@ -189,7 +189,7 @@ class GraphQL(
         request: Request | WebSocket,
         stream: Callable[[], AsyncIterator[str]],
         sub_response: Response,
-        headers: dict[str, str],
+        headers: Mapping[str, str],
     ) -> Response:
         return StreamingResponse(
             stream(),

--- a/strawberry/channels/handlers/http_handler.py
+++ b/strawberry/channels/handlers/http_handler.py
@@ -315,7 +315,7 @@ class GraphQLHTTPConsumer(
         request: ChannelsRequest,
         stream: Callable[[], AsyncGenerator[str, None]],
         sub_response: TemporalResponse,
-        headers: dict[str, str],
+        headers: Mapping[str, str],
     ) -> MultipartChannelsResponse:
         status = sub_response.status_code or 200
 

--- a/strawberry/django/views.py
+++ b/strawberry/django/views.py
@@ -37,7 +37,7 @@ from strawberry.http.typevars import (
 from .context import StrawberryDjangoContext
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Callable
+    from collections.abc import AsyncIterator, Callable, Mapping
 
     from django.template.response import TemplateResponse
 
@@ -111,7 +111,7 @@ class BaseView:
         request: HttpRequest,
         stream: Callable[[], AsyncIterator[Any]],
         sub_response: TemporalHttpResponse,
-        headers: dict[str, str],
+        headers: Mapping[str, str],
     ) -> HttpResponseBase:
         return StreamingHttpResponse(
             streaming_content=stream(),

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
         AsyncIterator,
         Awaitable,
         Callable,
+        Mapping,
         Sequence,
     )
     from enum import Enum
@@ -285,7 +286,7 @@ class GraphQLRouter(
         request: Request,
         stream: Callable[[], AsyncIterator[str]],
         sub_response: Response,
-        headers: dict[str, str],
+        headers: Mapping[str, str],
     ) -> Response:
         return StreamingResponse(
             stream(),

--- a/strawberry/http/async_base_view.py
+++ b/strawberry/http/async_base_view.py
@@ -43,6 +43,7 @@ from strawberry.types.unset import UNSET, UnsetType
 
 from .base import BaseView
 from .parse_content_type import parse_content_type
+from .streaming import HTTPStreamTransport, MultipartTransport
 from .typevars import (
     Context,
     Request,
@@ -104,6 +105,7 @@ class AsyncBaseHTTPView(
     graphql_ws_handler_class: type[BaseGraphQLWSHandler[Context, RootValue]] = (
         BaseGraphQLWSHandler[Context, RootValue]
     )
+    multipart_transport_class: type[MultipartTransport] = MultipartTransport
 
     @property
     @abc.abstractmethod
@@ -139,7 +141,7 @@ class AsyncBaseHTTPView(
         request: Request,
         stream: Callable[[], AsyncGenerator[str, None]],
         sub_response: SubResponse,
-        headers: dict[str, str],
+        headers: Mapping[str, str],
     ) -> Response:
         raise ValueError("Multipart responses are not supported")
 
@@ -366,22 +368,28 @@ class AsyncBaseHTTPView(
         )
 
         if isinstance(result, SubscriptionExecutionResult):
-            stream = self._get_stream(request, result)
+            if (
+                transport := self._get_stream_transport("multipart-subscription")
+            ) is None:
+                raise RuntimeError(
+                    "No HTTP stream transport configured for multipart-subscription"
+                )
+
+            stream = self._get_stream(request, result, transport)
 
             return await self.create_streaming_response(
                 request,
                 stream,
                 sub_response,
-                headers={
-                    "Content-Type": "multipart/mixed;boundary=graphql;subscriptionSpec=1.0,application/json",
-                },
+                headers=transport.headers,
             )
         if isinstance(result, GraphQLIncrementalExecutionResults):
+            multipart_transport = self.multipart_transport_class()
 
-            async def stream() -> AsyncGenerator[str, None]:
-                yield "---"
-
-                response = await self.process_result(request, result.initial_result)
+            async def data() -> AsyncGenerator[object, None]:
+                response: GraphQLHTTPResponse = await self.process_result(
+                    request, result.initial_result
+                )
 
                 response["hasNext"] = result.initial_result.has_next
                 response["pending"] = [
@@ -389,7 +397,7 @@ class AsyncBaseHTTPView(
                 ]
                 response["extensions"] = result.initial_result.extensions
 
-                yield self.encode_multipart_data(response, "-")
+                yield response
 
                 all_pending = result.initial_result.pending
 
@@ -432,17 +440,13 @@ class AsyncBaseHTTPView(
 
                         response["incremental"] = incremental
 
-                    yield self.encode_multipart_data(response, "-")
-
-                yield "--\r\n"
+                    yield response
 
             return await self.create_streaming_response(
                 request,
-                stream,
+                multipart_transport.stream(data, self.encode_json_string),
                 sub_response,
-                headers={
-                    "Content-Type": 'multipart/mixed; boundary="-"',
-                },
+                headers=multipart_transport.headers,
             )
 
         response_data: GraphQLHTTPResponse | list[GraphQLHTTPResponse]
@@ -466,23 +470,18 @@ class AsyncBaseHTTPView(
             response_data=response_data, sub_response=sub_response
         )
 
-    def encode_multipart_data(self, data: Any, separator: str) -> str:
+    def encode_json_string(self, data: object) -> str:
         encoded_data = self.encode_json(data)
+
         if isinstance(encoded_data, bytes):
-            encoded_data = encoded_data.decode()
-        return "".join(
-            [
-                "\r\n",
-                "Content-Type: application/json; charset=utf-8\r\n",
-                "Content-Length: " + str(len(encoded_data)) + "\r\n",
-                "\r\n",
-                encoded_data,
-                f"\r\n--{separator}",
-            ]
-        )
+            return encoded_data.decode()
+
+        return encoded_data
 
     def _stream_with_heartbeat(
-        self, stream: Callable[[], AsyncGenerator[str, None]], separator: str
+        self,
+        stream: Callable[[], AsyncGenerator[str, None]],
+        transport: HTTPStreamTransport,
     ) -> Callable[[], AsyncGenerator[str, None]]:
         """Add heartbeat messages to a GraphQL stream to prevent connection timeouts.
 
@@ -544,11 +543,14 @@ class AsyncBaseHTTPView(
             await queue.put((False, True, None))  # Always use None with done=True
 
         async def heartbeat() -> None:
+            if not transport.send_initial_heartbeat:
+                await asyncio.sleep(transport.heartbeat_interval)
+
             while True:
-                item = self.encode_multipart_data({}, separator)
+                item = transport.heartbeat_message(self.encode_json_string)
                 await queue.put((False, False, item))
 
-                await asyncio.sleep(5)
+                await asyncio.sleep(transport.heartbeat_interval)
 
         async def merged() -> AsyncGenerator[str, None]:
             heartbeat_task = asyncio.create_task(heartbeat())
@@ -596,16 +598,16 @@ class AsyncBaseHTTPView(
         self,
         request: Request,
         result: SubscriptionExecutionResult,
-        separator: str = "graphql",
+        transport: HTTPStreamTransport,
     ) -> Callable[[], AsyncGenerator[str, None]]:
         async def stream() -> AsyncGenerator[str, None]:
             async for value in result:
                 response = await self.process_result(request, value)
-                yield self.encode_multipart_data({"payload": response}, separator)
+                yield transport.encode_next(response, self.encode_json_string)
 
-            yield f"\r\n--{separator}--\r\n"
+            yield transport.encode_complete()
 
-        return self._stream_with_heartbeat(stream, separator)
+        return self._stream_with_heartbeat(stream, transport)
 
     async def parse_multipart_subscriptions(
         self, request: AsyncHTTPRequestAdapter
@@ -618,14 +620,11 @@ class AsyncBaseHTTPView(
     async def parse_http_body(
         self, request: AsyncHTTPRequestAdapter
     ) -> GraphQLRequestData | list[GraphQLRequestData]:
-        headers = {key.lower(): value for key, value in request.headers.items()}
         content_type, _ = parse_content_type(request.content_type or "")
-        accept = headers.get("accept", "")
+        transport = self._get_stream_transport_from_headers(request.headers)
 
         protocol: Literal["http", "multipart-subscription"] = (
-            "multipart-subscription"
-            if self._is_multipart_subscriptions(*parse_content_type(accept))
-            else "http"
+            transport.protocol if transport else "http"
         )
 
         if request.method == "GET":

--- a/strawberry/http/base.py
+++ b/strawberry/http/base.py
@@ -1,5 +1,6 @@
 import json
 from collections.abc import Mapping
+from functools import cached_property
 from typing import Any, Generic
 from typing_extensions import Protocol
 
@@ -10,6 +11,7 @@ from strawberry.http.ides import GraphQL_IDE, get_graphql_ide_html
 from strawberry.http.types import HTTPMethod, QueryParams
 from strawberry.schema.base import BaseSchema
 
+from .streaming import HTTPStreamTransport, MultipartSubscriptionTransport
 from .typevars import Request
 
 
@@ -28,6 +30,9 @@ class BaseView(Generic[Request]):
     graphql_ide: GraphQL_IDE | None
     multipart_uploads_enabled: bool = False
     schema: BaseSchema
+    stream_transport_classes: Mapping[str, type[HTTPStreamTransport]] = {
+        MultipartSubscriptionTransport.protocol: MultipartSubscriptionTransport,
+    }
 
     def should_render_graphql_ide(self, request: BaseRequestProtocol) -> bool:
         return (
@@ -75,14 +80,43 @@ class BaseView(Generic[Request]):
     def graphql_ide_html(self) -> str:
         return get_graphql_ide_html(graphql_ide=self.graphql_ide)
 
-    def _is_multipart_subscriptions(
+    @cached_property
+    def _stream_transport_map(self) -> dict[str, HTTPStreamTransport]:
+        return {
+            protocol: transport_class()
+            for protocol, transport_class in self.stream_transport_classes.items()
+        }
+
+    def _get_stream_transport(self, protocol: str) -> HTTPStreamTransport | None:
+        return self._stream_transport_map.get(protocol)
+
+    def _get_stream_transport_from_headers(
+        self, headers: Mapping[str, str]
+    ) -> HTTPStreamTransport | None:
+        accept = next(
+            (value for key, value in headers.items() if key.lower() == "accept"),
+            "",
+        )
+
+        return next(
+            (
+                transport
+                for transport in self._stream_transport_map.values()
+                if transport.accepts(accept)
+            ),
+            None,
+        )
+
+    def _get_stream_transport_from_content_type(
         self, content_type: str, params: dict[str, str]
-    ) -> bool:
-        subscription_spec = params.get("subscriptionspec", "").strip("'\"")
-        return (
-            content_type == "multipart/mixed"
-            and ("boundary" not in params or params["boundary"] == "graphql")
-            and subscription_spec.startswith("1.0")
+    ) -> HTTPStreamTransport | None:
+        return next(
+            (
+                transport
+                for transport in self._stream_transport_map.values()
+                if transport.accepts_content_type(content_type, params)
+            ),
+            None,
         )
 
     def _validate_batch_request(
@@ -91,10 +125,8 @@ class BaseView(Generic[Request]):
         if self.schema.config.batching_config is None:
             raise HTTPException(400, "Batching is not enabled")
 
-        if protocol == "multipart-subscription":
-            raise HTTPException(
-                400, "Batching is not supported for multipart subscriptions"
-            )
+        if transport := self._get_stream_transport(protocol):
+            raise HTTPException(400, transport.batching_error)
 
         if len(request_data) > self.schema.config.batching_config["max_operations"]:
             raise HTTPException(400, "Too many operations")

--- a/strawberry/http/streaming.py
+++ b/strawberry/http/streaming.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import abc
+from collections.abc import AsyncGenerator, Callable, Mapping
+from typing import TYPE_CHECKING, ClassVar, Literal
+
+if TYPE_CHECKING:
+    from strawberry.http import GraphQLHTTPResponse
+
+from .parse_content_type import parse_content_type
+
+JSONEncoder = Callable[[object], str]
+
+MULTIPART_SUBSCRIPTION_BOUNDARY = "graphql"
+MULTIPART_SUBSCRIPTION_HEARTBEAT_INTERVAL = 5
+MULTIPART_INCREMENTAL_BOUNDARY = "-"
+HTTPStreamProtocol = Literal["multipart-subscription"]
+MultipartDataStream = Callable[[], AsyncGenerator[object, None]]
+MultipartTextStream = Callable[[], AsyncGenerator[str, None]]
+
+
+def _multipart_subscription_content_type(separator: str) -> str:
+    return f"multipart/mixed;boundary={separator};subscriptionSpec=1.0,application/json"
+
+
+MULTIPART_SUBSCRIPTION_CONTENT_TYPE = _multipart_subscription_content_type(
+    MULTIPART_SUBSCRIPTION_BOUNDARY
+)
+
+
+class MultipartTransport:
+    def __init__(self, separator: str = MULTIPART_INCREMENTAL_BOUNDARY) -> None:
+        self.separator = separator
+
+    @property
+    def headers(self) -> Mapping[str, str]:
+        return {"Content-Type": f'multipart/mixed; boundary="{self.separator}"'}
+
+    def stream(
+        self, data: MultipartDataStream, encode_json: JSONEncoder
+    ) -> MultipartTextStream:
+        async def stream() -> AsyncGenerator[str, None]:
+            yield f"--{self.separator}"
+
+            async for value in data():
+                yield self.encode_multipart_data(value, encode_json)
+
+            yield "--\r\n"
+
+        return stream
+
+    def encode_multipart_data(self, data: object, encode_json: JSONEncoder) -> str:
+        encoded_data = encode_json(data)
+        encoded_data_length = len(encoded_data.encode())
+
+        return "".join(
+            [
+                "\r\n",
+                "Content-Type: application/json; charset=utf-8\r\n",
+                "Content-Length: " + str(encoded_data_length) + "\r\n",
+                "\r\n",
+                encoded_data,
+                f"\r\n--{self.separator}",
+            ]
+        )
+
+
+class HTTPStreamTransport(abc.ABC):
+    protocol: ClassVar[HTTPStreamProtocol]
+    batching_error: ClassVar[str]
+    sync_not_supported_error: ClassVar[str] = (
+        "Streaming responses are not supported in sync mode"
+    )
+    heartbeat_interval: ClassVar[float]
+    send_initial_heartbeat: ClassVar[bool]
+
+    @property
+    @abc.abstractmethod
+    def headers(self) -> Mapping[str, str]: ...
+
+    @abc.abstractmethod
+    def accepts(self, accept: str) -> bool: ...
+
+    def accepts_content_type(self, content_type: str, params: dict[str, str]) -> bool:
+        return False
+
+    @abc.abstractmethod
+    def encode_next(
+        self, response: GraphQLHTTPResponse, encode_json: JSONEncoder
+    ) -> str: ...
+
+    @abc.abstractmethod
+    def encode_complete(self) -> str: ...
+
+    @abc.abstractmethod
+    def heartbeat_message(self, encode_json: JSONEncoder) -> str: ...
+
+
+class MultipartSubscriptionTransport(MultipartTransport, HTTPStreamTransport):
+    protocol: ClassVar[HTTPStreamProtocol] = "multipart-subscription"
+    batching_error: ClassVar[str] = (
+        "Batching is not supported for multipart subscriptions"
+    )
+    sync_not_supported_error: ClassVar[str] = (
+        "Multipart subscriptions are not supported in sync mode"
+    )
+    heartbeat_interval: ClassVar[float] = MULTIPART_SUBSCRIPTION_HEARTBEAT_INTERVAL
+    send_initial_heartbeat: ClassVar[bool] = True
+
+    def __init__(self, separator: str = MULTIPART_SUBSCRIPTION_BOUNDARY) -> None:
+        super().__init__(separator)
+
+    @property
+    def headers(self) -> Mapping[str, str]:
+        return {"Content-Type": _multipart_subscription_content_type(self.separator)}
+
+    def accepts_content_type(self, content_type: str, params: dict[str, str]) -> bool:
+        subscription_spec = params.get("subscriptionspec", "").strip("'\"")
+
+        return (
+            content_type == "multipart/mixed"
+            and (
+                "boundary" not in params
+                or params["boundary"] == MULTIPART_SUBSCRIPTION_BOUNDARY
+            )
+            and subscription_spec.startswith("1.0")
+        )
+
+    def accepts(self, accept: str) -> bool:
+        return self.accepts_content_type(*parse_content_type(accept))
+
+    def encode_next(
+        self, response: GraphQLHTTPResponse, encode_json: JSONEncoder
+    ) -> str:
+        return self.encode_multipart_data({"payload": response}, encode_json)
+
+    def encode_complete(self) -> str:
+        return f"\r\n--{self.separator}--\r\n"
+
+    def heartbeat_message(self, encode_json: JSONEncoder) -> str:
+        return self.encode_multipart_data({}, encode_json)
+
+
+__all__ = [
+    "HTTPStreamTransport",
+    "MultipartSubscriptionTransport",
+    "MultipartTransport",
+]

--- a/strawberry/http/sync_base_view.py
+++ b/strawberry/http/sync_base_view.py
@@ -1,10 +1,7 @@
 import abc
 import json
 from collections.abc import Callable
-from typing import (
-    Generic,
-    Literal,
-)
+from typing import Generic
 
 from cross_web import HTTPException, SyncHTTPRequestAdapter
 from graphql import GraphQLError
@@ -157,15 +154,10 @@ class SyncBaseHTTPView(
     def parse_http_body(
         self, request: SyncHTTPRequestAdapter
     ) -> GraphQLRequestData | list[GraphQLRequestData]:
-        headers = {key.lower(): value for key, value in request.headers.items()}
         content_type, params = parse_content_type(request.content_type or "")
-        accept = headers.get("accept", "")
+        transport = self._get_stream_transport_from_headers(request.headers)
 
-        protocol: Literal["http", "multipart-subscription"] = (
-            "multipart-subscription"
-            if self._is_multipart_subscriptions(*parse_content_type(accept))
-            else "http"
-        )
+        protocol = transport.protocol if transport else "http"
 
         if request.method == "GET":
             data = self.parse_query_params(request.query_params)
@@ -174,10 +166,10 @@ class SyncBaseHTTPView(
         # TODO: multipart via get?
         elif self.multipart_uploads_enabled and content_type == "multipart/form-data":
             data = self.parse_multipart(request)
-        elif self._is_multipart_subscriptions(content_type, params):
-            raise HTTPException(
-                400, "Multipart subscriptions are not supported in sync mode"
-            )
+        elif transport := self._get_stream_transport_from_content_type(
+            content_type, params
+        ):
+            raise HTTPException(400, transport.sync_not_supported_error)
         else:
             raise HTTPException(400, "Unsupported content type")
 

--- a/strawberry/litestar/controller.py
+++ b/strawberry/litestar/controller.py
@@ -295,7 +295,7 @@ class GraphQLController(
         request: Request,
         stream: Callable[[], AsyncIterator[str]],
         sub_response: Response,
-        headers: dict[str, str],
+        headers: Mapping[str, str],
     ) -> Response:
         return Stream(
             stream(),

--- a/strawberry/quart/views.py
+++ b/strawberry/quart/views.py
@@ -145,7 +145,7 @@ class GraphQLView(
         request: Request,
         stream: Callable[[], AsyncGenerator[str, None]],
         sub_response: Response,
-        headers: dict[str, str],
+        headers: Mapping[str, str],
     ) -> Response:
         return (
             stream(),

--- a/strawberry/sanic/views.py
+++ b/strawberry/sanic/views.py
@@ -18,7 +18,7 @@ from strawberry.http.typevars import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator, Callable
+    from collections.abc import AsyncGenerator, Callable, Mapping
 
     from strawberry.http import GraphQLHTTPResponse
     from strawberry.http.ides import GraphQL_IDE
@@ -125,7 +125,7 @@ class GraphQLView(
         request: Request,
         stream: Callable[[], AsyncGenerator[str, None]],
         sub_response: TemporalResponse,
-        headers: dict[str, str],
+        headers: Mapping[str, str],
     ) -> HTTPResponse:
         response = await self.request.respond(
             status=sub_response.status_code,

--- a/tests/http/test_async_base_view.py
+++ b/tests/http/test_async_base_view.py
@@ -3,11 +3,12 @@ from asyncio import sleep
 from collections import Counter
 from collections.abc import AsyncGenerator
 from random import random
-from typing import Any, cast
+from typing import cast
 
 import pytest
 
 from strawberry.http.async_base_view import AsyncBaseHTTPView
+from strawberry.http.streaming import MultipartSubscriptionTransport
 
 
 @pytest.mark.parametrize(
@@ -38,10 +39,11 @@ async def test_stream_with_heartbeat_should_yield_items_correctly(
     assert len(set(expected)) == len(expected), "Test requires unique elements"
 
     class MockAsyncBaseHTTPView:
-        def encode_multipart_data(self, *_: Any, **__: Any) -> str:
+        def encode_json_string(self, _data: object) -> str:
             return ""
 
     view = MockAsyncBaseHTTPView()
+    transport = MultipartSubscriptionTransport(separator="")
 
     async def stream() -> AsyncGenerator[str, None]:
         for elem in expected:
@@ -50,7 +52,7 @@ async def test_stream_with_heartbeat_should_yield_items_correctly(
     async def collect() -> list[str]:
         result = []
         async for item in AsyncBaseHTTPView._stream_with_heartbeat(
-            cast("AsyncBaseHTTPView", view), stream, ""
+            cast("AsyncBaseHTTPView", view), stream, transport
         )():
             result.append(item)
             # Random sleep to promote race conditions between concurrent tasks
@@ -78,3 +80,32 @@ async def test_stream_with_heartbeat_should_yield_items_correctly(
                 f"Order incorrect: '{curr}' (at index {item_indices[curr]}) "
                 f"should appear before '{next_item}' (at index {item_indices[next_item]})"
             )
+
+
+async def test_stream_with_heartbeat_uses_transport_heartbeat_message() -> None:
+    class MockAsyncBaseHTTPView:
+        def encode_json_string(self, _data: object) -> str:
+            return ""
+
+    class MockTransport(MultipartSubscriptionTransport):
+        heartbeat_interval = 60
+
+        def heartbeat_message(self, _encode_json: object) -> str:
+            return "heartbeat"
+
+    view = MockAsyncBaseHTTPView()
+    transport = MockTransport()
+
+    async def stream() -> AsyncGenerator[str, None]:
+        await sleep(0)
+        yield "last"
+
+    result = [
+        item
+        async for item in AsyncBaseHTTPView._stream_with_heartbeat(
+            cast("AsyncBaseHTTPView", view), stream, transport
+        )()
+    ]
+
+    assert "heartbeat" in result
+    assert "last" in result

--- a/tests/http/test_streaming.py
+++ b/tests/http/test_streaming.py
@@ -1,0 +1,108 @@
+import json
+from collections.abc import AsyncGenerator
+
+from strawberry.http.base import BaseView
+from strawberry.http.streaming import (
+    MultipartSubscriptionTransport,
+    MultipartTransport,
+)
+
+
+def test_multipart_transport_encode_multipart_data_uses_utf8_byte_length() -> None:
+    encoded_json = json.dumps({"value": "\u00e9"}, ensure_ascii=False)
+    transport = MultipartTransport()
+
+    data = transport.encode_multipart_data({"value": "\u00e9"}, lambda _: encoded_json)
+
+    assert f"Content-Length: {len(encoded_json.encode())}\r\n" in data
+
+
+async def test_multipart_transport_streams_data() -> None:
+    transport = MultipartTransport()
+
+    async def data() -> AsyncGenerator[object, None]:
+        yield {"data": {"ok": True}}
+
+    stream = transport.stream(data, json.dumps)
+
+    result = [chunk async for chunk in stream()]
+
+    assert transport.headers == {"Content-Type": 'multipart/mixed; boundary="-"'}
+    assert result[0] == "---"
+    assert '"data": {"ok": true}' in result[1]
+    assert result[-1] == "--\r\n"
+
+
+def test_multipart_subscription_transport_accepts_content_type() -> None:
+    transport = MultipartSubscriptionTransport()
+
+    assert transport.accepts_content_type(
+        "multipart/mixed",
+        {"boundary": "graphql", "subscriptionspec": "1.0,application/json"},
+    )
+    assert transport.accepts_content_type(
+        "multipart/mixed",
+        {"subscriptionspec": '"1.0",application/json'},
+    )
+    assert not transport.accepts_content_type(
+        "multipart/mixed",
+        {"boundary": "other", "subscriptionspec": "1.0,application/json"},
+    )
+    assert not transport.accepts_content_type(
+        "application/json",
+        {"subscriptionspec": "1.0,application/json"},
+    )
+
+
+def test_multipart_subscription_transport_accepts_header() -> None:
+    transport = MultipartSubscriptionTransport()
+
+    assert transport.accepts(
+        "multipart/mixed;boundary=graphql;subscriptionSpec=1.0,application/json"
+    )
+
+
+def test_multipart_subscription_transport_encodes_messages() -> None:
+    transport = MultipartSubscriptionTransport(separator="custom")
+
+    next_message = transport.encode_next({"data": {"ok": True}}, json.dumps)
+    heartbeat_message = transport.heartbeat_message(json.dumps)
+
+    assert transport.headers == {
+        "Content-Type": "multipart/mixed;boundary=custom;subscriptionSpec=1.0,application/json"
+    }
+    assert '"payload": {"data": {"ok": true}}' in next_message
+    assert next_message.endswith("\r\n--custom")
+    assert heartbeat_message.endswith("{}\r\n--custom")
+    assert transport.encode_complete() == "\r\n--custom--\r\n"
+
+
+def test_base_view_caches_stream_transport_map() -> None:
+    class MockTransport(MultipartSubscriptionTransport):
+        calls = 0
+
+        def __init__(self) -> None:
+            super().__init__()
+            type(self).calls += 1
+
+    class MockView(BaseView[object]):
+        stream_transport_classes = {
+            MockTransport.protocol: MockTransport,
+        }
+
+    view = MockView()
+
+    transport = view._get_stream_transport("multipart-subscription")
+
+    assert transport is view._get_stream_transport_from_headers(
+        {
+            "Accept": (
+                "multipart/mixed;boundary=graphql;subscriptionSpec=1.0,application/json"
+            )
+        }
+    )
+    assert transport is view._get_stream_transport_from_content_type(
+        "multipart/mixed",
+        {"boundary": "graphql", "subscriptionspec": "1.0,application/json"},
+    )
+    assert MockTransport.calls == 1


### PR DESCRIPTION
Doing this to make it easier to add a SSE transport 😊

<!-- shortcake:start -->
## Stack [🍰](https://shortcake.patrick.wtf)

- #4466 (`2026-06-14-add-support-for-sse`)
- #4460 (`2026-06-14-unify-streaming-execution-behind-schema-stream`)
- **#4469** (`2026-06-14-extract-http-stream-transports`) <-- this PR
<!-- shortcake:end -->