### PR TITLE
Fix `print_schema` duplicating types shared between schema directives and the schema

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,43 @@
+---
+release type: patch
+social_messages:
+  x: >-
+    {project_name} {version} fixes `print_schema` emitting duplicate type definitions when a type is used both as a schema directive field and elsewhere in the schema.
+  linkedin: >-
+    {project_name} {version} fixes a bug where `print_schema` produced invalid SDL by printing a type twice when it was referenced both by a schema directive field and as a regular schema type. Upgrade to get valid, spec-compliant SDL output.
+---
+
+This release fixes a bug where `print_schema` would emit a type definition
+twice when the same type (for example an enum) was referenced both as a schema
+directive field and elsewhere in the schema. The duplicated definition produced
+invalid SDL that violates the GraphQL spec and is rejected by `graphql-core`'s
+`build_schema`.
+
+For example, the following schema now prints `enum Role` only once:
+
+```python
+import enum
+
+import strawberry
+from strawberry.schema_directive import Location
+
+
+@strawberry.enum
+class Role(enum.Enum):
+    EDITOR = "editor"
+    VIEWER = "viewer"
+
+
+@strawberry.schema_directive(locations=[Location.FIELD_DEFINITION])
+class RequiresRole:
+    roles: list[Role]
+
+
+@strawberry.type
+class Query:
+    secret: str = strawberry.field(directives=[RequiresRole(roles=[Role.EDITOR])])
+
+    @strawberry.field
+    def assign(self, role: Role) -> bool:
+        return True
+```

--- a/strawberry/printer/printer.py
+++ b/strawberry/printer/printer.py
@@ -43,12 +43,13 @@ from strawberry.types.unset import UNSET
 from .ast_from_value import ast_from_value
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterable
 
     from graphql import (
         GraphQLArgument,
         GraphQLEnumType,
         GraphQLEnumValue,
+        GraphQLNamedType,
         GraphQLScalarType,
         GraphQLUnionType,
     )
@@ -635,19 +636,28 @@ def print_schema(schema: BaseSchema) -> str:
             return type_._scalar_definition.name
         return type_.__name__
 
+    def _print_extra_types() -> Iterable[str]:
+        # Make sure extra types are ordered for predictive printing
+        for type_ in sorted(extras.types, key=_name_getter):
+            graphql_type = cast(
+                "GraphQLNamedType", schema.schema_converter.from_type(type_)
+            )
+
+            # Skip types that are already part of the schema's type map, otherwise
+            # they'd be printed twice (e.g. an enum used both as a regular type and
+            # as a schema directive field), producing invalid SDL.
+            if graphql_type.name in type_map:
+                continue
+
+            yield _print_type(graphql_type, schema, extras=extras)
+
     return "\n\n".join(
         chain(
             sorted(extras.directives),
             filter(None, [schema_definition]),
             directives,
             types_printed,
-            (
-                _print_type(
-                    schema.schema_converter.from_type(type_), schema, extras=extras
-                )
-                # Make sure extra types are ordered for predictive printing
-                for type_ in sorted(extras.types, key=_name_getter)
-            ),
+            _print_extra_types(),
         )
     )
 

--- a/tests/test_printer/test_schema_directives.py
+++ b/tests/test_printer/test_schema_directives.py
@@ -419,6 +419,86 @@ def test_prints_with_enum():
     assert print_schema(schema) == textwrap.dedent(expected_output).strip()
 
 
+def test_does_not_duplicate_enum_used_as_type_and_directive_field():
+    # https://github.com/strawberry-graphql/strawberry/issues/4502
+    # an enum referenced both as a regular schema type and as a schema directive
+    # field must only be printed once, otherwise the SDL is invalid.
+    @strawberry.enum
+    class Role(Enum):
+        EDITOR = "editor"
+        VIEWER = "viewer"
+
+    @strawberry.schema_directive(locations=[Location.FIELD_DEFINITION])
+    class RequiresRole:
+        roles: list[Role]
+
+    @strawberry.type
+    class Query:
+        secret: str = strawberry.field(directives=[RequiresRole(roles=[Role.EDITOR])])
+
+        @strawberry.field
+        def assign(self, role: Role) -> bool:
+            return True
+
+    expected_output = """
+    directive @requiresRole(roles: [Role!]!) on FIELD_DEFINITION
+
+    type Query {
+      secret: String! @requiresRole(roles: [EDITOR])
+      assign(role: Role!): Boolean!
+    }
+
+    enum Role {
+      EDITOR
+      VIEWER
+    }
+    """
+
+    schema = strawberry.Schema(query=Query)
+
+    assert print_schema(schema) == textwrap.dedent(expected_output).strip()
+
+
+def test_does_not_duplicate_renamed_type_used_as_type_and_directive_field():
+    # https://github.com/strawberry-graphql/strawberry/issues/4502
+    # dedup must resolve the *GraphQL* name (not the Python class name), otherwise
+    # a type with a `name=` override used both as a regular type and as a schema
+    # directive field would still be printed twice. An empty list is used as the
+    # directive value to keep the output stable across graphql-core versions.
+    @strawberry.input(name="RenamedInput")
+    class Config:
+        key: str
+
+    @strawberry.schema_directive(locations=[Location.FIELD_DEFINITION])
+    class WithConfig:
+        configs: list[Config]
+
+    @strawberry.type
+    class Query:
+        secret: str = strawberry.field(directives=[WithConfig(configs=[])])
+
+        @strawberry.field
+        def run(self, config: Config) -> bool:
+            return True
+
+    expected_output = """
+    directive @withConfig(configs: [RenamedInput!]!) on FIELD_DEFINITION
+
+    type Query {
+      secret: String! @withConfig(configs: [])
+      run(config: RenamedInput!): Boolean!
+    }
+
+    input RenamedInput {
+      key: String!
+    }
+    """
+
+    schema = strawberry.Schema(query=Query)
+
+    assert print_schema(schema) == textwrap.dedent(expected_output).strip()
+
+
 def test_does_not_print_definition():
     @strawberry.schema_directive(
         locations=[Location.FIELD_DEFINITION], print_definition=False


### PR DESCRIPTION
<!-- shortcake:start -->
## Stack [🍰](https://shortcake.patrick.wtf)

- **#4504** (`2026-07-06-fix-print-schema-duplicating-types-shared-between`) <-- this PR
<!-- shortcake:end -->

Closes #4502

## Summary by Sourcery

Ensure schema printing skips duplicate type definitions when types are shared between schema directives and regular schema fields.

Bug Fixes:
- Prevent print_schema from emitting duplicate type definitions when a type is referenced both by a schema directive field and elsewhere in the schema, avoiding invalid SDL output.

Documentation:
- Add a patch release note documenting the fix for duplicate type definitions in print_schema and its impact on SDL validity.

Tests:
- Add a regression test covering enums used both as schema types and as directive fields to verify they are printed only once.

## Summary by Sourcery

Prevent schema printing from duplicating type definitions when types are shared between schema directives and regular schema fields.

Bug Fixes:
- Skip printing extra types that already exist in the schema type map so enums and other shared types are emitted only once, producing valid SDL output.

Documentation:
- Add a patch release note describing the fix for duplicate type definitions in print_schema and its impact on SDL validity.

Tests:
- Add a regression test ensuring an enum used both as a schema type and as a directive field is printed only once in the generated SDL.