### PR TITLE
Require release URL in social copy

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -86,9 +86,23 @@ jobs:
 
             Check social copy when present:
             - social_messages includes useful x and linkedin entries
+            - the X copy starts naturally, preferably with
+              "{project_name} {version} is out!"
+            - the LinkedIn copy starts naturally, preferably with
+              "{project_name} {version} is out."
+            - each post reads like a release announcement, not a compressed
+              changelog entry or implementation-first summary
+            - if the change is mainly useful for integration or framework
+              authors, the copy says that instead of implying every Strawberry
+              application needs to adopt it
             - the X copy is no longer than 280 characters after template
               variables are considered
+            - the X copy includes the website release URL template
+              `https://strawberry.rocks/release/{version}`
             - LinkedIn copy is clear as a standalone post
+            - detailed semantics, ordering rules, warnings, and edge cases stay
+              in the release note or docs unless they are the central
+              user-facing change
             - neither post leaks raw Markdown link syntax like [label](url)
 
             Deliver the review in up to three ways:
@@ -113,11 +127,17 @@ jobs:
                    release type: <the existing value>
                    social_messages:
                      x: >-
-                       {project_name} {version} <one concise sentence>
+                       {project_name} {version} is out! <one natural sentence
+                       about the user-facing change>. 🍓
+                       https://strawberry.rocks/release/{version}
                      linkedin: >-
-                       {project_name} {version} <one or two clear sentences>
-               Use the {project_name} and {version} placeholders verbatim, and
-               keep the x copy under 280 characters once they are filled in.
+                       {project_name} {version} is out. <one or two natural
+                       sentences about what changed, who benefits, and why it
+                       matters.>
+               Use the {project_name} and {version} placeholders verbatim. Use
+               the exact X URL template
+               `https://strawberry.rocks/release/{version}`, and keep the x
+               copy under 280 characters once placeholders are filled in.
 
             2. One sticky summary comment (always). Publish an overall summary
                as a single PR comment - actually post it, do not just return it

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -43,4 +43,4 @@ jobs:
           command: check
           autopub-version: "1.0.0a58"
           fail-on-missing: "true"
-          extra-plugins: "strawberry-autopub-plugins>=0.2.0"
+          extra-plugins: "strawberry-autopub-plugins>=0.3.0"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           command: check
           autopub-version: "1.0.0a58"
           github-token: ${{ secrets.BOT_TOKEN }}
-          extra-plugins: "strawberry-autopub-plugins>=0.2.0"
+          extra-plugins: "strawberry-autopub-plugins>=0.3.0"
 
   publish:
     name: Publish to PyPI
@@ -54,21 +54,21 @@ jobs:
         with:
           command: prepare
           autopub-version: "1.0.0a58"
-          extra-plugins: "strawberry-autopub-plugins>=0.2.0"
+          extra-plugins: "strawberry-autopub-plugins>=0.3.0"
 
       - name: Build package
         uses: autopub/autopub-action@5fdc82e84c048a82303de6b5c5a9d027665e73cf # v1.1.1
         with:
           command: build
           autopub-version: "1.0.0a58"
-          extra-plugins: "strawberry-autopub-plugins>=0.2.0"
+          extra-plugins: "strawberry-autopub-plugins>=0.3.0"
 
       - name: Publish to PyPI
         uses: autopub/autopub-action@5fdc82e84c048a82303de6b5c5a9d027665e73cf # v1.1.1
         with:
           command: publish
           autopub-version: "1.0.0a58"
-          extra-plugins: "strawberry-autopub-plugins>=0.2.0"
+          extra-plugins: "strawberry-autopub-plugins>=0.3.0"
           github-token: ${{ secrets.BOT_TOKEN }}
           git-username: botberry
           git-email: bot@strawberry.rocks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,10 +160,11 @@ Here's an example of RELEASE.md:
 release type: patch
 social_messages:
   x: >-
-    {project_name} {version} fixes schema printing for nullable input defaults.
+    {project_name} {version} is out! This release fixes schema printing for
+    nullable input defaults. https://strawberry.rocks/release/{version}
   linkedin: >-
-    {project_name} {version} fixes schema printing for nullable input defaults
-    so generated SDL now keeps explicit null values.
+    {project_name} {version} is out. This release fixes schema printing for
+    nullable input defaults so generated SDL now keeps explicit null values.
 ---
 
 This release fixes schema printing for nullable input defaults.
@@ -179,4 +180,5 @@ doubt feel free to ask.
 Release notes should start with `This release adds ...` or
 `This release fixes ...` and should explain the user-visible behavior first.
 Include social messages for X and LinkedIn so the release announcement reads
-well on each platform.
+well on each platform. X messages must include the website release URL template:
+`https://strawberry.rocks/release/{version}`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,6 +190,9 @@ platforms = ["x", "linkedin", "bluesky", "mastodon"]
 publish-mode = "next-free-slot"
 require-social-message = true
 required-social-platforms = ["x", "linkedin"]
+required-message-substrings = { x = [
+  "https://strawberry.rocks/release/{version}",
+] }
 require-release-note-lead = true
 
 [tool.pyright]


### PR DESCRIPTION
## Summary
- require the Strawberry website release URL in X social messages via AutoPub Typefully config
- update the Claude release-copy review prompt and CONTRIBUTING example so suggested social copy includes the URL
- require strawberry-autopub-plugins >=0.3.0 in release workflows so CI uses the plugin version with required-message-substrings support

## Validation
- git diff --check
- commit hooks: alex, whitespace, merge-conflict check, TOML check, blacken-docs, taplo-format passed

Note: actionlint is not installed locally, so workflow YAML was reviewed by diff only.

## Summary by Sourcery

Enforce inclusion of the Strawberry website release URL in X social release messages and align workflows, tooling, and documentation with this requirement.

New Features:
- Require a specific website release URL template in X social messages via AutoPub configuration.

Enhancements:
- Update the Claude release-copy review prompt and example social messages to reflect the required release URL and clearer announcement phrasing.
- Document the requirement for X messages to include the website release URL template in CONTRIBUTING guidelines.

Build:
- Bump strawberry-autopub-plugins dependency to >=0.3.0 in release-related GitHub workflows to use substring validation support.

CI:
- Adjust release and release-check workflows to use the updated autopub plugin version supporting required social message substrings.