### PR TITLE
Use GITHUB_TOKEN for release copy review comment

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,6 +36,11 @@ jobs:
         uses: anthropics/claude-code-action@a92e7c70a4da9793dc164451d829089dc057a464 # v1.0.159
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Use the workflow's built-in token to post the review comment.
+          # Avoids the OIDC -> Claude-app-token exchange, which 401s here
+          # because the org's pre-existing Claude app install isn't linked
+          # to the account behind CLAUDE_CODE_OAUTH_TOKEN.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           label_trigger: release-copy-review
           use_sticky_comment: true
           include_fix_links: false


### PR DESCRIPTION
## Summary

The `Claude release copy review` workflow (added in #4495) fails on every run with:

```
Exchanging OIDC token for app token...
App token exchange failed: 401 Unauthorized - Invalid OIDC token
```

The action was minting a GitHub App token via the OIDC → `api.anthropic.com/api/github/github-app-token-exchange` flow. That endpoint 401s here because the org's **pre-existing** Claude app installation isn't linked to the Anthropic account behind `CLAUDE_CODE_OAUTH_TOKEN` — re-running `/install-github-app` doesn't fix it (the install short-circuits when the app is already present).

## Fix

Pass the workflow's built-in `GITHUB_TOKEN` via the action's `github_token` input. Per `claude-code-action`'s `token.ts`, providing it sets `OVERRIDE_GITHUB_TOKEN` and the action returns the token directly ("Using provided GITHUB_TOKEN for authentication") — skipping the OIDC exchange entirely. The job already grants `pull-requests: write` and `issues: write`, so it can post the sticky comment.

## Notes

- LLM auth is unchanged — the review still runs on `CLAUDE_CODE_OAUTH_TOKEN` (subscription billing).
- Cosmetic: the review comment now posts as `github-actions[bot]` instead of `claude[bot]`.
- `id-token: write` in the job permissions is now unused but left in place; harmless.
- Must land on `main` to take effect — `pull_request_target` always runs the workflow definition from the default branch.

## Summary by Sourcery

CI:
- Update claude-code-action configuration in the release copy review workflow to pass GITHUB_TOKEN via the github_token input instead of relying on GitHub App token exchange.