### PR TITLE
fix(relay): return correct items when combining first with before

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,10 @@
+---
+release type: patch
+social_messages:
+  x: >-
+    {project_name} {version} is out! Fixes Relay pagination returning the wrong items when `first` and `before` are combined. 🍓 https://strawberry.rocks/release/{version}
+  linkedin: >-
+    {project_name} {version} is out. This patch fixes a Relay connection pagination bug where combining `first` with `before` returned items from the wrong end of the list instead of the first N items before the cursor.
+---
+
+This release fixes a bug in Relay connection pagination where combining `first` with `before` returned the wrong slice of items — walking backward from the `before` cursor instead of taking the first `first` items among those before it, per the Relay Cursor Connections spec.

--- a/strawberry/relay/utils.py
+++ b/strawberry/relay/utils.py
@@ -157,10 +157,7 @@ class SliceMetadata:
                     f"Argument 'first' cannot be higher than {max_results}."
                 )
 
-            if end is not None:
-                start = max(0, end - 1)
-
-            end = start + first
+            end = min(end, start + first) if end is not None else start + first
         if isinstance(last, int):
             if last < 0:
                 raise ValueError("Argument 'last' must be a non-negative integer.")

--- a/tests/relay/test_fields.py
+++ b/tests/relay/test_fields.py
@@ -769,6 +769,10 @@ async def test_query_connection_filtering_last_async(mocker, query_attr: str):
 
 @pytest.mark.parametrize("query_attr", attrs)
 def test_query_connection_filtering_first_with_before(query_attr: str):
+    # `before` bounds the edges to positions 0..2 (Banana, Apple, Pineapple);
+    # `first: 1` then takes the first 1 of *that* filtered slice, per the
+    # Relay spec's reference algorithm -- not the 1 item immediately
+    # preceding the `before` cursor.
     result = schema.execute_sync(
         fruits_query.format(query_attr),
         variable_values={"first": 1, "before": to_base64("arrayconnection", "3")},
@@ -778,19 +782,19 @@ def test_query_connection_filtering_first_with_before(query_attr: str):
         query_attr: {
             "edges": [
                 {
-                    "cursor": "YXJyYXljb25uZWN0aW9uOjI=",
+                    "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
                     "node": {
-                        "id": to_base64("Fruit", 3),
+                        "id": to_base64("Fruit", 1),
                         "color": "yellow",
-                        "name": "Pineapple",
+                        "name": "Banana",
                     },
                 },
             ],
             "pageInfo": {
                 "hasNextPage": True,
-                "hasPreviousPage": True,
-                "startCursor": to_base64("arrayconnection", "2"),
-                "endCursor": to_base64("arrayconnection", "2"),
+                "hasPreviousPage": False,
+                "startCursor": to_base64("arrayconnection", "0"),
+                "endCursor": to_base64("arrayconnection", "0"),
             },
         }
     }
@@ -811,19 +815,19 @@ async def test_query_connection_filtering_first_with_before_async(
         query_attr: {
             "edges": [
                 {
-                    "cursor": "YXJyYXljb25uZWN0aW9uOjI=",
+                    "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
                     "node": {
-                        "id": to_base64("Fruit", 3),
+                        "id": to_base64("Fruit", 1),
                         "color": "yellow",
-                        "name": "Pineapple",
+                        "name": "Banana",
                     },
                 },
             ],
             "pageInfo": {
                 "hasNextPage": True,
-                "hasPreviousPage": True,
-                "startCursor": to_base64("arrayconnection", "2"),
-                "endCursor": to_base64("arrayconnection", "2"),
+                "hasPreviousPage": False,
+                "startCursor": to_base64("arrayconnection", "0"),
+                "endCursor": to_base64("arrayconnection", "0"),
             },
         }
     }

--- a/tests/relay/test_utils.py
+++ b/tests/relay/test_utils.py
@@ -194,6 +194,12 @@ def test_get_slice_metadata(
         # `after` establishes the true start; `before` bounds the end; `first`
         # must only shrink that window from the end, never move `start`.
         (20, 5, 3, SliceMetadata(start=6, end=9, expected=3)),
+        # `first=0` boundary: an empty slice anchored at the start of the
+        # `before`-bounded window (position 0 here, since there is no `after`).
+        (15, None, 0, SliceMetadata(start=0, end=0, expected=0)),
+        # `first=0` with `after` set: still an empty slice, but anchored at the
+        # `after`-derived start (position 6), not reset to 0.
+        (15, 5, 0, SliceMetadata(start=6, end=6, expected=0)),
     ],
 )
 def test_get_slice_metadata_first_with_before(

--- a/tests/relay/test_utils.py
+++ b/tests/relay/test_utils.py
@@ -144,8 +144,8 @@ def test_to_base64_with_invalid_type(value: Any):
             10,
             None,
             100,
-            SliceMetadata(start=14, end=24, expected=10),
-            25,
+            SliceMetadata(start=0, end=10, expected=10),
+            11,
         ),
         (
             None,
@@ -178,3 +178,41 @@ def test_get_slice_metadata(
     )
     assert slice_metadata == expected
     assert slice_metadata.overfetch == expected_overfetch
+
+
+@pytest.mark.parametrize(
+    ("before", "after", "first", "expected"),
+    [
+        # `before=15, first=10`: the Relay spec's reference algorithm applies
+        # `before` first (keep edges strictly before it, i.e. positions 0..14),
+        # then `first` takes the first N of *that* filtered slice. The result
+        # must stay anchored at 0, not jump forward to just before `before`.
+        (15, None, 10, SliceMetadata(start=0, end=10, expected=10)),
+        # Fewer edges exist before the cursor than `first` asks for: the
+        # window is bounded by `before`, not padded out to `first` items.
+        (5, None, 10, SliceMetadata(start=0, end=5, expected=5)),
+        # `after` establishes the true start; `before` bounds the end; `first`
+        # must only shrink that window from the end, never move `start`.
+        (20, 5, 3, SliceMetadata(start=6, end=9, expected=3)),
+    ],
+)
+def test_get_slice_metadata_first_with_before(
+    before: int,
+    after: int | None,
+    first: int,
+    expected: SliceMetadata,
+):
+    """Regression test: `first` combined with `before` must paginate forward
+    from the existing `start` (0, or wherever `after` put it), capping `end`
+    at `start + first` -- not discard `start` and walk backward from `before`.
+    """
+    info = mock.Mock()
+    info.schema.config = StrawberryConfig(relay_max_results=100)
+    slice_metadata = SliceMetadata.from_arguments(
+        info,
+        before=to_base64(PREFIX, before),
+        after=after and to_base64(PREFIX, after),
+        first=first,
+        last=None,
+    )
+    assert slice_metadata == expected


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

`first` combined with `before` returned the wrong slice — it walked backward from `before` instead of taking the first N items of the before-bounded list, per the Relay spec. The fix mirrors what the `last` branch already does correctly (adjust
the far bound, keep the near one fixed): cap `end` at `start + first` instead of overwriting `start`.

Two existing tests had asserted the buggy output — corrected both to the spec-correct values (verified by running the actual query and checking the result). Added 3 new regression tests for `first`+`before` alone, `first`+`before` with fewer items than `first` asks for, and `after`+`before`+`first` together (also silently broken before this fix).

Used an AI assistant to find this bug and draft the fix; I reviewed, ran the full test suite, and verified the corrected outputs myself before submitting.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*Fixes #4515

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Fix Relay connection pagination to return the correct slice when combining `first` with `before`, and mark the change as a patch release.

Bug Fixes:
- Correct handling of `first` with `before` so pagination returns the first N items before the cursor instead of walking backward from the `before` position.

Enhancements:
- Align Relay pagination behavior with the Relay Cursor Connections specification for `first` and `before` bounds.

Documentation:
- Add release notes describing the Relay pagination bug fix and its impact.

Tests:
- Update existing Relay pagination tests to assert spec-compliant behavior for `first` with `before`, and add regression tests covering `first`+`before` and `after`+`before`+`first` combinations.

Chores:
- Add release metadata marking this change as a patch release with prepared social media messages.