### PR TITLE
Unpack input-mutation arguments during argument conversion

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,15 +1,19 @@
 ---
 release type: patch
+social_messages:
+  x: >-
+    {project_name} {version} fixes `InputMutationExtension` — permission classes and other extensions on input-mutation fields now receive individual arguments instead of the wrapping input object.
+  linkedin: >-
+    {project_name} {version} fixes `InputMutationExtension`: permission classes and field extensions on input-mutation fields now receive the resolver's individual arguments (e.g. `name`, `color`) instead of the wrapping `input` object.
 ---
 
-`InputMutationExtension` now unpacks its generated `input` argument into the
-resolver's individual keyword arguments during argument conversion, instead of
-doing so in a field-extension resolver.
+This release fixes `InputMutationExtension` to unpack its generated `input`
+object into the resolver's individual keyword arguments before permission
+classes and other field extensions run.
 
-This is mostly an internal cleanup, but it has one observable effect: permission
-classes and other field extensions applied to an input-mutation field now
-receive the resolver's individual arguments (for example `name` and `color`)
-instead of the wrapping `input` object.
+Previously, permission classes and field extensions on an input-mutation field
+received the wrapping `input` object; they now receive the individual arguments
+(for example `name` and `color`).
 
 ```python
 import strawberry

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,7 @@
 release type: patch
 social_messages:
   x: >-
-    {project_name} {version} fixes `InputMutationExtension` — permission classes and other extensions on input-mutation fields now receive individual arguments instead of the wrapping input object.
+    {project_name} {version} fixes InputMutationExtension — permission classes and other extensions on input-mutation fields now receive individual arguments instead of the wrapping input object.
   linkedin: >-
     {project_name} {version} fixes InputMutationExtension: permission classes and field extensions on input-mutation fields now receive the resolver's individual arguments (e.g. name, color) instead of the wrapping input object.
 ---

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,7 +4,7 @@ social_messages:
   x: >-
     {project_name} {version} fixes `InputMutationExtension` — permission classes and other extensions on input-mutation fields now receive individual arguments instead of the wrapping input object.
   linkedin: >-
-    {project_name} {version} fixes `InputMutationExtension`: permission classes and field extensions on input-mutation fields now receive the resolver's individual arguments (e.g. `name`, `color`) instead of the wrapping `input` object.
+    {project_name} {version} fixes InputMutationExtension: permission classes and field extensions on input-mutation fields now receive the resolver's individual arguments (e.g. name, color) instead of the wrapping input object.
 ---
 
 This release fixes `InputMutationExtension` to unpack its generated `input`

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,37 @@
+---
+release type: patch
+---
+
+`InputMutationExtension` now unpacks its generated `input` argument into the
+resolver's individual keyword arguments during argument conversion, instead of
+doing so in a field-extension resolver.
+
+This is mostly an internal cleanup, but it has one observable effect: permission
+classes and other field extensions applied to an input-mutation field now
+receive the resolver's individual arguments (for example `name` and `color`)
+instead of the wrapping `input` object.
+
+```python
+import strawberry
+from strawberry.field_extensions import InputMutationExtension
+from strawberry.permission import BasePermission
+
+
+class IsAuthenticated(BasePermission):
+    message = "Not authenticated"
+
+    def has_permission(self, source, info, **kwargs) -> bool:
+        # Previously: kwargs == {"input": CreateFruitInput(name=..., color=...)}
+        # Now:        kwargs == {"name": ..., "color": ...}
+        return True
+
+
+@strawberry.type
+class Mutation:
+    @strawberry.mutation(
+        extensions=[InputMutationExtension()],
+        permission_classes=[IsAuthenticated],
+    )
+    def create_fruit(self, name: str, color: str) -> Fruit:
+        return Fruit(name=name, color=color)
+```

--- a/strawberry/extensions/field_extension.py
+++ b/strawberry/extensions/field_extension.py
@@ -34,6 +34,17 @@ class FieldExtension:
             "Async Resolve is not supported for this Field Extension"
         )
 
+    def map_arguments(self, kwargs: dict[str, Any]) -> dict[str, Any]:
+        """Reshape the resolver's keyword arguments after they are converted.
+
+        Called during argument conversion, before the resolver (and the resolve
+        chain) runs, and only when conversion succeeds. Extensions that change a
+        field's argument shape (e.g. ``InputMutationExtension``) use this instead
+        of a resolve wrapper, so they never see the un-converted arguments passed
+        along the argument-conversion-error path.
+        """
+        return kwargs
+
     @cached_property
     def supports_sync(self) -> bool:
         return type(self).resolve is not FieldExtension.resolve
@@ -41,6 +52,15 @@ class FieldExtension:
     @cached_property
     def supports_async(self) -> bool:
         return type(self).resolve_async is not FieldExtension.resolve_async
+
+    @cached_property
+    def has_resolver(self) -> bool:
+        """Whether the extension takes part in the resolve chain.
+
+        Extensions that implement neither ``resolve`` nor ``resolve_async`` only
+        hook into ``apply``/``map_arguments`` and are left out of the chain.
+        """
+        return self.supports_sync or self.supports_async
 
 
 class SyncToAsyncExtension(FieldExtension):
@@ -84,8 +104,14 @@ def build_field_extension_resolvers(
     if not field.extensions:
         return []  # pragma: no cover
 
+    # Extensions that only hook into ``apply``/``map_arguments`` (no ``resolve``
+    # or ``resolve_async``) take no part in the resolve chain, so leave them out.
+    extensions = [extension for extension in field.extensions if extension.has_resolver]
+    if not extensions:
+        return []
+
     non_async_extensions = [
-        extension for extension in field.extensions if not extension.supports_async
+        extension for extension in extensions if not extension.supports_async
     ]
     non_async_extension_names = ",".join(
         [extension.__class__.__name__ for extension in non_async_extensions]
@@ -98,19 +124,19 @@ def build_field_extension_resolvers(
                 f"to the async resolver of Field {field.name}. "
                 f"Please add a resolve_async method to the extension(s)."
             )
-        return _get_async_resolvers(field.extensions)
+        return _get_async_resolvers(extensions)
     # Try to wrap all sync resolvers in async so that we can use async extensions
     # on sync fields. This is not possible the other way around since
     # the result of an async resolver would have to be awaited before calling
     # the sync extension, making it impossible for the extension to modify
     # any arguments.
     non_sync_extensions = [
-        extension for extension in field.extensions if not extension.supports_sync
+        extension for extension in extensions if not extension.supports_sync
     ]
 
     if len(non_sync_extensions) == 0:
         # Resolve everything sync
-        return _get_sync_resolvers(field.extensions)
+        return _get_sync_resolvers(extensions)
 
     # We have async-only extensions and need to wrap the resolver
     # That means we can't have sync-only extensions after the first async one
@@ -122,7 +148,7 @@ def build_field_extension_resolvers(
 
     # All sync only extensions must be found before the first async-only one
     found_sync_only_extensions = 0
-    for extension in field.extensions:
+    for extension in extensions:
         # ...A, abort
         if extension in non_sync_extensions:
             break
@@ -137,9 +163,9 @@ def build_field_extension_resolvers(
         # Prepend sync to async extension to field extensions
         return list(
             itertools.chain(
-                _get_sync_resolvers(field.extensions[:found_sync_extensions]),
+                _get_sync_resolvers(extensions[:found_sync_extensions]),
                 [SyncToAsyncExtension().resolve_async],
-                _get_async_resolvers(field.extensions[found_sync_extensions:]),
+                _get_async_resolvers(extensions[found_sync_extensions:]),
             )
         )
 

--- a/strawberry/field_extensions/input_mutation.py
+++ b/strawberry/field_extensions/input_mutation.py
@@ -4,11 +4,7 @@ from typing import Any
 
 import strawberry
 from strawberry.annotation import StrawberryAnnotation
-from strawberry.extensions.field_extension import (
-    AsyncExtensionResolver,
-    FieldExtension,
-    SyncExtensionResolver,
-)
+from strawberry.extensions.field_extension import FieldExtension
 from strawberry.types.arguments import StrawberryArgument
 from strawberry.types.field import StrawberryField
 from strawberry.utils.str_converters import capitalize_first, to_camel_case
@@ -55,35 +51,11 @@ class InputMutationExtension(FieldExtension):
             )
         ]
 
-    def resolve(
-        self,
-        next_: SyncExtensionResolver,
-        source: Any,
-        info: strawberry.Info,
-        **kwargs: Any,
-    ) -> Any:
+    def map_arguments(self, kwargs: dict[str, Any]) -> dict[str, Any]:
+        # Unpack the generated ``input`` object into the resolver's individual
+        # keyword arguments, so the resolver keeps its original signature.
         input_args = kwargs.pop("input")
-        return next_(
-            source,
-            info,
-            **kwargs,
-            **vars(input_args),
-        )
-
-    async def resolve_async(
-        self,
-        next_: AsyncExtensionResolver,
-        source: Any,
-        info: strawberry.Info,
-        **kwargs: Any,
-    ) -> Any:
-        input_args = kwargs.pop("input")
-        return await next_(
-            source,
-            info,
-            **kwargs,
-            **vars(input_args),
-        )
+        return {**kwargs, **vars(input_args)}
 
 
 __all__ = ["InputMutationExtension"]

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -228,27 +228,20 @@ def get_arguments(
     config: StrawberryConfig,
     scalar_registry: Mapping[object, ScalarWrapper | ScalarDefinition],
 ) -> tuple[list[Any], dict[str, Any]]:
-    # TODO: An extension might have changed the resolver arguments,
-    # but we need them here since we are calling it.
-    # This is a bit of a hack, but it's the easiest way to get the arguments
-    # This happens in mutation.InputMutationExtension
-    field_arguments = field.arguments[:]
-    if field.base_resolver:
-        existing = {arg.python_name for arg in field_arguments}
-        field_arguments.extend(
-            [
-                arg
-                for arg in field.base_resolver.arguments
-                if arg.python_name not in existing
-            ]
-        )
-
     kwargs = convert_arguments(
         kwargs,
-        field_arguments,
+        field.arguments,
         scalar_registry=scalar_registry,
         config=config,
     )
+
+    # Let field extensions reshape the converted arguments before the resolver
+    # is called (e.g. ``InputMutationExtension`` unpacks its ``input`` object
+    # into the resolver's individual keyword arguments). This only runs when
+    # conversion succeeds; on the conversion-error path the resolver is never
+    # called and the extensions run with the raw arguments instead.
+    for extension in field.extensions:
+        kwargs = extension.map_arguments(kwargs)
 
     # the following code allows to omit info and root arguments
     # by inspecting the original resolver arguments,

--- a/tests/schema/extensions/test_field_extensions.py
+++ b/tests/schema/extensions/test_field_extensions.py
@@ -411,3 +411,50 @@ def test_extension_has_custom_info_class():
     result = schema.execute_sync(query)
     assert result.data, result.errors
     assert result.data["string"] == "This is a test!!"
+
+
+class DoublingExtension(FieldExtension):
+    """Transparent extension: only ``apply``/``map_arguments``, no resolve."""
+
+    def __init__(self) -> None:
+        self.applied = False
+
+    def apply(self, field: Any) -> None:
+        self.applied = True
+
+    def map_arguments(self, kwargs: dict[str, Any]) -> dict[str, Any]:
+        return {**kwargs, "value": kwargs["value"] * 2}
+
+
+def test_extension_without_resolve_is_transparent():
+    # An extension implementing neither resolve nor resolve_async takes no part
+    # in the resolve chain, but its apply() and map_arguments() still run.
+    extension = DoublingExtension()
+
+    @strawberry.type
+    class Query:
+        @strawberry.field(extensions=[extension])
+        def echo(self, value: int) -> int:
+            return value
+
+    schema = strawberry.Schema(query=Query)
+    assert extension.applied
+
+    result = schema.execute_sync("query { echo(value: 3) }")
+    assert result.errors is None
+    assert result.data == {"echo": 6}
+
+
+async def test_extension_without_resolve_is_transparent_on_async_field():
+    # The same extension must work on an async field: a transparent extension
+    # imposes no sync/async constraint on the resolve chain.
+    @strawberry.type
+    class Query:
+        @strawberry.field(extensions=[DoublingExtension()])
+        async def echo(self, value: int) -> int:
+            return value
+
+    schema = strawberry.Schema(query=Query)
+    result = await schema.execute("query { echo(value: 4) }")
+    assert result.errors is None
+    assert result.data == {"echo": 8}

--- a/tests/schema/extensions/test_input_mutation.py
+++ b/tests/schema/extensions/test_input_mutation.py
@@ -3,6 +3,7 @@ from typing import Annotated
 
 import strawberry
 from strawberry.field_extensions import InputMutationExtension
+from strawberry.permission import BasePermission
 from strawberry.schema_directive import Location, schema_directive
 
 
@@ -162,3 +163,44 @@ async def test_input_mutation_async():
             "color": "red",
         },
     }
+
+
+def test_input_is_unpacked_before_field_extensions_and_permissions_run():
+    # The synthetic ``input`` argument is unpacked into the resolver's original
+    # keyword arguments during argument conversion, so permission classes and
+    # other field extensions see the individual arguments (``name``, ``color``)
+    # rather than the wrapping ``input`` object.
+    seen_kwargs = {}
+
+    class RecordKwargs(BasePermission):
+        message = "denied"
+
+        def has_permission(self, source, info, **kwargs) -> bool:  # noqa: ANN003
+            seen_kwargs.update(kwargs)
+            return True
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation(
+            extensions=[InputMutationExtension()],
+            permission_classes=[RecordKwargs],
+        )
+        def create_fruit(self, name: str, color: str) -> Fruit:
+            return Fruit(name=name, color=color)
+
+    schema = strawberry.Schema(query=Query, mutation=Mutation)
+
+    result = schema.execute_sync(
+        """
+        mutation {
+            createFruit(input: { name: "Banana", color: "yellow" }) {
+                name
+                color
+            }
+        }
+        """
+    )
+
+    assert result.errors is None
+    assert result.data == {"createFruit": {"name": "Banana", "color": "yellow"}}
+    assert seen_kwargs == {"name": "Banana", "color": "yellow"}


### PR DESCRIPTION
<!-- shortcake:start -->
## Stack [🍰](https://shortcake.patrick.wtf)

- #3965 (`feature/pydantic-first-class`)
- #4492 (`2026-06-28-add-generic-exception-handlers`)
- **#4510** (`2026-07-06-unpack-input-mutation-arguments`) <-- this PR
<!-- shortcake:end -->

## Summary by Sourcery

Ensure input-mutation fields unpack their synthetic input objects into individual resolver arguments during argument conversion so permissions and field extensions see the original arguments, and treat extensions without resolve hooks as transparent to the resolve chain.

Bug Fixes:
- Fix InputMutationExtension so permission classes and other field extensions receive the resolver’s individual arguments instead of the wrapping input object.

Enhancements:
- Introduce FieldExtension.map_arguments to allow extensions to reshape converted resolver arguments before execution.
- Treat extensions that do not implement sync or async resolve methods as transparent, excluding them from the resolve chain while still running their apply and argument-mapping hooks.

Documentation:
- Add a release note describing the InputMutationExtension fix and how permissions now receive unpacked arguments.

Tests:
- Add tests verifying transparent behavior of extensions without resolve methods on sync and async fields.
- Add tests confirming that input-mutation arguments are unpacked before permissions and other field extensions run.