### PR TITLE
Sync graphql over http spec tests

### DIFF
--- a/tests/http/test_graphql_over_http_spec.py
+++ b/tests/http/test_graphql_over_http_spec.py
@@ -539,6 +539,21 @@ async def test_bcf8(http_client):
     assert response.status_code == 400
 
 
+async def test_b7n8(http_client):
+    """
+    SHOULD use 400 status code on JSON parsing failure when accepting application/graphql-response+json
+    """
+    response = await http_client.post(
+        url="/graphql",
+        headers={
+            "Content-Type": "application/json",
+            "Accept": "application/graphql-response+json",
+        },
+        data=b'{ "not a JSON',
+    )
+    assert response.status_code == 400
+
+
 async def test_8764(http_client):
     """
     MAY use 4xx or 5xx status codes if parameters are invalid

--- a/tests/http/test_graphql_over_http_spec.py
+++ b/tests/http/test_graphql_over_http_spec.py
@@ -438,6 +438,8 @@ async def test_d6d5(http_client):
         headers={"Accept": "application/graphql-response+json"},
     )
     assert response.status_code == 200
+    assert isinstance(response.json, dict)
+    assert "errors" not in response.json
 
 
 async def test_6a70(http_client):

--- a/tests/http/test_graphql_over_http_spec.py
+++ b/tests/http/test_graphql_over_http_spec.py
@@ -5,6 +5,8 @@ https://github.com/graphql/graphql-http/blob/main/src/audits/server.ts
 
 import pytest
 
+from .clients.base import JSON, HttpClient
+
 try:
     from tests.http.clients.chalice import ChaliceHttpClient
 except ImportError:
@@ -25,7 +27,7 @@ except ImportError:
     reason="Our integrations currently only return application/json",
     raises=AssertionError,
 )
-async def test_22eb(http_client):
+async def test_22eb(http_client: HttpClient):
     """
     SHOULD accept application/graphql-response+json and match the content-type
     """
@@ -41,7 +43,7 @@ async def test_22eb(http_client):
     assert "application/graphql-response+json" in response.headers["content-type"]
 
 
-async def test_4655(http_client):
+async def test_4655(http_client: HttpClient):
     """
     MUST accept application/json and match the content-type
     """
@@ -57,7 +59,7 @@ async def test_4655(http_client):
     assert "application/json" in response.headers["content-type"]
 
 
-async def test_47de(http_client):
+async def test_47de(http_client: HttpClient):
     """
     SHOULD accept */* and use application/json for the content-type
     """
@@ -73,7 +75,7 @@ async def test_47de(http_client):
     assert "application/json" in response.headers["content-type"]
 
 
-async def test_80d8(http_client):
+async def test_80d8(http_client: HttpClient):
     """
     SHOULD assume application/json content-type when accept is missing
     """
@@ -86,7 +88,7 @@ async def test_80d8(http_client):
     assert "application/json" in response.headers["content-type"]
 
 
-async def test_82a3(http_client):
+async def test_82a3(http_client: HttpClient):
     """
     MUST use utf-8 encoding when responding
     """
@@ -104,7 +106,7 @@ async def test_82a3(http_client):
         pytest.fail("Response body is not UTF-8 encoded")
 
 
-async def test_bf61(http_client):
+async def test_bf61(http_client: HttpClient):
     """
     MUST accept utf-8 encoded request
     """
@@ -116,7 +118,7 @@ async def test_bf61(http_client):
     assert response.status_code == 200
 
 
-async def test_78d5(http_client):
+async def test_78d5(http_client: HttpClient):
     """
     MUST assume utf-8 in request if encoding is unspecified
     """
@@ -128,7 +130,7 @@ async def test_78d5(http_client):
     assert response.status_code == 200
 
 
-async def test_2c94(http_client):
+async def test_2c94(http_client: HttpClient):
     """
     MUST accept POST requests
     """
@@ -140,7 +142,7 @@ async def test_2c94(http_client):
     assert response.status_code == 200
 
 
-async def test_5a70(http_client):
+async def test_5a70(http_client: HttpClient):
     """
     MAY accept application/x-www-form-urlencoded formatted GET requests
     """
@@ -148,7 +150,7 @@ async def test_5a70(http_client):
     assert response.status_code == 200
 
 
-async def test_9c48(http_client):
+async def test_9c48(http_client: HttpClient):
     """
     MAY NOT allow executing mutations on GET requests
     """
@@ -164,7 +166,7 @@ async def test_9c48(http_client):
     reason="OPTIONAL - currently supported by Channels, Chalice, Django, and Sanic",
     raises=AssertionError,
 )
-async def test_9abe(http_client):
+async def test_9abe(http_client: HttpClient):
     """
     SHOULD respond with 4xx status code if content-type is not supplied on POST requests
     """
@@ -176,7 +178,7 @@ async def test_9abe(http_client):
     assert 400 <= response.status_code <= 499
 
 
-async def test_03d4(http_client):
+async def test_03d4(http_client: HttpClient):
     """
     MUST accept application/json POST requests
     """
@@ -188,7 +190,7 @@ async def test_03d4(http_client):
     assert response.status_code == 200
 
 
-async def test_a5bf(http_client):
+async def test_a5bf(http_client: HttpClient):
     """
     MAY use 400 status code when request body is missing on POST
     """
@@ -199,7 +201,7 @@ async def test_a5bf(http_client):
     assert response.status_code == 400
 
 
-async def test_423l(http_client):
+async def test_423l(http_client: HttpClient):
     """
     MAY use 400 status code on missing {query} parameter
     """
@@ -219,7 +221,7 @@ async def test_423l(http_client):
     [{"obj": "ect"}, 0, False, ["array"]],
     ids=["LKJ0", "LKJ1", "LKJ2", "LKJ3"],
 )
-async def test_lkj_(http_client, invalid):
+async def test_lkj_(http_client: HttpClient, invalid: JSON):
     """
     MAY use 400 status code on invalid {query} parameter
     """
@@ -231,7 +233,7 @@ async def test_lkj_(http_client, invalid):
     assert response.status_code == 400
 
 
-async def test_34a2(http_client):
+async def test_34a2(http_client: HttpClient):
     """
     SHOULD allow string {query} parameter when accepting application/graphql-response+json
     """
@@ -246,7 +248,7 @@ async def test_34a2(http_client):
     assert response.status_code == 200
 
 
-async def test_13ee(http_client):
+async def test_13ee(http_client: HttpClient):
     """
     MUST allow string {query} parameter when accepting application/json
     """
@@ -268,7 +270,7 @@ async def test_13ee(http_client):
     [{"obj": "ect"}, 0, False, ["array"]],
     ids=["6C00", "6C01", "6C02", "6C03"],
 )
-async def test_6c0_(http_client, invalid):
+async def test_6c0_(http_client: HttpClient, invalid: JSON):
     """
     MAY use 400 status code on invalid {operationName} parameter
     """
@@ -283,7 +285,7 @@ async def test_6c0_(http_client, invalid):
     assert response.status_code == 400
 
 
-async def test_8161(http_client):
+async def test_8161(http_client: HttpClient):
     """
     SHOULD allow string {operationName} parameter when accepting application/graphql-response+json
     """
@@ -301,7 +303,7 @@ async def test_8161(http_client):
     assert response.status_code == 200
 
 
-async def test_b8b3(http_client):
+async def test_b8b3(http_client: HttpClient):
     """
     MUST allow string {operationName} parameter when accepting application/json
     """
@@ -326,7 +328,7 @@ async def test_b8b3(http_client):
     ["variables", "operationName", "extensions"],
     ids=["94B0", "94B1", "94B2"],
 )
-async def test_94b_(http_client, parameter):
+async def test_94b_(http_client: HttpClient, parameter: str):
     """
     SHOULD allow null variables/operationName/extensions parameter when accepting application/graphql-response+json
     """
@@ -342,6 +344,7 @@ async def test_94b_(http_client, parameter):
         },
     )
     assert response.status_code == 200
+    assert isinstance(response.json, dict)
     assert "errors" not in response.json
 
 
@@ -350,7 +353,7 @@ async def test_94b_(http_client, parameter):
     ["variables", "operationName", "extensions"],
     ids=["0220", "0221", "0222"],
 )
-async def test_022_(http_client, parameter):
+async def test_022_(http_client: HttpClient, parameter: str):
     """
     MUST allow null variables/operationName/extensions parameter when accepting application/json
     """
@@ -366,6 +369,7 @@ async def test_022_(http_client, parameter):
         },
     )
     assert response.status_code == 200
+    assert isinstance(response.json, dict)
     assert "errors" not in response.json
 
 
@@ -374,7 +378,7 @@ async def test_022_(http_client, parameter):
     ["string", 0, False, ["array"]],
     ids=["4760", "4761", "4762", "4763"],
 )
-async def test_476_(http_client, invalid):
+async def test_476_(http_client: HttpClient, invalid: JSON):
     """
     MAY use 400 status code on invalid {variables} parameter
     """
@@ -389,7 +393,7 @@ async def test_476_(http_client, invalid):
     assert response.status_code == 400
 
 
-async def test_2ea1(http_client):
+async def test_2ea1(http_client: HttpClient):
     """
     SHOULD allow map {variables} parameter when accepting application/graphql-response+json
     """
@@ -407,7 +411,7 @@ async def test_2ea1(http_client):
     assert response.status_code == 200
 
 
-async def test_28b9(http_client):
+async def test_28b9(http_client: HttpClient):
     """
     MUST allow map {variables} parameter when accepting application/json
     """
@@ -427,7 +431,7 @@ async def test_28b9(http_client):
     assert "errors" not in response.json
 
 
-async def test_d6d5(http_client):
+async def test_d6d5(http_client: HttpClient):
     """
     MAY allow URL-encoded JSON string {variables} parameter in GETs when accepting application/graphql-response+json
     """
@@ -442,7 +446,7 @@ async def test_d6d5(http_client):
     assert "errors" not in response.json
 
 
-async def test_6a70(http_client):
+async def test_6a70(http_client: HttpClient):
     """
     MAY allow URL-encoded JSON string {variables} parameter in GETs when accepting application/json
     """
@@ -462,7 +466,7 @@ async def test_6a70(http_client):
     ["string", 0, False, ["array"]],
     ids=["58B0", "58B1", "58B2", "58B3"],
 )
-async def test_58b_(http_client, invalid):
+async def test_58b_(http_client: HttpClient, invalid: JSON):
     """
     MAY use 400 status code on invalid {extensions} parameter
     """
@@ -477,7 +481,7 @@ async def test_58b_(http_client, invalid):
     assert response.status_code == 400
 
 
-async def test_428f(http_client):
+async def test_428f(http_client: HttpClient):
     """
     SHOULD allow map {extensions} parameter when accepting application/graphql-response+json
     """
@@ -495,7 +499,7 @@ async def test_428f(http_client):
     assert response.status_code == 200
 
 
-async def test_1b7a(http_client):
+async def test_1b7a(http_client: HttpClient):
     """
     MUST allow map {extensions} parameter when accepting application/json
     """
@@ -515,7 +519,7 @@ async def test_1b7a(http_client):
     assert "errors" not in response.json
 
 
-async def test_b6dc(http_client):
+async def test_b6dc(http_client: HttpClient):
     """
     MAY use 2xx, 4xx, or 5xx status codes on JSON parsing failure when accepting application/json
     """
@@ -536,7 +540,7 @@ async def test_b6dc(http_client):
     )
 
 
-async def test_bcf8(http_client):
+async def test_bcf8(http_client: HttpClient):
     """
     SHOULD use 400 status code on JSON parsing failure when accepting application/json
     """
@@ -551,7 +555,7 @@ async def test_bcf8(http_client):
     assert response.status_code == 400
 
 
-async def test_b7n8(http_client):
+async def test_b7n8(http_client: HttpClient):
     """
     SHOULD use 400 status code on JSON parsing failure when accepting application/graphql-response+json
     """
@@ -566,7 +570,7 @@ async def test_b7n8(http_client):
     assert response.status_code == 400
 
 
-async def test_8764(http_client):
+async def test_8764(http_client: HttpClient):
     """
     MAY use 4xx or 5xx status codes if parameters are invalid
     """
@@ -578,7 +582,7 @@ async def test_8764(http_client):
     assert 400 <= response.status_code <= 599
 
 
-async def test_3e3a(http_client):
+async def test_3e3a(http_client: HttpClient):
     """
     MAY use 400 status code if parameters are invalid
     """
@@ -590,7 +594,7 @@ async def test_3e3a(http_client):
     assert response.status_code == 400
 
 
-async def test_39aa(http_client):
+async def test_39aa(http_client: HttpClient):
     """
     MUST accept a map for the {extensions} parameter
     """
@@ -610,7 +614,7 @@ async def test_39aa(http_client):
     assert "errors" not in response.json
 
 
-async def test_572b(http_client):
+async def test_572b(http_client: HttpClient):
     """
     SHOULD use 200 status code on document parsing failure when accepting application/json
     """
@@ -625,7 +629,7 @@ async def test_572b(http_client):
     assert response.status_code == 200
 
 
-async def test_dfe2(http_client):
+async def test_dfe2(http_client: HttpClient):
     """
     SHOULD use 200 status code on document validation failure when accepting application/json
     """
@@ -642,7 +646,7 @@ async def test_dfe2(http_client):
     assert response.status_code == 200
 
 
-async def test_7b9b(http_client):
+async def test_7b9b(http_client: HttpClient):
     """
     SHOULD use a status code of 200 on variable coercion failure when accepting application/json
     """
@@ -663,7 +667,7 @@ async def test_7b9b(http_client):
 @pytest.mark.xfail(
     reason="Currently results in status 200 with GraphQL errors", raises=AssertionError
 )
-async def test_865d(http_client):
+async def test_865d(http_client: HttpClient):
     """
     SHOULD use 4xx or 5xx status codes on document parsing failure when accepting application/graphql-response+json
     """
@@ -681,7 +685,7 @@ async def test_865d(http_client):
 @pytest.mark.xfail(
     reason="Currently results in status 200 with GraphQL errors", raises=AssertionError
 )
-async def test_556a(http_client):
+async def test_556a(http_client: HttpClient):
     """
     SHOULD use 400 status code on document parsing failure when accepting application/graphql-response+json
     """
@@ -699,7 +703,7 @@ async def test_556a(http_client):
 @pytest.mark.xfail(
     reason="Currently results in status 200 with GraphQL errors", raises=AssertionError
 )
-async def test_d586(http_client):
+async def test_d586(http_client: HttpClient):
     """
     SHOULD NOT contain the data entry on document parsing failure when accepting application/graphql-response+json
     """
@@ -712,13 +716,14 @@ async def test_d586(http_client):
         json={"query": "{"},
     )
     assert response.status_code == 400
+    assert isinstance(response.json, dict)
     assert "data" not in response.json
 
 
 @pytest.mark.xfail(
     reason="Currently results in status 200 with GraphQL errors", raises=AssertionError
 )
-async def test_51fe(http_client):
+async def test_51fe(http_client: HttpClient):
     """
     SHOULD use 4xx or 5xx status codes on document validation failure when accepting application/graphql-response+json
     """
@@ -738,7 +743,7 @@ async def test_51fe(http_client):
 @pytest.mark.xfail(
     reason="Currently results in status 200 with GraphQL errors", raises=AssertionError
 )
-async def test_74ff(http_client):
+async def test_74ff(http_client: HttpClient):
     """
     SHOULD use 400 status code on document validation failure when accepting application/graphql-response+json
     """
@@ -758,7 +763,7 @@ async def test_74ff(http_client):
 @pytest.mark.xfail(
     reason="Currently results in status 200 with GraphQL errors", raises=AssertionError
 )
-async def test_5e5b(http_client):
+async def test_5e5b(http_client: HttpClient):
     """
     SHOULD NOT contain the data entry on document validation failure when accepting application/graphql-response+json
     """
@@ -773,13 +778,14 @@ async def test_5e5b(http_client):
         },
     )
     assert response.status_code == 400
+    assert isinstance(response.json, dict)
     assert "data" not in response.json
 
 
 @pytest.mark.xfail(
     reason="Currently results in status 200 with GraphQL errors", raises=AssertionError
 )
-async def test_86ee(http_client):
+async def test_86ee(http_client: HttpClient):
     """
     SHOULD use a status code of 400 on variable coercion failure when accepting application/graphql-response+json
     """

--- a/tests/http/test_graphql_over_http_spec.py
+++ b/tests/http/test_graphql_over_http_spec.py
@@ -166,7 +166,7 @@ async def test_9c48(http_client):
 )
 async def test_9abe(http_client):
     """
-    MAY respond with 4xx status code if content-type is not supplied on POST requests
+    SHOULD respond with 4xx status code if content-type is not supplied on POST requests
     """
     response = await http_client.post(
         url="/graphql",

--- a/tests/http/test_graphql_over_http_spec.py
+++ b/tests/http/test_graphql_over_http_spec.py
@@ -517,23 +517,35 @@ async def test_1b7a(http_client):
 
 async def test_b6dc(http_client):
     """
-    MAY use 4xx or 5xx status codes on JSON parsing failure
+    MAY use 2xx, 4xx, or 5xx status codes on JSON parsing failure when accepting application/json
     """
     response = await http_client.post(
         url="/graphql",
-        headers={"Content-Type": "application/json"},
+        headers={
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        },
         data=b'{ "not a JSON',
     )
-    assert 400 <= response.status_code <= 599
+    assert any(
+        [
+            200 <= response.status_code <= 299,
+            400 <= response.status_code <= 499,
+            500 <= response.status_code <= 599,
+        ]
+    )
 
 
 async def test_bcf8(http_client):
     """
-    MAY use 400 status code on JSON parsing failure
+    SHOULD use 400 status code on JSON parsing failure when accepting application/json
     """
     response = await http_client.post(
         url="/graphql",
-        headers={"Content-Type": "application/json"},
+        headers={
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        },
         data=b'{ "not a JSON',
     )
     assert response.status_code == 400


### PR DESCRIPTION
## Description

This PR syncs our graphql-over-http spec test suite with upstream PRs I landed:

- https://github.com/graphql/graphql-http/pull/145
- https://github.com/graphql/graphql-http/pull/147
- https://github.com/graphql/graphql-http/pull/148
- https://github.com/graphql/graphql-http/pull/149

It also adds type hints for test parameters and fixes typing-related issues with test assertions.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Summary by Sourcery

Sync GraphQL-over-HTTP conformance tests with the latest upstream spec changes and strengthen type annotations for the HTTP test client and JSON parameters.

Enhancements:
- Tighten HTTP spec tests around content negotiation, JSON parsing failures, and error/status-code expectations to match updated GraphQL-over-HTTP requirements.
- Add type hints for the shared HTTP client and JSON-like test parameters to improve type safety and test clarity.

Tests:
- Expand and adjust GraphQL-over-HTTP test coverage, including new cases for JSON parsing failures with different Accept headers and stricter assertions on response payload structure (e.g., dict JSON bodies, absence of errors/data fields).