### PR TITLE
Fix crash when an input-type argument has a default instance value

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,7 +4,7 @@ social_messages:
   x: >-
     {project_name} {version} fixes a crash when a resolver argument of an input
     type used a constructed instance as its default value and the argument was
-    omitted.
+    omitted. 🍓 https://strawberry.rocks/release/{version}
   linkedin: >-
     {project_name} {version} fixes a `TypeError` crash that happened when a
     resolver argument of an input type used a constructed instance (e.g.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -23,6 +23,7 @@ class Pagination:
     limit: int = 10
     offset: int = 0
 
+
 @strawberry.type
 class Query:
     @strawberry.field

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,35 @@
+---
+release type: patch
+social_messages:
+  x: >-
+    {project_name} {version} fixes a crash when a resolver argument of an input
+    type used a constructed instance as its default value and the argument was
+    omitted.
+  linkedin: >-
+    {project_name} {version} fixes a `TypeError` crash that happened when a
+    resolver argument of an input type used a constructed instance (e.g.
+    `Pagination()`) as its default value and the argument was omitted. Such
+    default instances are now passed through correctly instead of being treated
+    as a mapping of field values.
+---
+
+This release fixes a crash when a resolver argument of an input type has a
+constructed instance as its default value and the argument is omitted, for
+example:
+
+```python
+@strawberry.input
+class Pagination:
+    limit: int = 10
+    offset: int = 0
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def items(self, pagination: Pagination = Pagination()) -> str: ...
+```
+
+Calling `{ items }` previously raised `TypeError: argument of type
+'Pagination' is not a container or iterable`, because the default instance
+reached argument conversion as an already-built object rather than a mapping.
+Such default instances are now passed through unchanged.

--- a/strawberry/types/arguments.py
+++ b/strawberry/types/arguments.py
@@ -244,6 +244,13 @@ def convert_argument(
         return convert_argument(value, enum_definition, scalar_registry, config)
 
     if has_object_definition(type_):
+        # A default value declared in Python (e.g. ``arg: Input = Input(...)``)
+        # is supplied by graphql-core already constructed, rather than as a
+        # mapping of field values. Pass it through unchanged instead of trying
+        # to index it like a mapping. See #4070.
+        if isinstance(type_, type) and isinstance(value, type_):
+            return value
+
         kwargs = {}
 
         type_definition = type_.__strawberry_definition__

--- a/tests/schema/test_arguments.py
+++ b/tests/schema/test_arguments.py
@@ -235,3 +235,32 @@ def test_argument_parse_order():
 
     assert str(schema_a) == str(schema_b)
     assert str(schema_a) == textwrap.dedent(expected).strip()
+
+
+def test_input_object_argument_default_value():
+    # https://github.com/strawberry-graphql/strawberry/issues/4070
+    # An input-object argument with a constructed instance as its default used to
+    # crash ("... is not a container or iterable") when the argument was omitted,
+    # because the default instance reached convert_argument as a non-mapping.
+    @strawberry.input
+    class Pagination:
+        limit: int = 10
+        offset: int = 0
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def items(self, pagination: Pagination = Pagination(limit=10, offset=0)) -> str:
+            return f"limit={pagination.limit} offset={pagination.offset}"
+
+    schema = strawberry.Schema(query=Query)
+
+    # Argument omitted -> the Python default instance is used, no crash.
+    result = schema.execute_sync("{ items }")
+    assert result.errors is None
+    assert result.data == {"items": "limit=10 offset=0"}
+
+    # Argument provided -> the mapping path still converts to the input type.
+    result = schema.execute_sync("{ items(pagination: { limit: 5, offset: 2 }) }")
+    assert result.errors is None
+    assert result.data == {"items": "limit=5 offset=2"}


### PR DESCRIPTION
Fixes #4070

## Description

A resolver argument of an input type whose default is a constructed instance crashed when the argument was omitted:

```python
import strawberry

@strawberry.input
class Pagination:
    limit: int = 10
    offset: int = 0

@strawberry.type
class Query:
    @strawberry.field
    def items(self, pagination: Pagination = Pagination(limit=10, offset=0)) -> str:
        return f"limit={pagination.limit} offset={pagination.offset}"

schema = strawberry.Schema(query=Query)
schema.execute_sync("{ items }")
```

```
TypeError: argument of type 'Pagination' is not a container or iterable
```

When the argument is omitted, graphql-core supplies the Python default, which is an already-constructed `Pagination` instance. `convert_argument` (`strawberry/types/arguments.py`) reached the `has_object_definition` branch and did `if graphql_name in value`, assuming `value` is a mapping of field values — but here it is the input instance itself, so the membership test raised `TypeError`.

## Fix

In the `has_object_definition` branch, if `value` is already an instance of the target input type, pass it through unchanged (it is already the fully-constructed object and needs no conversion). The mapping path is unaffected for values supplied via the query.

## Tests

Added `test_input_object_argument_default_value` asserting that omitting the argument uses the default instance (no crash) and that providing the argument via the query still converts through the mapping path. It fails on `main` with the `TypeError` and passes with the fix. `tests/schema/test_arguments.py`, `test_input.py`, `test_mutation.py` all pass.

## Summary by Sourcery

Handle default constructed input object instances in argument conversion to avoid crashes when arguments are omitted.

Bug Fixes:
- Prevent TypeError when a resolver argument of an input type has a constructed instance as its default and the argument is omitted.

Documentation:
- Add release note documenting the fix for input-object arguments with constructed default instances.

Tests:
- Add regression test covering input-object arguments with constructed default values being omitted and explicitly provided.