### PR TITLE
Fix pydantic SkipJsonSchema[None] in unions being treated as a union instead of optional

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,27 @@
+---
+release type: patch
+social_messages:
+  x: >-
+    {project_name} {version} fixes schema generation crashing when a Pydantic
+    field uses `SkipJsonSchema[None]` in a union — the field is now correctly an
+    optional.
+  linkedin: >-
+    {project_name} {version} fixes a bug where a Pydantic model field using
+    `SkipJsonSchema[None]` in a union (e.g. `str | SkipJsonSchema[None]`)
+    crashed schema generation with `InvalidUnionTypeError`. The annotated `None`
+    is now treated as null, so the field becomes an optional as expected.
+---
+
+This release fixes schema generation raising `InvalidUnionTypeError` when a
+Pydantic model field uses `SkipJsonSchema[None]` in a union type, for example:
+
+```python
+class ModelA(BaseModel):
+    field_a: str | SkipJsonSchema[None] = None
+```
+
+`SkipJsonSchema[None]` expands to `Annotated[None, SkipJsonSchema()]`, and the
+annotated `None` was not recognised as `None`, so the field was treated as a
+(invalid) GraphQL union of `str` and `None` instead of an optional `str`. The
+annotation metadata is now stripped during conversion, so the field correctly
+becomes a nullable `String`.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,7 +4,7 @@ social_messages:
   x: >-
     {project_name} {version} fixes schema generation crashing when a Pydantic
     field uses `SkipJsonSchema[None]` in a union — the field is now correctly an
-    optional.
+    optional. 🍓 https://strawberry.rocks/release/{version}
   linkedin: >-
     {project_name} {version} fixes a bug where a Pydantic model field using
     `SkipJsonSchema[None]` in a union (e.g. `str | SkipJsonSchema[None]`)

--- a/strawberry/experimental/pydantic/fields.py
+++ b/strawberry/experimental/pydantic/fields.py
@@ -52,7 +52,14 @@ def replace_types_recursively(
 
     # TODO: investigate if we could move the check for annotated to the top
     if origin is Annotated and converted:
-        converted = (converted[0],)
+        # Drop the annotation metadata and keep only the underlying type.
+        # copy_with() would re-wrap the type in Annotated, preserving the
+        # metadata; when the wrapped type is None (e.g. pydantic's
+        # ``SkipJsonSchema[None]`` produces ``Annotated[None, SkipJsonSchema()]``)
+        # the leftover Annotated is not recognised as None, so ``str |
+        # SkipJsonSchema[None]`` is treated as a real union instead of an
+        # optional and schema generation fails. See #3992.
+        return converted[0]
 
     replaced_type = replaced_type.copy_with(converted)
 

--- a/tests/experimental/pydantic/test_basic.py
+++ b/tests/experimental/pydantic/test_basic.py
@@ -16,6 +16,7 @@ from strawberry.types.base import (
 )
 from strawberry.types.enum import StrawberryEnumDefinition
 from strawberry.types.union import StrawberryUnion
+from tests.experimental.pydantic.utils import needs_pydantic_v2
 
 
 def test_basic_type_all_fields():
@@ -939,3 +940,35 @@ def test_nested_annotated():
     assert isinstance(field_b.type, StrawberryOptional)
     assert isinstance(field_b.type.of_type, StrawberryList)
     assert field_b.type.of_type.of_type is int
+
+
+@needs_pydantic_v2
+def test_annotated_none_in_union_is_optional():
+    # https://github.com/strawberry-graphql/strawberry/issues/3992
+    # ``SkipJsonSchema[None]`` produces ``Annotated[None, SkipJsonSchema()]``.
+    # The annotated None must be treated as None so ``str | SkipJsonSchema[None]``
+    # becomes an optional instead of a (invalid) GraphQL union of ``str`` and None.
+    from pydantic.json_schema import SkipJsonSchema
+
+    class ModelA(pydantic.BaseModel):
+        field_a: str | SkipJsonSchema[None] = None
+
+    @strawberry.experimental.pydantic.type(model=ModelA, all_fields=True)
+    class TypeA:
+        pass
+
+    definition: StrawberryObjectDefinition = TypeA.__strawberry_definition__
+    [field] = definition.fields
+    assert field.python_name == "field_a"
+    assert isinstance(field.type, StrawberryOptional)
+    assert field.type.of_type is str
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def example(self) -> TypeA:  # pragma: no cover
+            return TypeA()
+
+    # Schema generation used to raise InvalidUnionTypeError here.
+    schema = strawberry.Schema(query=Query)
+    assert "fieldA: String" in schema.as_str()

--- a/tests/experimental/pydantic/test_basic.py
+++ b/tests/experimental/pydantic/test_basic.py
@@ -971,4 +971,10 @@ def test_annotated_none_in_union_is_optional():
 
     # Schema generation used to raise InvalidUnionTypeError here.
     schema = strawberry.Schema(query=Query)
-    assert "fieldA: String" in schema.as_str()
+    schema_str = schema.as_str()
+    # The field must be nullable (``String``), not ``String!``. A plain
+    # ``"fieldA: String" in ...`` check would also pass for the non-null form
+    # since it is a substring, so assert the exact nullable line and the
+    # absence of the non-null one.
+    assert "fieldA: String\n" in schema_str
+    assert "fieldA: String!" not in schema_str


### PR DESCRIPTION
Fixes #3992

## Description

Schema generation raised `InvalidUnionTypeError` when a Pydantic model field used `SkipJsonSchema[None]` in a union:

```python
import strawberry
from pydantic import BaseModel
from pydantic.json_schema import SkipJsonSchema

class ModelA(BaseModel):
    field_a: str | SkipJsonSchema[None] = None

@strawberry.experimental.pydantic.type(model=ModelA, all_fields=True)
class TypeA:
    pass
```

```
strawberry.exceptions.invalid_union_type.InvalidUnionTypeError: Type `str` cannot be used in a GraphQL Union
```

`SkipJsonSchema[None]` expands to `Annotated[None, SkipJsonSchema()]`, so the field annotation is `str | Annotated[None, SkipJsonSchema()]`. In `replace_types_recursively` (`strawberry/experimental/pydantic/fields.py`), the `Annotated` branch reduced `converted` to just the underlying type but then called `copy_with(...)`, which re-wraps it back into `Annotated[None, SkipJsonSchema()]`. The leftover annotation meant the wrapped `None` was not recognised as `None`, so `str | Annotated[None, ...]` was treated as a real (invalid) GraphQL union instead of an optional `str`.

## Fix

Return the unwrapped underlying type for the `Annotated` branch instead of re-wrapping it. This drops the annotation metadata (which has no meaning in the GraphQL schema) and matches the behaviour the existing `test_annotated`/`test_nested_annotated` tests already expect (`Annotated[int, "metadata"]` resolves to bare `int`). The field now correctly becomes a nullable `String`.

## Tests

Added `test_annotated_none_in_union_is_optional` (guarded by `needs_pydantic_v2`) asserting the field resolves to `StrawberryOptional[str]` and that schema generation succeeds. It fails on `main` (field resolves to `StrawberryUnion`) and passes with the fix. Full `tests/experimental/pydantic/` suite passes (153 passed).

## Summary by Sourcery

Treat Pydantic fields using Annotated None (e.g. SkipJsonSchema[None]) as optional rather than GraphQL unions during schema generation.

Bug Fixes:
- Fix InvalidUnionTypeError when Pydantic model fields use SkipJsonSchema[None] in a union type by correctly recognising annotated None as optional.

Documentation:
- Add RELEASE notes describing the fix for SkipJsonSchema[None] unions being handled as optional fields.

Tests:
- Add a Pydantic v2-only test verifying that fields with SkipJsonSchema[None] in a union become StrawberryOptional and that schema generation succeeds.