### PR TITLE
Add support for mapping exception to types via unions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,10 +161,10 @@ release type: patch
 social_messages:
   x: >-
     {project_name} {version} is out! This release fixes schema printing for
-    nullable input defaults. https://strawberry.rocks/release/{version}
+    nullable input defaults. 🍓 https://strawberry.rocks/release/{version}
   linkedin: >-
     {project_name} {version} is out. This release fixes schema printing for
-    nullable input defaults so generated SDL now keeps explicit null values.
+    nullable input defaults, so generated SDL now keeps explicit null values.
 ---
 
 This release fixes schema printing for nullable input defaults.
@@ -180,5 +180,7 @@ doubt feel free to ask.
 Release notes should start with `This release adds ...` or
 `This release fixes ...` and should explain the user-visible behavior first.
 Include social messages for X and LinkedIn so the release announcement reads
-well on each platform. X messages must include the website release URL template:
+well on each platform. They should read like natural release announcements,
+start with `{project_name} {version} is out`, and explain what changed and who
+benefits. X messages must include the website release URL template:
 `https://strawberry.rocks/release/{version}`.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,68 @@
+---
+release type: minor
+social_messages:
+  x: >-
+    {project_name} {version} is out! This release adds exception handlers, a building block for integrations that want to turn expected Python errors into typed GraphQL results. 🍓 https://strawberry.rocks/release/{version}
+  linkedin: >-
+    {project_name} {version} is out. This release adds exception handlers, a schema-level hook for integrations that need to turn framework validation errors, such as Pydantic errors, into typed GraphQL union results. Most applications will not need to use this directly, but it gives framework integrations a cleaner path without adding try/except blocks to every resolver.
+---
+
+This release adds configurable exception handlers that map Python exceptions to
+typed GraphQL union results.
+
+Most applications do not need to adopt this directly. It is primarily useful for
+integrations and framework-level helpers: for example, catching validation
+exceptions from a library such as Pydantic and exposing them as an explicit
+GraphQL error type, without requiring every resolver to catch and convert those
+exceptions manually.
+
+Handlers are passed to `strawberry.Schema` (and `strawberry.federation.Schema`):
+
+```python
+import strawberry
+from strawberry.types.field import StrawberryField
+
+
+class ValidationProblem(Exception):
+    pass
+
+
+@strawberry.type
+class ValidationError:
+    message: str
+
+
+class ValidationErrorHandler(
+    strawberry.ExceptionHandler[ValidationProblem, ValidationError]
+):
+    def handle(
+        self,
+        exception: ValidationProblem,
+        *,
+        field: StrawberryField,
+        info: strawberry.Info,
+    ) -> ValidationError:
+        return ValidationError(message=str(exception))
+
+
+schema = strawberry.Schema(
+    query=Query,
+    mutation=Mutation,
+    exception_handlers=[ValidationErrorHandler()],
+)
+```
+
+Handlers can alternatively declare `exception_type` and `error_type` class
+attributes instead of type parameters, which also covers types that are only
+known at runtime. Declaring both a type parameter and a conflicting attribute
+for the same slot raises an error at schema creation.
+
+Strawberry only converts the exception when the field return type includes the
+handler's GraphQL error type. Other fields continue to raise normal GraphQL
+errors, so applications can opt in one field at a time. Exceptions raised by
+the resolver, during argument conversion, or by field extensions are all
+covered.
+
+Exception handlers apply to query and mutation fields. Subscriptions are not
+covered: exceptions raised while establishing a subscription are not converted
+into union results.

--- a/docs/guides/errors.md
+++ b/docs/guides/errors.md
@@ -311,6 +311,152 @@ This approach allows you to express the possible error states in the schema and
 so provide a robust interface for your client to account for all the potential
 outcomes from a mutation.
 
+### Mapping expected exceptions to union results
+
+If your application or integration already raises a specific exception for an
+expected failure, you can map that exception to one of the GraphQL error types
+in the field's return union by passing `exception_handlers` to
+`strawberry.Schema`.
+
+```python
+import strawberry
+from strawberry.types import Info
+from strawberry.types.field import StrawberryField
+
+
+class UsernameAlreadyExists(Exception):
+    def __init__(self, username: str):
+        self.username = username
+
+
+@strawberry.type
+class RegisterUserSuccess:
+    user: User
+
+
+@strawberry.type
+class UsernameAlreadyExistsError:
+    username: str
+
+
+class UsernameAlreadyExistsHandler(
+    strawberry.ExceptionHandler[UsernameAlreadyExists, UsernameAlreadyExistsError]
+):
+    def handle(
+        self,
+        exception: UsernameAlreadyExists,
+        *,
+        field: StrawberryField,
+        info: Info,
+    ) -> UsernameAlreadyExistsError:
+        return UsernameAlreadyExistsError(username=exception.username)
+
+
+@strawberry.type
+class Mutation:
+    @strawberry.mutation
+    def register_user(
+        self, username: str, password: str
+    ) -> RegisterUserSuccess | UsernameAlreadyExistsError:
+        # create_user may raise UsernameAlreadyExists
+        user = create_user(username, password)
+        return RegisterUserSuccess(user=user)
+
+
+schema = strawberry.Schema(
+    query=Query,
+    mutation=Mutation,
+    exception_handlers=[UsernameAlreadyExistsHandler()],
+)
+```
+
+Strawberry only converts exceptions when both of these are true:
+
+- the exception is an instance of the handler's declared exception type
+- the field return type is a union, or nullable union, containing the handler's
+  declared error type
+
+The two type parameters — the exception type the handler receives and the
+GraphQL error type it returns — are the single source of truth: they drive the
+matching at runtime, and type checkers use them to verify the signature of
+`handle` against the declared types.
+
+To map several Python exception classes to the same GraphQL error type,
+parameterize the handler with their union, e.g.
+`strawberry.ExceptionHandler[ErrorA | ErrorB, MyErrorType]`.
+
+If you prefer explicit class attributes — or you are not using a type checker —
+the same handler can declare its types with `exception_type` and `error_type`
+attributes instead of type parameters:
+
+```python
+class UsernameAlreadyExistsHandler(strawberry.ExceptionHandler):
+    exception_type = UsernameAlreadyExists
+    error_type = UsernameAlreadyExistsError
+
+    def handle(self, exception, *, field, info):
+        return UsernameAlreadyExistsError(username=exception.username)
+```
+
+With this style `exception_type` accepts a single exception type or a tuple of
+them, and the attributes also cover types that are only known at runtime. You
+can mix the styles — for example parameterize the exception and supply a
+runtime-only `error_type` as an attribute — but declaring both a type parameter
+and a conflicting attribute for the same slot raises a `TypeError` at schema
+creation. Note that type checkers will not verify the signature of `handle` when
+you use attributes.
+
+Handlers cover exceptions raised by the resolver, during argument conversion,
+and by field extensions (for example a permission or validation extension
+wrapping the field). Argument conversion runs before the field-extension chain,
+so a conversion error is mapped directly and bypasses the field extensions —
+matching how conversion errors have always been raised before permissions run.
+Field extensions may catch or transform resolver exceptions before the handler
+sees the final exception leaving the extension chain.
+
+If multiple handlers match, Strawberry uses the first matching handler from the
+`exception_handlers` list. Handlers do not apply to subscription fields or to
+list fields such as `list[Success | UsernameAlreadyExistsError]`.
+
+A handler can decline an individual exception by returning `None` (or an
+awaitable resolving to `None`). Declining re-raises the original exception, so
+it propagates as a normal GraphQL error as if no handler had matched. This lets
+`handle` act as a per-instance filter — match a broad exception type, but only
+convert the instances you recognize:
+
+```python
+class ValidationErrorHandler(
+    strawberry.ExceptionHandler[ValidationProblem, ValidationError]
+):
+    def handle(
+        self,
+        exception: ValidationProblem,
+        *,
+        field: StrawberryField,
+        info: Info,
+    ) -> ValidationError | None:
+        if exception.is_user_facing:
+            return ValidationError(message=str(exception))
+        # Not one we want to expose — let it propagate as a normal error.
+        return None
+```
+
+When the error type is generic, parameterize the handler with the concrete
+instantiation that appears in the union (for example
+`strawberry.ExceptionHandler[MyError, ValidationError[int]]`), rather than the
+bare generic (`ValidationError`), so it matches the correct member of the union.
+
+Converted exceptions are treated as expected GraphQL results. They are not added
+to the response's top-level `errors` list and are not passed to
+`Schema.process_errors`, so avoid using broad exception types such as
+`Exception` unless every matching error is safe to expose as a typed result.
+
+On a synchronously executed field, `handle` must return its result
+synchronously. An `async` handler returns a coroutine, which fails the same way
+an `async` resolver does on a sync field: `execute_sync` returns an
+`ExecutionResult` whose `errors` contain a `GraphQLError` stating that execution
+could not complete synchronously.
+
 ---
 
 ## Additional resources:

--- a/docs/types/schema.md
+++ b/docs/types/schema.md
@@ -108,6 +108,12 @@ schema = strawberry.Schema(Query, types=[Individual, Company])
 
 List of [extensions](/docs/extensions) to add to your Schema.
 
+#### `exception_handlers: Iterable[ExceptionHandler] = ()`
+
+List of handlers that convert expected Python exceptions into typed GraphQL
+union results. See
+[dealing with expected errors](/docs/guides/errors#mapping-expected-exceptions-to-union-results).
+
 #### `scalar_overrides: Optional[Dict[object, ScalarWrapper]] = None`
 
 Override the implementation of the built in scalars.

--- a/strawberry/__init__.py
+++ b/strawberry/__init__.py
@@ -9,7 +9,7 @@ from .directive import directive, directive_field
 from .parent import Parent
 from .permission import BasePermission
 from .scalars import ID
-from .schema import Schema
+from .schema import ExceptionHandler, Schema
 from .schema_directive import schema_directive
 from .streamable import Streamable
 from .types.arguments import argument
@@ -31,6 +31,7 @@ __all__ = [
     "ID",
     "UNSET",
     "BasePermission",
+    "ExceptionHandler",
     "Info",
     "LazyType",
     "Maybe",

--- a/strawberry/exceptions/handler.py
+++ b/strawberry/exceptions/handler.py
@@ -10,7 +10,10 @@ from .exception import StrawberryException, UnableToFindExceptionSource
 original_threading_exception_hook = threading.excepthook
 
 
-ExceptionHandler = Callable[
+# Signature of ``sys.excepthook`` / ``threading.excepthook`` handlers. Named
+# ``ExcepthookHandler`` (not ``ExceptionHandler``) to avoid colliding with the
+# public ``strawberry.ExceptionHandler`` schema protocol.
+ExcepthookHandler = Callable[
     [type[BaseException], BaseException, TracebackType | None], None
 ]
 
@@ -21,7 +24,7 @@ def should_use_rich_exceptions() -> bool:
     return errors_disabled.lower() not in ["true", "1", "yes"]
 
 
-def _get_handler(exception_type: type[BaseException]) -> ExceptionHandler:
+def _get_handler(exception_type: type[BaseException]) -> ExcepthookHandler:
     if issubclass(exception_type, StrawberryException):
         try:
             import rich

--- a/strawberry/federation/schema.py
+++ b/strawberry/federation/schema.py
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
     from strawberry.extensions import SchemaExtension
     from strawberry.federation.schema_directives import ComposeDirective
     from strawberry.schema.config import StrawberryConfig
+    from strawberry.schema.exception_handlers import ExceptionHandler
     from strawberry.schema_directive import StrawberrySchemaDirective
     from strawberry.types.enum import StrawberryEnumDefinition
 
@@ -75,6 +76,7 @@ class Schema(BaseSchema):
             "2.10",
             "2.11",
         ] = "2.11",
+        exception_handlers: Iterable["ExceptionHandler[Any]"] = (),
     ) -> None:
         # Convert version string (e.g., "2.5") to version tuple (e.g., (2, 5))
         self.federation_version = parse_version(federation_version)
@@ -110,6 +112,7 @@ class Schema(BaseSchema):
             config=config,
             scalar_overrides=federation_scalar_overrides,
             schema_directives=schema_directives,
+            exception_handlers=exception_handlers,
         )
 
         self.schema_directives = list(schema_directives)

--- a/strawberry/schema/__init__.py
+++ b/strawberry/schema/__init__.py
@@ -1,4 +1,5 @@
 from .base import BaseSchema
+from .exception_handlers import ExceptionHandler
 from .schema import Schema
 
-__all__ = ["BaseSchema", "Schema"]
+__all__ = ["BaseSchema", "ExceptionHandler", "Schema"]

--- a/strawberry/schema/base.py
+++ b/strawberry/schema/base.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from graphql import GraphQLError
 
     from strawberry.directive import StrawberryDirective
+    from strawberry.schema.exception_handlers import ExceptionHandler
     from strawberry.schema.schema import StreamResult, SubscriptionResult
     from strawberry.schema.schema_converter import GraphQLCoreConverter
     from strawberry.types import (
@@ -37,6 +38,7 @@ class BaseSchema(Protocol):
     mutation: type[WithStrawberryObjectDefinition] | None
     subscription: type[WithStrawberryObjectDefinition] | None
     schema_directives: list[object]
+    exception_handlers: tuple[ExceptionHandler[Any], ...]
 
     @abstractmethod
     async def execute(

--- a/strawberry/schema/exception_handlers.py
+++ b/strawberry/schema/exception_handlers.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import types
+import typing
+from collections.abc import Iterable
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Protocol,
+    Union,
+    get_args,
+    get_origin,
+    runtime_checkable,
+)
+from typing_extensions import TypeVar
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable
+
+    from strawberry.types.field import StrawberryField
+    from strawberry.types.info import Info
+
+
+ExceptionType = TypeVar("ExceptionType", bound=Exception, contravariant=True)
+ErrorType = TypeVar("ErrorType", covariant=True, default=Any)
+
+
+@runtime_checkable
+class ExceptionHandler(Protocol[ExceptionType, ErrorType]):
+    """Converts expected Python exceptions into GraphQL union results.
+
+    The exception type the handler receives and the GraphQL error type it
+    returns are declared as type parameters::
+
+        class MyHandler(strawberry.ExceptionHandler[MyError, MyErrorType]):
+            def handle(self, exception: MyError, *, field, info) -> MyErrorType: ...
+
+    To handle several exception types with one handler, parameterize with
+    their union (e.g. ``strawberry.ExceptionHandler[ErrorA | ErrorB,
+    MyErrorType]``).
+
+    When a type is only known at runtime, set the ``exception_type`` (a single
+    exception type or a collection of them) and/or ``error_type`` class
+    attributes instead of parameterizing that slot. Declaring both a type
+    parameter and a conflicting attribute for the same slot raises a
+    ``TypeError`` at schema creation.
+
+    ``handle`` may decline an individual exception by returning ``None`` (or an
+    awaitable resolving to ``None``). Declining re-raises the original exception
+    so it propagates as a normal GraphQL error, exactly as if no handler had
+    matched. This lets ``handle`` act as a per-instance filter: match a broad
+    exception type, but only convert the instances you recognize.
+    """
+
+    def handle(
+        self,
+        exception: ExceptionType,
+        *,
+        field: StrawberryField,
+        info: Info,
+    ) -> ErrorType | Awaitable[ErrorType] | None: ...
+
+
+def _get_declared_types(handler_cls: type) -> tuple[Any, Any]:
+    """Type arguments of the ``ExceptionHandler[...]`` base, if any."""
+    for klass in handler_cls.__mro__:
+        for base in klass.__dict__.get("__orig_bases__", ()):
+            if get_origin(base) is not ExceptionHandler:
+                continue
+
+            args = get_args(base)
+            exception_type = args[0] if args else None
+            error_type = args[1] if len(args) > 1 else None
+
+            # An unparameterized (or partially parameterized) generic leaves
+            # type variables or the ``Any`` default behind — treat those as
+            # not declared.
+            if isinstance(exception_type, typing.TypeVar):
+                exception_type = None
+            if isinstance(error_type, typing.TypeVar) or error_type is Any:
+                error_type = None
+
+            return exception_type, error_type
+
+    return None, None
+
+
+def _normalize_exception_types(value: Any) -> tuple[type[Exception], ...]:
+    if isinstance(value, type):
+        return (value,)
+
+    if get_origin(value) in (Union, types.UnionType):
+        return get_args(value)
+
+    # A collection of types. ``str``/``bytes`` are iterable but never a valid
+    # declaration, so keep them whole and let the caller reject them with a
+    # clear error rather than silently iterating them into characters.
+    if isinstance(value, Iterable) and not isinstance(value, (str, bytes)):
+        return tuple(value)
+
+    return (value,)
+
+
+def get_exception_types(
+    handler: ExceptionHandler[Any],
+) -> tuple[type[Exception], ...]:
+    attribute = getattr(handler, "exception_type", None)
+    declared, _ = _get_declared_types(type(handler))
+
+    if (
+        attribute is not None
+        and declared is not None
+        and set(_normalize_exception_types(attribute))
+        != set(_normalize_exception_types(declared))
+    ):
+        raise TypeError(
+            f"Exception handler {type(handler).__name__!r} declares conflicting "
+            "exception types via its type parameter and its `exception_type` "
+            "attribute. Declare the exception type in one place."
+        )
+
+    exception_type = attribute if attribute is not None else declared
+
+    if exception_type is None:
+        raise TypeError(
+            f"Exception handler {type(handler).__name__!r} does not declare "
+            "which exceptions it handles. Parameterize the handler, e.g. "
+            "`class MyHandler(strawberry.ExceptionHandler[MyError, MyErrorType])`, "
+            "or set an `exception_type` attribute."
+        )
+
+    exception_types = _normalize_exception_types(exception_type)
+
+    for exc_type in exception_types:
+        if not (isinstance(exc_type, type) and issubclass(exc_type, Exception)):
+            raise TypeError(
+                f"Exception handler {type(handler).__name__!r} declares "
+                f"{exc_type!r} as an exception it handles, but that is not a "
+                "subclass of `Exception`."
+            )
+
+    return exception_types
+
+
+def get_error_type(handler: ExceptionHandler[Any]) -> Any:
+    attribute = getattr(handler, "error_type", None)
+    _, declared = _get_declared_types(type(handler))
+
+    if attribute is not None and declared is not None and attribute != declared:
+        raise TypeError(
+            f"Exception handler {type(handler).__name__!r} declares conflicting "
+            "GraphQL error types via its type parameter and its `error_type` "
+            "attribute. Declare the error type in one place."
+        )
+
+    error_type = attribute if attribute is not None else declared
+
+    if error_type is None:
+        raise TypeError(
+            f"Exception handler {type(handler).__name__!r} does not declare "
+            "the GraphQL error type it returns. Parameterize the handler, e.g. "
+            "`class MyHandler(strawberry.ExceptionHandler[MyError, MyErrorType])`, "
+            "or set an `error_type` attribute."
+        )
+
+    return error_type
+
+
+__all__ = [
+    "ExceptionHandler",
+    "get_error_type",
+    "get_exception_types",
+]

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -92,6 +92,7 @@ if TYPE_CHECKING:
     from graphql.validation import ASTValidationRule
 
     from strawberry.directive import StrawberryDirective
+    from strawberry.schema.exception_handlers import ExceptionHandler
     from strawberry.types.base import StrawberryType
     from strawberry.types.enum import StrawberryEnumDefinition
     from strawberry.types.field import StrawberryField
@@ -271,6 +272,7 @@ class Schema(BaseSchema):
             Mapping[object, type | ScalarWrapper | ScalarDefinition] | None
         ) = None,
         schema_directives: Iterable[object] = (),
+        exception_handlers: Iterable[ExceptionHandler[Any]] = (),
     ) -> None:
         """Default Schema to be used in a Strawberry application.
 
@@ -293,6 +295,8 @@ class Schema(BaseSchema):
             config: The configuration for the schema.
             scalar_overrides: A dictionary of overrides for scalars.
             schema_directives: A list of schema directives for the schema.
+            exception_handlers: A list of handlers that can convert Python
+                exceptions into explicit GraphQL union return values.
 
         Example:
         ```python
@@ -332,12 +336,14 @@ class Schema(BaseSchema):
             execution_context_class or StrawberryGraphQLCoreExecutionContext
         )
         self.config = config or StrawberryConfig()
+        self.exception_handlers = tuple(exception_handlers)
 
         self.schema_converter = GraphQLCoreConverter(
             self.config,
             scalar_overrides=scalar_overrides or {},  # type: ignore
             scalar_map=self.config.scalar_map,
             get_fields=self.get_fields,
+            exception_handlers=self.exception_handlers,
         )
 
         self.directives = directives

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
+import inspect
 import sys
 import typing
 from functools import partial, reduce
@@ -50,6 +51,10 @@ from strawberry.exceptions import (
 )
 from strawberry.extensions.field_extension import build_field_extension_resolvers
 from strawberry.relay.types import GlobalID
+from strawberry.schema.exception_handlers import (
+    get_error_type,
+    get_exception_types,
+)
 from strawberry.schema.types.scalar import (
     DEFAULT_SCALAR_REGISTRY,
     _make_scalar_type,
@@ -79,7 +84,7 @@ from . import compat
 from .types.concrete_type import ConcreteType
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable, Mapping
+    from collections.abc import Awaitable, Callable, Iterable, Mapping
 
     from graphql import (
         GraphQLInputType,
@@ -90,11 +95,127 @@ if TYPE_CHECKING:
 
     from strawberry.directive import StrawberryDirective
     from strawberry.schema.config import StrawberryConfig
+    from strawberry.schema.exception_handlers import ExceptionHandler
     from strawberry.schema_directive import StrawberrySchemaDirective
     from strawberry.types.enum import EnumValue
     from strawberry.types.field import StrawberryField
     from strawberry.types.info import Info
     from strawberry.types.scalar import ScalarDefinition
+
+
+UNHANDLED = object()
+
+
+def resolve_lazy_type(type_: object) -> object:
+    if isinstance(type_, LazyType):
+        return type_.resolve_type()
+
+    if isinstance(type_, StrawberryOptional) and isinstance(type_.of_type, LazyType):
+        return StrawberryOptional(type_.of_type.resolve_type())
+
+    return type_
+
+
+def is_same_type(left: object, right: object) -> bool:
+    left = resolve_lazy_type(left)
+    right = resolve_lazy_type(right)
+
+    if left is right:
+        return True
+
+    left_definition = get_object_definition(left)
+    right_definition = get_object_definition(right)
+
+    if left_definition is None or right_definition is None:
+        return False
+
+    return is_same_type_definition(left_definition, right_definition)
+
+
+def is_same_type_definition(
+    first_type_definition: StrawberryObjectDefinition | StrawberryType,
+    second_type_definition: StrawberryObjectDefinition | StrawberryType,
+) -> bool:
+    # TODO: maybe move this on the StrawberryType class
+    if not isinstance(
+        first_type_definition, StrawberryObjectDefinition
+    ) or not isinstance(second_type_definition, StrawberryObjectDefinition):
+        return False
+
+    if first_type_definition.origin is second_type_definition.origin:
+        return True
+
+    # When sys.modules is cleared (e.g. by test runners or Django reloaders)
+    # and a module is reimported, Python creates brand-new class objects.
+    # The identity check above fails, so fall back to comparing the
+    # fully-qualified class name which survives reimports.
+    first_origin = first_type_definition.origin
+    second_origin = second_type_definition.origin
+    if (
+        first_origin.__qualname__ == second_origin.__qualname__
+        and first_origin.__module__ == second_origin.__module__
+    ):
+        return True
+
+    if (
+        first_type_definition.concrete_of is None
+        or first_type_definition.concrete_of != second_type_definition.concrete_of
+        or (
+            first_type_definition.type_var_map.keys()
+            != second_type_definition.type_var_map.keys()
+        )
+    ):
+        return False
+
+    for type_var, type1 in first_type_definition.type_var_map.items():
+        type2 = second_type_definition.type_var_map[type_var]
+
+        resolved_type1 = resolve_lazy_type(type1)
+        resolved_type2 = resolve_lazy_type(type2)
+
+        same_type = resolved_type1 == resolved_type2
+        # If both types have object definitions, we are handling a nested generic
+        # type like `Foo[Foo[int]]`, meaning we need to compare their type definitions
+        # as they will actually be different instances of the type.
+        if (
+            not same_type
+            and has_object_definition(resolved_type1)
+            and has_object_definition(resolved_type2)
+        ):
+            same_type = is_same_type_definition(
+                resolved_type1.__strawberry_definition__,
+                resolved_type2.__strawberry_definition__,
+            )
+
+        if not same_type:
+            return False
+
+    return True
+
+
+def field_contains_type(field: StrawberryField, type_: Any) -> bool:
+    field_type = resolve_lazy_type(field.type)
+
+    if typing.get_origin(field_type) is Annotated:
+        field_type = StrawberryAnnotation(field_type).resolve()
+
+    if isinstance(field_type, StrawberryOptional):
+        field_type = resolve_lazy_type(field_type.of_type)
+        if typing.get_origin(field_type) is Annotated:
+            field_type = StrawberryAnnotation(field_type).resolve()
+
+    if not isinstance(field_type, StrawberryUnion):
+        return False
+
+    # Resolve the target the same way the union members were resolved at schema
+    # build time. A concrete generic error type (e.g. ``Error[int]``) otherwise
+    # collapses to the bare generic definition and silently never matches the
+    # ``Error[int]`` member of the union.
+    target_type = resolve_lazy_type(type_)
+    if typing.get_origin(target_type) is not None:
+        target_type = StrawberryAnnotation(target_type).resolve()
+
+    return any(is_same_type(union_type, target_type) for union_type in field_type.types)
 
 
 FieldType = TypeVar(
@@ -279,11 +400,22 @@ class GraphQLCoreConverter:
         scalar_overrides: Mapping[object, ScalarWrapper | ScalarDefinition],
         scalar_map: Mapping[object, ScalarDefinition],
         get_fields: Callable[[StrawberryObjectDefinition], list[StrawberryField]],
+        exception_handlers: Iterable[ExceptionHandler[Any]] = (),
     ) -> None:
         self.type_map: dict[str, ConcreteType] = {}
         self.config = config
         self.scalar_registry = self._get_scalar_registry(scalar_overrides, scalar_map)
         self.get_fields = get_fields
+        self.exception_handlers = tuple(exception_handlers)
+        # Resolving the exception and error types validates each handler, so a
+        # misconfigured one fails at schema creation instead of silently never
+        # matching.
+        self._exception_handler_specs: tuple[
+            tuple[tuple[type[Exception], ...], Any, ExceptionHandler[Any]], ...
+        ] = tuple(
+            (get_exception_types(handler), get_error_type(handler), handler)
+            for handler in self.exception_handlers
+        )
 
     def _get_scalar_registry(
         self,
@@ -715,12 +847,47 @@ class GraphQLCoreConverter:
 
         return graphql_object_type
 
+    def _get_field_exception_handlers(
+        self, field: StrawberryField
+    ) -> tuple[tuple[tuple[type[Exception], ...], ExceptionHandler[Any]], ...]:
+        """Handlers that can apply to ``field``, resolved once at build time.
+
+        Each entry pairs a handler with its pre-computed exception-type tuple so
+        the request path only needs an ``isinstance`` check. Subscriptions never
+        convert exceptions into union results.
+        """
+        if not self._exception_handler_specs or field.is_subscription:
+            return ()
+
+        return tuple(
+            (exception_types, handler)
+            for exception_types, error_type, handler in self._exception_handler_specs
+            if field_contains_type(field, error_type)
+        )
+
     def from_resolver(
         self, field: StrawberryField
     ) -> Callable:  # TODO: Take StrawberryResolver
         field.default_resolver = self.config.default_resolver
 
-        if field.is_basic_field:
+        # Apply field extensions before anything reads ``field.type``. An
+        # extension's ``apply`` may change the return type (for example widening
+        # ``Success`` to ``Success | ErrorPayload``), and both the
+        # exception-handler matching below and the SDL type resolved by
+        # ``from_field`` must see that final type — otherwise a handler whose
+        # error type the extension just added would be silently skipped.
+        for extension in field.extensions:
+            extension.apply(field)
+
+        # Handlers whose ``error_type`` is part of this field's return union,
+        # computed once at schema-build time. ``field_contains_type`` only
+        # depends on the field type and the handler, so the request path is left
+        # with the cheap ``isinstance`` check below. When this is empty (no
+        # handler can ever apply — including for subscriptions) the resolver
+        # takes the pre-feature fast paths, so existing schemas pay no overhead.
+        field_exception_handlers = self._get_field_exception_handlers(field)
+
+        if field.is_basic_field and not field_exception_handlers:
 
             def _get_basic_result(_source: Any, *args: str, **kwargs: Any) -> Any:
                 # Call `get_result` without an info object or any args or
@@ -747,11 +914,82 @@ class GraphQLCoreConverter:
                 _source, info=info, args=field_args, kwargs=field_kwargs
             )
 
+        def _find_handler(exc: Exception) -> ExceptionHandler[Any] | None:
+            for exception_types, handler in field_exception_handlers:
+                if isinstance(exc, exception_types):
+                    return handler
+
+            return None
+
+        def _handle_exception(exc: Exception, info: Info) -> Any:
+            handler = _find_handler(exc)
+            if handler is None:
+                return UNHANDLED
+
+            return handler.handle(exc, field=field, info=info)
+
+        def _deliver_handled(handled: Any, exc: Exception) -> Any:
+            # Deliver a handler result with the same sync/async shape the
+            # resolver would have produced. The outer async resolver awaits the
+            # result below, which is also where an async ``handle`` implementation
+            # is awaited.
+            #
+            # A handler may decline an individual exception by returning ``None``
+            # (or an awaitable resolving to ``None``). Declining re-raises the
+            # original exception so it propagates as a normal GraphQL error,
+            # exactly as if no handler had matched.
+            if field.is_async:
+
+                async def _resolve_handled() -> Any:
+                    resolved = await await_maybe(handled)
+                    if resolved is None:
+                        raise exc
+                    return resolved
+
+                return _resolve_handled()
+
+            if handled is None:
+                raise exc
+
+            return handled
+
+        def _call_with_exception_handling(
+            info: Info, get_result: Callable[[], Any]
+        ) -> Any:
+            try:
+                result = get_result()
+            except Exception as exc:
+                handled = _handle_exception(exc, info)
+                if handled is UNHANDLED:
+                    raise
+                return _deliver_handled(handled, exc)
+
+            if inspect.isawaitable(result):
+
+                async def await_result(result: Any) -> Any:
+                    try:
+                        return await result
+                    except Exception as exc:
+                        handled = _handle_exception(exc, info)
+                        if handled is UNHANDLED:
+                            raise
+                        # A handler may decline by returning ``None`` (or an
+                        # awaitable resolving to ``None``); re-raise the original
+                        # exception so it propagates as a normal GraphQL error.
+                        resolved = await await_maybe(handled)
+                        if resolved is None:
+                            raise
+                        return resolved
+
+                return await_result(result)
+
+            return result
+
         def wrap_field_extensions() -> Callable[..., Any]:
             """Wrap the provided field resolver with the middleware."""
-            for extension in field.extensions:
-                extension.apply(field)
-
+            # ``extension.apply`` already ran at the top of ``from_resolver`` so
+            # that type-changing extensions are reflected before handlers are
+            # matched; here we only need to build the resolver chain.
             extension_functions = build_field_extension_resolvers(field)
 
             def extension_resolver(
@@ -781,13 +1019,16 @@ class GraphQLCoreConverter:
                 # separate arguments so we have to wrap the function so that we
                 # can pass them in
                 def wrapped_get_result(_source: Any, info: Info, **kwargs: Any) -> Any:
-                    # if the resolver function requested the info object info
+                    # if the resolver function requested the info object
                     # then put it back in the kwargs dictionary
                     if resolver_requested_info:
                         kwargs["info"] = info
 
                     return _get_result(
-                        _source, info, field_args=field_args, field_kwargs=kwargs
+                        _source,
+                        info,
+                        field_args=field_args,
+                        field_kwargs=kwargs,
                     )
 
                 # combine all the extension resolvers
@@ -804,10 +1045,20 @@ class GraphQLCoreConverter:
         def _resolver(_source: Any, info: GraphQLResolveInfo, **kwargs: Any) -> Any:
             strawberry_info = _strawberry_info_from_graphql(info)
 
-            return _get_result_with_extensions(
-                _source,
+            if not field_exception_handlers:
+                return _get_result_with_extensions(
+                    _source,
+                    strawberry_info,
+                    **kwargs,
+                )
+
+            return _call_with_exception_handling(
                 strawberry_info,
-                **kwargs,
+                lambda: _get_result_with_extensions(
+                    _source,
+                    strawberry_info,
+                    **kwargs,
+                ),
             )
 
         async def _async_resolver(
@@ -815,11 +1066,23 @@ class GraphQLCoreConverter:
         ) -> Any:
             strawberry_info = _strawberry_info_from_graphql(info)
 
+            if not field_exception_handlers:
+                return await await_maybe(
+                    _get_result_with_extensions(
+                        _source,
+                        strawberry_info,
+                        **kwargs,
+                    )
+                )
+
             return await await_maybe(
-                _get_result_with_extensions(
-                    _source,
+                _call_with_exception_handling(
                     strawberry_info,
-                    **kwargs,
+                    lambda: _get_result_with_extensions(
+                        _source,
+                        strawberry_info,
+                        **kwargs,
+                    ),
                 )
             )
 
@@ -1051,7 +1314,7 @@ class GraphQLCoreConverter:
         first_type_definition = cached_type.definition
         second_type_definition = type_definition
 
-        if self.is_same_type_definition(
+        if is_same_type_definition(
             first_type_definition,
             second_type_definition,
         ):
@@ -1072,82 +1335,6 @@ class GraphQLCoreConverter:
             second_origin = None
 
         raise DuplicatedTypeName(first_origin, second_origin, name)
-
-    def is_same_type_definition(
-        self,
-        first_type_definition: StrawberryObjectDefinition | StrawberryType,
-        second_type_definition: StrawberryObjectDefinition | StrawberryType,
-    ) -> bool:
-        # TODO: maybe move this on the StrawberryType class
-        if not isinstance(
-            first_type_definition, StrawberryObjectDefinition
-        ) or not isinstance(second_type_definition, StrawberryObjectDefinition):
-            return False
-
-        if first_type_definition.origin is second_type_definition.origin:
-            return True
-
-        # When sys.modules is cleared (e.g. by test runners or Django reloaders)
-        # and a module is reimported, Python creates brand-new class objects.
-        # The identity check above fails, so fall back to comparing the
-        # fully-qualified class name which survives reimports.
-        first_origin = first_type_definition.origin
-        second_origin = second_type_definition.origin
-        if (
-            first_origin.__qualname__ == second_origin.__qualname__
-            and first_origin.__module__ == second_origin.__module__
-        ):
-            return True
-
-        if (
-            first_type_definition.concrete_of is None
-            or first_type_definition.concrete_of != second_type_definition.concrete_of
-            or (
-                first_type_definition.type_var_map.keys()
-                != second_type_definition.type_var_map.keys()
-            )
-        ):
-            return False
-
-        # manually compare type_var_maps while resolving any lazy types
-        # so that they're considered equal to the actual types they're referencing
-        for type_var, type1 in first_type_definition.type_var_map.items():
-            type2 = second_type_definition.type_var_map[type_var]
-
-            # both lazy types are always resolved because two different lazy types
-            # may be referencing the same actual type
-            if isinstance(type1, LazyType):
-                type1 = type1.resolve_type()  # noqa: PLW2901
-            elif isinstance(type1, StrawberryOptional) and isinstance(
-                type1.of_type, LazyType
-            ):
-                type1.of_type = type1.of_type.resolve_type()
-
-            if isinstance(type2, LazyType):
-                type2 = type2.resolve_type()
-            elif isinstance(type2, StrawberryOptional) and isinstance(
-                type2.of_type, LazyType
-            ):
-                type2.of_type = type2.of_type.resolve_type()
-
-            same_type = type1 == type2
-            # If both types have object definitions, we are handling a nested generic
-            # type like `Foo[Foo[int]]`, meaning we need to compare their type definitions
-            # as they will actually be different instances of the type
-            if (
-                not same_type
-                and has_object_definition(type1)
-                and has_object_definition(type2)
-            ):
-                same_type = self.is_same_type_definition(
-                    type1.__strawberry_definition__,
-                    type2.__strawberry_definition__,
-                )
-
-            if not same_type:
-                return False
-
-        return True
 
 
 __all__ = ["GraphQLCoreConverter"]

--- a/tests/benchmarks/test_exception_handlers.py
+++ b/tests/benchmarks/test_exception_handlers.py
@@ -1,0 +1,86 @@
+import pytest
+from pytest_codspeed.plugin import BenchmarkFixture
+
+import strawberry
+
+
+class ValidationError(Exception):
+    pass
+
+
+@strawberry.type
+class ErrorResult:
+    message: str
+
+
+@strawberry.type
+class Value:
+    amount: int
+
+
+class Handler(strawberry.ExceptionHandler[ValidationError, ErrorResult]):
+    def handle(self, exception: ValidationError, *, field, info) -> ErrorResult:
+        return ErrorResult(message=str(exception))
+
+
+@strawberry.type
+class Item:
+    index: int
+
+    @strawberry.field
+    def plain(self, multiplier: int = 1) -> int:
+        # No handler applies (the return type is not a union containing
+        # ``ErrorResult``), so this exercises the fast path even when the schema
+        # has handlers configured.
+        return self.index * multiplier
+
+    @strawberry.field
+    def checked(self) -> Value | ErrorResult:
+        # A handler applies here, so this exercises the exception-handling
+        # wrapping. The resolver never raises, so it measures the steady-state
+        # overhead of the wrapping, not the conversion itself.
+        return Value(amount=self.index)
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def items(self, count: int) -> list[Item]:
+        return [Item(index=i) for i in range(count)]
+
+
+PLAIN_QUERY = "query ($count: Int!) { items(count: $count) { plain(multiplier: 2) } }"
+CHECKED_QUERY = "query ($count: Int!) { items(count: $count) { checked { ... on Value { amount } } } }"
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize(
+    "handlers",
+    [False, True],
+    ids=lambda x: "with_handlers" if x else "no_handlers",
+)
+def test_plain_resolver_field(benchmark: BenchmarkFixture, handlers: bool):
+    # Measures whether configuring handlers adds per-field overhead to a field
+    # they never apply to (the "existing schemas pay nothing" claim).
+    schema = strawberry.Schema(
+        query=Query, exception_handlers=[Handler()] if handlers else []
+    )
+
+    def run():
+        return schema.execute_sync(PLAIN_QUERY, variable_values={"count": 2_000})
+
+    result = benchmark(run)
+    assert result.errors is None
+
+
+@pytest.mark.benchmark
+def test_handled_union_field(benchmark: BenchmarkFixture):
+    # Measures the steady-state cost of the exception-handling wrapping on a
+    # field a handler applies to (no exception is actually raised).
+    schema = strawberry.Schema(query=Query, exception_handlers=[Handler()])
+
+    def run():
+        return schema.execute_sync(CHECKED_QUERY, variable_values={"count": 2_000})
+
+    result = benchmark(run)
+    assert result.errors is None

--- a/tests/schema/test_exception_handlers.py
+++ b/tests/schema/test_exception_handlers.py
@@ -1,0 +1,1852 @@
+import dataclasses
+from collections.abc import AsyncGenerator
+from typing import Annotated, Generic, TypeVar
+
+import pytest
+
+import strawberry
+from strawberry.extensions.field_extension import FieldExtension
+from strawberry.field_extensions import InputMutationExtension
+from strawberry.permission import BasePermission
+from strawberry.types import Info
+from strawberry.types.execution import PreExecutionError
+from strawberry.types.field import StrawberryField
+from strawberry.utils.aio import aclosing
+
+T = TypeVar("T")
+
+
+class CustomValidationError(Exception):
+    pass
+
+
+class UnexpectedError(Exception):
+    pass
+
+
+@strawberry.type
+class ValidationErrorPayload:
+    message: str
+
+
+@strawberry.type
+class OtherErrorPayload:
+    message: str
+
+
+@strawberry.type
+class Success:
+    value: str
+
+
+ValidationResult = Annotated[
+    Success | ValidationErrorPayload,
+    strawberry.union("ValidationResult"),
+]
+
+
+class CustomValidationHandler(
+    strawberry.ExceptionHandler[CustomValidationError, ValidationErrorPayload]
+):
+    def handle(
+        self,
+        exception: CustomValidationError,
+        *,
+        field: StrawberryField,
+        info: Info,
+    ) -> ValidationErrorPayload:
+        return ValidationErrorPayload(message=str(exception))
+
+
+class FirstValidationHandler(
+    strawberry.ExceptionHandler[CustomValidationError, ValidationErrorPayload]
+):
+    def handle(
+        self,
+        exception: CustomValidationError,
+        *,
+        field: StrawberryField,
+        info: Info,
+    ) -> ValidationErrorPayload:
+        return ValidationErrorPayload(message="first")
+
+
+class SecondValidationHandler(
+    strawberry.ExceptionHandler[CustomValidationError, ValidationErrorPayload]
+):
+    def handle(
+        self,
+        exception: CustomValidationError,
+        *,
+        field: StrawberryField,
+        info: Info,
+    ) -> ValidationErrorPayload:
+        return ValidationErrorPayload(message="second")
+
+
+class OtherValidationHandler(
+    strawberry.ExceptionHandler[CustomValidationError, OtherErrorPayload]
+):
+    def handle(
+        self,
+        exception: CustomValidationError,
+        *,
+        field: StrawberryField,
+        info: Info,
+    ) -> OtherErrorPayload:
+        return OtherErrorPayload(message="other")
+
+
+@strawberry.input
+class CustomInput:
+    value: str
+
+    def __post_init__(self) -> None:
+        if len(self.value) < 2:
+            raise CustomValidationError("value is too short")
+
+
+@strawberry.type
+class Query:
+    ok: bool = True
+
+
+def test_exception_handler_converts_argument_conversion_error_to_union_type():
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        def create(self, input: CustomInput) -> Success | ValidationErrorPayload:
+            return Success(value=input.value)
+
+    schema = strawberry.Schema(
+        query=Query,
+        mutation=Mutation,
+        exception_handlers=[CustomValidationHandler()],
+    )
+
+    result = schema.execute_sync(
+        """
+        mutation {
+            create(input: { value: "a" }) {
+                ... on Success {
+                    value
+                }
+                ... on ValidationErrorPayload {
+                    message
+                }
+            }
+        }
+        """
+    )
+
+    assert result.errors is None
+    assert result.data == {"create": {"message": "value is too short"}}
+
+
+def test_exception_handler_does_not_handle_when_error_type_is_not_in_return_union():
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        def create(self, input: CustomInput) -> Success:
+            return Success(value=input.value)
+
+    schema = strawberry.Schema(
+        query=Query,
+        mutation=Mutation,
+        exception_handlers=[CustomValidationHandler()],
+    )
+
+    result = schema.execute_sync(
+        """
+        mutation {
+            create(input: { value: "a" }) {
+                value
+            }
+        }
+        """
+    )
+
+    assert result.errors is not None
+    assert result.errors[0].message == "value is too short"
+    assert result.data is None
+
+
+def test_exception_handler_does_not_handle_unmatched_exception_type():
+    processed_errors = []
+
+    class TrackingSchema(strawberry.Schema):
+        def process_errors(self, errors, execution_context=None):
+            processed_errors.extend(errors)
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        def create(self, value: str) -> Success | ValidationErrorPayload:
+            raise UnexpectedError(f"unexpected value: {value}")
+
+    schema = TrackingSchema(
+        query=Query,
+        mutation=Mutation,
+        exception_handlers=[CustomValidationHandler()],
+    )
+
+    result = schema.execute_sync(
+        """
+        mutation {
+            create(value: "abc") {
+                ... on Success {
+                    value
+                }
+                ... on ValidationErrorPayload {
+                    message
+                }
+            }
+        }
+        """
+    )
+
+    assert result.errors is not None
+    assert result.errors[0].message == "unexpected value: abc"
+    assert result.data is None
+    assert len(processed_errors) == 1
+    assert processed_errors[0].message == "unexpected value: abc"
+
+
+def test_exception_handler_converts_resolver_error_to_union_type():
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        def create(self, value: str) -> Success | ValidationErrorPayload:
+            raise CustomValidationError(f"invalid value: {value}")
+
+    schema = strawberry.Schema(
+        query=Query,
+        mutation=Mutation,
+        exception_handlers=[CustomValidationHandler()],
+    )
+
+    result = schema.execute_sync(
+        """
+        mutation {
+            create(value: "abc") {
+                ... on Success {
+                    value
+                }
+                ... on ValidationErrorPayload {
+                    message
+                }
+            }
+        }
+        """
+    )
+
+    assert result.errors is None
+    assert result.data == {"create": {"message": "invalid value: abc"}}
+
+
+def test_exception_handler_converted_error_is_not_processed():
+    processed_errors = []
+
+    class TrackingSchema(strawberry.Schema):
+        def process_errors(self, errors, execution_context=None):
+            processed_errors.extend(errors)
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        def create(self, value: str) -> Success | ValidationErrorPayload:
+            raise CustomValidationError(f"invalid value: {value}")
+
+    schema = TrackingSchema(
+        query=Query,
+        mutation=Mutation,
+        exception_handlers=[CustomValidationHandler()],
+    )
+
+    result = schema.execute_sync(
+        """
+        mutation {
+            create(value: "abc") {
+                ... on Success {
+                    value
+                }
+                ... on ValidationErrorPayload {
+                    message
+                }
+            }
+        }
+        """
+    )
+
+    assert result.errors is None
+    assert result.data == {"create": {"message": "invalid value: abc"}}
+    assert processed_errors == []
+
+
+def test_exception_handler_uses_first_matching_handler():
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        def create(self, value: str) -> Success | ValidationErrorPayload:
+            raise CustomValidationError(f"invalid value: {value}")
+
+    schema = strawberry.Schema(
+        query=Query,
+        mutation=Mutation,
+        exception_handlers=[FirstValidationHandler(), SecondValidationHandler()],
+    )
+
+    result = schema.execute_sync(
+        """
+        mutation {
+            create(value: "abc") {
+                ... on Success {
+                    value
+                }
+                ... on ValidationErrorPayload {
+                    message
+                }
+            }
+        }
+        """
+    )
+
+    assert result.errors is None
+    assert result.data == {"create": {"message": "first"}}
+
+
+def test_exception_handler_skipped_when_error_type_not_in_field_union():
+    # ``OtherValidationHandler`` handles the same exception type but its
+    # ``error_type`` is not part of the field's return union, so the next
+    # matching handler wins.
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        def create(self, value: str) -> Success | ValidationErrorPayload:
+            raise CustomValidationError(f"invalid value: {value}")
+
+    schema = strawberry.Schema(
+        query=Query,
+        mutation=Mutation,
+        exception_handlers=[OtherValidationHandler(), SecondValidationHandler()],
+    )
+
+    result = schema.execute_sync(
+        """
+        mutation {
+            create(value: "abc") {
+                ... on Success {
+                    value
+                }
+                ... on ValidationErrorPayload {
+                    message
+                }
+            }
+        }
+        """
+    )
+
+    assert result.errors is None
+    assert result.data == {"create": {"message": "second"}}
+
+
+def test_exception_handler_converts_error_for_optional_union_type():
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        def create(self, input: CustomInput) -> Success | ValidationErrorPayload | None:
+            return Success(value=input.value)
+
+    schema = strawberry.Schema(
+        query=Query,
+        mutation=Mutation,
+        exception_handlers=[CustomValidationHandler()],
+    )
+
+    result = schema.execute_sync(
+        """
+        mutation {
+            create(input: { value: "a" }) {
+                ... on Success {
+                    value
+                }
+                ... on ValidationErrorPayload {
+                    message
+                }
+            }
+        }
+        """
+    )
+
+    assert result.errors is None
+    assert result.data == {"create": {"message": "value is too short"}}
+
+
+def test_exception_handler_returning_none_declines_on_optional_union_type():
+    # Even on an optional union, returning ``None`` declines rather than
+    # silently resolving the field to null: the original exception (here raised
+    # during argument conversion) propagates as a normal GraphQL error.
+    class NullValidationHandler(
+        strawberry.ExceptionHandler[CustomValidationError, ValidationErrorPayload]
+    ):
+        def handle(
+            self,
+            exception: CustomValidationError,
+            *,
+            field: StrawberryField,
+            info: Info,
+        ) -> ValidationErrorPayload | None:
+            return None
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        def create(self, input: CustomInput) -> Success | ValidationErrorPayload | None:
+            return Success(value=input.value)
+
+    schema = strawberry.Schema(
+        query=Query,
+        mutation=Mutation,
+        exception_handlers=[NullValidationHandler()],
+    )
+
+    result = schema.execute_sync(
+        """
+        mutation {
+            create(input: { value: "a" }) {
+                ... on Success {
+                    value
+                }
+                ... on ValidationErrorPayload {
+                    message
+                }
+            }
+        }
+        """
+    )
+
+    # The field is nullable, so GraphQL nulls just the errored field and records
+    # the propagated exception rather than converting it to a union result.
+    assert result.data == {"create": None}
+    assert result.errors is not None
+    assert result.errors[0].message == "value is too short"
+
+
+def test_exception_handler_accepts_multiple_exception_types():
+    class MultipleValidationHandler(
+        strawberry.ExceptionHandler[
+            CustomValidationError | UnexpectedError, ValidationErrorPayload
+        ]
+    ):
+        def handle(
+            self,
+            exception: CustomValidationError | UnexpectedError,
+            *,
+            field: StrawberryField,
+            info: Info,
+        ) -> ValidationErrorPayload:
+            return ValidationErrorPayload(message=str(exception))
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        def create(self, value: str) -> Success | ValidationErrorPayload:
+            raise UnexpectedError(f"unexpected value: {value}")
+
+    schema = strawberry.Schema(
+        query=Query,
+        mutation=Mutation,
+        exception_handlers=[MultipleValidationHandler()],
+    )
+
+    result = schema.execute_sync(
+        """
+        mutation {
+            create(value: "abc") {
+                ... on Success {
+                    value
+                }
+                ... on ValidationErrorPayload {
+                    message
+                }
+            }
+        }
+        """
+    )
+
+    assert result.errors is None
+    assert result.data == {"create": {"message": "unexpected value: abc"}}
+
+
+def test_exception_handler_does_not_handle_list_of_union_type():
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        def create(self, value: str) -> list[Success | ValidationErrorPayload]:
+            raise CustomValidationError(f"invalid value: {value}")
+
+    schema = strawberry.Schema(
+        query=Query,
+        mutation=Mutation,
+        exception_handlers=[CustomValidationHandler()],
+    )
+
+    result = schema.execute_sync(
+        """
+        mutation {
+            create(value: "abc") {
+                ... on Success {
+                    value
+                }
+                ... on ValidationErrorPayload {
+                    message
+                }
+            }
+        }
+        """
+    )
+
+    assert result.errors is not None
+    assert result.errors[0].message == "invalid value: abc"
+    assert result.data is None
+
+
+def test_exception_handler_matches_lazy_error_type_in_union():
+    LazyValidationErrorPayload = Annotated[
+        "ValidationErrorPayload",
+        strawberry.lazy("tests.schema.test_exception_handlers"),
+    ]
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        def create(self, value: str) -> Success | LazyValidationErrorPayload:
+            raise CustomValidationError(f"invalid value: {value}")
+
+    schema = strawberry.Schema(
+        query=Query,
+        mutation=Mutation,
+        exception_handlers=[CustomValidationHandler()],
+    )
+
+    result = schema.execute_sync(
+        """
+        mutation {
+            create(value: "abc") {
+                ... on Success {
+                    value
+                }
+                ... on ValidationErrorPayload {
+                    message
+                }
+            }
+        }
+        """
+    )
+
+    assert result.errors is None
+    assert result.data == {"create": {"message": "invalid value: abc"}}
+
+
+def test_exception_handler_matches_lazy_union_return_type():
+    LazyValidationResult = Annotated[
+        "ValidationResult",
+        strawberry.lazy("tests.schema.test_exception_handlers"),
+    ]
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        def create(self, value: str) -> LazyValidationResult:
+            raise CustomValidationError(f"invalid value: {value}")
+
+    schema = strawberry.Schema(
+        query=Query,
+        mutation=Mutation,
+        exception_handlers=[CustomValidationHandler()],
+    )
+
+    result = schema.execute_sync(
+        """
+        mutation {
+            create(value: "abc") {
+                ... on Success {
+                    value
+                }
+                ... on ValidationErrorPayload {
+                    message
+                }
+            }
+        }
+        """
+    )
+
+    assert result.errors is None
+    assert result.data == {"create": {"message": "invalid value: abc"}}
+
+
+def test_exception_handler_converts_resolver_error_inside_field_extension():
+    class PassthroughExtension(FieldExtension):
+        def resolve(self, next_, source, info, **kwargs):  # noqa: ANN003
+            return next_(source, info, **kwargs)
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation(extensions=[PassthroughExtension()])
+        def create(self, value: str) -> Success | ValidationErrorPayload:
+            raise CustomValidationError(f"invalid value: {value}")
+
+    schema = strawberry.Schema(
+        query=Query,
+        mutation=Mutation,
+        exception_handlers=[CustomValidationHandler()],
+    )
+
+    result = schema.execute_sync(
+        """
+        mutation {
+            create(value: "abc") {
+                ... on Success {
+                    value
+                }
+                ... on ValidationErrorPayload {
+                    message
+                }
+            }
+        }
+        """
+    )
+
+    assert result.errors is None
+    assert result.data == {"create": {"message": "invalid value: abc"}}
+
+
+def test_field_extension_can_transform_resolver_error_before_handler():
+    class TransformingExtension(FieldExtension):
+        def resolve(self, next_, source, info, **kwargs):  # noqa: ANN003
+            try:
+                return next_(source, info, **kwargs)
+            except CustomValidationError as exc:
+                raise UnexpectedError(f"transformed: {exc}") from exc
+
+    class UnexpectedErrorHandler(
+        strawberry.ExceptionHandler[UnexpectedError, ValidationErrorPayload]
+    ):
+        def handle(
+            self,
+            exception: UnexpectedError,
+            *,
+            field: StrawberryField,
+            info: Info,
+        ) -> ValidationErrorPayload:
+            return ValidationErrorPayload(message=str(exception))
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation(extensions=[TransformingExtension()])
+        def create(self, value: str) -> Success | ValidationErrorPayload:
+            raise CustomValidationError(f"invalid value: {value}")
+
+    schema = strawberry.Schema(
+        query=Query,
+        mutation=Mutation,
+        exception_handlers=[CustomValidationHandler(), UnexpectedErrorHandler()],
+    )
+
+    result = schema.execute_sync(
+        """
+        mutation {
+            create(value: "abc") {
+                ... on ValidationErrorPayload {
+                    message
+                }
+            }
+        }
+        """
+    )
+
+    assert result.errors is None
+    assert result.data == {"create": {"message": "transformed: invalid value: abc"}}
+
+
+def test_exception_handler_converts_field_extension_error():
+    class FailingExtension(FieldExtension):
+        def resolve(self, next_, source, info, **kwargs):  # noqa: ANN003
+            raise CustomValidationError("extension failed")
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation(extensions=[FailingExtension()])
+        def create(self, value: str) -> Success | ValidationErrorPayload:
+            return Success(value=value)
+
+    schema = strawberry.Schema(
+        query=Query,
+        mutation=Mutation,
+        exception_handlers=[CustomValidationHandler()],
+    )
+
+    result = schema.execute_sync(
+        """
+        mutation {
+            create(value: "abc") {
+                ... on Success {
+                    value
+                }
+                ... on ValidationErrorPayload {
+                    message
+                }
+            }
+        }
+        """
+    )
+
+    assert result.errors is None
+    assert result.data == {"create": {"message": "extension failed"}}
+
+
+def test_exception_handler_does_not_convert_unmatched_field_extension_error():
+    class FailingExtension(FieldExtension):
+        def resolve(self, next_, source, info, **kwargs):  # noqa: ANN003
+            raise UnexpectedError("extension failed")
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation(extensions=[FailingExtension()])
+        def create(self, value: str) -> Success | ValidationErrorPayload:
+            return Success(value=value)
+
+    schema = strawberry.Schema(
+        query=Query,
+        mutation=Mutation,
+        exception_handlers=[CustomValidationHandler()],
+    )
+
+    result = schema.execute_sync(
+        """
+        mutation {
+            create(value: "abc") {
+                ... on Success {
+                    value
+                }
+                ... on ValidationErrorPayload {
+                    message
+                }
+            }
+        }
+        """
+    )
+
+    assert result.errors is not None
+    assert result.errors[0].message == "extension failed"
+    assert result.data is None
+
+
+@pytest.mark.asyncio
+async def test_exception_handler_converts_async_field_extension_error():
+    class FailingExtension(FieldExtension):
+        async def resolve_async(self, next_, source, info, **kwargs):  # noqa: ANN003
+            raise CustomValidationError("extension failed")
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation(extensions=[FailingExtension()])
+        async def create(self, value: str) -> Success | ValidationErrorPayload:
+            return Success(value=value)
+
+    schema = strawberry.Schema(
+        query=Query,
+        mutation=Mutation,
+        exception_handlers=[CustomValidationHandler()],
+    )
+
+    result = await schema.execute(
+        """
+        mutation {
+            create(value: "abc") {
+                ... on Success {
+                    value
+                }
+                ... on ValidationErrorPayload {
+                    message
+                }
+            }
+        }
+        """
+    )
+
+    assert result.errors is None
+    assert result.data == {"create": {"message": "extension failed"}}
+
+
+def test_exception_handler_converts_error_transformed_by_field_extension():
+    # An extension may catch the resolver's error and re-raise a mapped one;
+    # the transformed exception is converted at the outermost layer.
+    class TranslatingExtension(FieldExtension):
+        def resolve(self, next_, source, info, **kwargs):  # noqa: ANN003
+            try:
+                return next_(source, info, **kwargs)
+            except UnexpectedError as exc:
+                raise CustomValidationError(str(exc)) from exc
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation(extensions=[TranslatingExtension()])
+        def create(self, value: str) -> Success | ValidationErrorPayload:
+            raise UnexpectedError(f"unexpected value: {value}")
+
+    schema = strawberry.Schema(
+        query=Query,
+        mutation=Mutation,
+        exception_handlers=[CustomValidationHandler()],
+    )
+
+    result = schema.execute_sync(
+        """
+        mutation {
+            create(value: "abc") {
+                ... on Success {
+                    value
+                }
+                ... on ValidationErrorPayload {
+                    message
+                }
+            }
+        }
+        """
+    )
+
+    assert result.errors is None
+    assert result.data == {"create": {"message": "unexpected value: abc"}}
+
+
+def test_exception_handler_converts_exception_that_blocks_attribute_assignment():
+    # Some exception types (frozen dataclasses, C-extension types such as
+    # pydantic's ValidationError) do not allow setting arbitrary attributes, so
+    # the conversion must not depend on mutating the raised exception.
+    @dataclasses.dataclass(frozen=True)
+    class FrozenValidationError(Exception):
+        detail: str = "frozen"
+
+    class FrozenValidationHandler(
+        strawberry.ExceptionHandler[FrozenValidationError, ValidationErrorPayload]
+    ):
+        def handle(
+            self,
+            exception: FrozenValidationError,
+            *,
+            field: StrawberryField,
+            info: Info,
+        ) -> ValidationErrorPayload:
+            return ValidationErrorPayload(message=str(exception))
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        def create(self, value: str) -> Success | ValidationErrorPayload:
+            raise FrozenValidationError(value)
+
+    schema = strawberry.Schema(
+        query=Query,
+        mutation=Mutation,
+        exception_handlers=[FrozenValidationHandler()],
+    )
+
+    result = schema.execute_sync(
+        """
+        mutation {
+            create(value: "abc") {
+                ... on Success {
+                    value
+                }
+                ... on ValidationErrorPayload {
+                    message
+                }
+            }
+        }
+        """
+    )
+
+    assert result.errors is None
+    assert result.data == {"create": {"message": "abc"}}
+
+
+def test_exception_handler_matches_reimported_error_type_definition():
+    def define_reloaded_error():
+        @strawberry.type
+        class ReloadedError:
+            message: str
+
+        return ReloadedError
+
+    # Two structurally identical definitions sharing a name and module, as would
+    # happen if the module defining the error type were reloaded/reimported.
+    OriginalReloadedError = define_reloaded_error()
+    ReimportedReloadedError = define_reloaded_error()
+
+    # ``ReimportedReloadedError`` only exists at runtime, so it cannot be a
+    # type parameter — the ``error_type`` attribute covers this case.
+    class ReimportedValidationHandler(
+        strawberry.ExceptionHandler[CustomValidationError]
+    ):
+        error_type = ReimportedReloadedError
+
+        def handle(
+            self,
+            exception: CustomValidationError,
+            *,
+            field: StrawberryField,
+            info: Info,
+        ):
+            return OriginalReloadedError(message=str(exception))
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        def create(self, value: str) -> Success | OriginalReloadedError:
+            raise CustomValidationError(f"invalid value: {value}")
+
+    schema = strawberry.Schema(
+        query=Query,
+        mutation=Mutation,
+        exception_handlers=[ReimportedValidationHandler()],
+    )
+
+    result = schema.execute_sync(
+        """
+        mutation {
+            create(value: "abc") {
+                ... on Success {
+                    value
+                }
+                ... on ReloadedError {
+                    message
+                }
+            }
+        }
+        """
+    )
+
+    assert result.errors is None
+    assert result.data == {"create": {"message": "invalid value: abc"}}
+
+
+def test_argument_conversion_error_is_mapped_before_permissions_run():
+    # Argument conversion happens before the field-extension chain, so a
+    # conversion error has always bypassed field extensions such as permissions.
+    # When a handler matches, the exception is mapped to a union result directly
+    # and the permission never runs.
+    permission_ran = False
+
+    class Deny(BasePermission):
+        message = "denied"
+
+        def has_permission(self, source, info, **kwargs):  # noqa: ANN003
+            nonlocal permission_ran
+            permission_ran = True
+            return False
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation(permission_classes=[Deny])
+        def create(self, input: CustomInput) -> Success | ValidationErrorPayload:
+            return Success(value=input.value)
+
+    schema = strawberry.Schema(
+        query=Query,
+        mutation=Mutation,
+        exception_handlers=[CustomValidationHandler()],
+    )
+
+    result = schema.execute_sync(
+        """
+        mutation {
+            create(input: { value: "a" }) {
+                ... on Success {
+                    value
+                }
+                ... on ValidationErrorPayload {
+                    message
+                }
+            }
+        }
+        """
+    )
+
+    assert result.errors is None
+    assert result.data == {"create": {"message": "value is too short"}}
+    assert permission_ran is False
+
+
+@pytest.mark.asyncio
+async def test_exception_handler_converts_async_resolver_error_to_union_type():
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        async def create(self, value: str) -> Success | ValidationErrorPayload:
+            raise CustomValidationError(f"invalid value: {value}")
+
+    schema = strawberry.Schema(
+        query=Query,
+        mutation=Mutation,
+        exception_handlers=[CustomValidationHandler()],
+    )
+
+    result = await schema.execute(
+        """
+        mutation {
+            create(value: "abc") {
+                ... on Success {
+                    value
+                }
+                ... on ValidationErrorPayload {
+                    message
+                }
+            }
+        }
+        """
+    )
+
+    assert result.errors is None
+    assert result.data == {"create": {"message": "invalid value: abc"}}
+
+
+@pytest.mark.asyncio
+async def test_exception_handler_converts_awaitable_from_sync_resolver():
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        def create(self, value: str) -> Success | ValidationErrorPayload:
+            async def resolve() -> Success | ValidationErrorPayload:
+                raise CustomValidationError(f"invalid value: {value}")
+
+            return resolve()  # type: ignore[return-value]
+
+    schema = strawberry.Schema(
+        query=Query,
+        mutation=Mutation,
+        exception_handlers=[CustomValidationHandler()],
+    )
+
+    result = await schema.execute(
+        """
+        mutation {
+            create(value: "abc") {
+                ... on ValidationErrorPayload {
+                    message
+                }
+            }
+        }
+        """
+    )
+
+    assert result.errors is None
+    assert result.data == {"create": {"message": "invalid value: abc"}}
+
+
+@pytest.mark.asyncio
+async def test_exception_handler_converts_async_argument_conversion_error():
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        async def create(self, input: CustomInput) -> Success | ValidationErrorPayload:
+            return Success(value=input.value)
+
+    schema = strawberry.Schema(
+        query=Query,
+        mutation=Mutation,
+        exception_handlers=[CustomValidationHandler()],
+    )
+
+    result = await schema.execute(
+        """
+        mutation {
+            create(input: { value: "a" }) {
+                ... on Success {
+                    value
+                }
+                ... on ValidationErrorPayload {
+                    message
+                }
+            }
+        }
+        """
+    )
+
+    assert result.errors is None
+    assert result.data == {"create": {"message": "value is too short"}}
+
+
+@pytest.mark.asyncio
+async def test_exception_handler_does_not_handle_subscription_setup_error():
+    @strawberry.type
+    class Subscription:
+        @strawberry.subscription
+        async def create(
+            self, input: CustomInput
+        ) -> AsyncGenerator[Success | ValidationErrorPayload, None]:
+            yield Success(value=input.value)
+
+    schema = strawberry.Schema(
+        query=Query,
+        subscription=Subscription,
+        exception_handlers=[CustomValidationHandler()],
+    )
+
+    result_source = await schema.subscribe(
+        """
+        subscription {
+            create(input: { value: "a" }) {
+                ... on Success {
+                    value
+                }
+                ... on ValidationErrorPayload {
+                    message
+                }
+            }
+        }
+        """
+    )
+
+    async with aclosing(result_source) as subscription_result:
+        result = await subscription_result.__anext__()
+
+    assert isinstance(result, PreExecutionError)
+    assert result.errors[0].message == "value is too short"
+    assert result.data is None
+
+
+def test_federation_schema_passes_exception_handlers_to_resolvers():
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        def create(self, input: CustomInput) -> Success | ValidationErrorPayload:
+            return Success(value=input.value)
+
+    schema = strawberry.federation.Schema(
+        query=Query,
+        mutation=Mutation,
+        exception_handlers=[CustomValidationHandler()],
+    )
+
+    result = schema.execute_sync(
+        """
+        mutation {
+            create(input: { value: "a" }) {
+                ... on Success {
+                    value
+                }
+                ... on ValidationErrorPayload {
+                    message
+                }
+            }
+        }
+        """
+    )
+
+    assert result.errors is None
+    assert result.data == {"create": {"message": "value is too short"}}
+
+
+@pytest.mark.asyncio
+async def test_exception_handler_converts_conversion_error_with_async_extension():
+    # An async field extension `await`s the inner result, so the handled payload
+    # produced on the conversion-error path must be awaitable too.
+    class Allow(BasePermission):
+        message = "denied"
+
+        async def has_permission(self, source, info, **kwargs) -> bool:  # noqa: ANN003
+            return True
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation(permission_classes=[Allow])
+        async def create(self, input: CustomInput) -> Success | ValidationErrorPayload:
+            return Success(value=input.value)
+
+    schema = strawberry.Schema(
+        query=Query,
+        mutation=Mutation,
+        exception_handlers=[CustomValidationHandler()],
+    )
+
+    result = await schema.execute(
+        """
+        mutation {
+            create(input: { value: "a" }) {
+                ... on Success {
+                    value
+                }
+                ... on ValidationErrorPayload {
+                    message
+                }
+            }
+        }
+        """
+    )
+
+    assert result.errors is None
+    assert result.data == {"create": {"message": "value is too short"}}
+
+
+def test_exception_handler_converts_conversion_error_with_input_mutation_extension():
+    # `InputMutationExtension` calls `vars(input)` on the arguments; the raw
+    # values passed on the conversion-error path must not crash it before the
+    # handler runs.
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation(extensions=[InputMutationExtension()])
+        def create(self, data: CustomInput) -> Success | ValidationErrorPayload:
+            return Success(value=data.value)
+
+    schema = strawberry.Schema(
+        query=Query,
+        mutation=Mutation,
+        exception_handlers=[CustomValidationHandler()],
+    )
+
+    result = schema.execute_sync(
+        """
+        mutation {
+            create(input: { data: { value: "a" } }) {
+                ... on Success {
+                    value
+                }
+                ... on ValidationErrorPayload {
+                    message
+                }
+            }
+        }
+        """
+    )
+
+    assert result.errors is None
+    assert result.data == {"create": {"message": "value is too short"}}
+
+
+def test_exception_handler_matches_concrete_generic_error_type_in_union():
+    @strawberry.type
+    class GenericError(Generic[T]):
+        message: str
+        value: T
+
+    class GenericHandler(
+        strawberry.ExceptionHandler[CustomValidationError, GenericError[int]]
+    ):
+        def handle(
+            self,
+            exception: CustomValidationError,
+            *,
+            field: StrawberryField,
+            info: Info,
+        ) -> "GenericError[int]":
+            return GenericError[int](message=str(exception), value=0)
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        def create(self) -> Success | GenericError[int]:
+            raise CustomValidationError("boom")
+
+    schema = strawberry.Schema(
+        query=Query,
+        mutation=Mutation,
+        exception_handlers=[GenericHandler()],
+    )
+
+    result = schema.execute_sync(
+        """
+        mutation {
+            create {
+                ... on Success {
+                    value
+                }
+                ... on IntGenericError {
+                    message
+                    intValue: value
+                }
+            }
+        }
+        """
+    )
+
+    assert result.errors is None
+    assert result.data == {"create": {"message": "boom", "intValue": 0}}
+
+
+def test_exception_handler_converts_basic_field_error_to_union_type():
+    # A "basic" field (a plain attribute with no resolver) whose return type is
+    # a union should still have its errors converted; whether an unrelated
+    # extension is attached must not change this.
+    @strawberry.type
+    class Query:
+        ok: bool = True
+        result: Success | ValidationErrorPayload
+
+    class Root:
+        ok = True
+
+        @property
+        def result(self) -> None:
+            raise CustomValidationError("basic field boom")
+
+    schema = strawberry.Schema(
+        query=Query,
+        exception_handlers=[CustomValidationHandler()],
+    )
+
+    result = schema.execute_sync(
+        """
+        {
+            result {
+                ... on Success {
+                    value
+                }
+                ... on ValidationErrorPayload {
+                    message
+                }
+            }
+        }
+        """,
+        root_value=Root(),
+    )
+
+    assert result.errors is None
+    assert result.data == {"result": {"message": "basic field boom"}}
+
+
+def test_exception_handler_conflicting_type_parameter_and_attribute_raises():
+    # The type parameter says ``UnexpectedError`` while the attribute says
+    # ``CustomValidationError``; a contradiction like this is a mistake, so it
+    # should fail loudly rather than silently pick one.
+    class ConflictingHandler(strawberry.ExceptionHandler[UnexpectedError]):
+        exception_type = CustomValidationError
+        error_type = ValidationErrorPayload
+
+        def handle(self, exception, *, field, info) -> ValidationErrorPayload:
+            return ValidationErrorPayload(message=str(exception))
+
+    with pytest.raises(TypeError, match="conflicting exception types"):
+        strawberry.Schema(query=Query, exception_handlers=[ConflictingHandler()])
+
+
+def test_exception_handler_conflicting_error_type_parameter_and_attribute_raises():
+    class ConflictingErrorHandler(
+        strawberry.ExceptionHandler[CustomValidationError, OtherErrorPayload]
+    ):
+        error_type = ValidationErrorPayload
+
+        def handle(self, exception, *, field, info) -> ValidationErrorPayload:
+            return ValidationErrorPayload(message=str(exception))
+
+    with pytest.raises(TypeError, match="conflicting GraphQL error types"):
+        strawberry.Schema(query=Query, exception_handlers=[ConflictingErrorHandler()])
+
+
+def test_exception_handler_attribute_fills_in_undeclared_error_type():
+    # Parameterizing only the exception slot and supplying the error type via an
+    # attribute is not a conflict: the slots do not overlap.
+    class SplitHandler(strawberry.ExceptionHandler[CustomValidationError]):
+        error_type = ValidationErrorPayload
+
+        def handle(self, exception, *, field, info) -> ValidationErrorPayload:
+            return ValidationErrorPayload(message=str(exception))
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        def create(self, value: str) -> Success | ValidationErrorPayload:
+            raise CustomValidationError(f"invalid value: {value}")
+
+    schema = strawberry.Schema(
+        query=Query,
+        mutation=Mutation,
+        exception_handlers=[SplitHandler()],
+    )
+
+    result = schema.execute_sync(
+        """
+        mutation {
+            create(value: "abc") {
+                ... on ValidationErrorPayload {
+                    message
+                }
+            }
+        }
+        """
+    )
+
+    assert result.errors is None
+    assert result.data == {"create": {"message": "invalid value: abc"}}
+
+
+def test_exception_handler_works_without_subclassing():
+    class DuckHandler:
+        exception_type = CustomValidationError
+        error_type = ValidationErrorPayload
+
+        def handle(self, exception, *, field, info):
+            return ValidationErrorPayload(message=str(exception))
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        def create(self, value: str) -> Success | ValidationErrorPayload:
+            raise CustomValidationError(f"invalid value: {value}")
+
+    schema = strawberry.Schema(
+        query=Query,
+        mutation=Mutation,
+        exception_handlers=[DuckHandler()],
+    )
+
+    result = schema.execute_sync(
+        """
+        mutation {
+            create(value: "abc") {
+                ... on ValidationErrorPayload {
+                    message
+                }
+            }
+        }
+        """
+    )
+
+    assert result.errors is None
+    assert result.data == {"create": {"message": "invalid value: abc"}}
+
+
+def test_exception_handler_without_exception_type_raises_at_schema_creation():
+    class IncompleteHandler(strawberry.ExceptionHandler):
+        def handle(self, exception, *, field, info) -> None:
+            return None
+
+    with pytest.raises(TypeError, match="does not declare which exceptions it handles"):
+        strawberry.Schema(query=Query, exception_handlers=[IncompleteHandler()])
+
+
+def test_exception_handler_without_error_type_raises_at_schema_creation():
+    class NoErrorTypeHandler(strawberry.ExceptionHandler[CustomValidationError]):
+        def handle(self, exception, *, field, info) -> None:
+            return None
+
+    with pytest.raises(TypeError, match="does not declare the GraphQL error type"):
+        strawberry.Schema(query=Query, exception_handlers=[NoErrorTypeHandler()])
+
+
+def test_exception_handler_matches_type_widened_by_field_extension():
+    # A field extension may widen the return type during ``apply`` (here from
+    # ``Success`` to ``Success | ValidationErrorPayload``). Handler matching must
+    # see the widened type, otherwise the SDL advertises the error member while
+    # the exception silently leaks as a top-level error.
+    class WidenReturnTypeExtension(FieldExtension):
+        def apply(self, field: StrawberryField) -> None:
+            field.type = Success | ValidationErrorPayload
+
+        def resolve(self, next_, source, info, **kwargs):  # noqa: ANN003
+            return next_(source, info, **kwargs)
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation(extensions=[WidenReturnTypeExtension()])
+        def create(self, value: str) -> Success:
+            raise CustomValidationError(f"invalid value: {value}")
+
+    schema = strawberry.Schema(
+        query=Query,
+        mutation=Mutation,
+        exception_handlers=[CustomValidationHandler()],
+    )
+
+    # The widened type is what ends up in the SDL.
+    assert "union" in schema.as_str()
+
+    result = schema.execute_sync(
+        """
+        mutation {
+            create(value: "abc") {
+                ... on ValidationErrorPayload {
+                    message
+                }
+            }
+        }
+        """
+    )
+
+    assert result.errors is None
+    assert result.data == {"create": {"message": "invalid value: abc"}}
+
+
+def test_exception_handler_non_exception_type_raises_at_schema_creation():
+    # ``int`` is a type but not an ``Exception`` subclass, so it could never
+    # match a raised exception; reject it up front instead of silently never
+    # matching.
+    class BadHandler:
+        exception_type = int
+        error_type = ValidationErrorPayload
+
+        def handle(self, exception, *, field, info):
+            return ValidationErrorPayload(message=str(exception))
+
+    with pytest.raises(TypeError, match="not a subclass of `Exception`"):
+        strawberry.Schema(query=Query, exception_handlers=[BadHandler()])
+
+
+def test_exception_handler_string_exception_type_raises_at_schema_creation():
+    # A string is iterable, so a naive normalization would split it into
+    # single-character "types"; it must be rejected whole at schema creation.
+    class BadHandler:
+        exception_type = "not an exception class"
+        error_type = ValidationErrorPayload
+
+        def handle(self, exception, *, field, info):
+            return ValidationErrorPayload(message=str(exception))
+
+    with pytest.raises(TypeError, match="not a subclass of `Exception`"):
+        strawberry.Schema(query=Query, exception_handlers=[BadHandler()])
+
+
+def test_exception_handler_protocol_is_runtime_checkable():
+    assert isinstance(CustomValidationHandler(), strawberry.ExceptionHandler)
+
+
+class DecliningValidationHandler(
+    strawberry.ExceptionHandler[CustomValidationError, ValidationErrorPayload]
+):
+    """Always declines, so the original exception should propagate."""
+
+    def handle(
+        self,
+        exception: CustomValidationError,
+        *,
+        field: StrawberryField,
+        info: Info,
+    ) -> ValidationErrorPayload | None:
+        return None
+
+
+def test_exception_handler_returning_none_reraises_original_exception():
+    processed_errors = []
+
+    class TrackingSchema(strawberry.Schema):
+        def process_errors(self, errors, execution_context=None):
+            processed_errors.extend(errors)
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        def create(self, value: str) -> Success | ValidationErrorPayload:
+            raise CustomValidationError(f"invalid value: {value}")
+
+    schema = TrackingSchema(
+        query=Query,
+        mutation=Mutation,
+        exception_handlers=[DecliningValidationHandler()],
+    )
+
+    result = schema.execute_sync(
+        """
+        mutation {
+            create(value: "abc") {
+                ... on ValidationErrorPayload {
+                    message
+                }
+            }
+        }
+        """
+    )
+
+    # Declining re-raises the original exception, so it propagates as a normal
+    # GraphQL error just as if no handler had matched.
+    assert result.data is None
+    assert result.errors is not None
+    assert result.errors[0].message == "invalid value: abc"
+    assert len(processed_errors) == 1
+    assert processed_errors[0].message == "invalid value: abc"
+
+
+def test_exception_handler_returning_none_reraises_on_nullable_union():
+    # On a nullable union the original exception must still surface as an error,
+    # not silently resolve the field to null.
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        def create(self, value: str) -> Success | ValidationErrorPayload | None:
+            raise CustomValidationError(f"invalid value: {value}")
+
+    schema = strawberry.Schema(
+        query=Query,
+        mutation=Mutation,
+        exception_handlers=[DecliningValidationHandler()],
+    )
+
+    result = schema.execute_sync(
+        """
+        mutation {
+            create(value: "abc") {
+                ... on ValidationErrorPayload {
+                    message
+                }
+            }
+        }
+        """
+    )
+
+    assert result.data == {"create": None}
+    assert result.errors is not None
+    assert result.errors[0].message == "invalid value: abc"
+
+
+def test_exception_handler_can_decline_per_instance():
+    # Match a broad exception type but only convert the instances we recognize;
+    # everything else propagates untouched.
+    class ConditionalHandler(
+        strawberry.ExceptionHandler[CustomValidationError, ValidationErrorPayload]
+    ):
+        def handle(
+            self,
+            exception: CustomValidationError,
+            *,
+            field: StrawberryField,
+            info: Info,
+        ) -> ValidationErrorPayload | None:
+            if str(exception).startswith("expose:"):
+                return ValidationErrorPayload(message=str(exception))
+            return None
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        def create(self, value: str) -> Success | ValidationErrorPayload:
+            raise CustomValidationError(value)
+
+    schema = strawberry.Schema(
+        query=Query,
+        mutation=Mutation,
+        exception_handlers=[ConditionalHandler()],
+    )
+
+    query = """
+        mutation ($value: String!) {
+            create(value: $value) {
+                ... on ValidationErrorPayload {
+                    message
+                }
+            }
+        }
+    """
+
+    converted = schema.execute_sync(query, variable_values={"value": "expose:oops"})
+    assert converted.errors is None
+    assert converted.data == {"create": {"message": "expose:oops"}}
+
+    declined = schema.execute_sync(query, variable_values={"value": "secret detail"})
+    assert declined.data is None
+    assert declined.errors is not None
+    assert declined.errors[0].message == "secret detail"
+
+
+def test_exception_handler_returning_none_reraises_argument_conversion_error():
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        def create(self, input: CustomInput) -> Success | ValidationErrorPayload:
+            return Success(value=input.value)
+
+    schema = strawberry.Schema(
+        query=Query,
+        mutation=Mutation,
+        exception_handlers=[DecliningValidationHandler()],
+    )
+
+    result = schema.execute_sync(
+        """
+        mutation {
+            create(input: { value: "a" }) {
+                ... on ValidationErrorPayload {
+                    message
+                }
+            }
+        }
+        """
+    )
+
+    assert result.data is None
+    assert result.errors is not None
+    assert result.errors[0].message == "value is too short"
+
+
+@pytest.mark.asyncio
+async def test_exception_handler_returning_none_reraises_on_async_field():
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        async def create(self, value: str) -> Success | ValidationErrorPayload:
+            raise CustomValidationError(f"invalid value: {value}")
+
+    schema = strawberry.Schema(
+        query=Query,
+        mutation=Mutation,
+        exception_handlers=[DecliningValidationHandler()],
+    )
+
+    result = await schema.execute(
+        """
+        mutation {
+            create(value: "abc") {
+                ... on ValidationErrorPayload {
+                    message
+                }
+            }
+        }
+        """
+    )
+
+    assert result.data is None
+    assert result.errors is not None
+    assert result.errors[0].message == "invalid value: abc"
+
+
+@pytest.mark.asyncio
+async def test_async_exception_handler_resolving_to_none_reraises():
+    # An async ``handle`` that awaits to ``None`` also declines.
+    class AsyncDecliningHandler(
+        strawberry.ExceptionHandler[CustomValidationError, ValidationErrorPayload]
+    ):
+        async def handle(
+            self,
+            exception: CustomValidationError,
+            *,
+            field: StrawberryField,
+            info: Info,
+        ) -> ValidationErrorPayload | None:
+            return None
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        async def create(self, value: str) -> Success | ValidationErrorPayload:
+            raise CustomValidationError(f"invalid value: {value}")
+
+    schema = strawberry.Schema(
+        query=Query,
+        mutation=Mutation,
+        exception_handlers=[AsyncDecliningHandler()],
+    )
+
+    result = await schema.execute(
+        """
+        mutation {
+            create(value: "abc") {
+                ... on ValidationErrorPayload {
+                    message
+                }
+            }
+        }
+        """
+    )
+
+    assert result.data is None
+    assert result.errors is not None
+    assert result.errors[0].message == "invalid value: abc"
+
+
+def test_declining_handler_with_field_extension_is_called_once():
+    calls = 0
+
+    class PassthroughExtension(FieldExtension):
+        def resolve(self, next_, source, info, **kwargs):  # noqa: ANN003
+            return next_(source, info, **kwargs)
+
+    class CountingDecliningHandler(
+        strawberry.ExceptionHandler[CustomValidationError, ValidationErrorPayload]
+    ):
+        def handle(
+            self,
+            exception: CustomValidationError,
+            *,
+            field: StrawberryField,
+            info: Info,
+        ) -> None:
+            nonlocal calls
+            calls += 1
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation(extensions=[PassthroughExtension()])
+        def create(self, value: str) -> Success | ValidationErrorPayload:
+            raise CustomValidationError(f"invalid value: {value}")
+
+    schema = strawberry.Schema(
+        query=Query,
+        mutation=Mutation,
+        exception_handlers=[CountingDecliningHandler()],
+    )
+
+    result = schema.execute_sync(
+        """
+        mutation {
+            create(value: "abc") {
+                ... on ValidationErrorPayload {
+                    message
+                }
+            }
+        }
+        """
+    )
+
+    assert result.data is None
+    assert result.errors is not None
+    assert result.errors[0].message == "invalid value: abc"
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_async_declining_handler_with_extension_is_called_once():
+    calls = 0
+
+    class PassthroughExtension(FieldExtension):
+        async def resolve_async(self, next_, source, info, **kwargs):  # noqa: ANN003
+            return await next_(source, info, **kwargs)
+
+    class CountingDecliningHandler(
+        strawberry.ExceptionHandler[CustomValidationError, ValidationErrorPayload]
+    ):
+        def handle(
+            self,
+            exception: CustomValidationError,
+            *,
+            field: StrawberryField,
+            info: Info,
+        ) -> None:
+            nonlocal calls
+            calls += 1
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation(extensions=[PassthroughExtension()])
+        async def create(self, value: str) -> Success | ValidationErrorPayload:
+            raise CustomValidationError(f"invalid value: {value}")
+
+    schema = strawberry.Schema(
+        query=Query,
+        mutation=Mutation,
+        exception_handlers=[CountingDecliningHandler()],
+    )
+
+    result = await schema.execute(
+        """
+        mutation {
+            create(value: "abc") {
+                ... on ValidationErrorPayload {
+                    message
+                }
+            }
+        }
+        """
+    )
+
+    assert result.data is None
+    assert result.errors is not None
+    assert result.errors[0].message == "invalid value: abc"
+    assert calls == 1


### PR DESCRIPTION
<!-- shortcake:start -->
## Stack [🍰](https://shortcake.patrick.wtf)

- #3965 (`feature/pydantic-first-class`)
- **#4492** (`2026-06-28-add-generic-exception-handlers`) <-- this PR
- #4510 (merged) (`2026-07-06-unpack-input-mutation-arguments`)
<!-- shortcake:end -->

## Summary by Sourcery

Add configurable exception handlers that map Python exceptions to GraphQL union results, and integrate them into schema construction and resolver execution while documenting usage and behavior.

New Features:
- Introduce a runtime-checkable ExceptionHandler protocol and helper utilities for declaring and validating exception-to-error mappings.
- Allow passing exception_handlers into Schema and federation Schema to convert matched exceptions into typed union return values for queries and mutations.
- Add support for matching generic, lazy, and re-imported error types when resolving union members in the schema converter.

Enhancements:
- Precompute per-field exception handler applicability at schema build time to avoid per-request overhead on fields where handlers cannot apply.
- Refactor type-definition equality logic into standalone helpers to better support nested generics and lazy types.
- Clarify CONTRIBUTING guidance on release notes and social messages formatting and tone.

Documentation:
- Extend the errors guide with a section on mapping expected exceptions to union results via exception_handlers.
- Document the new exception_handlers parameter on Schema types and how it integrates with error handling.
- Add release notes describing exception handlers and their intended use in framework integrations.

Tests:
- Add an extensive test suite covering exception handler behavior across sync/async resolvers, argument conversion, field extensions, generics, lazy types, permissions, subscriptions, and error-declining scenarios.
- Add benchmarks to measure overhead of configured exception handlers on both handled and unhandled fields.

Chores:
- Rename the internal excepthook handler alias to avoid colliding with the new public ExceptionHandler protocol.