### PR TITLE
fix for #4507

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+---
+release type: patch
+---
+
+This release fixes PyCharm support for classes decorated with `@strawberry.type` and `@strawberry.input`, so generated keyword constructors are recognized consistently.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,10 @@
 ---
 release type: patch
+social_messages:
+  x: >-
+    {project_name} {version} is out! Fixes false "Unexpected argument" errors in PyCharm for @strawberry.type and @strawberry.input classes. 🍓 https://strawberry.rocks/release/{version}
+  linkedin: >-
+    {project_name} {version} is out. This patch fixes a PyCharm issue where classes decorated with @strawberry.type and @strawberry.input incorrectly showed "Unexpected argument" errors on their generated keyword constructors. No runtime behaviour changes — PyCharm users will get accurate IDE feedback after updating.
 ---
 
-This release fixes PyCharm support for classes decorated with `@strawberry.type` and `@strawberry.input`, so generated keyword constructors are recognized consistently.
+This release fixes a PyCharm false positive where classes decorated with `@strawberry.type` and `@strawberry.input` reported "Unexpected argument" on their generated keyword constructors.

--- a/strawberry/types/object_type.py
+++ b/strawberry/types/object_type.py
@@ -221,6 +221,9 @@ def type(
 ) -> Callable[[T], T]: ...
 
 
+@dataclass_transform(
+    order_default=True, kw_only_default=True, field_specifiers=(field, StrawberryField)
+)
 def type(
     cls: T | None = None,
     *,
@@ -339,6 +342,9 @@ def input(
 ) -> Callable[[T], T]: ...
 
 
+@dataclass_transform(
+    order_default=True, kw_only_default=True, field_specifiers=(field, StrawberryField)
+)
 def input(
     cls: T | None = None,
     *,

--- a/tests/test_type.py
+++ b/tests/test_type.py
@@ -47,18 +47,3 @@ def test_get_object_definition_strict():
         match=r".* does not have a StrawberryObjectDefinition",
     ):
         get_object_definition(OtherFruit, strict=True)
-
-
-def test_public_decorators_have_dataclass_transform():
-    decorators = (strawberry.type, strawberry.input, strawberry.interface)
-
-    for decorator in decorators:
-        transform = decorator.__dataclass_transform__
-
-        assert transform["order_default"] is True
-        assert transform["kw_only_default"] is True
-
-        field_specifiers = transform["field_specifiers"]
-
-        assert field_specifiers
-        assert all(callable(field_specifier) for field_specifier in field_specifiers)

--- a/tests/test_type.py
+++ b/tests/test_type.py
@@ -6,6 +6,8 @@ import pytest
 
 import strawberry
 from strawberry.types.base import StrawberryObjectDefinition, get_object_definition
+from strawberry.types.field import StrawberryField
+from strawberry.types.object_type import field
 
 
 def test_get_object_definition():
@@ -47,3 +49,18 @@ def test_get_object_definition_strict():
         match=r".* does not have a StrawberryObjectDefinition",
     ):
         get_object_definition(OtherFruit, strict=True)
+
+
+def test_public_decorators_have_dataclass_transform():
+    expected = {
+        "eq_default": True,
+        "order_default": True,
+        "kw_only_default": True,
+        "frozen_default": False,
+        "field_specifiers": (field, StrawberryField),
+        "kwargs": {},
+    }
+
+    assert strawberry.type.__dataclass_transform__ == expected
+    assert strawberry.input.__dataclass_transform__ == expected
+    assert strawberry.interface.__dataclass_transform__ == expected

--- a/tests/test_type.py
+++ b/tests/test_type.py
@@ -6,8 +6,6 @@ import pytest
 
 import strawberry
 from strawberry.types.base import StrawberryObjectDefinition, get_object_definition
-from strawberry.types.field import StrawberryField
-from strawberry.types.object_type import field
 
 
 def test_get_object_definition():
@@ -52,15 +50,15 @@ def test_get_object_definition_strict():
 
 
 def test_public_decorators_have_dataclass_transform():
-    expected = {
-        "eq_default": True,
-        "order_default": True,
-        "kw_only_default": True,
-        "frozen_default": False,
-        "field_specifiers": (field, StrawberryField),
-        "kwargs": {},
-    }
+    decorators = (strawberry.type, strawberry.input, strawberry.interface)
 
-    assert strawberry.type.__dataclass_transform__ == expected
-    assert strawberry.input.__dataclass_transform__ == expected
-    assert strawberry.interface.__dataclass_transform__ == expected
+    for decorator in decorators:
+        transform = decorator.__dataclass_transform__
+
+        assert transform["order_default"] is True
+        assert transform["kw_only_default"] is True
+
+        field_specifiers = transform["field_specifiers"]
+
+        assert field_specifiers
+        assert all(callable(field_specifier) for field_specifier in field_specifiers)


### PR DESCRIPTION
PyCharm does not infer the generated dataclass-style `__init__` for classes decorated with `@strawberry.type`.

Example:

```python
@strawberry.type
class SuccessType:
    message: str
    obj_id: strawberry.ID | None = None

SuccessType(message="ok")
```

PyCharm reports:

```text
Unexpected argument
```

Runtime behavior is correct because Strawberry wraps the class with `dataclasses.dataclass(kw_only=True)` internally.

In `strawberry/types/object_type.py`, `@dataclass_transform(...)` is currently applied to the overload declarations of `type`/`input`/`interface`, but PyCharm appears to ignore it there when resolving the public decorator from `strawberry.type`.

Moving or duplicating the same `@dataclass_transform(...)` annotation onto the concrete implementation fixes the IDE warning:

```python
@overload
def type(...) -> T: ...

@overload
def type(...) -> Callable[[T], T]: ...

@dataclass_transform(
    order_default=True,
    kw_only_default=True,
    field_specifiers=(field, StrawberryField),
)
def type(...):
    ...
```

Same applies to `input`; `interface` already had the implementation-level transform in this installed version.

This keeps runtime behavior unchanged and improves PyCharm/static-analysis support for generated keyword constructors.
## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/strawberry-graphql/strawberry/issues/4507

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Ensure Strawberry's public decorators expose dataclass transformation metadata for better static analysis support.

Bug Fixes:
- Expose dataclass transform metadata on the concrete implementations of strawberry.type and strawberry.input so IDEs can infer generated __init__ signatures.

Tests:
- Add tests to verify that strawberry.type, strawberry.input, and strawberry.interface expose the expected __dataclass_transform__ metadata.