### PR TITLE
Return pre-execution errors from execute and execute_sync

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,28 @@
+---
+release type: minor
+---
+
+This release adds `Schema.stream(...)`, a shared execution API for custom
+streaming integrations.
+
+`Schema.stream(...)` accepts queries, mutations and subscriptions and always
+returns an async sequence of results: a single `ExecutionResult` for queries and
+mutations, and the stream of results for subscriptions. This lets streaming
+transports use one schema entry point instead of choosing between `execute` and
+`subscribe` themselves.
+
+Incremental delivery operations (`@defer`/`@stream`) are also supported: their
+initial result is yielded first, followed by each raw graphql-core patch frame,
+which the transport is responsible for formatting.
+
+The schema execution APIs accept either a string or an already-parsed
+`DocumentNode`, so a transport that parsed the document itself (for example to
+inspect the operation type before executing) can pass the node to avoid parsing
+it again.
+
+Strawberry's multipart HTTP transport and `graphql-transport-ws` handler now use
+this path internally.
+
+HTTP multipart response framing now lives in the stream transport layer instead
+of `AsyncBaseHTTPView.encode_multipart_data`. Integrations that customized that
+view method should customize the transport encoding instead.

--- a/strawberry/http/async_base_view.py
+++ b/strawberry/http/async_base_view.py
@@ -15,7 +15,6 @@ from typing import (
 from cross_web import AsyncHTTPRequestAdapter, HTTPException
 from graphql import GraphQLError
 
-from strawberry.exceptions import MissingQueryError
 from strawberry.file_uploads.utils import replace_placeholders_with_files
 from strawberry.http import (
     GraphQLHTTPResponse,
@@ -29,10 +28,6 @@ from strawberry.schema._graphql_core import (
     SubsequentIncrementalExecutionResult,
 )
 from strawberry.schema.base import BaseSchema
-from strawberry.schema.exceptions import (
-    CannotGetOperationTypeError,
-    InvalidOperationTypeError,
-)
 from strawberry.subscriptions import GRAPHQL_TRANSPORT_WS_PROTOCOL, GRAPHQL_WS_PROTOCOL
 from strawberry.subscriptions.protocols.graphql_transport_ws.handlers import (
     BaseGraphQLTransportWSHandler,
@@ -240,24 +235,17 @@ class AsyncBaseHTTPView(
         if not self.allow_queries_via_get and request_adapter.method == "GET":
             allowed_operation_types = allowed_operation_types - {OperationType.QUERY}
 
-        try:
-            result = await self.schema.execute(
-                request_data.query,
-                root_value=root_value,
-                variable_values=request_data.variables,
-                context_value=context,
-                operation_name=request_data.operation_name,
-                allowed_operation_types=allowed_operation_types,
-                operation_extensions=request_data.extensions,
-            )
-        except CannotGetOperationTypeError as e:
-            raise HTTPException(400, e.as_http_error_reason()) from e
-        except InvalidOperationTypeError as e:
-            raise HTTPException(
-                400, e.as_http_error_reason(request_adapter.method)
-            ) from e
-        except MissingQueryError as e:
-            raise HTTPException(400, "No GraphQL query found in the request") from e
+        result = await self.schema.execute(
+            request_data.query,
+            root_value=root_value,
+            variable_values=request_data.variables,
+            context_value=context,
+            operation_name=request_data.operation_name,
+            allowed_operation_types=allowed_operation_types,
+            operation_extensions=request_data.extensions,
+        )
+
+        self._raise_for_http_pre_execution_error(result)
 
         return result
 

--- a/strawberry/http/async_base_view.py
+++ b/strawberry/http/async_base_view.py
@@ -1,6 +1,5 @@
 import abc
 import asyncio
-import contextlib
 import json
 from collections.abc import AsyncGenerator, Callable, Mapping
 from datetime import timedelta
@@ -26,6 +25,8 @@ from strawberry.http import (
 from strawberry.http.ides import GraphQL_IDE
 from strawberry.schema._graphql_core import (
     GraphQLIncrementalExecutionResults,
+    InitialIncrementalExecutionResult,
+    SubsequentIncrementalExecutionResult,
 )
 from strawberry.schema.base import BaseSchema
 from strawberry.schema.exceptions import (
@@ -43,7 +44,12 @@ from strawberry.types.unset import UNSET, UnsetType
 
 from .base import BaseView
 from .parse_content_type import parse_content_type
-from .streaming import HTTPStreamTransport, MultipartTransport
+from .streaming import (
+    AsyncTextStream,
+    HTTPStreamTransport,
+    MultipartTransport,
+    merge_stream_with_heartbeat,
+)
 from .typevars import (
     Context,
     Request,
@@ -198,14 +204,17 @@ class AsyncBaseHTTPView(
                 ]
             )
 
-        if request_data.protocol == "multipart-subscription":
-            return await self.schema.subscribe(
+        if transport := self._get_stream_transport(request_data.protocol):
+            return await self.schema.stream(
                 request_data.query,  # type: ignore
                 variable_values=request_data.variables,
                 context_value=context,
                 root_value=root_value,
                 operation_name=request_data.operation_name,
                 operation_extensions=request_data.extensions,
+                allowed_operation_types=transport.allowed_operation_types(
+                    allowed_operation_types
+                ),
             )
 
         return await self.execute_single(
@@ -368,78 +377,27 @@ class AsyncBaseHTTPView(
         )
 
         if isinstance(result, SubscriptionExecutionResult):
-            if (
-                transport := self._get_stream_transport("multipart-subscription")
-            ) is None:
-                raise RuntimeError(
-                    "No HTTP stream transport configured for multipart-subscription"
-                )
-
-            stream = self._get_stream(request, result, transport)
-
-            return await self.create_streaming_response(
-                request,
-                stream,
-                sub_response,
-                headers=transport.headers,
+            return await self._create_streaming_response(
+                request=request,
+                result=result,
+                protocol="multipart-subscription",
+                sub_response=sub_response,
             )
         if isinstance(result, GraphQLIncrementalExecutionResults):
             multipart_transport = self.multipart_transport_class()
 
             async def data() -> AsyncGenerator[object, None]:
-                response: GraphQLHTTPResponse = await self.process_result(
-                    request, result.initial_result
+                all_pending: list[Any] = []
+                response, all_pending = await self._process_stream_result(
+                    request, result.initial_result, all_pending
                 )
-
-                response["hasNext"] = result.initial_result.has_next
-                response["pending"] = [
-                    p.formatted for p in result.initial_result.pending
-                ]
-                response["extensions"] = result.initial_result.extensions
 
                 yield response
 
-                all_pending = result.initial_result.pending
-
                 async for value in result.subsequent_results:
-                    response = {
-                        "hasNext": value.has_next,
-                        "extensions": value.extensions,
-                    }
-
-                    if value.pending:
-                        response["pending"] = [p.formatted for p in value.pending]
-
-                    if value.completed:
-                        response["completed"] = [p.formatted for p in value.completed]
-
-                    if value.incremental:
-                        incremental = []
-
-                        all_pending.extend(value.pending)
-
-                        for incremental_value in value.incremental:
-                            pending_value = next(
-                                (
-                                    v
-                                    for v in all_pending
-                                    if v.id == incremental_value.id
-                                ),
-                                None,
-                            )
-
-                            assert pending_value
-
-                            incremental.append(
-                                {
-                                    **incremental_value.formatted,
-                                    "path": pending_value.path,
-                                    "label": pending_value.label,
-                                }
-                            )
-
-                        response["incremental"] = incremental
-
+                    response, all_pending = await self._process_stream_result(
+                        request, value, all_pending
+                    )
                     yield response
 
             return await self.create_streaming_response(
@@ -478,136 +436,101 @@ class AsyncBaseHTTPView(
 
         return encoded_data
 
-    def _stream_with_heartbeat(
+    async def _create_streaming_response(
         self,
-        stream: Callable[[], AsyncGenerator[str, None]],
-        transport: HTTPStreamTransport,
-    ) -> Callable[[], AsyncGenerator[str, None]]:
-        """Add heartbeat messages to a GraphQL stream to prevent connection timeouts.
+        request: Request,
+        result: SubscriptionExecutionResult,
+        protocol: str,
+        sub_response: SubResponse,
+    ) -> Response:
+        transport = self._get_stream_transport(protocol)
+        if transport is None:
+            raise RuntimeError(f"No HTTP stream transport configured for {protocol}")
 
-        This method wraps an async stream generator with heartbeat functionality by:
-        1. Creating a queue to coordinate between data and heartbeat messages
-        2. Running two concurrent tasks: one for original stream data, one for heartbeats
-        3. Merging both message types into a single output stream
-
-        Messages in the queue are tuples of (raised, done, data) where:
-        - raised (bool): True if this contains an exception to be re-raised
-        - done (bool): True if this is the final signal indicating stream completion
-        - data: The actual message content to yield, or exception if raised=True
-               Note: data is always None when done=True and can be ignored
-
-        Note: This implementation addresses two critical concerns:
-
-        1. Race condition: There's a potential race between checking task.done() and
-           processing the final message. We solve this by having the drain task send
-           an explicit (False, True, None) completion signal as its final action.
-           Without this signal, we might exit before processing the final boundary.
-
-           Since the queue size is 1 and the drain task will only complete after
-           successfully queueing the done signal, task.done() guarantees the done
-           signal is either in the queue or has already been processed. This ensures
-           we never miss the final boundary.
-
-        2. Flow control: The queue has maxsize=1, which is essential because:
-           - It provides natural backpressure between producers and consumer
-           - Prevents heartbeat messages from accumulating when drain is active
-           - Ensures proper task coordination without complex synchronization
-           - Guarantees the done signal is queued before drain task completes
-
-        Heartbeats are sent every 5 seconds when the drain task isn't sending data.
-
-        Note: Due to the asynchronous nature of the heartbeat task, an extra heartbeat
-        message may be sent after the final stream boundary message. This is safe because
-        both the MIME specification (RFC 2046) and Apollo's GraphQL Multipart HTTP protocol
-        require clients to ignore any content after the final boundary marker. Additionally,
-        Apollo's protocol defines heartbeats as empty JSON objects that clients must
-        silently ignore.
-        """
-        queue: asyncio.Queue[tuple[bool, bool, Any]] = asyncio.Queue(
-            maxsize=1,  # Critical: maxsize=1 for flow control.
+        return await self.create_streaming_response(
+            request,
+            self._stream_result(request, result, transport),
+            sub_response,
+            headers=transport.headers,
         )
-        cancelling = False
 
-        async def drain() -> None:
-            try:
-                async for item in stream():
-                    await queue.put((False, False, item))
-            except Exception as e:
-                if not cancelling:
-                    await queue.put((True, False, e))
-                else:
-                    raise
-            # Send completion signal to prevent race conditions. The queue.put()
-            # blocks until space is available (due to maxsize=1), guaranteeing that
-            # when task.done() is True, the final stream message has been dequeued.
-            await queue.put((False, True, None))  # Always use None with done=True
-
-        async def heartbeat() -> None:
-            if not transport.send_initial_heartbeat:
-                await asyncio.sleep(transport.heartbeat_interval)
-
-            while True:
-                item = transport.heartbeat_message(self.encode_json_string)
-                await queue.put((False, False, item))
-
-                await asyncio.sleep(transport.heartbeat_interval)
-
-        async def merged() -> AsyncGenerator[str, None]:
-            heartbeat_task = asyncio.create_task(heartbeat())
-            task = asyncio.create_task(drain())
-
-            async def cancel_tasks() -> None:
-                nonlocal cancelling
-                cancelling = True
-                task.cancel()
-
-                with contextlib.suppress(asyncio.CancelledError):
-                    await task
-
-                heartbeat_task.cancel()
-
-                with contextlib.suppress(asyncio.CancelledError):
-                    await heartbeat_task
-
-            try:
-                # When task.done() is True, the final stream message has been
-                # dequeued due to queue size 1 and the blocking nature of queue.put().
-                while not task.done():
-                    raised, done, data = await queue.get()
-
-                    if done:
-                        # Received done signal (data is None), stream is complete.
-                        # Note that we may not get here because of the race between
-                        # task.done() and queue.get(), but that's OK because if
-                        # task.done() is True, the actual final message (including any
-                        # exception) has been consumed. The only intent here is to
-                        # ensure that data=None is not yielded.
-                        break
-
-                    if raised:
-                        await cancel_tasks()
-                        raise data
-
-                    yield data
-            finally:
-                await cancel_tasks()
-
-        return merged
-
-    def _get_stream(
+    def _stream_result(
         self,
         request: Request,
         result: SubscriptionExecutionResult,
         transport: HTTPStreamTransport,
-    ) -> Callable[[], AsyncGenerator[str, None]]:
+    ) -> AsyncTextStream:
         async def stream() -> AsyncGenerator[str, None]:
+            all_pending: list[Any] = []
+
             async for value in result:
-                response = await self.process_result(request, value)
+                response, all_pending = await self._process_stream_result(
+                    request, value, all_pending
+                )
                 yield transport.encode_next(response, self.encode_json_string)
 
             yield transport.encode_complete()
 
-        return self._stream_with_heartbeat(stream, transport)
+        return merge_stream_with_heartbeat(
+            stream,
+            lambda: transport.heartbeat_message(self.encode_json_string),
+            interval=transport.heartbeat_interval,
+            send_initial_heartbeat=transport.send_initial_heartbeat,
+        )
+
+    async def _process_stream_result(
+        self,
+        request: Request,
+        value: Any,
+        all_pending: list[Any],
+    ) -> tuple[GraphQLHTTPResponse, list[Any]]:
+        if isinstance(value, InitialIncrementalExecutionResult):
+            initial_response = await self.process_result(request, value)
+            initial_response["hasNext"] = value.has_next
+            initial_response["pending"] = [p.formatted for p in value.pending]
+            initial_response["extensions"] = value.extensions
+
+            return initial_response, list(value.pending)
+
+        if isinstance(value, SubsequentIncrementalExecutionResult):
+            subsequent_response: GraphQLHTTPResponse = {
+                "hasNext": value.has_next,
+                "extensions": value.extensions,
+            }
+
+            if value.pending:
+                subsequent_response["pending"] = [p.formatted for p in value.pending]
+
+            if value.completed:
+                subsequent_response["completed"] = [
+                    p.formatted for p in value.completed
+                ]
+
+            if value.incremental:
+                incremental = []
+                all_pending.extend(value.pending)
+
+                for incremental_value in value.incremental:
+                    pending_value = next(
+                        (p for p in all_pending if p.id == incremental_value.id),
+                        None,
+                    )
+
+                    assert pending_value
+
+                    incremental.append(
+                        {
+                            **incremental_value.formatted,
+                            "path": pending_value.path,
+                            "label": pending_value.label,
+                        }
+                    )
+
+                subsequent_response["incremental"] = incremental
+
+            return subsequent_response, all_pending
+
+        return await self.process_result(request, value), all_pending
 
     async def parse_multipart_subscriptions(
         self, request: AsyncHTTPRequestAdapter

--- a/strawberry/http/base.py
+++ b/strawberry/http/base.py
@@ -6,10 +6,16 @@ from typing_extensions import Protocol
 
 from cross_web import HTTPException
 
+from strawberry.exceptions import MissingQueryError
 from strawberry.http import GraphQLRequestData
 from strawberry.http.ides import GraphQL_IDE, get_graphql_ide_html
 from strawberry.http.types import HTTPMethod, QueryParams
 from strawberry.schema.base import BaseSchema
+from strawberry.schema.exceptions import (
+    CannotGetOperationTypeError,
+    InvalidOperationTypeError,
+)
+from strawberry.types import ExecutionResult
 
 from .streaming import HTTPStreamTransport, MultipartSubscriptionTransport
 from .typevars import Request
@@ -130,6 +136,30 @@ class BaseView(Generic[Request]):
 
         if len(request_data) > self.schema.config.batching_config["max_operations"]:
             raise HTTPException(400, "Too many operations")
+
+    def _raise_for_http_pre_execution_error(self, result: object) -> None:
+        if not isinstance(result, ExecutionResult):
+            return
+
+        if result.data is not None or not result.errors or len(result.errors) != 1:
+            return
+
+        error = result.errors[0]
+
+        if error.path is not None:
+            return
+
+        original_error = error.original_error
+
+        if isinstance(
+            original_error,
+            (
+                CannotGetOperationTypeError,
+                InvalidOperationTypeError,
+                MissingQueryError,
+            ),
+        ):
+            raise HTTPException(400, error.message) from original_error
 
 
 __all__ = ["BaseView"]

--- a/strawberry/http/streaming.py
+++ b/strawberry/http/streaming.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
 import abc
-from collections.abc import AsyncGenerator, Callable, Mapping
-from typing import TYPE_CHECKING, ClassVar, Literal
+import asyncio
+import contextlib
+from collections.abc import AsyncGenerator, Callable, Iterable, Mapping
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
+
+from strawberry.types.graphql import OperationType
 
 if TYPE_CHECKING:
     from strawberry.http import GraphQLHTTPResponse
 
 from .parse_content_type import parse_content_type
 
+AsyncTextStream = Callable[[], AsyncGenerator[str, None]]
 JSONEncoder = Callable[[object], str]
 
 MULTIPART_SUBSCRIPTION_BOUNDARY = "graphql"
@@ -84,6 +89,11 @@ class HTTPStreamTransport(abc.ABC):
     def accepts_content_type(self, content_type: str, params: dict[str, str]) -> bool:
         return False
 
+    def allowed_operation_types(
+        self, allowed_operation_types: set[OperationType]
+    ) -> Iterable[OperationType]:
+        return allowed_operation_types
+
     @abc.abstractmethod
     def encode_next(
         self, response: GraphQLHTTPResponse, encode_json: JSONEncoder
@@ -129,6 +139,11 @@ class MultipartSubscriptionTransport(MultipartTransport, HTTPStreamTransport):
     def accepts(self, accept: str) -> bool:
         return self.accepts_content_type(*parse_content_type(accept))
 
+    def allowed_operation_types(
+        self, allowed_operation_types: set[OperationType]
+    ) -> Iterable[OperationType]:
+        return (OperationType.SUBSCRIPTION,)
+
     def encode_next(
         self, response: GraphQLHTTPResponse, encode_json: JSONEncoder
     ) -> str:
@@ -141,8 +156,84 @@ class MultipartSubscriptionTransport(MultipartTransport, HTTPStreamTransport):
         return self.encode_multipart_data({}, encode_json)
 
 
+def merge_stream_with_heartbeat(
+    stream: AsyncTextStream,
+    heartbeat_message: Callable[[], str],
+    interval: float,
+    *,
+    send_initial_heartbeat: bool,
+) -> AsyncTextStream:
+    """Add heartbeat messages to a stream to prevent connection timeouts.
+
+    The source stream and heartbeat producer coordinate through a size-1 queue.
+    That keeps backpressure natural and avoids accumulating heartbeats while
+    data is active. The drain task sends an explicit completion message so a
+    fast source stream cannot finish before the consumer has read its final
+    chunk.
+    """
+
+    async def merged() -> AsyncGenerator[str, None]:
+        queue: asyncio.Queue[tuple[bool, bool, Any]] = asyncio.Queue(maxsize=1)
+        cancelling = False
+
+        async def drain() -> None:
+            try:
+                async for item in stream():
+                    await queue.put((False, False, item))
+            except Exception as e:
+                if not cancelling:
+                    await queue.put((True, False, e))
+                else:
+                    raise
+
+            await queue.put((False, True, None))
+
+        async def heartbeat() -> None:
+            if not send_initial_heartbeat:
+                await asyncio.sleep(interval)
+
+            while True:
+                await queue.put((False, False, heartbeat_message()))
+                await asyncio.sleep(interval)
+
+        heartbeat_task = asyncio.create_task(heartbeat())
+        task = asyncio.create_task(drain())
+
+        async def cancel_tasks() -> None:
+            nonlocal cancelling
+            cancelling = True
+            task.cancel()
+
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+            heartbeat_task.cancel()
+
+            with contextlib.suppress(asyncio.CancelledError):
+                await heartbeat_task
+
+        try:
+            while True:
+                raised, done, data = await queue.get()
+
+                if done:
+                    break
+
+                if raised:
+                    await cancel_tasks()
+                    raise data
+
+                yield data
+        finally:
+            await cancel_tasks()
+
+    return merged
+
+
 __all__ = [
+    "AsyncTextStream",
     "HTTPStreamTransport",
     "MultipartSubscriptionTransport",
     "MultipartTransport",
+    "merge_stream_with_heartbeat",
 ]

--- a/strawberry/http/sync_base_view.py
+++ b/strawberry/http/sync_base_view.py
@@ -6,7 +6,6 @@ from typing import Generic
 from cross_web import HTTPException, SyncHTTPRequestAdapter
 from graphql import GraphQLError
 
-from strawberry.exceptions import MissingQueryError
 from strawberry.file_uploads.utils import replace_placeholders_with_files
 from strawberry.http import (
     GraphQLHTTPResponse,
@@ -15,10 +14,6 @@ from strawberry.http import (
 )
 from strawberry.http.ides import GraphQL_IDE
 from strawberry.schema import BaseSchema
-from strawberry.schema.exceptions import (
-    CannotGetOperationTypeError,
-    InvalidOperationTypeError,
-)
 from strawberry.types import ExecutionResult
 from strawberry.types.graphql import OperationType
 from strawberry.types.unset import UNSET
@@ -121,24 +116,17 @@ class SyncBaseHTTPView(
         if not self.allow_queries_via_get and request_adapter.method == "GET":
             allowed_operation_types = allowed_operation_types - {OperationType.QUERY}
 
-        try:
-            result = self.schema.execute_sync(
-                request_data.query,
-                root_value=root_value,
-                variable_values=request_data.variables,
-                context_value=context,
-                operation_name=request_data.operation_name,
-                allowed_operation_types=allowed_operation_types,
-                operation_extensions=request_data.extensions,
-            )
-        except CannotGetOperationTypeError as e:
-            raise HTTPException(400, e.as_http_error_reason()) from e
-        except InvalidOperationTypeError as e:
-            raise HTTPException(
-                400, e.as_http_error_reason(request_adapter.method)
-            ) from e
-        except MissingQueryError as e:
-            raise HTTPException(400, "No GraphQL query found in the request") from e
+        result = self.schema.execute_sync(
+            request_data.query,
+            root_value=root_value,
+            variable_values=request_data.variables,
+            context_value=context,
+            operation_name=request_data.operation_name,
+            allowed_operation_types=allowed_operation_types,
+            operation_extensions=request_data.extensions,
+        )
+
+        self._raise_for_http_pre_execution_error(result)
 
         return result
 

--- a/strawberry/schema/_graphql_core.py
+++ b/strawberry/schema/_graphql_core.py
@@ -22,6 +22,7 @@ try:
     )
     from graphql.execution import (  # type: ignore[attr-defined]
         InitialIncrementalExecutionResult,  # pyright: ignore[reportAttributeAccessIssue]
+        SubsequentIncrementalExecutionResult,  # pyright: ignore[reportAttributeAccessIssue]
         experimental_execute_incrementally,  # pyright: ignore[reportAttributeAccessIssue]
     )
     from graphql.type.directives import (  # type: ignore[attr-defined]
@@ -38,9 +39,28 @@ try:
         OriginalGraphQLExecutionResult | InitialIncrementalExecutionResult
     )
 
+    # The individual frames produced when an incremental delivery container
+    # (`@defer`/`@stream`) is expanded into a flat stream of results.
+    GraphQLIncrementalResult: TypeAlias = (
+        InitialIncrementalExecutionResult | SubsequentIncrementalExecutionResult
+    )
+
 except ImportError:
-    GraphQLIncrementalExecutionResults = type(None)
+
+    class GraphQLIncrementalExecutionResults:  # type: ignore[no-redef]
+        pass
+
+    class InitialIncrementalExecutionResult:  # type: ignore[no-redef]
+        pass
+
+    class SubsequentIncrementalExecutionResult:  # type: ignore[no-redef]
+        pass
+
     GraphQLExecutionResult = OriginalGraphQLExecutionResult  # type: ignore
+    # Incremental delivery isn't available on graphql-core < 3.3, so no frame
+    # type exists. Fall back to the (empty) container type so annotations remain
+    # importable at runtime.
+    GraphQLIncrementalResult = GraphQLIncrementalExecutionResults  # type: ignore
 
     incremental_execution_directives = ()  # type: ignore
     experimental_execute_incrementally = None
@@ -66,7 +86,10 @@ __all__ = [
     "GraphQLExecutionContext",
     "GraphQLExecutionResult",
     "GraphQLIncrementalExecutionResults",
+    "GraphQLIncrementalResult",
+    "InitialIncrementalExecutionResult",
     "ResultType",
+    "SubsequentIncrementalExecutionResult",
     "execute",
     "execution_context_class_kwargs",
     "experimental_execute_incrementally",

--- a/strawberry/schema/base.py
+++ b/strawberry/schema/base.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from graphql import GraphQLError
 
     from strawberry.directive import StrawberryDirective
-    from strawberry.schema.schema import SubscriptionResult
+    from strawberry.schema.schema import StreamResult, SubscriptionResult
     from strawberry.schema.schema_converter import GraphQLCoreConverter
     from strawberry.types import (
         ExecutionContext,
@@ -67,13 +67,26 @@ class BaseSchema(Protocol):
     @abstractmethod
     async def subscribe(
         self,
-        query: str,
+        query: str | None,
         variable_values: dict[str, Any] | None = None,
         context_value: Any | None = None,
         root_value: Any | None = None,
         operation_name: str | None = None,
         operation_extensions: dict[str, Any] | None = None,
     ) -> SubscriptionResult:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def stream(
+        self,
+        query: str | None,
+        variable_values: dict[str, Any] | None = None,
+        context_value: Any | None = None,
+        root_value: Any | None = None,
+        operation_name: str | None = None,
+        operation_extensions: dict[str, Any] | None = None,
+        allowed_operation_types: Iterable[OperationType] | None = None,
+    ) -> StreamResult:
         raise NotImplementedError
 
     @abstractmethod

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -777,8 +777,14 @@ class Schema(BaseSchema):
             MissingQueryError,
             CannotGetOperationTypeError,
             InvalidOperationTypeError,
-        ):
-            raise
+        ) as error:
+            return await self._handle_execution_result(
+                execution_context,
+                PreExecutionError(
+                    data=None, errors=[_coerce_pre_execution_error(error)]
+                ),
+                extensions_runner,
+            )
         except Exception as exc:  # noqa: BLE001
             return await self._handle_execution_result(
                 execution_context,
@@ -877,8 +883,15 @@ class Schema(BaseSchema):
             MissingQueryError,
             CannotGetOperationTypeError,
             InvalidOperationTypeError,
-        ):
-            raise
+        ) as error:
+            errors = [_coerce_pre_execution_error(error)]
+            execution_context.pre_execution_errors = errors
+            self._process_errors(errors, execution_context)
+            return ExecutionResult(
+                data=None,
+                errors=errors,
+                extensions=extensions_runner.get_extensions_results_sync(),
+            )
         except Exception as exc:  # noqa: BLE001
             errors = [_coerce_error(exc)]
             execution_context.pre_execution_errors = errors

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import warnings
 from asyncio import ensure_future
 from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable, Iterable
@@ -69,6 +70,7 @@ from . import compat
 from ._graphql_core import (
     GraphQLExecutionContext,
     GraphQLIncrementalExecutionResults,
+    GraphQLIncrementalResult,
     ResultType,
     execute,
     execution_context_class_kwargs,
@@ -99,6 +101,14 @@ if TYPE_CHECKING:
 
 SubscriptionResult: TypeAlias = AsyncGenerator[
     PreExecutionError | ExecutionResult, None
+]
+
+# Unlike a pure subscription, ``stream`` can also run queries and mutations, and
+# expands incremental delivery (``@defer``/``@stream``) into its initial result
+# followed by raw graphql-core patch frames. Its element type is therefore wider
+# than ``SubscriptionResult``.
+StreamResult: TypeAlias = AsyncGenerator[
+    PreExecutionError | ExecutionResult | GraphQLIncrementalResult, None
 ]
 
 OriginSubscriptionResult: TypeAlias = (
@@ -149,10 +159,38 @@ def _run_validation(execution_context: ExecutionContext) -> None:
         )
 
 
+def _parse_operation_document(execution_context: ExecutionContext) -> None:
+    if execution_context.graphql_document is not None:
+        return
+
+    if not execution_context.query:
+        raise MissingQueryError
+
+    execution_context.graphql_document = parse(
+        execution_context.query,
+        **execution_context.parse_options,
+    )
+
+
 def _coerce_error(error: GraphQLError | Exception) -> GraphQLError:
     if isinstance(error, GraphQLError):
         return error
     return GraphQLError(str(error), original_error=error)
+
+
+def _coerce_pre_execution_error(error: Exception) -> GraphQLError:
+    if isinstance(error, CannotGetOperationTypeError):
+        return GraphQLError(error.as_http_error_reason(), original_error=error)
+
+    if isinstance(error, InvalidOperationTypeError):
+        operation_type = {
+            OperationType.QUERY: "queries",
+            OperationType.MUTATION: "mutations",
+            OperationType.SUBSCRIPTION: "subscriptions",
+        }[error.operation_type]
+        return GraphQLError(f"{operation_type} are not allowed", original_error=error)
+
+    return _coerce_error(error)
 
 
 class _OperationContextAwareGraphQLResolveInfo(NamedTuple):  # pyright: ignore
@@ -513,16 +551,16 @@ class Schema(BaseSchema):
     ) -> list[StrawberryField]:
         return type_definition.fields
 
-    async def _parse_and_validate_async(
+    async def _prepare_operation_async(
         self, context: ExecutionContext, extensions_runner: SchemaExtensionsRunner
     ) -> PreExecutionError | None:
-        if not context.query:
+        """Parse, check the operation type, and validate before execution."""
+        if not context.query and context.graphql_document is None:
             raise MissingQueryError
 
         async with extensions_runner.parsing():
             try:
-                if not context.graphql_document:
-                    context.graphql_document = parse(context.query)
+                _parse_operation_document(context)
 
             except GraphQLError as error:
                 context.pre_execution_errors = [error]
@@ -551,6 +589,46 @@ class Schema(BaseSchema):
 
         return None
 
+    def _prepare_operation_sync(
+        self, context: ExecutionContext, extensions_runner: SchemaExtensionsRunner
+    ) -> ExecutionResult | None:
+        """Parse, check the operation type, and validate before execution."""
+        if not context.query and context.graphql_document is None:
+            raise MissingQueryError
+
+        with extensions_runner.parsing():
+            try:
+                _parse_operation_document(context)
+
+            except GraphQLError as error:
+                context.pre_execution_errors = [error]
+                self._process_errors([error], context)
+                return ExecutionResult(
+                    data=None,
+                    errors=[error],
+                    extensions=extensions_runner.get_extensions_results_sync(),
+                )
+
+        try:
+            operation_type = context.operation_type
+        except RuntimeError as error:
+            raise CannotGetOperationTypeError(context.operation_name) from error
+
+        if operation_type not in context.allowed_operations:
+            raise InvalidOperationTypeError(operation_type)
+
+        with extensions_runner.validation():
+            _run_validation(context)
+            if context.pre_execution_errors:
+                self._process_errors(context.pre_execution_errors, context)
+                return ExecutionResult(
+                    data=None,
+                    errors=context.pre_execution_errors,
+                    extensions=extensions_runner.get_extensions_results_sync(),
+                )
+
+        return None
+
     async def _handle_execution_result(
         self,
         context: ExecutionContext,
@@ -574,6 +652,68 @@ class Schema(BaseSchema):
             result = ExecutionResult(data=result.data, errors=result.errors)
         result.extensions = await extensions_runner.get_extensions_results(context)
         context.result = result
+        return result
+
+    def _get_execute_function(self) -> Callable[..., Any]:
+        """Return the graphql-core execution function for the current config.
+
+        Uses ``experimental_execute_incrementally`` when incremental execution is
+        enabled, falling back to ``execute`` otherwise. Single-sourced so the
+        graphql-core version guard cannot drift between execution paths.
+        """
+        if self.config.enable_experimental_incremental_execution:
+            if experimental_execute_incrementally is None:
+                raise RuntimeError(
+                    "Incremental execution is enabled but experimental_execute_incrementally is not available, "
+                    "please install graphql-core>=3.3.0"
+                )
+            return experimental_execute_incrementally
+        return execute
+
+    async def _execute_operation(
+        self,
+        execution_context: ExecutionContext,
+        extensions_runner: SchemaExtensionsRunner,
+        middleware_manager: MiddlewareManager,
+        execute_function: Callable[..., Any],
+        custom_context_kwargs: dict[str, Any],
+    ) -> ResultType:
+        assert execution_context.graphql_document is not None
+
+        async with extensions_runner.executing():
+            if not execution_context.result:
+                result = await await_maybe(
+                    execute_function(
+                        self._schema,
+                        execution_context.graphql_document,
+                        root_value=execution_context.root_value,
+                        middleware=middleware_manager,
+                        variable_values=execution_context.variables,
+                        operation_name=execution_context.operation_name,
+                        context_value=execution_context.context,
+                        is_awaitable=optimized_is_awaitable,
+                        **execution_context_class_kwargs(self.execution_context_class),
+                        **custom_context_kwargs,
+                    )
+                )
+                execution_context.result = result
+            else:
+                result = execution_context.result
+
+            # Also set errors on the execution_context so that it's easier
+            # to access in extensions.
+            #
+            # TODO: maybe here use the first result from incremental execution
+            # if it exists.
+            if isinstance(result, GraphQLExecutionResult) and result.errors:
+                execution_context.pre_execution_errors = result.errors
+
+                # Run the `Schema.process_errors` function here before
+                # extensions have a chance to modify them (see the MaskErrors
+                # extension). That way we can log the original errors but
+                # only return a sanitised version to the client.
+                self._process_errors(result.errors, execution_context)
+
         return result
 
     async def execute(
@@ -606,16 +746,7 @@ class Schema(BaseSchema):
         extensions_runner = self.create_extensions_runner(execution_context, extensions)
         middleware_manager = self._get_middleware_manager(extensions)
 
-        execute_function: Callable[..., Any] = execute
-
-        if self.config.enable_experimental_incremental_execution:
-            if experimental_execute_incrementally is None:
-                raise RuntimeError(
-                    "Incremental execution is enabled but experimental_execute_incrementally is not available, "
-                    "please install graphql-core>=3.3.0"
-                )
-
-            execute_function = experimental_execute_incrementally
+        execute_function = self._get_execute_function()
 
         custom_context_kwargs = self._get_custom_context_kwargs(operation_extensions)
 
@@ -624,7 +755,7 @@ class Schema(BaseSchema):
                 # Note: In graphql-core the schema would be validated here but in
                 # Strawberry we are validating it at initialisation time instead
 
-                if errors := await self._parse_and_validate_async(
+                if errors := await self._prepare_operation_async(
                     execution_context, extensions_runner
                 ):
                     return await self._handle_execution_result(
@@ -634,39 +765,13 @@ class Schema(BaseSchema):
                     )
 
                 assert execution_context.graphql_document
-                async with extensions_runner.executing():
-                    if not execution_context.result:
-                        result = await await_maybe(
-                            execute_function(
-                                self._schema,
-                                execution_context.graphql_document,
-                                root_value=execution_context.root_value,
-                                middleware=middleware_manager,
-                                variable_values=execution_context.variables,
-                                operation_name=execution_context.operation_name,
-                                context_value=execution_context.context,
-                                is_awaitable=optimized_is_awaitable,
-                                **execution_context_class_kwargs(
-                                    self.execution_context_class
-                                ),
-                                **custom_context_kwargs,
-                            )
-                        )
-                        execution_context.result = result
-                    else:
-                        result = execution_context.result
-                    # Also set errors on the execution_context so that it's easier
-                    # to access in extensions
-
-                    # TODO: maybe here use the first result from incremental execution if it exists
-                    if isinstance(result, GraphQLExecutionResult) and result.errors:
-                        execution_context.pre_execution_errors = result.errors
-
-                        # Run the `Schema.process_errors` function here before
-                        # extensions have a chance to modify them (see the MaskErrors
-                        # extension). That way we can log the original errors but
-                        # only return a sanitised version to the client.
-                        self._process_errors(result.errors, execution_context)
+                result = await self._execute_operation(
+                    execution_context,
+                    extensions_runner,
+                    middleware_manager,
+                    execute_function,
+                    custom_context_kwargs,
+                )
 
         except (
             MissingQueryError,
@@ -715,16 +820,7 @@ class Schema(BaseSchema):
         extensions_runner = self.create_extensions_runner(execution_context, extensions)
         middleware_manager = self._get_middleware_manager(extensions)
 
-        execute_function: Callable[..., Any] = execute
-
-        if self.config.enable_experimental_incremental_execution:
-            if experimental_execute_incrementally is None:
-                raise RuntimeError(
-                    "Incremental execution is enabled but experimental_execute_incrementally is not available, "
-                    "please install graphql-core>=3.3.0"
-                )
-
-            execute_function = experimental_execute_incrementally
+        execute_function = self._get_execute_function()
         custom_context_kwargs = self._get_custom_context_kwargs(
             operation_extensions, sync=True
         )
@@ -733,48 +829,14 @@ class Schema(BaseSchema):
             with extensions_runner.operation():
                 # Note: In graphql-core the schema would be validated here but in
                 # Strawberry we are validating it at initialisation time instead
-                if not execution_context.query:
-                    raise MissingQueryError  # noqa: TRY301
+                if (
+                    pre_execution_result := self._prepare_operation_sync(
+                        execution_context, extensions_runner
+                    )
+                ) is not None:
+                    return pre_execution_result
 
-                with extensions_runner.parsing():
-                    try:
-                        if not execution_context.graphql_document:
-                            execution_context.graphql_document = parse(
-                                execution_context.query,
-                                **execution_context.parse_options,
-                            )
-
-                    except GraphQLError as error:
-                        execution_context.pre_execution_errors = [error]
-                        self._process_errors([error], execution_context)
-                        return ExecutionResult(
-                            data=None,
-                            errors=[error],
-                            extensions=extensions_runner.get_extensions_results_sync(),
-                        )
-
-                try:
-                    operation_type = execution_context.operation_type
-                except RuntimeError as error:
-                    raise CannotGetOperationTypeError(
-                        execution_context.operation_name
-                    ) from error
-
-                if operation_type not in execution_context.allowed_operations:
-                    raise InvalidOperationTypeError(operation_type)  # noqa: TRY301
-
-                with extensions_runner.validation():
-                    _run_validation(execution_context)
-                    if execution_context.pre_execution_errors:
-                        self._process_errors(
-                            execution_context.pre_execution_errors, execution_context
-                        )
-                        return ExecutionResult(
-                            data=None,
-                            errors=execution_context.pre_execution_errors,
-                            extensions=extensions_runner.get_extensions_results_sync(),
-                        )
-
+                assert execution_context.graphql_document is not None
                 with extensions_runner.executing():
                     if not execution_context.result:
                         result = execute_function(
@@ -832,28 +894,57 @@ class Schema(BaseSchema):
             extensions=extensions_runner.get_extensions_results_sync(),
         )
 
-    async def _subscribe(
+    async def _stream(
         self,
         execution_context: ExecutionContext,
         extensions_runner: SchemaExtensionsRunner,
         middleware_manager: MiddlewareManager,
         execution_context_class: type[GraphQLExecutionContext] | None = None,
         operation_extensions: dict[str, Any] | None = None,
-    ) -> AsyncGenerator[ExecutionResult, None]:
+    ) -> StreamResult:
         async with extensions_runner.operation():
-            if initial_error := await self._parse_and_validate_async(
-                context=execution_context,
-                extensions_runner=extensions_runner,
-            ):
+            try:
+                initial_error = await self._prepare_operation_async(
+                    context=execution_context,
+                    extensions_runner=extensions_runner,
+                )
+            except (
+                MissingQueryError,
+                CannotGetOperationTypeError,
+                InvalidOperationTypeError,
+            ) as error:
+                initial_error = PreExecutionError(
+                    data=None, errors=[_coerce_pre_execution_error(error)]
+                )
+
+            if initial_error:
                 initial_error.extensions = (
                     await extensions_runner.get_extensions_results(execution_context)
                 )
                 yield await self._handle_execution_result(
                     execution_context, initial_error, extensions_runner
                 )
+                return
+
+            assert execution_context.graphql_document is not None
+
+            # Queries and mutations executed over a streaming transport yield a
+            # single result and then the stream completes. Only subscriptions
+            # produce an async generator of multiple results.
+            if execution_context.operation_type is not OperationType.SUBSCRIPTION:
+                result_source = self._stream_non_subscription(
+                    execution_context,
+                    extensions_runner,
+                    middleware_manager,
+                    operation_extensions,
+                )
+                async with aclosing(result_source):
+                    async for result in result_source:
+                        yield result
+                return
+
             try:
                 async with extensions_runner.executing():
-                    assert execution_context.graphql_document is not None
                     gql_33_kwargs = {
                         "middleware": middleware_manager,
                         "operation_extensions": operation_extensions,
@@ -915,6 +1006,64 @@ class Schema(BaseSchema):
                     extensions_runner,
                 )
 
+    async def _stream_non_subscription(
+        self,
+        execution_context: ExecutionContext,
+        extensions_runner: SchemaExtensionsRunner,
+        middleware_manager: MiddlewareManager,
+        operation_extensions: dict[str, Any] | None = None,
+    ) -> StreamResult:
+        """Run a query/mutation over a streaming transport.
+
+        Yields a single ``ExecutionResult`` for an ordinary operation. For
+        incremental delivery (``@defer``/``@stream``) the result is a container,
+        which is expanded into its initial frame followed by each subsequent
+        patch so callers see one flat sequence of frames.
+        """
+        execute_function = self._get_execute_function()
+
+        custom_context_kwargs = self._get_custom_context_kwargs(operation_extensions)
+
+        assert execution_context.graphql_document is not None
+
+        try:
+            result = await self._execute_operation(
+                execution_context,
+                extensions_runner,
+                middleware_manager,
+                execute_function,
+                custom_context_kwargs,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            yield await self._handle_execution_result(
+                execution_context,
+                PreExecutionError(data=None, errors=[_coerce_error(exc)]),
+                extensions_runner,
+            )
+            return
+
+        # Incremental delivery (`@defer`/`@stream`) produces a container rather
+        # than a single result. Normalize the initial result through Strawberry's
+        # result handling, then yield subsequent graphql-core patch frames as-is:
+        # their errors are nested inside incremental payloads and transport
+        # formatting is responsible for those frame shapes.
+        if isinstance(result, GraphQLIncrementalExecutionResults):
+            yield await self._handle_execution_result(
+                execution_context,
+                result.initial_result,
+                extensions_runner,
+            )
+            async with aclosing(result.subsequent_results) as subsequent_results:
+                async for incremental_result in subsequent_results:
+                    yield incremental_result
+            return
+
+        yield await self._handle_execution_result(
+            execution_context, result, extensions_runner, skip_process_errors=True
+        )
+
     async def subscribe(
         self,
         query: str | None,
@@ -924,20 +1073,71 @@ class Schema(BaseSchema):
         operation_name: str | None = None,
         operation_extensions: dict[str, Any] | None = None,
     ) -> SubscriptionResult:
+        """Execute a subscription and stream its results.
+
+        Thin wrapper around :meth:`stream` restricted to subscriptions. New
+        streaming transports should prefer :meth:`stream`, which can also run
+        queries and mutations.
+        """
+        # Subscriptions never produce incremental-delivery frames, so the result
+        # is always a ``SubscriptionResult`` even though ``stream`` is wider.
+        return cast(
+            "SubscriptionResult",
+            await self.stream(
+                query=query,
+                variable_values=variable_values,
+                context_value=context_value,
+                root_value=root_value,
+                operation_name=operation_name,
+                operation_extensions=operation_extensions,
+                allowed_operation_types=(OperationType.SUBSCRIPTION,),
+            ),
+        )
+
+    async def stream(
+        self,
+        query: str | None,
+        variable_values: dict[str, Any] | None = None,
+        context_value: Any | None = None,
+        root_value: Any | None = None,
+        operation_name: str | None = None,
+        operation_extensions: dict[str, Any] | None = None,
+        allowed_operation_types: Iterable[OperationType] | None = None,
+    ) -> StreamResult:
+        """Execute an operation and stream its result(s).
+
+        Parses the document once, inside the extension lifecycle, and dispatches
+        on the operation type: subscriptions stream their results, while queries
+        and mutations yield a single result and then complete. This lets a
+        streaming transport (SSE, multipart, WebSocket) run any operation without
+        having to parse and route on the operation type itself.
+
+        The yielded element is a strawberry :class:`ExecutionResult` (or
+        :class:`PreExecutionError`) for queries, mutations and subscriptions. For
+        incremental delivery (``@defer``/``@stream``) the raw graphql-core frames
+        are yielded instead, which the caller must format for its transport.
+
+        Custom parsing or parser caching should be implemented with an
+        ``on_parse`` extension that populates ``execution_context.graphql_document``.
+        """
+        if allowed_operation_types is None:
+            allowed_operation_types = DEFAULT_ALLOWED_OPERATION_TYPES
+
         execution_context = self._create_execution_context(
             query=query,
-            allowed_operation_types=(OperationType.SUBSCRIPTION,),
+            allowed_operation_types=allowed_operation_types,
             variable_values=variable_values,
             context_value=context_value,
             root_value=root_value,
             operation_name=operation_name,
+            operation_extensions=operation_extensions,
         )
         extensions = self.get_extensions()
         # TODO (#3571): remove this when we implement execution context as parameter.
         for extension in extensions:
             extension.execution_context = execution_context
 
-        return self._subscribe(
+        return self._stream(
             execution_context,
             extensions_runner=self.create_extensions_runner(
                 execution_context, extensions

--- a/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_transport_ws/handlers.py
@@ -10,7 +10,7 @@ from typing import (
     cast,
 )
 
-from graphql import GraphQLError, GraphQLSyntaxError, parse
+from graphql import GraphQLError, GraphQLSyntaxError
 
 from strawberry.exceptions import ConnectionRejectionError
 from strawberry.http.exceptions import (
@@ -29,18 +29,20 @@ from strawberry.subscriptions.protocols.graphql_transport_ws.types import (
     PongMessage,
     SubscribeMessage,
 )
-from strawberry.types import ExecutionResult
-from strawberry.types.execution import PreExecutionError
-from strawberry.types.graphql import OperationType
+from strawberry.types.execution import ExecutionResult, PreExecutionError
 from strawberry.types.unset import UnsetType
-from strawberry.utils.operation import get_operation_type
+from strawberry.utils.aio import aclosing
 
 if TYPE_CHECKING:
     from datetime import timedelta
 
     from strawberry.http.async_base_view import AsyncBaseHTTPView, AsyncWebSocketAdapter
     from strawberry.schema import BaseSchema
-    from strawberry.schema.schema import SubscriptionResult
+    from strawberry.schema.schema import StreamResult
+
+
+class _OperationStreamClosed(Exception):
+    """Raised when an operation closes the websocket instead of completing."""
 
 
 class BaseGraphQLTransportWSHandler(Generic[Context, RootValue]):
@@ -213,27 +215,6 @@ class BaseGraphQLTransportWSHandler(Generic[Context, RootValue]):
             await self.websocket.close(code=4401, reason="Unauthorized")
             return
 
-        try:
-            graphql_document = parse(message["payload"]["query"])
-        except GraphQLSyntaxError as exc:
-            await self.websocket.close(code=4400, reason=exc.message)
-            return
-
-        operation_name = message["payload"].get("operationName")
-
-        try:
-            operation_type = get_operation_type(graphql_document, operation_name)
-        except RuntimeError:
-            # Unlike in the other protocol implementations, we access the operation type
-            # before executing the operation. Therefore, we don't get a nice
-            # CannotGetOperationTypeError, but rather the underlying RuntimeError.
-            e = CannotGetOperationTypeError(operation_name)
-            await self.websocket.close(
-                code=4400,
-                reason=e.as_http_error_reason(),
-            )
-            return
-
         if message["id"] in self.operations:
             reason = f"Subscriber for {message['id']} already exists"
             await self.websocket.close(code=4409, reason=reason)
@@ -258,7 +239,6 @@ class BaseGraphQLTransportWSHandler(Generic[Context, RootValue]):
         operation = Operation(
             self,
             message["id"],
-            operation_type,
             message["payload"]["query"],
             message["payload"].get("variables"),
             message["payload"].get("operationName"),
@@ -270,51 +250,24 @@ class BaseGraphQLTransportWSHandler(Generic[Context, RootValue]):
 
     async def run_operation(self, operation: Operation[Context, RootValue]) -> None:
         """The operation task's top level method. Cleans-up and de-registers the operation once it is done."""
-        result_source: ExecutionResult | SubscriptionResult
-
         try:
-            # Get an AsyncGenerator yielding the results
-            if operation.operation_type == OperationType.SUBSCRIPTION:
-                result_source = await self.schema.subscribe(
-                    query=operation.query,
-                    variable_values=operation.variables,
-                    operation_name=operation.operation_name,
-                    context_value=self.context,
-                    root_value=self.root_value,
-                )
-            else:
-                result_source = await self.schema.execute(
-                    query=operation.query,
-                    variable_values=operation.variables,
-                    context_value=self.context,
-                    root_value=self.root_value,
-                    operation_name=operation.operation_name,
-                )
+            result_source = await self.schema.stream(
+                operation.query,
+                variable_values=operation.variables,
+                context_value=self.context,
+                root_value=self.root_value,
+                operation_name=operation.operation_name,
+            )
 
-            # TODO: maybe change PreExecutionError to an exception that can be caught
-
-            if isinstance(result_source, ExecutionResult):
-                if isinstance(result_source, PreExecutionError):
-                    assert result_source.errors
-                    await operation.send_initial_errors(result_source.errors)
-                else:
-                    await operation.send_next(result_source)
-            else:
-                is_first_result = True
-
-                async for result in result_source:
-                    if is_first_result and isinstance(result, PreExecutionError):
-                        assert result.errors
-                        await operation.send_initial_errors(result.errors)
-                        break
-
-                    await operation.send_next(result)
-                    is_first_result = False
+            async with aclosing(result_source):
+                await self._send_result_stream(operation, result_source)
 
             await operation.send_operation_message(
                 CompleteMessage(id=operation.id, type="complete")
             )
 
+        except _OperationStreamClosed:
+            return
         except Exception as error:  # pragma: no cover
             await self.handle_task_exception(error)
 
@@ -327,6 +280,53 @@ class BaseGraphQLTransportWSHandler(Generic[Context, RootValue]):
 
             raise
 
+    async def _send_result_stream(
+        self,
+        operation: Operation[Context, RootValue],
+        result_source: StreamResult,
+    ) -> None:
+        is_first_result = True
+
+        async for result in result_source:
+            if is_first_result and isinstance(result, PreExecutionError):
+                await self._handle_pre_execution_error(operation, result)
+                return
+
+            if not isinstance(result, ExecutionResult):
+                await self._reject_incremental_delivery(operation)
+                return
+
+            await operation.send_next(result)
+            is_first_result = False
+
+    async def _handle_pre_execution_error(
+        self,
+        operation: Operation[Context, RootValue],
+        result: PreExecutionError,
+    ) -> None:
+        assert result.errors
+        if close_reason := self._get_pre_execution_close_reason(result.errors[0]):
+            await self.websocket.close(code=4400, reason=close_reason)
+            self.operations.pop(operation.id, None)
+            raise _OperationStreamClosed
+
+        await operation.send_initial_errors(result.errors)
+
+    async def _reject_incremental_delivery(
+        self, operation: Operation[Context, RootValue]
+    ) -> None:
+        # Incremental delivery (``@defer``/``@stream``) yields raw graphql-core
+        # frames that the graphql-transport-ws ``next`` message has no wire
+        # representation for. Reject the operation rather than send a malformed
+        # or partial payload.
+        await operation.send_initial_errors(
+            [
+                GraphQLError(
+                    "Incremental delivery is not supported over graphql-transport-ws"
+                )
+            ]
+        )
+
     def forget_id(self, id: str) -> None:
         # de-register the operation id making it immediately available
         # for reuse
@@ -337,6 +337,16 @@ class BaseGraphQLTransportWSHandler(Generic[Context, RootValue]):
 
     async def handle_invalid_message(self, error_message: str) -> None:
         await self.websocket.close(code=4400, reason=error_message)
+
+    @staticmethod
+    def _get_pre_execution_close_reason(error: GraphQLError) -> str | None:
+        if isinstance(error, GraphQLSyntaxError):
+            return error.message
+
+        if isinstance(error.original_error, CannotGetOperationTypeError):
+            return error.original_error.as_http_error_reason()
+
+        return None
 
     async def send_message(self, message: Message) -> None:
         await self.websocket.send_json(message)
@@ -359,7 +369,6 @@ class Operation(Generic[Context, RootValue]):
         "handler",
         "id",
         "operation_name",
-        "operation_type",
         "query",
         "task",
         "variables",
@@ -369,14 +378,12 @@ class Operation(Generic[Context, RootValue]):
         self,
         handler: BaseGraphQLTransportWSHandler[Context, RootValue],
         id: str,
-        operation_type: OperationType,
         query: str,
         variables: dict[str, object] | None,
         operation_name: str | None,
     ) -> None:
         self.handler = handler
         self.id = id
-        self.operation_type = operation_type
         self.query = query
         self.variables = variables
         self.operation_name = operation_name

--- a/strawberry/subscriptions/protocols/graphql_ws/handlers.py
+++ b/strawberry/subscriptions/protocols/graphql_ws/handlers.py
@@ -13,7 +13,6 @@ from typing import (
 from strawberry.exceptions import ConnectionRejectionError
 from strawberry.http.exceptions import NonTextMessageReceived, WebSocketDisconnected
 from strawberry.http.typevars import Context, RootValue
-from strawberry.schema.exceptions import CannotGetOperationTypeError
 from strawberry.subscriptions.protocols.graphql_ws.types import (
     CompleteMessage,
     ConnectionInitMessage,
@@ -214,14 +213,6 @@ class BaseGraphQLWSHandler(Generic[Context, RootValue]):
 
             await self.send_message(CompleteMessage(type="complete", id=operation_id))
 
-        except CannotGetOperationTypeError as e:
-            await self.send_message(
-                ErrorMessage(
-                    type="error",
-                    id=operation_id,
-                    payload={"message": e.as_http_error_reason()},
-                )
-            )
         except asyncio.CancelledError:
             await self.send_message(CompleteMessage(type="complete", id=operation_id))
 

--- a/tests/http/incremental/test_multipart_subscription.py
+++ b/tests/http/incremental/test_multipart_subscription.py
@@ -128,6 +128,31 @@ async def test_multipart_subscription_use_the_views_decode_json_method(
     assert spy.call_count == 1
 
 
+async def test_multipart_subscription_returns_error_for_query_operation(
+    http_client: HttpClient,
+):
+    response = await http_client.query(
+        query="{ hello }",
+        headers={
+            "accept": "multipart/mixed;boundary=graphql;subscriptionSpec=1.0,application/json",
+            "content-type": "application/json",
+        },
+    )
+
+    data = [d async for d in response.streaming_json()]
+
+    assert data == [
+        {
+            "payload": {
+                "data": None,
+                "errors": [{"message": "queries are not allowed"}],
+                "extensions": {"example": "example"},
+            }
+        }
+    ]
+    assert response.status_code == 200
+
+
 async def test_returns_error_when_trying_to_use_batching_with_multipart_subscriptions(
     http_client_class: type[HttpClient],
 ):

--- a/tests/http/test_async_base_view.py
+++ b/tests/http/test_async_base_view.py
@@ -3,12 +3,10 @@ from asyncio import sleep
 from collections import Counter
 from collections.abc import AsyncGenerator
 from random import random
-from typing import cast
 
 import pytest
 
-from strawberry.http.async_base_view import AsyncBaseHTTPView
-from strawberry.http.streaming import MultipartSubscriptionTransport
+from strawberry.http.streaming import merge_stream_with_heartbeat
 
 
 @pytest.mark.parametrize(
@@ -23,7 +21,7 @@ async def test_stream_with_heartbeat_should_yield_items_correctly(
     expected: list[str],
 ) -> None:
     """
-    Verifies _stream_with_heartbeat reliably delivers all items in correct order.
+    Verifies merge_stream_with_heartbeat reliably delivers all items in correct order.
 
     Tests three critical stream properties:
     1. Completeness: All source items appear in output (especially the last item)
@@ -38,21 +36,17 @@ async def test_stream_with_heartbeat_should_yield_items_correctly(
 
     assert len(set(expected)) == len(expected), "Test requires unique elements"
 
-    class MockAsyncBaseHTTPView:
-        def encode_json_string(self, _data: object) -> str:
-            return ""
-
-    view = MockAsyncBaseHTTPView()
-    transport = MultipartSubscriptionTransport(separator="")
-
     async def stream() -> AsyncGenerator[str, None]:
         for elem in expected:
             yield elem
 
     async def collect() -> list[str]:
         result = []
-        async for item in AsyncBaseHTTPView._stream_with_heartbeat(
-            cast("AsyncBaseHTTPView", view), stream, transport
+        async for item in merge_stream_with_heartbeat(
+            stream,
+            lambda: "",
+            interval=5,
+            send_initial_heartbeat=True,
         )():
             result.append(item)
             # Random sleep to promote race conditions between concurrent tasks
@@ -82,28 +76,18 @@ async def test_stream_with_heartbeat_should_yield_items_correctly(
             )
 
 
-async def test_stream_with_heartbeat_uses_transport_heartbeat_message() -> None:
-    class MockAsyncBaseHTTPView:
-        def encode_json_string(self, _data: object) -> str:
-            return ""
-
-    class MockTransport(MultipartSubscriptionTransport):
-        heartbeat_interval = 60
-
-        def heartbeat_message(self, _encode_json: object) -> str:
-            return "heartbeat"
-
-    view = MockAsyncBaseHTTPView()
-    transport = MockTransport()
-
+async def test_stream_with_heartbeat_uses_heartbeat_message() -> None:
     async def stream() -> AsyncGenerator[str, None]:
         await sleep(0)
         yield "last"
 
     result = [
         item
-        async for item in AsyncBaseHTTPView._stream_with_heartbeat(
-            cast("AsyncBaseHTTPView", view), stream, transport
+        async for item in merge_stream_with_heartbeat(
+            stream,
+            lambda: "heartbeat",
+            interval=60,
+            send_initial_heartbeat=True,
         )()
     ]
 

--- a/tests/http/test_query.py
+++ b/tests/http/test_query.py
@@ -225,7 +225,7 @@ async def test_missing_query(http_client: HttpClient):
     )
 
     assert response.status_code == 400
-    assert "No GraphQL query found in the request" in response.text
+    assert 'Request data is missing a "query" value' in response.text
 
 
 @pytest.mark.parametrize(

--- a/tests/http/test_query_via_get.py
+++ b/tests/http/test_query_via_get.py
@@ -27,14 +27,14 @@ async def test_sending_empty_query(http_client_class):
     )
 
     assert response.status_code == 400
-    assert "No GraphQL query found in the request" in response.text
+    assert 'Request data is missing a "query" value' in response.text
 
 
 async def test_does_not_allow_mutation(http_client: HttpClient):
     response = await http_client.query(method="get", query="mutation { hello }")
 
     assert response.status_code == 400
-    assert "mutations are not allowed when using GET" in response.text
+    assert "mutations are not allowed" in response.text
 
 
 async def test_fails_if_allow_queries_via_get_false(http_client_class):
@@ -43,4 +43,4 @@ async def test_fails_if_allow_queries_via_get_false(http_client_class):
     response = await http_client.query(method="get", query="{ hello }")
 
     assert response.status_code == 400
-    assert "queries are not allowed when using GET" in response.text
+    assert "queries are not allowed" in response.text

--- a/tests/http/test_upload.py
+++ b/tests/http/test_upload.py
@@ -267,7 +267,7 @@ async def test_sending_invalid_form_data(enabled_http_client: HttpClient):
     # TODO: consolidate this, it seems only AIOHTTP returns the second error
     # due to validating the boundary
     assert (
-        "No GraphQL query found in the request" in response.text
+        'Request data is missing a "query" value' in response.text
         or "Unable to parse the multipart body" in response.text
     )
 

--- a/tests/schema/extensions/schema_extensions/test_subscription.py
+++ b/tests/schema/extensions/schema_extensions/test_subscription.py
@@ -160,6 +160,37 @@ async def test_extensions_results_are_cleared_between_subscription_yields(
         res_num += 1
 
 
+async def test_subscription_extension_access_to_operation_extensions(
+    default_query_types_and_query: SchemaHelper,
+) -> None:
+    operation_extensions = None
+
+    class MyExtension(SchemaExtension):
+        async def on_operation(self):
+            nonlocal operation_extensions
+            yield
+            operation_extensions = self.execution_context.operation_extensions
+
+    schema = strawberry.Schema(
+        query=default_query_types_and_query.query_type,
+        subscription=default_query_types_and_query.subscription_type,
+        extensions=[MyExtension],
+    )
+
+    results = [
+        result
+        async for result in assert_agen(
+            await schema.subscribe(
+                default_query_types_and_query.subscription,
+                operation_extensions={"MyExtension": {"enabled": True}},
+            )
+        )
+    ]
+
+    assert [result.data["count"] for result in results] == list(range(5))
+    assert operation_extensions == {"MyExtension": {"enabled": True}}
+
+
 async def test_subscription_catches_extension_errors(
     default_query_types_and_query: SchemaHelper,
 ) -> None:

--- a/tests/schema/extensions/test_datadog.py
+++ b/tests/schema/extensions/test_datadog.py
@@ -316,9 +316,11 @@ async def test_uses_query_missing_operation_if_no_query(datadog_extension, mocke
 
     schema = strawberry.Schema(query=Query, mutation=Mutation, extensions=[extension])
 
-    # A missing query error is expected here, but the extension will run anyways
-    with pytest.raises(strawberry.exceptions.MissingQueryError):
-        await schema.execute(None)
+    # A missing query error result is expected here, but the extension will run anyways
+    result = await schema.execute(None)
+
+    assert result.errors
+    assert result.errors[0].message == 'Request data is missing a "query" value'
 
     mock.tracer.assert_has_calls(
         [

--- a/tests/schema/extensions/test_max_tokens.py
+++ b/tests/schema/extensions/test_max_tokens.py
@@ -1,3 +1,5 @@
+import pytest
+
 import strawberry
 from strawberry.extensions.max_tokens import MaxTokensLimiter
 
@@ -54,6 +56,26 @@ def test_no_errors_exactly_max_number_of_tokens():
     assert result.data
 
 
+@pytest.mark.asyncio
+async def test_async_execute_uses_max_tokens():
+    query = """
+    {
+      matt: user(name: "matt") {
+        name
+        email
+      }
+    }
+    """
+
+    result = await _execute_async_with_max_tokens(query, 13)
+
+    assert len(result.errors) == 1
+    assert (
+        result.errors[0].message
+        == "Syntax Error: Document contains more than 13 tokens. Parsing aborted."
+    )
+
+
 def _execute_with_max_tokens(query: str, max_token_count: int):
     schema = strawberry.Schema(
         Query,
@@ -61,3 +83,12 @@ def _execute_with_max_tokens(query: str, max_token_count: int):
     )
 
     return schema.execute_sync(query)
+
+
+async def _execute_async_with_max_tokens(query: str, max_token_count: int):
+    schema = strawberry.Schema(
+        Query,
+        extensions=[lambda: MaxTokensLimiter(max_token_count=max_token_count)],
+    )
+
+    return await schema.execute(query)

--- a/tests/schema/test_execution.py
+++ b/tests/schema/test_execution.py
@@ -11,6 +11,7 @@ from strawberry.extensions import (
     DisableValidation,
     SchemaExtension,
 )
+from strawberry.types.graphql import OperationType
 from strawberry.utils import IS_GQL_32
 
 
@@ -101,6 +102,104 @@ async def test_invalid_query_with_validation_enabled():
         "4 |     \n"
         "  |     ^"
     )
+
+
+@pytest.mark.asyncio
+async def test_execute_unknown_operation_name_returns_specific_pre_execution_error():
+    @strawberry.type
+    class Query:
+        example: str | None = None
+
+    schema = strawberry.Schema(query=Query)
+
+    result = await schema.execute(
+        """
+        query First {
+            example
+        }
+
+        query Second {
+            example
+        }
+        """,
+        operation_name="Missing",
+    )
+
+    assert result.data is None
+    assert result.errors
+    assert result.errors[0].message == 'Unknown operation named "Missing".'
+
+
+def test_execute_sync_unknown_operation_name_returns_specific_pre_execution_error():
+    @strawberry.type
+    class Query:
+        example: str | None = None
+
+    schema = strawberry.Schema(query=Query)
+
+    result = schema.execute_sync(
+        """
+        query First {
+            example
+        }
+
+        query Second {
+            example
+        }
+        """,
+        operation_name="Missing",
+    )
+
+    assert result.data is None
+    assert result.errors
+    assert result.errors[0].message == 'Unknown operation named "Missing".'
+
+
+@pytest.mark.asyncio
+async def test_execute_disallowed_operation_returns_specific_pre_execution_error():
+    @strawberry.type
+    class Query:
+        example: str | None = None
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        async def example(self) -> str:
+            return "hi"
+
+    schema = strawberry.Schema(query=Query, mutation=Mutation)
+
+    result = await schema.execute(
+        "mutation { example }",
+        allowed_operation_types=(OperationType.QUERY,),
+    )
+
+    assert result.data is None
+    assert result.errors
+    assert result.errors[0].message == "mutations are not allowed"
+
+
+def test_execute_sync_disallowed_operation_returns_specific_pre_execution_error():
+    @strawberry.type
+    class Query:
+        example: str | None = None
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        def example(self) -> str:
+            return "hi"
+
+    schema = strawberry.Schema(query=Query, mutation=Mutation)
+
+    result = schema.execute_sync(
+        "mutation { example }",
+        allowed_operation_types=(OperationType.QUERY,),
+    )
+
+    assert result.data is None
+    assert result.errors
+    assert result.errors[0].message == "mutations are not allowed"
 
 
 @pytest.mark.asyncio

--- a/tests/schema/test_stream.py
+++ b/tests/schema/test_stream.py
@@ -1,0 +1,324 @@
+from collections.abc import AsyncGenerator
+
+import pytest
+from graphql import GraphQLError
+
+import strawberry
+from strawberry.extensions import MaxTokensLimiter, SchemaExtension
+from strawberry.schema._graphql_core import GraphQLIncrementalExecutionResults
+from strawberry.schema.config import StrawberryConfig
+from strawberry.types.execution import ExecutionResult, PreExecutionError
+from strawberry.types.graphql import OperationType
+from strawberry.utils.aio import aclosing
+from tests.conftest import skip_if_gql_32
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def hello(self) -> str:
+        return "world"
+
+
+@strawberry.type
+class Mutation:
+    @strawberry.mutation
+    def echo(self, message: str) -> str:
+        return message
+
+
+@strawberry.type
+class Subscription:
+    @strawberry.subscription
+    async def count(self, target: int = 3) -> AsyncGenerator[int, None]:
+        for i in range(target):
+            yield i
+
+
+schema = strawberry.Schema(query=Query, mutation=Mutation, subscription=Subscription)
+
+
+async def collect(stream):
+    async with aclosing(stream) as results:
+        return [result async for result in results]
+
+
+@pytest.mark.asyncio
+async def test_stream_query_yields_single_result():
+    results = await collect(await schema.stream("{ hello }"))
+
+    assert len(results) == 1
+    assert not results[0].errors
+    assert results[0].data == {"hello": "world"}
+
+
+@pytest.mark.asyncio
+async def test_stream_mutation_yields_single_result():
+    results = await collect(await schema.stream('mutation { echo(message: "hi") }'))
+
+    assert len(results) == 1
+    assert results[0].data == {"echo": "hi"}
+
+
+@pytest.mark.asyncio
+async def test_stream_subscription_yields_multiple_results():
+    results = await collect(await schema.stream("subscription { count(target: 3) }"))
+
+    assert [result.data["count"] for result in results] == [0, 1, 2]
+
+
+@pytest.mark.asyncio
+async def test_stream_syntax_error_yields_single_pre_execution_error():
+    results = await collect(await schema.stream("{ hello"))
+
+    assert len(results) == 1
+    assert isinstance(results[0], PreExecutionError)
+    assert results[0].errors
+
+
+@pytest.mark.asyncio
+async def test_stream_validation_error_yields_single_pre_execution_error():
+    results = await collect(await schema.stream("{ doesNotExist }"))
+
+    assert len(results) == 1
+    assert isinstance(results[0], PreExecutionError)
+    assert results[0].errors
+
+
+@pytest.mark.asyncio
+async def test_stream_respects_parse_options_from_extensions():
+    limited_schema = strawberry.Schema(
+        query=Query,
+        extensions=[lambda: MaxTokensLimiter(max_token_count=2)],
+    )
+
+    results = await collect(await limited_schema.stream("{ hello }"))
+
+    assert len(results) == 1
+    assert isinstance(results[0], PreExecutionError)
+    assert results[0].errors
+    assert (
+        results[0].errors[0].message
+        == "Syntax Error: Document contains more than 2 tokens. Parsing aborted."
+    )
+
+
+@pytest.mark.asyncio
+async def test_stream_none_query_yields_single_pre_execution_error():
+    results = await collect(await schema.stream(None))
+
+    assert len(results) == 1
+    assert isinstance(results[0], PreExecutionError)
+    assert results[0].errors
+    assert results[0].errors[0].message == 'Request data is missing a "query" value'
+
+
+@pytest.mark.asyncio
+async def test_stream_empty_query_yields_single_pre_execution_error():
+    results = await collect(await schema.stream(""))
+
+    assert len(results) == 1
+    assert isinstance(results[0], PreExecutionError)
+    assert results[0].errors
+    assert results[0].errors[0].message == 'Request data is missing a "query" value'
+
+
+@pytest.mark.asyncio
+async def test_stream_query_processes_errors_exactly_once(mocker):
+    @strawberry.type
+    class ErrorQuery:
+        @strawberry.field
+        def boom(self) -> str:
+            raise ValueError("boom")
+
+    error_schema = strawberry.Schema(query=ErrorQuery)
+    spy = mocker.spy(error_schema, "process_errors")
+
+    results = await collect(await error_schema.stream("{ boom }"))
+
+    assert len(results) == 1
+    assert results[0].errors
+    # The single-result path must run process_errors once (and not again via
+    # _handle_execution_result), matching `Schema.execute`.
+    spy.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_stream_query_attaches_extension_results():
+    class MyExtension(SchemaExtension):
+        def get_results(self) -> dict[str, object]:
+            return {"example": "result"}
+
+    extended_schema = strawberry.Schema(query=Query, extensions=[MyExtension])
+
+    results = await collect(await extended_schema.stream("{ hello }"))
+
+    assert len(results) == 1
+    assert results[0].extensions == {"example": "result"}
+
+
+@pytest.mark.asyncio
+async def test_stream_disallowed_operation_type_yields_single_pre_execution_error():
+    results = await collect(
+        await schema.stream(
+            "subscription { count }",
+            allowed_operation_types=(OperationType.QUERY, OperationType.MUTATION),
+        )
+    )
+
+    assert len(results) == 1
+    assert isinstance(results[0], PreExecutionError)
+    assert results[0].errors
+    assert results[0].errors[0].message == "subscriptions are not allowed"
+
+
+@skip_if_gql_32("GraphQL 3.3.0 is required for incremental execution")
+@pytest.mark.asyncio
+async def test_stream_expands_incremental_delivery():
+    @strawberry.type
+    class StreamQuery:
+        @strawberry.field
+        async def streamable_field(self) -> strawberry.Streamable[str]:
+            for value in ["a", "b", "c"]:
+                yield value
+
+    incremental_schema = strawberry.Schema(
+        query=StreamQuery,
+        config=StrawberryConfig(enable_experimental_incremental_execution=True),
+    )
+
+    frames = await collect(
+        await incremental_schema.stream("{ streamableField @stream }")
+    )
+
+    # The incremental container is expanded into discrete frames, not yielded
+    # whole — so a streaming transport sees one uniform sequence of results.
+    assert len(frames) >= 2
+    assert not any(
+        isinstance(frame, GraphQLIncrementalExecutionResults) for frame in frames
+    )
+    # First frame is the initial result; later frames carry the `@stream` patches.
+    assert frames[0].data == {"streamableField": []}
+    assert frames[0].has_next is True
+    assert frames[-1].has_next is False
+    assert any(getattr(frame, "incremental", None) for frame in frames[1:])
+
+
+@pytest.mark.asyncio
+async def test_stream_handles_incremental_initial_result(monkeypatch):
+    from strawberry.schema import schema as schema_module
+
+    processed_errors = []
+
+    class MyExtension(SchemaExtension):
+        def get_results(self) -> dict[str, object]:
+            return {"example": "result"}
+
+    class FakeSubsequentResults:
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise StopAsyncIteration
+
+        async def aclose(self) -> None:
+            pass
+
+    class FakeIncrementalExecutionResults:
+        def __init__(self) -> None:
+            self.initial_result = ExecutionResult(
+                data=None,
+                errors=[
+                    GraphQLError(
+                        "original error",
+                        original_error=ValueError("original error"),
+                    )
+                ],
+            )
+            self.subsequent_results = FakeSubsequentResults()
+
+    class CustomSchema(strawberry.Schema):
+        def process_errors(self, errors, execution_context):
+            processed_errors.append(errors[0])
+            errors[0] = GraphQLError("masked error")
+
+    incremental_result = FakeIncrementalExecutionResults()
+    incremental_schema = CustomSchema(query=Query, extensions=[MyExtension])
+
+    async def fake_execute_operation(*args: object, **kwargs: object):
+        return incremental_result
+
+    monkeypatch.setattr(
+        schema_module,
+        "GraphQLIncrementalExecutionResults",
+        FakeIncrementalExecutionResults,
+    )
+    monkeypatch.setattr(
+        incremental_schema,
+        "_execute_operation",
+        fake_execute_operation,
+    )
+
+    results = await collect(await incremental_schema.stream("{ hello }"))
+
+    assert len(results) == 1
+    assert results[0].errors
+    assert results[0].errors[0].message == "masked error"
+    assert results[0].extensions == {"example": "result"}
+    assert processed_errors[0].message == "original error"
+
+
+@pytest.mark.asyncio
+async def test_stream_closes_incremental_subsequent_results_when_abandoned(monkeypatch):
+    from strawberry.schema import schema as schema_module
+
+    class FakeSubsequentResults:
+        def __init__(self) -> None:
+            self.closed = False
+            self._remaining_results = ["patch"]
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            if self._remaining_results:
+                return self._remaining_results.pop(0)
+
+            raise StopAsyncIteration
+
+        async def aclose(self) -> None:
+            self.closed = True
+
+    class FakeIncrementalExecutionResults:
+        def __init__(self, subsequent_results: FakeSubsequentResults) -> None:
+            self.initial_result = ExecutionResult(data={"initial": True}, errors=None)
+            self.subsequent_results = subsequent_results
+
+    subsequent_results = FakeSubsequentResults()
+    incremental_result = FakeIncrementalExecutionResults(subsequent_results)
+    incremental_schema = strawberry.Schema(query=Query)
+
+    async def fake_execute_operation(*args: object, **kwargs: object):
+        return incremental_result
+
+    monkeypatch.setattr(
+        schema_module,
+        "GraphQLIncrementalExecutionResults",
+        FakeIncrementalExecutionResults,
+    )
+    monkeypatch.setattr(
+        incremental_schema,
+        "_execute_operation",
+        fake_execute_operation,
+    )
+
+    results = await incremental_schema.stream("{ hello }")
+
+    initial_result = await results.__anext__()
+    assert initial_result.data == {"initial": True}
+    assert await results.__anext__() == "patch"
+    assert not subsequent_results.closed
+
+    await results.aclose()
+
+    assert subsequent_results.closed

--- a/tests/websockets/test_graphql_transport_ws.py
+++ b/tests/websockets/test_graphql_transport_ws.py
@@ -11,9 +11,15 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 import pytest_asyncio
+from graphql import parse
 from pytest_mock import MockerFixture
 
+from strawberry.extensions import ParserCache
+from strawberry.extensions import parser_cache as parser_cache_module
 from strawberry.subscriptions import GRAPHQL_TRANSPORT_WS_PROTOCOL
+from strawberry.subscriptions.protocols.graphql_transport_ws import (
+    handlers as transport_handlers,
+)
 from strawberry.subscriptions.protocols.graphql_transport_ws.types import (
     CompleteMessage,
     ConnectionAckMessage,
@@ -25,7 +31,7 @@ from strawberry.subscriptions.protocols.graphql_transport_ws.types import (
     SubscribeMessage,
 )
 from tests.http.clients.base import DebuggableGraphQLTransportWSHandler
-from tests.views.schema import MyExtension, Schema, Subscription, schema
+from tests.views.schema import MyExtension, Query, Schema, Subscription, schema
 
 if TYPE_CHECKING:
     from tests.http.clients.base import HttpClient, WebSocketClient
@@ -469,6 +475,75 @@ async def test_simple_subscription(ws: WebSocketClient):
     await ws.send_message({"id": "sub1", "type": "complete"})
 
 
+async def test_document_is_parsed_by_schema_once(
+    ws: WebSocketClient, mocker: MockerFixture
+):
+    from strawberry.schema import schema as schema_module
+
+    parse_spy = mocker.spy(schema_module, "parse")
+
+    await ws.send_message(
+        {
+            "id": "sub1",
+            "type": "subscribe",
+            "payload": {"query": 'subscription { echo(message: "Hi") }'},
+        }
+    )
+
+    next_message: NextMessage = await ws.receive_json()
+    assert_next(next_message, "sub1", {"echo": "Hi"})
+    await ws.send_message({"id": "sub1", "type": "complete"})
+
+    parse_spy.assert_called_once()
+
+
+async def test_document_parsing_uses_schema_extensions(
+    http_client_class: type[HttpClient],
+):
+    from strawberry.schema import schema as schema_module
+
+    parser_cache_module._get_parse_cache.cache_clear()
+    cached_schema = Schema(
+        query=Query,
+        subscription=Subscription,
+        extensions=[ParserCache],
+    )
+    test_client = http_client_class(cached_schema)
+
+    with (
+        patch.object(
+            transport_handlers,
+            "parse",
+            side_effect=AssertionError("transport should not parse GraphQL documents"),
+            create=True,
+        ),
+        patch("strawberry.extensions.parser_cache.parse", wraps=parse) as cache_parse,
+        patch.object(schema_module, "parse", wraps=schema_module.parse) as schema_parse,
+    ):
+        async with test_client.ws_connect(
+            "/graphql", protocols=[GRAPHQL_TRANSPORT_WS_PROTOCOL]
+        ) as ws:
+            await ws.send_message({"type": "connection_init"})
+            connection_ack_message: ConnectionAckMessage = await ws.receive_json()
+            assert connection_ack_message == {"type": "connection_ack"}
+
+            await ws.send_message(
+                {
+                    "id": "sub1",
+                    "type": "subscribe",
+                    "payload": {"query": 'subscription { echo(message: "Hi") }'},
+                }
+            )
+
+            next_message: NextMessage = await ws.receive_json()
+            assert_next(next_message, "sub1", {"echo": "Hi"})
+            await ws.send_message({"id": "sub1", "type": "complete"})
+
+    cache_parse.assert_called_once_with('subscription { echo(message: "Hi") }')
+    schema_parse.assert_not_called()
+    parser_cache_module._get_parse_cache.cache_clear()
+
+
 @pytest.mark.parametrize(
     ("extra_payload", "expected_message"),
     [
@@ -586,6 +661,56 @@ async def test_subscription_field_errors(ws: WebSocketClient):
         )
 
         process_errors.assert_called_once()
+
+
+async def test_incremental_delivery_frames_are_rejected(ws: WebSocketClient):
+    """``stream`` expands incremental delivery (``@defer``/``@stream``) into raw
+    graphql-core frames, which the graphql-transport-ws ``next`` message cannot
+    represent. The handler must reject such an operation with an ``error`` rather
+    than crash or emit a malformed payload.
+
+    A synthetic frame is injected so the behaviour is exercised regardless of the
+    installed graphql-core version (incremental delivery needs >= 3.3).
+    """
+
+    class FakeIncrementalFrame:
+        # Mimics a graphql-core incremental frame: notably NOT a strawberry
+        # ``ExecutionResult`` and missing ``data``/``errors`` accessors.
+        has_next = True
+        incremental = ()
+
+    stream_closed = asyncio.Event()
+
+    async def fake_stream(
+        self, *args: object, **kwargs: object
+    ) -> AsyncGenerator[FakeIncrementalFrame, None]:
+        async def frames() -> AsyncGenerator[FakeIncrementalFrame, None]:
+            try:
+                yield FakeIncrementalFrame()
+                await asyncio.sleep(999)
+            finally:
+                stream_closed.set()
+
+        return frames()
+
+    with patch.object(Schema, "stream", fake_stream):
+        await ws.send_message(
+            {
+                "id": "sub1",
+                "type": "subscribe",
+                "payload": {"query": 'subscription { echo(message: "Hi") }'},
+            }
+        )
+
+        error_message: ErrorMessage = await ws.receive_json()
+        assert error_message["type"] == "error"
+        assert error_message["id"] == "sub1"
+        assert len(error_message["payload"]) == 1
+        assert (
+            "Incremental delivery is not supported"
+            in error_message["payload"][0]["message"]
+        )
+        await asyncio.wait_for(stream_closed.wait(), timeout=2)
 
 
 async def test_subscription_cancellation(ws: WebSocketClient):


### PR DESCRIPTION
<!-- shortcake:start -->
## Stack [🍰](https://shortcake.patrick.wtf)

- **#4474** (`2026-06-20-return-pre-execution-errors-from-execute-and-execu`) <-- this PR
- #4460 (merged) (`2026-06-14-unify-streaming-execution-behind-schema-stream`)
- #4469 (merged) (`2026-06-14-extract-http-stream-transports`)
<!-- shortcake:end -->