### PR TITLE
docs: add missing Query type to pendulum scalar example

### DIFF
--- a/docs/types/scalars.md
+++ b/docs/types/scalars.md
@@ -387,6 +387,13 @@ def parse_datetime(value: str) -> Union[pendulum.DateTime, datetime]:  # type: i
     return pendulum.parse(value)  # type: ignore
 
 
+@strawberry.type
+class Query:
+    @strawberry.field
+    def current_time(self) -> datetime:
+        return datetime.now()
+
+
 schema = strawberry.Schema(
     Query,
     config=StrawberryConfig(


### PR DESCRIPTION
Closes #1294

The pendulum datetime example was missing a `Query` type definition,
making the snippet impossible to run as-is. Added the missing class
so the example is self-contained and copy-pasteable.

## Summary by Sourcery

Documentation:
- Update the pendulum datetime scalar example to include a Query type with a current_time field, making the example self-contained.