### PR TITLE
Raise release copy review turn limit to 20

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -85,6 +85,6 @@ jobs:
             Keep the review practical and short. Do not ask maintainers to run
             tests.
           claude_args: |
-            --max-turns 8
+            --max-turns 20
             --allowedTools Read,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh api:*)
             --disallowedTools Edit,Write,MultiEdit,NotebookEdit


### PR DESCRIPTION
## Summary

Follow-up to #4496. With auth fixed, the `Claude release copy review` job now runs but fails with `Reached maximum number of turns (8)` and posts **no** comment — the agent spends all 8 turns on `gh pr view` + `gh pr diff` + reading `RELEASE.md` + reasoning, and never reaches the sticky-comment post step.

Raise `--max-turns` from 8 to 20 so the review can complete. The agent stops as soon as it's done, so this is just headroom, not a fixed cost.

Must land on `main` to take effect (`pull_request_target` uses the default-branch workflow definition).

## Summary by Sourcery

CI:
- Raise the `--max-turns` limit for the Claude release copy review job from 8 to 20 in the GitHub Actions workflow.