### PR TITLE
Allow easy swapping between SSE and WS connections.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+Release type: minor
+
+Add SSE `connection_params` mirroring and `on_sse_connect` to drop SSE connections at the transport level.
+
+SSE subscriptions mirror the `Authorization` header into `context["connection_params"]["authorization"]`, matching WebSocket behaviour. Override `on_sse_connect` to accept or reject connections at the transport level. Before now, there was no equivalent to `on_ws_connect` for SSE — the only way to reject an unauthorized connection was to throw inside the subscription resolver after the stream had already started.

--- a/docs/general/multipart-subscriptions.md
+++ b/docs/general/multipart-subscriptions.md
@@ -30,7 +30,6 @@ Multipart subscriptions are opt-in. Enable them by including
 from strawberry.fastapi import GraphQLRouter
 from strawberry.subscriptions import (
     GRAPHQL_TRANSPORT_WS_PROTOCOL,
-    GRAPHQL_WS_PROTOCOL,
     MULTIPART_SUBSCRIPTION_PROTOCOL,
 )
 
@@ -40,7 +39,6 @@ graphql_router = GraphQLRouter(
     schema,
     subscription_protocols=[
         GRAPHQL_TRANSPORT_WS_PROTOCOL,
-        GRAPHQL_WS_PROTOCOL,
         MULTIPART_SUBSCRIPTION_PROTOCOL,
     ],
 )

--- a/docs/general/subscriptions.md
+++ b/docs/general/subscriptions.md
@@ -160,8 +160,7 @@ server-to-client streaming. SSE is opt-in; enable it by including
 from strawberry.asgi import GraphQL
 from strawberry.subscriptions import (
     GRAPHQL_SSE_PROTOCOL,
-    GRAPHQL_TRANSPORT_WS_PROTOCOL,
-    GRAPHQL_WS_PROTOCOL,
+    GRAPHQL_TRANSPORT_WS_PROTOCOL
 )
 
 from api.schema import schema
@@ -170,8 +169,7 @@ app = GraphQL(
     schema,
     subscription_protocols=[
         GRAPHQL_TRANSPORT_WS_PROTOCOL,
-        GRAPHQL_WS_PROTOCOL,
-        GRAPHQL_SSE_PROTOCOL,
+        GRAPHQL_SSE_PROTOCOL
     ],
 )
 ```
@@ -292,7 +290,9 @@ parameters, or a `fetch`-based GraphQL SSE client when you need header-based
 authentication in the browser.
 
 Use your integration's `get_context` hook for SSE authentication, like you would
-for queries and mutations:
+for queries and mutations. Strawberry also mirrors the `Authorization` header
+into `context["connection_params"]["authorization"]` for parity with
+WebSocket subscriptions, so a single resolver can serve both transports:
 
 ```python
 from starlette.requests import Request
@@ -327,7 +327,8 @@ class Subscription:
     async def count(
         self, info: strawberry.Info, target: int = 100
     ) -> AsyncGenerator[int, None]:
-        token = info.context["token"]
+        # Works for both WebSocket and SSE subscriptions
+        token = info.context["connection_params"]["authorization"]
         if not authenticate_token(token):
             raise Exception("Forbidden!")
 
@@ -336,9 +337,23 @@ class Subscription:
             await asyncio.sleep(0.5)
 ```
 
-`on_ws_connect` and `connection_params` are websocket-specific APIs. SSE does
-not have a separate connection initialisation message, so Strawberry does not
-call a separate SSE connect hook.
+To accept or reject an SSE connection at the transport level, override the
+`on_sse_connect` hook on your view. Raise `ConnectionRejectionError` to reject;
+the client receives an SSE `error` event followed by `complete`:
+
+```python
+from strawberry.exceptions import ConnectionRejectionError
+from strawberry.asgi import GraphQL
+
+
+class AuthenticatedGraphQL(GraphQL):
+    async def on_sse_connect(self, context):
+        token = context["connection_params"].get("authorization")
+        if not authenticate_token(token):
+            raise ConnectionRejectionError(
+                {"message": "Invalid token", "code": "INVALID_TOKEN"}
+            )
+```
 
 ### Resuming after a reconnect
 
@@ -561,8 +576,7 @@ accepted. Multipart subscriptions and SSE are opt-in.
 from strawberry.aiohttp.views import GraphQLView
 from strawberry.subscriptions import (
     GRAPHQL_SSE_PROTOCOL,
-    GRAPHQL_TRANSPORT_WS_PROTOCOL,
-    GRAPHQL_WS_PROTOCOL,
+    GRAPHQL_TRANSPORT_WS_PROTOCOL
 )
 from api.schema import schema
 
@@ -570,8 +584,7 @@ view = GraphQLView(
     schema,
     subscription_protocols=[
         GRAPHQL_TRANSPORT_WS_PROTOCOL,
-        GRAPHQL_WS_PROTOCOL,
-        GRAPHQL_SSE_PROTOCOL,
+        GRAPHQL_SSE_PROTOCOL
     ],
 )
 ```
@@ -583,7 +596,6 @@ from strawberry.asgi import GraphQL
 from strawberry.subscriptions import (
     GRAPHQL_SSE_PROTOCOL,
     GRAPHQL_TRANSPORT_WS_PROTOCOL,
-    GRAPHQL_WS_PROTOCOL,
 )
 from api.schema import schema
 
@@ -591,7 +603,6 @@ app = GraphQL(
     schema,
     subscription_protocols=[
         GRAPHQL_TRANSPORT_WS_PROTOCOL,
-        GRAPHQL_WS_PROTOCOL,
         GRAPHQL_SSE_PROTOCOL,
     ],
 )
@@ -606,8 +617,7 @@ from django.core.asgi import get_asgi_application
 from strawberry.channels import GraphQLProtocolTypeRouter
 from strawberry.subscriptions import (
     GRAPHQL_SSE_PROTOCOL,
-    GRAPHQL_TRANSPORT_WS_PROTOCOL,
-    GRAPHQL_WS_PROTOCOL,
+    GRAPHQL_TRANSPORT_WS_PROTOCOL
 )
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "mysite.settings")
@@ -623,7 +633,6 @@ application = GraphQLProtocolTypeRouter(
     django_application=django_asgi_app,
     subscription_protocols=[
         GRAPHQL_TRANSPORT_WS_PROTOCOL,
-        GRAPHQL_WS_PROTOCOL,
         GRAPHQL_SSE_PROTOCOL,
     ],
 )
@@ -639,7 +648,7 @@ from strawberry.fastapi import GraphQLRouter
 from strawberry.subscriptions import (
     GRAPHQL_SSE_PROTOCOL,
     GRAPHQL_TRANSPORT_WS_PROTOCOL,
-    GRAPHQL_WS_PROTOCOL,
+
 )
 from fastapi import FastAPI
 from api.schema import schema
@@ -648,7 +657,6 @@ graphql_router = GraphQLRouter(
     schema,
     subscription_protocols=[
         GRAPHQL_TRANSPORT_WS_PROTOCOL,
-        GRAPHQL_WS_PROTOCOL,
         GRAPHQL_SSE_PROTOCOL,
     ],
 )
@@ -664,7 +672,6 @@ from strawberry.quart.views import GraphQLView
 from strawberry.subscriptions import (
     GRAPHQL_SSE_PROTOCOL,
     GRAPHQL_TRANSPORT_WS_PROTOCOL,
-    GRAPHQL_WS_PROTOCOL,
 )
 from quart import Quart
 from api.schema import schema
@@ -674,7 +681,6 @@ view = GraphQLView.as_view(
     schema=schema,
     subscription_protocols=[
         GRAPHQL_TRANSPORT_WS_PROTOCOL,
-        GRAPHQL_WS_PROTOCOL,
         GRAPHQL_SSE_PROTOCOL,
     ],
 )

--- a/docs/general/subscriptions.md
+++ b/docs/general/subscriptions.md
@@ -158,19 +158,13 @@ server-to-client streaming. SSE is opt-in; enable it by including
 
 ```python
 from strawberry.asgi import GraphQL
-from strawberry.subscriptions import (
-    GRAPHQL_SSE_PROTOCOL,
-    GRAPHQL_TRANSPORT_WS_PROTOCOL
-)
+from strawberry.subscriptions import GRAPHQL_SSE_PROTOCOL, GRAPHQL_TRANSPORT_WS_PROTOCOL
 
 from api.schema import schema
 
 app = GraphQL(
     schema,
-    subscription_protocols=[
-        GRAPHQL_TRANSPORT_WS_PROTOCOL,
-        GRAPHQL_SSE_PROTOCOL
-    ],
+    subscription_protocols=[GRAPHQL_TRANSPORT_WS_PROTOCOL, GRAPHQL_SSE_PROTOCOL],
 )
 ```
 
@@ -291,8 +285,8 @@ authentication in the browser.
 
 Use your integration's `get_context` hook for SSE authentication, like you would
 for queries and mutations. Strawberry also mirrors the `Authorization` header
-into `context["connection_params"]["authorization"]` for parity with
-WebSocket subscriptions, so a single resolver can serve both transports:
+into `context["connection_params"]["authorization"]` for parity with WebSocket
+subscriptions, so a single resolver can serve both transports:
 
 ```python
 from starlette.requests import Request
@@ -574,18 +568,12 @@ accepted. Multipart subscriptions and SSE are opt-in.
 
 ```python
 from strawberry.aiohttp.views import GraphQLView
-from strawberry.subscriptions import (
-    GRAPHQL_SSE_PROTOCOL,
-    GRAPHQL_TRANSPORT_WS_PROTOCOL
-)
+from strawberry.subscriptions import GRAPHQL_SSE_PROTOCOL, GRAPHQL_TRANSPORT_WS_PROTOCOL
 from api.schema import schema
 
 view = GraphQLView(
     schema,
-    subscription_protocols=[
-        GRAPHQL_TRANSPORT_WS_PROTOCOL,
-        GRAPHQL_SSE_PROTOCOL
-    ],
+    subscription_protocols=[GRAPHQL_TRANSPORT_WS_PROTOCOL, GRAPHQL_SSE_PROTOCOL],
 )
 ```
 
@@ -615,10 +603,7 @@ import os
 
 from django.core.asgi import get_asgi_application
 from strawberry.channels import GraphQLProtocolTypeRouter
-from strawberry.subscriptions import (
-    GRAPHQL_SSE_PROTOCOL,
-    GRAPHQL_TRANSPORT_WS_PROTOCOL
-)
+from strawberry.subscriptions import GRAPHQL_SSE_PROTOCOL, GRAPHQL_TRANSPORT_WS_PROTOCOL
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "mysite.settings")
 django_asgi_app = get_asgi_application()
@@ -648,7 +633,6 @@ from strawberry.fastapi import GraphQLRouter
 from strawberry.subscriptions import (
     GRAPHQL_SSE_PROTOCOL,
     GRAPHQL_TRANSPORT_WS_PROTOCOL,
-
 )
 from fastapi import FastAPI
 from api.schema import schema

--- a/strawberry/http/async_base_view.py
+++ b/strawberry/http/async_base_view.py
@@ -669,7 +669,8 @@ class AsyncBaseHTTPView(
     ) -> None:
         """Populate ``connection_params`` on the context from the SSE request's
         ``Authorization`` header, so SSE resolvers can reuse WebSocket auth code
-        that reads ``context["connection_params"]["authorization"]``."""
+        that reads ``context["connection_params"]["authorization"]``.
+        """
         headers = {k.lower(): v for k, v in request_adapter.headers.items()}
         connection_params: dict[str, Any] = {}
 

--- a/strawberry/http/async_base_view.py
+++ b/strawberry/http/async_base_view.py
@@ -1,6 +1,7 @@
 import abc
 import asyncio
 import json
+import warnings
 from collections.abc import AsyncGenerator, Callable, Mapping, Sequence
 from datetime import timedelta
 from typing import (
@@ -657,20 +658,19 @@ class AsyncBaseHTTPView(
     ) -> UnsetType | None | dict[str, object]:
         return UNSET
 
-    async def on_sse_connect(
-        self, context: Context
-    ) -> UnsetType | None | dict[str, object]:
-        return UNSET
+    async def on_sse_connect(self, context: Context) -> None:
+        """Override to perform validation before an SSE stream begins.
+
+        Raise :exc:`~strawberry.exceptions.ConnectionRejectionError` to reject
+        the connection. The return value is ignored.
+        """
+        return
 
     def _inject_sse_connection_params(
         self,
         context: Context,
         request_adapter: AsyncHTTPRequestAdapter,
     ) -> None:
-        """Populate ``connection_params`` on the context from the SSE request's
-        ``Authorization`` header, so SSE resolvers can reuse WebSocket auth code
-        that reads ``context["connection_params"]["authorization"]``.
-        """
         headers = {k.lower(): v for k, v in request_adapter.headers.items()}
         connection_params: dict[str, Any] = {}
 
@@ -681,6 +681,12 @@ class AsyncBaseHTTPView(
             context["connection_params"] = connection_params
         elif hasattr(context, "connection_params"):
             context.connection_params = connection_params
+        else:
+            warnings.warn(
+                "SSE connection_params injection skipped: context is neither "
+                "a dict nor does it have a connection_params attribute.",
+                stacklevel=2,
+            )
 
     async def _create_sse_error_response(
         self,

--- a/strawberry/http/async_base_view.py
+++ b/strawberry/http/async_base_view.py
@@ -14,7 +14,7 @@ from typing import (
 from cross_web import AsyncHTTPRequestAdapter, HTTPException
 from graphql import GraphQLError
 
-from strawberry.exceptions import MissingQueryError
+from strawberry.exceptions import ConnectionRejectionError, MissingQueryError
 from strawberry.file_uploads.utils import replace_placeholders_with_files
 from strawberry.http import (
     GraphQLHTTPResponse,
@@ -48,6 +48,7 @@ from .streaming import (
     AsyncTextStream,
     HTTPStreamTransport,
     MultipartTransport,
+    SSETransport,
     merge_stream_with_heartbeat,
 )
 from .typevars import (
@@ -399,6 +400,24 @@ class AsyncBaseHTTPView(
             # Only single (non-batch) operations stream; a batch with a
             # streaming transport is rejected while parsing.
             assert isinstance(request_data, GraphQLRequestData)
+
+            if request_data.protocol == "sse":
+                self._inject_sse_connection_params(context, request_adapter)
+
+                try:
+                    await self.on_sse_connect(context)
+                except ConnectionRejectionError as e:
+                    payload = e.payload or {
+                        "message": "Forbidden",
+                        "code": "FORBIDDEN",
+                    }
+                    return await self._create_sse_error_response(
+                        request=request,
+                        sub_response=sub_response,
+                        message=str(payload.get("message", "Forbidden")),
+                        code=str(payload.get("code", "FORBIDDEN")),
+                    )
+
             return await self._create_streaming_response(
                 request=request,
                 result=result,
@@ -637,6 +656,56 @@ class AsyncBaseHTTPView(
         self, context: Context
     ) -> UnsetType | None | dict[str, object]:
         return UNSET
+
+    async def on_sse_connect(
+        self, context: Context
+    ) -> UnsetType | None | dict[str, object]:
+        return UNSET
+
+    def _inject_sse_connection_params(
+        self,
+        context: Context,
+        request_adapter: AsyncHTTPRequestAdapter,
+    ) -> None:
+        """Populate ``connection_params`` on the context from the SSE request's
+        ``Authorization`` header, so SSE resolvers can reuse WebSocket auth code
+        that reads ``context["connection_params"]["authorization"]``."""
+        headers = {k.lower(): v for k, v in request_adapter.headers.items()}
+        connection_params: dict[str, Any] = {}
+
+        if "authorization" in headers:
+            connection_params["authorization"] = headers["authorization"]
+
+        if isinstance(context, dict):
+            context["connection_params"] = connection_params
+        elif hasattr(context, "connection_params"):
+            context.connection_params = connection_params
+
+    async def _create_sse_error_response(
+        self,
+        request: Request,
+        sub_response: SubResponse,
+        *,
+        message: str,
+        code: str,
+    ) -> Response:
+        transport = self._get_stream_transport("sse")
+        assert isinstance(transport, SSETransport)
+
+        encoded_errors = self.encode_json_string(
+            [{"message": message, "extensions": {"code": code}}]
+        )
+
+        async def error_stream() -> AsyncGenerator[str, None]:
+            yield transport.encode_event("error", encoded_errors)
+            yield transport.encode_complete()
+
+        return await self.create_streaming_response(
+            request,
+            error_stream,
+            sub_response,
+            headers=transport.headers,
+        )
 
 
 __all__ = ["AsyncBaseHTTPView"]

--- a/tests/http/test_sse.py
+++ b/tests/http/test_sse.py
@@ -8,7 +8,6 @@ import pytest
 
 import strawberry
 from strawberry.exceptions import ConnectionRejectionError
-from strawberry.http.async_base_view import AsyncBaseHTTPView
 from strawberry.http.base import BaseView
 from strawberry.http.streaming import SSETransport
 from strawberry.schema.config import StrawberryConfig

--- a/tests/http/test_sse.py
+++ b/tests/http/test_sse.py
@@ -1020,7 +1020,11 @@ async def test_sse_connect_acceptance_proceeds_normally(
     hook_calls: list[object] = []
 
     async def accept(self, context: object) -> None:
+        # Record the context passed to the hook so we can assert on it after the SSE call.
         hook_calls.append(context)
+        # Strengthen the test by validating that SSE auth injection populates connection_params.
+        assert isinstance(context, dict)
+        assert "connection_params" in context
 
     mocker.patch(
         "strawberry.http.async_base_view.AsyncBaseHTTPView.on_sse_connect", accept
@@ -1031,6 +1035,7 @@ async def test_sse_connect_acceptance_proceeds_normally(
         headers={
             "accept": "text/event-stream",
             "content-type": "application/json",
+            "authorization": "Bearer strawberry",
         },
     )
 
@@ -1046,3 +1051,7 @@ async def test_sse_connect_acceptance_proceeds_normally(
         ("complete", ""),
     ]
     assert len(hook_calls) == 1
+    context = hook_calls[0]
+    assert isinstance(context, dict)
+    assert "connection_params" in context
+    assert context["connection_params"]["authorization"] == "Bearer strawberry"

--- a/tests/http/test_sse.py
+++ b/tests/http/test_sse.py
@@ -7,6 +7,8 @@ from typing import Literal
 import pytest
 
 import strawberry
+from strawberry.exceptions import ConnectionRejectionError
+from strawberry.http.async_base_view import AsyncBaseHTTPView
 from strawberry.http.base import BaseView
 from strawberry.http.streaming import SSETransport
 from strawberry.schema.config import StrawberryConfig
@@ -887,3 +889,161 @@ async def test_sse_stream_directive(http_client: HttpClient):
         },
     )
     assert events[-1] == ("complete", "")
+
+
+async def test_sse_injects_authorization_header_as_connection_params(
+    http_client: HttpClient,
+):
+    """The ``Authorization`` header is mirrored into
+    ``context["connection_params"]["authorization"]`` so SSE resolvers can reuse
+    WebSocket auth code."""
+    response = await http_client.query(
+        query="subscription { connectionParams }",
+        headers={
+            "accept": "text/event-stream",
+            "content-type": "application/json",
+            "Authorization": "Bearer strawberry",
+        },
+    )
+
+    assert_sse_response(response)
+    assert parse_sse_events(await get_response_text(response)) == [
+        (
+            "next",
+            {
+                "data": {"connectionParams": {"authorization": "Bearer strawberry"}},
+                "extensions": {"example": "example"},
+            },
+        ),
+        ("complete", ""),
+    ]
+
+
+async def test_sse_connection_params_empty_without_authorization_header(
+    http_client: HttpClient,
+):
+    """When no ``Authorization`` header is present, ``connection_params`` is an
+    empty dict rather than absent."""
+    response = await http_client.query(
+        query="subscription { connectionParams }",
+        headers={
+            "accept": "text/event-stream",
+            "content-type": "application/json",
+        },
+    )
+
+    assert_sse_response(response)
+    assert parse_sse_events(await get_response_text(response)) == [
+        (
+            "next",
+            {
+                "data": {"connectionParams": {}},
+                "extensions": {"example": "example"},
+            },
+        ),
+        ("complete", ""),
+    ]
+
+
+async def test_sse_connect_rejection_returns_error_event(
+    http_client: HttpClient, mocker
+):
+    """Raising ``ConnectionRejectionError`` from ``on_sse_connect`` emits an SSE
+    ``error`` event followed by ``complete``."""
+
+    async def reject(self, context: object) -> None:
+        raise ConnectionRejectionError
+
+    mocker.patch(
+        "strawberry.http.async_base_view.AsyncBaseHTTPView.on_sse_connect", reject
+    )
+
+    response = await http_client.query(
+        query="subscription { connectionParams }",
+        headers={
+            "accept": "text/event-stream",
+            "content-type": "application/json",
+        },
+    )
+
+    assert_sse_response(response)
+    events = parse_sse_events(await get_response_text(response))
+    assert len(events) == 2
+
+    event, payload = events[0]
+    assert event == "error"
+    assert isinstance(payload, list)
+    assert payload[0]["message"] == "Forbidden"
+    assert payload[0]["extensions"]["code"] == "FORBIDDEN"
+    assert events[1] == ("complete", "")
+
+
+async def test_sse_connect_with_custom_rejection_payload(
+    http_client: HttpClient, mocker
+):
+    """A ``ConnectionRejectionError`` with a custom payload surfaces its message
+    and code in the error event."""
+
+    async def reject(self, context: object) -> None:
+        raise ConnectionRejectionError(
+            {"message": "Token expired", "code": "TOKEN_EXPIRED"}
+        )
+
+    mocker.patch(
+        "strawberry.http.async_base_view.AsyncBaseHTTPView.on_sse_connect", reject
+    )
+
+    response = await http_client.query(
+        query="subscription { connectionParams }",
+        headers={
+            "accept": "text/event-stream",
+            "content-type": "application/json",
+        },
+    )
+
+    assert_sse_response(response)
+    events = parse_sse_events(await get_response_text(response))
+    assert len(events) == 2
+
+    event, payload = events[0]
+    assert event == "error"
+    assert isinstance(payload, list)
+    assert payload[0]["message"] == "Token expired"
+    assert payload[0]["extensions"]["code"] == "TOKEN_EXPIRED"
+    assert events[1] == ("complete", "")
+
+
+async def test_sse_connect_acceptance_proceeds_normally(
+    http_client: HttpClient, mocker
+):
+    """When ``on_sse_connect`` returns without raising, the stream proceeds as
+    normal."""
+    hook_calls: list[object] = []
+
+    async def accept(self, context: object) -> None:
+        hook_calls.append(context)
+
+    mocker.patch(
+        "strawberry.http.async_base_view.AsyncBaseHTTPView.on_sse_connect", accept
+    )
+
+    response = await http_client.query(
+        query='subscription { echo(message: "Hello world") }',
+        headers={
+            "accept": "text/event-stream",
+            "content-type": "application/json",
+        },
+    )
+
+    assert_sse_response(response)
+    assert parse_sse_events(await get_response_text(response)) == [
+        (
+            "next",
+            {
+                "data": {"echo": "Hello world"},
+                "extensions": {"example": "example"},
+            },
+        ),
+        ("complete", ""),
+    ]
+    assert len(hook_calls) == 1


### PR DESCRIPTION
SSE protocol authenticates via authorization headers similar to normal HTTP requests. However, websockets don't have this and use `connection_params` instead.

This PR introduces the ability to easily swap between different protocol providers, for the following reasons:

* Allows incremental upgrade to websocket protocol and vice versa.
* Convenience to pick the protocol of choice without frontend refactor.

## Description

Restores SSE auth convenience features that were dropped during the SSE overhaul.

SSE subscriptions now auto-populate `context["connection_params"]["authorization"]` from the request's `Authorization` header, so SSE resolvers can reuse the same auth code patterns as WebSocket subscriptions without needing a custom `get_context` override solely for auth.

Additionally, a new `on_sse_connect(context)` hook is called before the subscription stream begins. Override it to perform transport-level connection validation. Raise `ConnectionRejectionError` to reject the connection; the client receives an SSE `error` event followed by `complete`.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Align SSE subscriptions with WebSocket authentication and connection handling for easier protocol swapping.

New Features:
- Mirror SSE request Authorization headers into context connection_params for subscriptions.
- Introduce an on_sse_connect hook to allow transport-level acceptance or rejection of SSE connections, returning structured error events on rejection.

Enhancements:
- Add helpers to inject SSE connection params and generate SSE error responses in the async HTTP view.
- Simplify subscription protocol configuration examples in the documentation to focus on the modern WebSocket and SSE transports.

Documentation:
- Update subscription docs to describe SSE Authorization mirroring, unified resolver auth patterns, and the new on_sse_connect hook.
- Refresh protocol configuration examples across frameworks and multipart subscription docs to remove legacy GRAPHQL_WS_PROTOCOL usage.

Tests:
- Add SSE tests covering Authorization header mirroring into connection_params and behavior of on_sse_connect for accepted and rejected connections.