### PR TITLE
Make sure we always have a nice social release copy

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - main
     paths:
+      - "RELEASE.md"
       - "strawberry/**"
       - "pyproject.toml"
 
@@ -42,4 +43,4 @@ jobs:
           command: check
           autopub-version: "1.0.0a58"
           fail-on-missing: "true"
-          extra-plugins: strawberry-autopub-plugins
+          extra-plugins: "strawberry-autopub-plugins>=0.2.0"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           command: check
           autopub-version: "1.0.0a58"
           github-token: ${{ secrets.BOT_TOKEN }}
-          extra-plugins: strawberry-autopub-plugins
+          extra-plugins: "strawberry-autopub-plugins>=0.2.0"
 
   publish:
     name: Publish to PyPI
@@ -54,21 +54,21 @@ jobs:
         with:
           command: prepare
           autopub-version: "1.0.0a58"
-          extra-plugins: strawberry-autopub-plugins
+          extra-plugins: "strawberry-autopub-plugins>=0.2.0"
 
       - name: Build package
         uses: autopub/autopub-action@5fdc82e84c048a82303de6b5c5a9d027665e73cf # v1.1.1
         with:
           command: build
           autopub-version: "1.0.0a58"
-          extra-plugins: strawberry-autopub-plugins
+          extra-plugins: "strawberry-autopub-plugins>=0.2.0"
 
       - name: Publish to PyPI
         uses: autopub/autopub-action@5fdc82e84c048a82303de6b5c5a9d027665e73cf # v1.1.1
         with:
           command: publish
           autopub-version: "1.0.0a58"
-          extra-plugins: strawberry-autopub-plugins
+          extra-plugins: "strawberry-autopub-plugins>=0.2.0"
           github-token: ${{ secrets.BOT_TOKEN }}
           git-username: botberry
           git-email: bot@strawberry.rocks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,16 +148,35 @@ present, your code will not be merged.
 
 ##### RELEASE.md files
 
-When you submit a PR, make sure to include a RELEASE.md file. We use that to automatically do releases here on GitHub and, most importantly, to PyPI!
+When you submit a PR, make sure to include a RELEASE.md file. We use that to
+automatically do releases here on GitHub and, most importantly, to PyPI.
 
-So as soon as your PR is merged, a release will be made.
+As soon as your PR is merged, a release will be made.
 
 Here's an example of RELEASE.md:
 
-```text
-Release type: patch
+```markdown
+---
+release type: patch
+social_messages:
+  x: >-
+    {project_name} {version} fixes schema printing for nullable input defaults.
+  linkedin: >-
+    {project_name} {version} fixes schema printing for nullable input defaults
+    so generated SDL now keeps explicit null values.
+---
 
-Description of the changes, ideally with some examples, if adding a new feature.
+This release fixes schema printing for nullable input defaults.
+
+Strawberry now preserves explicit `None` values in printed nested input
+defaults, including fields set with `strawberry.Some(None)`.
 ```
 
-Release type can be one of patch, minor or major. We use [semver](https://semver.org/), so make sure to pick the appropriate type. If in doubt feel free to ask :)
+Release type can be one of patch, minor or major. We use
+[semver](https://semver.org/), so make sure to pick the appropriate type. If in
+doubt feel free to ask.
+
+Release notes should start with `This release adds ...` or
+`This release fixes ...` and should explain the user-visible behavior first.
+Include social messages for X and LinkedIn so the release announcement reads
+well on each platform.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,6 +188,9 @@ plugins = [
 project-name = "Strawberry GraphQL"
 platforms = ["x", "linkedin", "bluesky", "mastodon"]
 publish-mode = "next-free-slot"
+require-social-message = true
+required-social-platforms = ["x", "linkedin"]
+require-release-note-lead = true
 
 [tool.pyright]
 # include = ["strawberry"]


### PR DESCRIPTION
## Summary

This wires Strawberry to the Typefully plugin changes released in `strawberry-autopub-plugins==0.2.0` and makes better release/social copy part of the normal release check.

- Pin the release workflows to `strawberry-autopub-plugins>=0.2.0`.
- Require release notes to include Typefully social copy and start with a user-facing lead.
- Require social copy coverage for X and LinkedIn.
- Re-run the release check when `RELEASE.md` changes.
- Update the contributor docs with the frontmatter format and social message example.

## Why

The old release flow could publish raw Markdown into social posts and truncate LinkedIn copy with X-sized limits. The plugin now fixes the default formatting, and this PR makes Strawberry use the new validation hooks so future release posts are intentionally written instead of generated from whatever release note happened to fit.

## Release note

This PR intentionally does not include `RELEASE.md`; it changes release process/docs rather than Strawberry's runtime package behavior.

Because the current base `release-check.yml` still has `fail-on-missing: "true"` for PRs that touch `pyproject.toml`, the existing release check may report the missing release file on this branch. Once this PR lands, normal publish-on-main behavior still skips publishing when there is no `RELEASE.md`.

## Validation

- `git diff --check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release.yml .github/workflows/release-check.yml`
- commit hooks: passed, with cached Node-version warnings for skipped unhealthy hook installs

## Summary by Sourcery

Integrate updated autopub plugins so releases enforce structured release notes and social copy requirements.

Enhancements:
- Configure release tooling to require social messages for X and LinkedIn and a user-facing lead line in release notes.

Build:
- Pin release workflows to use strawberry-autopub-plugins version 0.2.0 or newer.

CI:
- Trigger the release-check workflow when RELEASE.md changes and run it with the updated autopub plugins.

Documentation:
- Document the RELEASE.md frontmatter format, including social_messages for X and LinkedIn and a user-facing release note lead.