### PR TITLE
Preserve user-defined methods on experimental pydantic types

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,32 @@
+---
+release type: patch
+social_messages:
+  x: >-
+    {project_name} {version} keeps user-defined methods on experimental Pydantic types.
+  linkedin: >-
+    {project_name} {version} fixes experimental Pydantic types dropping user-defined
+    static, class, and instance methods (and properties) from the decorated class body.
+---
+
+Fix `strawberry.experimental.pydantic.type` (and `.input` / `.interface`) stripping
+user-defined methods from the decorated class.
+
+Previously any `staticmethod`, `classmethod`, regular method, or `property` defined on
+the class body — other than `from_pydantic` / `to_pydantic` — was dropped, because the
+type is rebuilt with `make_dataclass` from the original bases rather than from the class
+itself, so calling it raised `AttributeError`:
+
+```python
+@strawberry.experimental.pydantic.type(model=Foo)
+class FooType:
+    bar: strawberry.auto
+
+    @staticmethod
+    def do_something() -> str:
+        return "done"
+
+
+FooType.do_something()  # used to raise AttributeError
+```
+
+These members are now carried over and remain accessible at runtime.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -29,4 +29,4 @@ class FooType:
 FooType.do_something()  # used to raise AttributeError
 ```
 
-These members are now carried over and remain accessible at runtime.
+These members are now carried over and keep working at runtime.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,7 @@ release type: patch
 social_messages:
   x: >-
     {project_name} {version} keeps user-defined methods on experimental Pydantic types.
+    🍓 https://strawberry.rocks/release/{version}
   linkedin: >-
     {project_name} {version} fixes experimental Pydantic types dropping user-defined
     static, class, and instance methods (and properties) from the decorated class body.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,8 +8,8 @@ social_messages:
     static, class, and instance methods (and properties) from the decorated class body.
 ---
 
-Fix `strawberry.experimental.pydantic.type` (and `.input` / `.interface`) stripping
-user-defined methods from the decorated class.
+This release fixes `strawberry.experimental.pydantic.type` (and `.input` /
+`.interface`) stripping user-defined methods from the decorated class.
 
 Previously any `staticmethod`, `classmethod`, regular method, or `property` defined on
 the class body — other than `from_pydantic` / `to_pydantic` — was dropped, because the

--- a/strawberry/experimental/pydantic/object_type.py
+++ b/strawberry/experimental/pydantic/object_type.py
@@ -244,6 +244,24 @@ def type(
         if hasattr(cls, "resolve_reference"):
             namespace["resolve_reference"] = cls.resolve_reference
 
+        dataclass_fields = [field.to_tuple() for field in all_model_fields]
+        field_names = {field_tuple[0] for field_tuple in dataclass_fields}
+
+        # `make_dataclass` below builds a brand new class from `cls.__bases__`
+        # rather than from `cls` itself, so any attribute defined directly on the
+        # decorated class body that is not a field — a regular/static/class method
+        # or a property — would otherwise be dropped and become inaccessible at
+        # runtime. Carry those over so user-defined methods keep working (#3601).
+        for attr_name, attr_value in cls.__dict__.items():
+            if attr_name.startswith("__"):
+                continue
+            if attr_name in namespace or attr_name in field_names:
+                continue
+            if isinstance(
+                attr_value, (staticmethod, classmethod, property)
+            ) or callable(attr_value):
+                namespace[attr_name] = attr_value
+
         kwargs: dict[str, object] = {}
 
         # Python 3.10.1 introduces the kw_only param to `make_dataclass`.
@@ -256,7 +274,7 @@ def type(
 
         cls = dataclasses.make_dataclass(
             cls.__name__,
-            [field.to_tuple() for field in all_model_fields],
+            dataclass_fields,
             bases=cls.__bases__,
             namespace=namespace,
             **kwargs,  # type: ignore

--- a/tests/experimental/pydantic/test_basic.py
+++ b/tests/experimental/pydantic/test_basic.py
@@ -126,6 +126,42 @@ def test_auto_fields_other_sentinel():
     assert field3.type is OtherSentinel
 
 
+def test_preserves_user_defined_methods():
+    # https://github.com/strawberry-graphql/strawberry/issues/3601
+    # Methods defined on the decorated class (other than from_pydantic /
+    # to_pydantic) used to be stripped because the type is rebuilt with
+    # make_dataclass from the original bases, so calling them raised
+    # AttributeError. They must remain accessible at runtime.
+    class Foo(pydantic.BaseModel):
+        bar: int
+
+    @strawberry.experimental.pydantic.type(model=Foo)
+    class FooType:
+        bar: strawberry.auto
+
+        @staticmethod
+        def do_something() -> str:
+            return "static"
+
+        @classmethod
+        def build(cls) -> str:
+            return "class"
+
+        def describe(self) -> str:
+            return "instance"
+
+        @property
+        def label(self) -> str:
+            return "property"
+
+    assert FooType.do_something() == "static"
+    assert FooType.build() == "class"
+
+    instance = FooType(bar=1)
+    assert instance.describe() == "instance"
+    assert instance.label == "property"
+
+
 def test_referencing_other_models_fails_when_not_registered():
     class Group(pydantic.BaseModel):
         name: str


### PR DESCRIPTION
## Description

Closes #3601.

`strawberry.experimental.pydantic.type` rebuilds the decorated class with `dataclasses.make_dataclass(..., bases=cls.__bases__, namespace=namespace)`. Because it builds from the original *bases* rather than from `cls` itself, only the entries explicitly put into `namespace` (`is_type_of`, and custom `from_pydantic` / `to_pydantic` / `resolve_reference`) survive. Any other attribute defined on the class body — a `staticmethod`, `classmethod`, regular method, or `property` — was silently dropped, so accessing it raised `AttributeError`:

```python
@strawberry.experimental.pydantic.type(model=Foo)
class FooType:
    bar: strawberry.auto

    @staticmethod
    def do_something() -> str:
        return "done"


FooType.do_something()  # AttributeError: type object 'FooType' has no attribute 'do_something'
```

(`@strawberry.field` resolvers were unaffected because they are collected as fields; only non-field members were lost.)

## Fix

Before calling `make_dataclass`, carry the decorated class's own non-field methods/properties into `namespace`, skipping dunders, existing fields, and anything already handled (`is_type_of` / custom `from_pydantic` / `to_pydantic` / `resolve_reference`). `.input` and `.interface` delegate to the same wrapper, so they get the fix too.

## Testing

Added `test_preserves_user_defined_methods` covering a staticmethod (the reported case) plus classmethod, instance method, and property. Verified it fails on `main` with the exact `AttributeError` and passes after the change. Full `tests/experimental/pydantic/` suite: 154 passed, 12 skipped, 1 xfailed. `ruff format` / `ruff check` clean.

## Summary by Sourcery

Preserve user-defined methods and properties on experimental Pydantic-based Strawberry types so they remain accessible at runtime.

Bug Fixes:
- Ensure static, class, instance methods, and properties defined on experimental Pydantic type classes are retained instead of being dropped during dataclass reconstruction.

Documentation:
- Add release notes documenting the fix for user-defined methods being stripped from experimental Pydantic types.

Tests:
- Add regression test verifying static, class, instance methods, and properties remain callable on experimental Pydantic types.