### PR TITLE
Fix print_schema duplicating types referenced by schema directives

### DIFF
--- a/strawberry/printer/printer.py
+++ b/strawberry/printer/printer.py
@@ -647,6 +647,7 @@ def print_schema(schema: BaseSchema) -> str:
                 )
                 # Make sure extra types are ordered for predictive printing
                 for type_ in sorted(extras.types, key=_name_getter)
+                if _name_getter(type_) not in type_map
             ),
         )
     )

--- a/tests/test_printer/test_schema_directives.py
+++ b/tests/test_printer/test_schema_directives.py
@@ -419,6 +419,59 @@ def test_prints_with_enum():
     assert print_schema(schema) == textwrap.dedent(expected_output).strip()
 
 
+def test_prints_with_enum_used_elsewhere_does_not_duplicate():
+    @strawberry.enum
+    class Reason(str, Enum):
+        EXAMPLE = "example"
+
+        __slots__ = ()
+
+    @strawberry.schema_directive(locations=[Location.FIELD_DEFINITION])
+    class Sensitive:
+        reason: Reason
+
+    @strawberry.type
+    class Query:
+        first_name: str = strawberry.field(
+            directives=[Sensitive(reason=Reason.EXAMPLE)]
+        )
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        def set_reason(self, reason: Reason) -> bool:
+            return True
+
+    expected_output = """
+    directive @sensitive(reason: Reason!) on FIELD_DEFINITION
+
+    schema {
+      query: Query
+      mutation: Mutation
+    }
+
+    type Mutation {
+      setReason(reason: Reason!): Boolean!
+    }
+
+    type Query {
+      firstName: String! @sensitive(reason: EXAMPLE)
+    }
+
+    enum Reason {
+      EXAMPLE
+    }
+    """
+
+    schema = strawberry.Schema(
+        query=Query,
+        mutation=Mutation,
+        schema_directives=[Sensitive],
+    )
+
+    assert print_schema(schema) == textwrap.dedent(expected_output).strip()
+
+
 def test_does_not_print_definition():
     @strawberry.schema_directive(
         locations=[Location.FIELD_DEFINITION], print_definition=False


### PR DESCRIPTION
When a type (e.g. an enum) was used both in a schema directive field and elsewhere in the schema, print_schema would emit its definition twice — once from the type_map and once from extras.types — producing invalid SDL.

Skip extras.types entries that already exist in the schema's type_map.

## Description

See issue: #4502

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #4502

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Prevent schema printing from duplicating type definitions when types are used both in schema directives and elsewhere in the schema.

Bug Fixes:
- Avoid emitting duplicate SDL definitions for types referenced by schema directives and also present in the schema type map.

Tests:
- Add regression test ensuring enums used in both schema directives and fields are printed once without duplication.