### PR TITLE
Make sure to close spans in Datadog extension

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,7 @@
 release type: patch
 social_messages:
   x: >-
-    {project_name} {version} makes sure the Datadog extension always closes spans.
+    {project_name} {version} fixes a bug where Datadog spans could be left open when an operation raised an exception.
   linkedin: >-
     {project_name} {version} makes sure the Datadog extension always closes spans.
 ---

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,7 +4,7 @@ social_messages:
   x: >-
     {project_name} {version} fixes a bug where Datadog spans could be left open when an operation raised an exception.
   linkedin: >-
-    {project_name} {version} makes sure the Datadog extension always closes spans.
+    {project_name} {version} fixes a bug in the Datadog tracing extension where spans could be left open indefinitely when a GraphQL operation raised an exception. Upgrade to get correct span lifecycle management in all error paths.
 ---
 
 This release fixes a bug in the Datadog extension where spans could be left open indefinitely when a GraphQL operation raised an exception.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,7 +7,7 @@ social_messages:
     {project_name} {version} makes sure the Datadog extension always closes spans.
 ---
 
-This release fixes an issue with the Datadog extension.
+This release fixes a bug in the Datadog extension where spans could be left open indefinitely when a GraphQL operation raised an exception.
 
 Strawberry now makes sure that the Datadog extension always closes spans,
 also in the case of exceptions.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,30 +1,13 @@
-release type: minor
+---
+release type: patch
 social_messages:
   x: >-
-    {project_name} {version} removes the long-deprecated `info.field_nodes` property. Migrate to `info.selected_fields` before upgrading.
+    {project_name} {version} makes sure the Datadog extension always closes spans.
   linkedin: >-
-    {project_name} {version} removes the `info.field_nodes` property that was deprecated since v0.73.1. Update your resolvers to use `info.selected_fields` instead.
+    {project_name} {version} makes sure the Datadog extension always closes spans.
+---
 
-This release removes the deprecated `info.field_nodes` property from `strawberry.Info` (deprecated since [0.73.1](https://github.com/strawberry-graphql/strawberry/releases/tag/0.73.1)).
+This release fixes an issue with the Datadog extension.
 
-### Migration guide
-
-**Before (deprecated):**
-```python
-@strawberry.type
-class Query:
-    @strawberry.field
-    def example(self, info: strawberry.Info) -> str:
-        field_nodes = info.field_nodes
-        ...
-```
-
-**After:**
-```python
-@strawberry.type
-class Query:
-    @strawberry.field
-    def example(self, info: strawberry.Info) -> str:
-        selected_fields = info.selected_fields
-        ...
-```
+Strawberry now makes sure that the Datadog extension always closes spans,
+also in the case of exceptions.

--- a/strawberry/extensions/tracing/datadog.py
+++ b/strawberry/extensions/tracing/datadog.py
@@ -83,48 +83,44 @@ class DatadogTracingExtension(SchemaExtension):
             f"{self._operation_name}" if self._operation_name else "Anonymous Query"
         )
 
-        self.request_span = self.create_span(
+        with self.create_span(
             LifecycleStep.OPERATION,
             span_name,
             resource=self._resource_name,
             service="strawberry",
-        )
-        self.request_span.set_tag("graphql.operation_name", self._operation_name)
+        ) as self.request_span:
+            self.request_span.set_tag("graphql.operation_name", self._operation_name)
 
-        query = self.execution_context.query
+            query = self.execution_context.query
 
-        if query is not None:
-            query = query.strip()
-            operation_type = "query"
+            if query is not None:
+                query = query.strip()
+                operation_type = "query"
 
-            if query.startswith("mutation"):
-                operation_type = "mutation"
-            elif query.startswith("subscription"):  # pragma: no cover
-                operation_type = "subscription"
-        else:
-            operation_type = "query_missing"
+                if query.startswith("mutation"):
+                    operation_type = "mutation"
+                elif query.startswith("subscription"):  # pragma: no cover
+                    operation_type = "subscription"
+            else:
+                operation_type = "query_missing"
 
-        self.request_span.set_tag("graphql.operation_type", operation_type)
+            self.request_span.set_tag("graphql.operation_type", operation_type)
 
-        yield
-
-        self.request_span.finish()
+            yield
 
     def on_validate(self) -> Generator[None, None, None]:
-        self.validation_span = self.create_span(
+        with self.create_span(
             lifecycle_step=LifecycleStep.VALIDATION,
             name="Validation",
-        )
-        yield
-        self.validation_span.finish()
+        ) as self.validation_span:
+            yield
 
     def on_parse(self) -> Generator[None, None, None]:
-        self.parsing_span = self.create_span(
+        with self.create_span(
             lifecycle_step=LifecycleStep.PARSE,
             name="Parsing",
-        )
-        yield
-        self.parsing_span.finish()
+        ) as self.parsing_span:
+            yield
 
     async def resolve(
         self,

--- a/tests/schema/extensions/test_datadog.py
+++ b/tests/schema/extensions/test_datadog.py
@@ -10,11 +10,28 @@ if typing.TYPE_CHECKING:
     from strawberry.extensions.tracing.datadog import DatadogTracingExtension
 
 
+def _simulate_context_manager(tracer_mock) -> None:
+    """Make the tracer mock behave like a context manager.
+
+    Entering the context returns the span. And exiting the context
+    calls `finish()` on the span.
+    """
+    span = tracer_mock.trace.return_value
+    span.__enter__.return_value = span
+
+    def _exit(*args: object, **kwargs: Any):
+        span.finish()
+        return False
+
+    span.__exit__.side_effect = _exit
+
+
 @pytest.fixture
 def ddtrace_version_2(mocker):
     ddtrace_mock = mocker.MagicMock()
     ddtrace_mock.__version__ = "2.20.0"
     mocker.patch.dict("sys.modules", ddtrace=ddtrace_mock)
+    _simulate_context_manager(ddtrace_mock.tracer)
     return ddtrace_mock
 
 
@@ -26,6 +43,7 @@ def ddtrace_version_3(mocker):
 
     trace_mock = mocker.MagicMock()
     mocker.patch.dict("sys.modules", {"ddtrace.trace": trace_mock})
+    _simulate_context_manager(trace_mock.tracer)
     return trace_mock
 
 
@@ -114,21 +132,18 @@ async def test_datadog_tracer(datadog_extension, mocker):
             mocker.call.trace().set_tag("graphql.operation_name", None),
             mocker.call.trace().set_tag("graphql.operation_type", "query"),
             mocker.call.trace("Parsing", span_type="graphql"),
-            mocker.call.trace().finish(),
+            mocker.call.trace().finish(),  # on_parse
             mocker.call.trace("Validation", span_type="graphql"),
-            mocker.call.trace().finish(),
+            mocker.call.trace().finish(),  # on_validate
             mocker.call.trace("Resolving: Query.personAsync", span_type="graphql"),
-            mocker.call.trace().__enter__(),
-            mocker.call.trace()
-            .__enter__()
-            .set_tag("graphql.field_name", "personAsync"),
-            mocker.call.trace().__enter__().set_tag("graphql.parent_type", "Query"),
-            mocker.call.trace()
-            .__enter__()
-            .set_tag("graphql.field_path", "Query.personAsync"),
-            mocker.call.trace().__enter__().set_tag("graphql.path", "personAsync"),
-            mocker.call.trace().__exit__(None, None, None),
-            mocker.call.trace().finish(),
+            mocker.call.trace().__enter__(),  # resolve
+            mocker.call.trace().set_tag("graphql.field_name", "personAsync"),
+            mocker.call.trace().set_tag("graphql.parent_type", "Query"),
+            mocker.call.trace().set_tag("graphql.field_path", "Query.personAsync"),
+            mocker.call.trace().set_tag("graphql.path", "personAsync"),
+            mocker.call.trace().__exit__(None, None, None),  # resolve
+            mocker.call.trace().finish(),  # resolve
+            mocker.call.trace().finish(),  # on_operation
         ]
     )
 
@@ -216,19 +231,18 @@ def test_datadog_tracer_sync(datadog_extension_sync, mocker):
             mocker.call.trace().set_tag("graphql.operation_name", None),
             mocker.call.trace().set_tag("graphql.operation_type", "query"),
             mocker.call.trace("Parsing", span_type="graphql"),
-            mocker.call.trace().finish(),
+            mocker.call.trace().finish(),  # on_parse
             mocker.call.trace("Validation", span_type="graphql"),
-            mocker.call.trace().finish(),
+            mocker.call.trace().finish(),  # on_validate
             mocker.call.trace("Resolving: Query.person", span_type="graphql"),
-            mocker.call.trace().__enter__(),
-            mocker.call.trace().__enter__().set_tag("graphql.field_name", "person"),
-            mocker.call.trace().__enter__().set_tag("graphql.parent_type", "Query"),
-            mocker.call.trace()
-            .__enter__()
-            .set_tag("graphql.field_path", "Query.person"),
-            mocker.call.trace().__enter__().set_tag("graphql.path", "person"),
-            mocker.call.trace().__exit__(None, None, None),
-            mocker.call.trace().finish(),
+            mocker.call.trace().__enter__(),  # resolve
+            mocker.call.trace().set_tag("graphql.field_name", "person"),
+            mocker.call.trace().set_tag("graphql.parent_type", "Query"),
+            mocker.call.trace().set_tag("graphql.field_path", "Query.person"),
+            mocker.call.trace().set_tag("graphql.path", "person"),
+            mocker.call.trace().__exit__(None, None, None),  # resolve
+            mocker.call.trace().finish(),  # resolve
+            mocker.call.trace().finish(),  # on_operation
         ]
     )
 

--- a/tests/schema/extensions/test_datadog.py
+++ b/tests/schema/extensions/test_datadog.py
@@ -5,6 +5,8 @@ from typing import Any
 import pytest
 
 import strawberry
+from strawberry.schema.exceptions import InvalidOperationTypeError
+from strawberry.types.graphql import OperationType
 
 if typing.TYPE_CHECKING:
     from strawberry.extensions.tracing.datadog import DatadogTracingExtension
@@ -129,11 +131,16 @@ async def test_datadog_tracer(datadog_extension, mocker):
                 span_type="graphql",
                 service="strawberry",
             ),
+            mocker.call.trace().__enter__(),  # on_operation
             mocker.call.trace().set_tag("graphql.operation_name", None),
             mocker.call.trace().set_tag("graphql.operation_type", "query"),
             mocker.call.trace("Parsing", span_type="graphql"),
+            mocker.call.trace().__enter__(),  # on_parse
+            mocker.call.trace().__exit__(None, None, None),  # on_parse
             mocker.call.trace().finish(),  # on_parse
             mocker.call.trace("Validation", span_type="graphql"),
+            mocker.call.trace().__enter__(),  # on_validate
+            mocker.call.trace().__exit__(None, None, None),  # on_validate
             mocker.call.trace().finish(),  # on_validate
             mocker.call.trace("Resolving: Query.personAsync", span_type="graphql"),
             mocker.call.trace().__enter__(),  # resolve
@@ -143,6 +150,7 @@ async def test_datadog_tracer(datadog_extension, mocker):
             mocker.call.trace().set_tag("graphql.path", "personAsync"),
             mocker.call.trace().__exit__(None, None, None),  # resolve
             mocker.call.trace().finish(),  # resolve
+            mocker.call.trace().__exit__(None, None, None),  # on_operation
             mocker.call.trace().finish(),  # on_operation
         ]
     )
@@ -228,11 +236,16 @@ def test_datadog_tracer_sync(datadog_extension_sync, mocker):
                 span_type="graphql",
                 service="strawberry",
             ),
+            mocker.call.trace().__enter__(),  # on_operation
             mocker.call.trace().set_tag("graphql.operation_name", None),
             mocker.call.trace().set_tag("graphql.operation_type", "query"),
             mocker.call.trace("Parsing", span_type="graphql"),
+            mocker.call.trace().__enter__(),  # on_parse
+            mocker.call.trace().__exit__(None, None, None),  # on_parse
             mocker.call.trace().finish(),  # on_parse
             mocker.call.trace("Validation", span_type="graphql"),
+            mocker.call.trace().__enter__(),  # on_validate
+            mocker.call.trace().__exit__(None, None, None),  # on_validate
             mocker.call.trace().finish(),  # on_validate
             mocker.call.trace("Resolving: Query.person", span_type="graphql"),
             mocker.call.trace().__enter__(),  # resolve
@@ -242,6 +255,7 @@ def test_datadog_tracer_sync(datadog_extension_sync, mocker):
             mocker.call.trace().set_tag("graphql.path", "person"),
             mocker.call.trace().__exit__(None, None, None),  # resolve
             mocker.call.trace().finish(),  # resolve
+            mocker.call.trace().__exit__(None, None, None),  # on_operation
             mocker.call.trace().finish(),  # on_operation
         ]
     )
@@ -342,7 +356,58 @@ async def test_uses_query_missing_operation_if_no_query(datadog_extension, mocke
                 span_type="graphql",
                 service="strawberry",
             ),
+            mocker.call.trace().__enter__(),  # on_operation
             mocker.call.trace().set_tag("graphql.operation_name", None),
             mocker.call.trace().set_tag("graphql.operation_type", "query_missing"),
+            mocker.call.trace().__exit__(
+                strawberry.exceptions.MissingQueryError, mocker.ANY, mocker.ANY
+            ),  # on_operation
+            mocker.call.trace().finish(),  # on_operation
+        ]
+    )
+
+
+def test_datadog_spans_are_closed_on_exception(datadog_extension_sync, mocker):
+    """Test that Datadog spans are also closed when an exception is raised while an
+    operation is processed.
+    """
+    extension, mock = datadog_extension_sync
+
+    schema = strawberry.Schema(query=Query, mutation=Mutation, extensions=[extension])
+
+    query = """
+        mutation MyMutation {
+            sayHi
+        }
+    """
+
+    with pytest.raises(InvalidOperationTypeError):
+        # calling a mutation when only queries are allowed will raise an InvalidOperationTypeError
+        schema.execute_sync(
+            query,
+            operation_name="MyMutation",
+            allowed_operation_types=[OperationType.QUERY],
+        )
+
+    mock.tracer.assert_has_calls(
+        [
+            mocker.call.trace(
+                "MyMutation",
+                resource=mocker.ANY,
+                span_type="graphql",
+                service="strawberry",
+            ),
+            mocker.call.trace().__enter__(),  # on_operation
+            mocker.call.trace().set_tag("graphql.operation_name", "MyMutation"),
+            mocker.call.trace().set_tag("graphql.operation_type", "mutation"),
+            mocker.call.trace("Parsing", span_type="graphql"),
+            mocker.call.trace().__enter__(),  # on_parse
+            mocker.call.trace().__exit__(None, None, None),  # on_parse
+            mocker.call.trace().finish(),  # on_parse
+            mocker.call.trace().__exit__(
+                InvalidOperationTypeError, mocker.ANY, mocker.ANY
+            ),  # on_operation
+            # finish is called on the span
+            mocker.call.trace().finish(),  # on_operation
         ]
     )


### PR DESCRIPTION
## Description

The Datadog extension is creating APM spans for different GraphQL operations (`on_parse`, `on_validate`, `on_operation`, `resolve`). This is working fine, but in case an exception is raised while the operation is executed, the span is not closed correctly. If a span is not closed, it will remain in memory indefinitely (according to the [Datadog docs](https://ddtrace.readthedocs.io/en/stable/api.html#ddtrace.trace.Tracer.trace:~:text=The%20returned%20span,%3E%3E%3E)) and it will not get processed correctly. This PR suggests to use a context manager in the different hooks of the extension, to make sure that the span is always closed.

It's best to review the PR commit-by-commit. The first commit in this PR changes the `dd-trace` mock in the existing tests, so that the mock simulates the context manager behaviour. And the second commit does the actual fix.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Ensure Datadog tracing spans created by the GraphQL extension are always closed, even when operations raise exceptions.

Bug Fixes:
- Prevent Datadog spans from being left open in memory when GraphQL operations error or abort.
- Correct span lifecycle handling for parse, validate, operation, and resolve phases by relying on context manager semantics.

Documentation:
- Add a patch-level release note describing the Datadog span-closing fix.

Tests:
- Extend Datadog extension tests to simulate context manager behaviour in the ddtrace mock and assert spans are closed on both success and error paths.
- Add a regression test verifying spans are finished when an InvalidOperationTypeError is raised during execution.