### PR TITLE
Resolve interface fields returning a mapping via __typename

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,7 +3,8 @@ release type: patch
 social_messages:
   x: >-
     {project_name} {version} applies a custom default_resolver to interface fields
-    that return a mapping, picking the concrete type from __typename.
+    that return a mapping, picking the concrete type from __typename. 🍓
+    https://strawberry.rocks/release/{version}
   linkedin: >-
     {project_name} {version} fixes a custom default_resolver not being applied to
     fields typed as an interface: a mapping returned for such a field is now

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,45 @@
+---
+release type: patch
+social_messages:
+  x: >-
+    {project_name} {version} applies a custom default_resolver to interface fields
+    that return a mapping, picking the concrete type from __typename.
+  linkedin: >-
+    {project_name} {version} fixes a custom default_resolver not being applied to
+    fields typed as an interface: a mapping returned for such a field is now
+    resolved to the concrete type named by its __typename.
+---
+
+This release fixes a custom `default_resolver` not being applied to fields typed
+as an interface.
+
+When a `default_resolver` returned a mapping (for example a `dict`) for a field
+whose type is an interface, Strawberry could not determine the concrete type and
+reported `Expected value of type '...'`. The concrete type is now selected from
+the mapping's `__typename`, so interface fields work the same way non-interface
+fields already do:
+
+```python
+@strawberry.interface
+class UserInterface:
+    name: str
+
+
+@strawberry.type
+class Client(UserInterface):
+    company_name: str
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def user(self) -> UserInterface:
+        return {"name": "Patrick", "company_name": "company", "__typename": "Client"}
+
+
+schema = strawberry.Schema(
+    query=Query,
+    types=[Client],
+    config=StrawberryConfig(default_resolver=lambda obj, key: obj[key]),
+)
+```

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import dataclasses
 import sys
 import typing
+from collections.abc import Mapping
 from functools import partial, reduce
 from typing import (
     TYPE_CHECKING,
@@ -79,7 +80,7 @@ from . import compat
 from .types.concrete_type import ConcreteType
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable, Mapping
+    from collections.abc import Awaitable, Callable
 
     from graphql import (
         GraphQLInputType,
@@ -594,6 +595,17 @@ class GraphQLCoreConverter:
             def resolve_type(
                 obj: Any, info: GraphQLResolveInfo, abstract_type: GraphQLAbstractType
             ) -> Awaitable[str | None] | str | None:
+                # A resolver may return a mapping rather than an instance of the
+                # type - e.g. when a custom ``default_resolver`` reads fields off a
+                # dict. Such a value can't be matched by ``isinstance`` below or by
+                # the members' ``is_type_of``, so honor an explicit ``__typename``
+                # to pick the concrete type, matching how non-interface fields
+                # already resolve dicts via the default resolver (#3715).
+                if isinstance(obj, Mapping):
+                    typename = obj.get("__typename")
+                    if typename is not None:
+                        return typename
+
                 if isinstance(obj, interface.origin):
                     type_definition = get_object_definition(obj, strict=True)
 
@@ -686,6 +698,12 @@ class GraphQLCoreConverter:
             def is_type_of(obj: Any, _info: GraphQLResolveInfo) -> bool:
                 if (type_cast := get_strawberry_type_cast(obj)) is not None:
                     return type_cast in possible_types
+
+                # A mapping (e.g. a dict returned through a custom
+                # ``default_resolver``) is not an instance of the type, so match
+                # it by its explicit ``__typename`` instead (#3715).
+                if isinstance(obj, Mapping):
+                    return obj.get("__typename") == object_type_name
 
                 if object_type.concrete_of and (
                     has_object_definition(obj)

--- a/tests/schema/test_fields.py
+++ b/tests/schema/test_fields.py
@@ -74,6 +74,48 @@ def test_can_change_default_resolver():
     assert result.data["user"]["name"] == "Patrick"
 
 
+def test_default_resolver_works_for_interface_field_with_typename():
+    # A field typed as an interface that returns a mapping (via a custom
+    # default_resolver) resolves to the concrete type named by ``__typename``.
+    # Regression test for #3715.
+    @strawberry.interface
+    class UserInterface:
+        name: str
+
+    @strawberry.type
+    class Client(UserInterface):
+        company_name: str
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def user(self) -> UserInterface:
+            return {  # type: ignore
+                "name": "Patrick",
+                "company_name": "company",
+                "__typename": "Client",
+            }
+
+    schema = strawberry.Schema(
+        query=Query,
+        types=[Client],
+        config=StrawberryConfig(default_resolver=getitem),
+    )
+
+    result = schema.execute_sync(
+        "{ user { name __typename ... on Client { companyName } } }"
+    )
+
+    assert not result.errors
+    assert result.data == {
+        "user": {
+            "name": "Patrick",
+            "__typename": "Client",
+            "companyName": "company",
+        }
+    }
+
+
 def test_field_metadata():
     @strawberry.type
     class Query:


### PR DESCRIPTION
## Description

Closes #3715.

The docs show that a custom `default_resolver` can return a `dict` and have it converted to the GraphQL type. This does not work when the field is typed as an **interface**: the value never reaches the field resolvers and execution fails with `Expected value of type '<Concrete>' but got: {...}`.

Root cause is type resolution. For an interface field the interface's `resolve_type` and each member's `is_type_of` both key off `isinstance(obj, ...)`. A mapping returned by the resolver is not an instance of the concrete type, so `resolve_type` falls through to `default_type_resolver`, every member's `is_type_of` returns `False`, and no runtime type is found.

```python
@strawberry.interface
class UserInterface:
    name: str

@strawberry.type
class Client(UserInterface):
    company_name: str

@strawberry.type
class Query:
    @strawberry.field
    def user(self) -> UserInterface:
        return {"name": "Patrick", "company_name": "company", "__typename": "Client"}

schema = strawberry.Schema(
    query=Query, types=[Client],
    config=StrawberryConfig(default_resolver=lambda obj, key: obj[key]),
)
# used to raise: Expected value of type 'Client' but got: {...}
```

## Fix

Honor an explicit `__typename` on a returned mapping in both places that resolve the concrete type:

- the interface's `resolve_type` returns `obj["__typename"]` when the value is a `Mapping` carrying it;
- the object type's `is_type_of` (called by graphql-core to confirm the resolved type) matches a `Mapping` by `__typename == <type name>`.

This mirrors how non-interface fields already resolve dicts through `default_resolver`, and matches the direction @patrick91 outlined on the issue. Only affects values that are mappings with a `__typename` key; every existing path is unchanged.

## Testing

Added `test_default_resolver_works_for_interface_field_with_typename` (the docs example). Verified it fails on `main` with the exact `Expected value of type 'Client'` error and passes after the change. `tests/schema/test_fields.py`, `test_interface.py`, `test_union.py` (51 passed, 1 xfailed) and `tests/federation` (76 passed) all green. `ruff` and `pre-commit` clean.

## Summary by Sourcery

Fix resolution of interface-typed fields when a custom default_resolver returns a mapping by honoring __typename in type resolution and is_type_of checks.

Bug Fixes:
- Allow interface fields that return mappings via a custom default_resolver to resolve concrete types using __typename.

Documentation:
- Document the interface default_resolver fix in a new patch RELEASE note with usage example.

Tests:
- Add regression test ensuring mappings returned for interface fields resolve correctly to concrete types by __typename.