### PR TITLE
fix: preserve NewType in pydantic type resolution for scalar_map

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,17 +1,20 @@
 ---
 release type: patch
+social_messages:
+  x: >-
+    {project_name} {version} is out! Pydantic fields now keep their NewType
+    scalar mappings when Strawberry builds the GraphQL schema. 🍓
+    https://strawberry.rocks/release/{version}
+  linkedin: >-
+    {project_name} {version} is out. Pydantic fields annotated with NewType now
+    respect StrawberryConfig scalar mappings during schema generation, keeping
+    the generated GraphQL scalar consistent with runtime conversion.
 ---
 
-Fix `scalar_map` not being applied to pydantic model fields during schema
-generation. Previously, `NewType` wrappers on pydantic fields were
-unconditionally unwrapped to their underlying type (e.g. `str`) during
-pydantic type resolution, which destroyed the type identity before the
-`scalar_map` from `StrawberryConfig` could intercept it at schema
-construction time.
+This release fixes `StrawberryConfig.scalar_map` being ignored for Pydantic
+fields annotated with `NewType`.
 
-This change removes the early `NewType` unwrapping in the pydantic compat
-layer and instead adds `__supertype__` fallback logic to `is_scalar()` and
-`from_scalar()`, so that:
-- `NewType` annotations in `scalar_map` are matched correctly (the fix)
-- `NewType` fields without a `scalar_map` entry still resolve to their
-  underlying type via the new fallback (backward compatible)
+Strawberry now preserves the annotation until schema scalar resolution, so the
+generated GraphQL type and runtime scalar conversion use the same configured
+scalar. Unmapped `NewType` annotations continue to resolve through their
+underlying type.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,17 @@
+---
+release type: patch
+---
+
+Fix `scalar_map` not being applied to pydantic model fields during schema
+generation. Previously, `NewType` wrappers on pydantic fields were
+unconditionally unwrapped to their underlying type (e.g. `str`) during
+pydantic type resolution, which destroyed the type identity before the
+`scalar_map` from `StrawberryConfig` could intercept it at schema
+construction time.
+
+This change removes the early `NewType` unwrapping in the pydantic compat
+layer and instead adds `__supertype__` fallback logic to `is_scalar()` and
+`from_scalar()`, so that:
+- `NewType` annotations in `scalar_map` are matched correctly (the fix)
+- `NewType` fields without a `scalar_map` entry still resolve to their
+  underlying type via the new fallback (backward compatible)

--- a/strawberry/experimental/pydantic/_compat.py
+++ b/strawberry/experimental/pydantic/_compat.py
@@ -205,6 +205,15 @@ class PydanticV2Compat:
         return get_fields_map_for_v2()
 
     def get_basic_type(self, type_: Any) -> type[Any]:
+        if is_new_type(type_):
+            supertype = new_type_supertype(type_)
+            # Only unwrap when the underlying type is a pydantic model
+            # (needed for replace_pydantic_types detection). For scalar
+            # supertypes, preserve the NewType so scalar_map entries
+            # keyed by NewType identity can intercept.
+            if is_model_class(supertype):
+                return supertype
+
         if type_ in self.fields_map:
             type_ = self.fields_map[type_]
 
@@ -261,6 +270,11 @@ class PydanticV1Compat:
         }
 
     def get_basic_type(self, type_: Any) -> type[Any]:
+        if is_new_type(type_):
+            supertype = new_type_supertype(type_)
+            if is_model_class(supertype):
+                return supertype
+
         if IS_PYDANTIC_V1:
             ConstrainedInt = pydantic.ConstrainedInt
             ConstrainedFloat = pydantic.ConstrainedFloat

--- a/strawberry/experimental/pydantic/_compat.py
+++ b/strawberry/experimental/pydantic/_compat.py
@@ -211,9 +211,6 @@ class PydanticV2Compat:
             if type_ is None:
                 raise UnsupportedTypeError
 
-        if is_new_type(type_):
-            return new_type_supertype(type_)
-
         return type_
 
     def model_dump(self, model_instance: BaseModel) -> dict[Any, Any]:
@@ -289,9 +286,6 @@ class PydanticV1Compat:
 
             if type_ is None:
                 raise UnsupportedTypeError
-
-        if is_new_type(type_):
-            return new_type_supertype(type_)
 
         return type_
 

--- a/strawberry/experimental/pydantic/_compat.py
+++ b/strawberry/experimental/pydantic/_compat.py
@@ -205,8 +205,8 @@ class PydanticV2Compat:
         return get_fields_map_for_v2()
 
     def get_basic_type(self, type_: Any) -> type[Any]:
-        if (model_supertype := _get_new_type_model_supertype(type_)) is not None:
-            return model_supertype
+        if (model_type := _resolve_new_type_model(type_)) is not None:
+            return model_type
 
         if type_ in self.fields_map:
             type_ = self.fields_map[type_]
@@ -264,8 +264,8 @@ class PydanticV1Compat:
         }
 
     def get_basic_type(self, type_: Any) -> type[Any]:
-        if (model_supertype := _get_new_type_model_supertype(type_)) is not None:
-            return model_supertype
+        if (model_type := _resolve_new_type_model(type_)) is not None:
+            return model_type
 
         if IS_PYDANTIC_V1:
             ConstrainedInt = pydantic.ConstrainedInt
@@ -344,7 +344,7 @@ def is_model_class(type_: Any) -> bool:
     return lenient_issubclass(type_, BASE_MODEL_TYPES)
 
 
-def _get_new_type_model_supertype(type_: Any) -> Any | None:
+def _resolve_new_type_model(type_: Any) -> Any | None:
     while is_new_type(type_):
         type_ = new_type_supertype(type_)
         if is_model_class(type_):

--- a/strawberry/experimental/pydantic/_compat.py
+++ b/strawberry/experimental/pydantic/_compat.py
@@ -205,14 +205,9 @@ class PydanticV2Compat:
         return get_fields_map_for_v2()
 
     def get_basic_type(self, type_: Any) -> type[Any]:
-        if is_new_type(type_):
-            supertype = new_type_supertype(type_)
-            # Only unwrap when the underlying type is a pydantic model
-            # (needed for replace_pydantic_types detection). For scalar
-            # supertypes, preserve the NewType so scalar_map entries
-            # keyed by NewType identity can intercept.
-            if is_model_class(supertype):
-                return supertype
+        model_supertype = _get_new_type_model_supertype(type_)
+        if model_supertype is not None:
+            return model_supertype
 
         if type_ in self.fields_map:
             type_ = self.fields_map[type_]
@@ -270,10 +265,9 @@ class PydanticV1Compat:
         }
 
     def get_basic_type(self, type_: Any) -> type[Any]:
-        if is_new_type(type_):
-            supertype = new_type_supertype(type_)
-            if is_model_class(supertype):
-                return supertype
+        model_supertype = _get_new_type_model_supertype(type_)
+        if model_supertype is not None:
+            return model_supertype
 
         if IS_PYDANTIC_V1:
             ConstrainedInt = pydantic.ConstrainedInt
@@ -350,6 +344,15 @@ else:
 
 def is_model_class(type_: Any) -> bool:
     return lenient_issubclass(type_, BASE_MODEL_TYPES)
+
+
+def _get_new_type_model_supertype(type_: Any) -> Any | None:
+    while is_new_type(type_):
+        type_ = new_type_supertype(type_)
+        if is_model_class(type_):
+            return type_
+
+    return None
 
 
 def is_model_instance(value: Any) -> bool:

--- a/strawberry/experimental/pydantic/_compat.py
+++ b/strawberry/experimental/pydantic/_compat.py
@@ -205,8 +205,7 @@ class PydanticV2Compat:
         return get_fields_map_for_v2()
 
     def get_basic_type(self, type_: Any) -> type[Any]:
-        model_supertype = _get_new_type_model_supertype(type_)
-        if model_supertype is not None:
+        if (model_supertype := _get_new_type_model_supertype(type_)) is not None:
             return model_supertype
 
         if type_ in self.fields_map:
@@ -265,8 +264,7 @@ class PydanticV1Compat:
         }
 
     def get_basic_type(self, type_: Any) -> type[Any]:
-        model_supertype = _get_new_type_model_supertype(type_)
-        if model_supertype is not None:
+        if (model_supertype := _get_new_type_model_supertype(type_)) is not None:
             return model_supertype
 
         if IS_PYDANTIC_V1:

--- a/strawberry/scalars.py
+++ b/strawberry/scalars.py
@@ -39,10 +39,11 @@ def is_scalar(
     if hasattr(annotation, "_scalar_definition"):
         return True
 
-    # NewType fallback: if the annotation is a NewType not in the registry,
-    # check whether its supertype is a known scalar.
-    if hasattr(annotation, "__supertype__"):
-        return is_scalar(annotation.__supertype__, scalar_registry)
+    while isinstance(annotation, NewType):
+        annotation = annotation.__supertype__
+
+        if annotation in scalar_registry or hasattr(annotation, "_scalar_definition"):
+            return True
 
     return False
 

--- a/strawberry/scalars.py
+++ b/strawberry/scalars.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, NewType, get_origin
+from typing import TYPE_CHECKING, Any, NewType, cast, get_origin
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -24,28 +24,48 @@ Base64 = NewType("Base64", bytes)
 """Represent binary data as Base64-encoded strings."""
 
 
+def _get_scalar_definition(
+    annotation: Any,
+    scalar_registry: Mapping[object, ScalarWrapper | ScalarDefinition],
+) -> ScalarDefinition | None:
+    while True:
+        if annotation in scalar_registry:
+            scalar_definition = scalar_registry[annotation]
+            return cast(
+                "ScalarDefinition",
+                getattr(
+                    scalar_definition,
+                    "_scalar_definition",
+                    scalar_definition,
+                ),
+            )
+
+        origin = get_origin(annotation)
+        if origin is not None and origin in scalar_registry:
+            scalar_definition = scalar_registry[origin]
+            return cast(
+                "ScalarDefinition",
+                getattr(
+                    scalar_definition,
+                    "_scalar_definition",
+                    scalar_definition,
+                ),
+            )
+
+        if hasattr(annotation, "_scalar_definition"):
+            return cast("ScalarDefinition", annotation._scalar_definition)
+
+        if not isinstance(annotation, NewType):
+            return None
+
+        annotation = annotation.__supertype__
+
+
 def is_scalar(
     annotation: Any,
     scalar_registry: Mapping[object, ScalarWrapper | ScalarDefinition],
 ) -> bool:
-    if annotation in scalar_registry:
-        return True
-
-    # Keep scalar checks consistent for schema generation and argument conversion.
-    origin = get_origin(annotation)
-    if origin is not None and origin in scalar_registry:
-        return True
-
-    if hasattr(annotation, "_scalar_definition"):
-        return True
-
-    while isinstance(annotation, NewType):
-        annotation = annotation.__supertype__
-
-        if annotation in scalar_registry or hasattr(annotation, "_scalar_definition"):
-            return True
-
-    return False
+    return _get_scalar_definition(annotation, scalar_registry) is not None
 
 
 __all__ = [

--- a/strawberry/scalars.py
+++ b/strawberry/scalars.py
@@ -36,7 +36,15 @@ def is_scalar(
     if origin is not None and origin in scalar_registry:
         return True
 
-    return hasattr(annotation, "_scalar_definition")
+    if hasattr(annotation, "_scalar_definition"):
+        return True
+
+    # NewType fallback: if the annotation is a NewType not in the registry,
+    # check whether its supertype is a known scalar.
+    if hasattr(annotation, "__supertype__"):
+        return is_scalar(annotation.__supertype__, scalar_registry)
+
+    return False
 
 
 __all__ = [

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -1107,10 +1107,17 @@ class GraphQLCoreConverter:
             if origin is not None and origin in self.scalar_registry:
                 scalar = origin
             elif hasattr(scalar, "__supertype__"):
-                # NewType fallback: unwrap to the underlying supertype so
-                # the scalar can be resolved via the default registry or
-                # scalar_map entries keyed by Python builtins.
-                scalar = scalar.__supertype__
+                # NewType fallback: walk the __supertype__ chain until
+                # we find a matching registry entry. This mirrors the
+                # recursive is_scalar() behaviour for chained NewTypes.
+                resolved = scalar
+                while hasattr(resolved, "__supertype__"):
+                    resolved = resolved.__supertype__
+                    if resolved in self.scalar_registry:
+                        scalar = resolved
+                        break
+                else:
+                    scalar = scalar.__supertype__
 
         if scalar in self.scalar_registry:
             _scalar_definition = self.scalar_registry[scalar]

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -1106,6 +1106,11 @@ class GraphQLCoreConverter:
             origin = typing.get_origin(scalar)
             if origin is not None and origin in self.scalar_registry:
                 scalar = origin
+            elif hasattr(scalar, "__supertype__"):
+                # NewType fallback: unwrap to the underlying supertype so
+                # the scalar can be resolved via the default registry or
+                # scalar_map entries keyed by Python builtins.
+                scalar = scalar.__supertype__
 
         if scalar in self.scalar_registry:
             _scalar_definition = self.scalar_registry[scalar]

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -1093,11 +1093,7 @@ class GraphQLCoreConverter:
         _resolver._is_default = not field.base_resolver  # type: ignore
         return _resolver
 
-    def from_scalar(
-        self,
-        scalar: object,
-        scalar_definition: ScalarDefinition | None = None,
-    ) -> GraphQLScalarType:
+    def from_scalar(self, scalar: object) -> GraphQLScalarType:
         from strawberry.relay.types import GlobalID
 
         if not self.config.relay_use_legacy_global_id and scalar is GlobalID:
@@ -1105,9 +1101,7 @@ class GraphQLCoreConverter:
 
             return self.from_scalar(ID)
 
-        if scalar_definition is None:
-            scalar_definition = _get_scalar_definition(scalar, self.scalar_registry)
-
+        scalar_definition = _get_scalar_definition(scalar, self.scalar_registry)
         if scalar_definition is None:
             raise TypeError(f"Unexpected scalar '{scalar}'")
 
@@ -1189,10 +1183,10 @@ class GraphQLCoreConverter:
             if typing.get_origin(resolved) is Annotated:
                 return self.from_type(StrawberryAnnotation(resolved).resolve())
             return self.from_type(resolved)
-        if (
-            scalar_definition := _get_scalar_definition(type_, self.scalar_registry)
-        ) is not None:  # TODO: Replace with StrawberryScalar
-            return self.from_scalar(type_, scalar_definition)
+        if compat.is_scalar(
+            type_, self.scalar_registry
+        ):  # TODO: Replace with StrawberryScalar
+            return self.from_scalar(type_)
         if isinstance(type_, typing.NewType):
             return self.from_type(cast("StrawberryType | type", type_.__supertype__))
 

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -1106,12 +1106,12 @@ class GraphQLCoreConverter:
             origin = typing.get_origin(scalar)
             if origin is not None and origin in self.scalar_registry:
                 scalar = origin
-            elif hasattr(scalar, "__supertype__"):
+            elif isinstance(scalar, typing.NewType):
                 # NewType fallback: walk the __supertype__ chain until
                 # we find a matching registry entry. This mirrors the
                 # recursive is_scalar() behaviour for chained NewTypes.
                 resolved = scalar
-                while hasattr(resolved, "__supertype__"):
+                while isinstance(resolved, typing.NewType):
                     resolved = resolved.__supertype__
                     if resolved in self.scalar_registry or hasattr(
                         resolved, "_scalar_definition"
@@ -1213,6 +1213,8 @@ class GraphQLCoreConverter:
             type_, self.scalar_registry
         ):  # TODO: Replace with StrawberryScalar
             return self.from_scalar(type_)
+        if isinstance(type_, typing.NewType):
+            return self.from_type(cast("StrawberryType | type", type_.__supertype__))
 
         raise TypeError(f"Unexpected type '{type_}'")
 

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -1113,11 +1113,13 @@ class GraphQLCoreConverter:
                 resolved = scalar
                 while hasattr(resolved, "__supertype__"):
                     resolved = resolved.__supertype__
-                    if resolved in self.scalar_registry:
+                    if resolved in self.scalar_registry or hasattr(
+                        resolved, "_scalar_definition"
+                    ):
                         scalar = resolved
                         break
                 else:
-                    scalar = scalar.__supertype__
+                    scalar = resolved
 
         if scalar in self.scalar_registry:
             _scalar_definition = self.scalar_registry[scalar]

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -51,6 +51,7 @@ from strawberry.exceptions import (
 )
 from strawberry.extensions.field_extension import build_field_extension_resolvers
 from strawberry.relay.types import GlobalID
+from strawberry.scalars import _get_scalar_definition
 from strawberry.schema.exception_handlers import (
     get_error_type,
     get_exception_types,
@@ -1092,7 +1093,11 @@ class GraphQLCoreConverter:
         _resolver._is_default = not field.base_resolver  # type: ignore
         return _resolver
 
-    def from_scalar(self, scalar: type) -> GraphQLScalarType:
+    def from_scalar(
+        self,
+        scalar: object,
+        scalar_definition: ScalarDefinition | None = None,
+    ) -> GraphQLScalarType:
         from strawberry.relay.types import GlobalID
 
         if not self.config.relay_use_legacy_global_id and scalar is GlobalID:
@@ -1100,36 +1105,11 @@ class GraphQLCoreConverter:
 
             return self.from_scalar(ID)
 
-        scalar_definition: ScalarDefinition
+        if scalar_definition is None:
+            scalar_definition = _get_scalar_definition(scalar, self.scalar_registry)
 
-        if scalar not in self.scalar_registry:
-            origin = typing.get_origin(scalar)
-            if origin is not None and origin in self.scalar_registry:
-                scalar = origin
-            elif isinstance(scalar, typing.NewType):
-                # NewType fallback: walk the __supertype__ chain until
-                # we find a matching registry entry. This mirrors the
-                # recursive is_scalar() behaviour for chained NewTypes.
-                resolved = scalar
-                while isinstance(resolved, typing.NewType):
-                    resolved = resolved.__supertype__
-                    if resolved in self.scalar_registry or hasattr(
-                        resolved, "_scalar_definition"
-                    ):
-                        scalar = resolved
-                        break
-                else:
-                    scalar = resolved
-
-        if scalar in self.scalar_registry:
-            _scalar_definition = self.scalar_registry[scalar]
-            # TODO: check why we need the cast and we are not trying with getattr first
-            if isinstance(_scalar_definition, ScalarWrapper):
-                scalar_definition = _scalar_definition._scalar_definition
-            else:
-                scalar_definition = _scalar_definition
-        else:
-            scalar_definition = scalar._scalar_definition  # type: ignore[attr-defined]
+        if scalar_definition is None:
+            raise TypeError(f"Unexpected scalar '{scalar}'")
 
         scalar_name = self.config.name_converter.from_type(scalar_definition)
 
@@ -1209,10 +1189,10 @@ class GraphQLCoreConverter:
             if typing.get_origin(resolved) is Annotated:
                 return self.from_type(StrawberryAnnotation(resolved).resolve())
             return self.from_type(resolved)
-        if compat.is_scalar(
-            type_, self.scalar_registry
-        ):  # TODO: Replace with StrawberryScalar
-            return self.from_scalar(type_)
+        if (
+            scalar_definition := _get_scalar_definition(type_, self.scalar_registry)
+        ) is not None:  # TODO: Replace with StrawberryScalar
+            return self.from_scalar(type_, scalar_definition)
         if isinstance(type_, typing.NewType):
             return self.from_type(cast("StrawberryType | type", type_.__supertype__))
 

--- a/tests/experimental/pydantic/schema/test_basic.py
+++ b/tests/experimental/pydantic/schema/test_basic.py
@@ -213,6 +213,40 @@ def test_basic_type_with_nested_model():
     assert result.data["user"]["hobby"]["name"] == "Skii"
 
 
+def test_basic_type_with_newtype_chain_nested_model():
+    from typing import NewType
+
+    class Hobby(pydantic.BaseModel):
+        name: str
+
+    HobbyRef = NewType("HobbyRef", Hobby)
+    WrappedHobbyRef = NewType("WrappedHobbyRef", HobbyRef)
+
+    @strawberry.experimental.pydantic.type(Hobby)
+    class HobbyType:
+        name: strawberry.auto
+
+    class User(pydantic.BaseModel):
+        hobby: WrappedHobbyRef
+
+    @strawberry.experimental.pydantic.type(User)
+    class UserType:
+        hobby: strawberry.auto
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def user(self) -> UserType:
+            return UserType(hobby=HobbyType(name="Skii"))
+
+    schema = strawberry.Schema(query=Query)
+
+    result = schema.execute_sync("{ user { hobby { name } } }")
+
+    assert not result.errors
+    assert result.data["user"]["hobby"]["name"] == "Skii"
+
+
 def test_basic_type_with_list_of_nested_model():
     class Hobby(pydantic.BaseModel):
         name: str

--- a/tests/experimental/pydantic/schema/test_basic.py
+++ b/tests/experimental/pydantic/schema/test_basic.py
@@ -213,6 +213,63 @@ def test_basic_type_with_nested_model():
     assert result.data["user"]["hobby"]["name"] == "Skii"
 
 
+def test_basic_type_with_newtype_scalar_map():
+    from typing import NewType
+
+    from strawberry.schema.config import StrawberryConfig
+
+    UserID = NewType("UserID", str)
+
+    class RemoveUserInputModel(pydantic.BaseModel):
+        id: UserID
+
+    @strawberry.experimental.pydantic.input(RemoveUserInputModel, all_fields=True)
+    class RemoveUserInput:
+        pass
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def echo(self, data: RemoveUserInput) -> UserID:
+            return data.id
+
+    unmapped_schema = strawberry.Schema(query=Query)
+
+    assert "id: String!" in str(unmapped_schema)
+
+    schema = strawberry.Schema(
+        query=Query,
+        config=StrawberryConfig(
+            scalar_map={
+                UserID: strawberry.scalar(
+                    name="UserID",
+                    serialize=str,
+                    parse_value=lambda value: UserID(f"parsed:{value}"),
+                )
+            }
+        ),
+    )
+
+    expected_schema = """
+    type Query {
+      echo(data: RemoveUserInput!): UserID!
+    }
+
+    input RemoveUserInput {
+      id: UserID!
+    }
+
+    scalar UserID
+    """
+
+    assert str(schema) == textwrap.dedent(expected_schema).strip()
+
+    result = schema.execute_sync('{ echo(data: {id: "123"}) }')
+
+    assert not result.errors
+    assert result.data == {"echo": "parsed:123"}
+
+
 def test_basic_type_with_newtype_chain_nested_model():
     from typing import NewType
 
@@ -245,6 +302,45 @@ def test_basic_type_with_newtype_chain_nested_model():
 
     assert not result.errors
     assert result.data["user"]["hobby"]["name"] == "Skii"
+
+
+def test_basic_type_with_newtype_enum():
+    from typing import NewType
+
+    @strawberry.enum
+    class Status(Enum):
+        ACTIVE = "active"
+
+    StatusAlias = NewType("StatusAlias", Status)
+
+    class UserModel(pydantic.BaseModel):
+        status: StatusAlias
+
+    @strawberry.experimental.pydantic.type(UserModel, all_fields=True)
+    class User:
+        pass
+
+    @strawberry.type
+    class Query:
+        user: User
+
+    schema = strawberry.Schema(query=Query)
+
+    expected_schema = """
+    type Query {
+      user: User!
+    }
+
+    enum Status {
+      ACTIVE
+    }
+
+    type User {
+      status: Status!
+    }
+    """
+
+    assert str(schema) == textwrap.dedent(expected_schema).strip()
 
 
 def test_basic_type_with_list_of_nested_model():

--- a/tests/schema/test_scalars.py
+++ b/tests/schema/test_scalars.py
@@ -625,6 +625,40 @@ def test_scalar_map_with_newtype():
     assert result.data == {"processString": "processed: world"}
 
 
+def test_newtype_chain_to_custom_scalar():
+    """Test chained NewType wrappers resolve to their custom scalar."""
+    from typing import NewType
+
+    BaseScalar = strawberry.scalar(
+        NewType("BaseScalar", str),
+        name="BaseScalar",
+        serialize=lambda v: str(v).upper(),
+        parse_value=lambda v: str(v).lower(),
+    )
+    Alias = NewType("Alias", BaseScalar)
+    WrappedAlias = NewType("WrappedAlias", Alias)
+
+    @strawberry.type
+    class Query:
+        value: WrappedAlias
+
+        @strawberry.field
+        def echo(self, value: WrappedAlias) -> WrappedAlias:
+            return value
+
+    schema = strawberry.Schema(query=Query)
+
+    assert "scalar BaseScalar" in str(schema)
+    assert "value: BaseScalar!" in str(schema)
+
+    result = schema.execute_sync(
+        '{ value echo(value: "WORLD") }', root_value=Query(value=WrappedAlias("hello"))
+    )
+
+    assert not result.errors
+    assert result.data == {"value": "HELLO", "echo": "WORLD"}
+
+
 def test_scalar_map_override_builtin():
     """Test scalar_map can override built-in scalars."""
     from strawberry.schema.config import StrawberryConfig


### PR DESCRIPTION
Fixes #4482 — `scalar_map` entries keyed by `typing.NewType` were silently ignored for pydantic model fields during schema generation.

## Problem

The pydantic compat layer (`PydanticV1Compat.get_basic_type` / `PydanticV2Compat.get_basic_type` in `strawberry/experimental/pydantic/_compat.py`) unconditionally unwrapped `typing.NewType` annotations to their underlying supertype (e.g. `ID = NewType("ID", str)` → `str`) during field type resolution. This happens at decorator time, so by the time the schema converter consults `scalar_registry` (which includes `scalar_map` entries), the original NewType identity has already been destroyed — the field type is `str`, not the NewType the user keyed in `scalar_map`.

## Fix

Three coordinated changes:
1. **_compat.py**: Remove the `if is_new_type(type_): return new_type_supertype(type_)` lines from both compat classes (4 lines)
2. **scalars.py**: Add `__supertype__` fallback to `is_scalar()` — if a NewType is not in `scalar_registry`, recursively check its supertype
3. **schema_converter.py**: Add `__supertype__` fallback to `from_scalar()` — unwrap a NewType to its supertype as a last resort

This ensures:
- NewTypes in `scalar_map` are matched correctly (the fix)
- NewTypes without a `scalar_map` entry still resolve via their supertype (backward compatible)
- No behavioral change for existing code that does not use `scalar_map` with NewTypes

This pull request was prepared with the assistance of AI, under my direction and review.

## Summary by Sourcery

Preserve typing.NewType identities during scalar resolution so pydantic-backed fields correctly respect scalar mappings while maintaining fallback behavior via supertypes.

Bug Fixes:
- Ensure scalar_map entries keyed by typing.NewType are honored for pydantic model fields during schema generation.
- Prevent NewType-based scalar annotations from being silently treated as their underlying builtin types when resolving schema scalars.

Enhancements:
- Add recursive supertype fallback in scalar and schema conversion logic so NewTypes without explicit scalar mappings still resolve via their supertypes.