### PR TITLE
Add support for typing.Literal annotations

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,6 +14,24 @@ social_messages:
 This release adds support for using `typing.Literal` annotations in Strawberry
 fields and arguments.
 
+```python
+from typing import Literal
+
+import strawberry
+
+
+@strawberry.type
+class Query:
+    status: Literal["ready"] = "ready"
+
+    @strawberry.field
+    def echo_priority(self, priority: Literal[1, 2, 3]) -> int:
+        return priority
+
+
+schema = strawberry.Schema(query=Query)
+```
+
 Homogeneous string, integer, and boolean literals map to their underlying
 GraphQL scalar type. Strawberry validates input values against the allowed
 literal values before calling the resolver, including literals nested inside

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,25 @@
+---
+release type: minor
+social_messages:
+  x: >-
+    {project_name} {version} is out! Strawberry fields and arguments can now use
+    typing.Literal, with allowed input values checked before resolvers run. 🍓
+    https://strawberry.rocks/release/{version}
+  linkedin: >-
+    {project_name} {version} is out. Strawberry fields and arguments can now use
+    typing.Literal annotations. Literal values map to their underlying GraphQL
+    scalar, and Strawberry validates inputs before calling resolvers.
+---
+
+This release adds support for using `typing.Literal` annotations in Strawberry
+fields and arguments.
+
+Homogeneous string, integer, and boolean literals map to their underlying
+GraphQL scalar type. Strawberry validates input values against the allowed
+literal values before calling the resolver, including literals nested inside
+input objects, lists, and optional fields.
+
+GraphQL introspection exposes the underlying scalar rather than the allowed
+values. Applications that need clients to discover the available choices from
+the schema should continue to use Strawberry enums. Mixed or unsupported literal
+value types produce an error when the schema is created.

--- a/docs/concepts/typings.md
+++ b/docs/concepts/typings.md
@@ -52,6 +52,35 @@ express the required Strawberry graphQL type annotation.
 - The annotation `typing.Optional[Type]` is shorthand for
   `typing.Union[None, Type]`, which is itself equivalent to `None | Type`.
 
+## Literal types
+
+Strawberry supports homogeneous `typing.Literal` annotations containing strings,
+integers, or booleans. They are represented in the GraphQL schema by their
+underlying scalar type:
+
+```python
+from typing import Literal
+
+import strawberry
+
+
+@strawberry.type
+class Query:
+    status: Literal["ready"]
+
+    @strawberry.field
+    def echo_priority(self, priority: Literal[1, 2, 3]) -> int:
+        return priority
+```
+
+This produces `String` for `status` and `Int` for `priority`. Strawberry also
+checks input values against the allowed values before calling the resolver.
+
+GraphQL introspection exposes the underlying scalar rather than the allowed
+values. Use a Strawberry enum when clients need to discover the choices from the
+schema. Literal annotations containing mixed or unsupported value types raise an
+error while the schema is being created.
+
 ## Example
 
 A complete example of this, extending upon

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -73,6 +73,7 @@ from strawberry.types.cast import get_strawberry_type_cast
 from strawberry.types.enum import StrawberryEnumDefinition, has_enum_definition
 from strawberry.types.field import UNRESOLVED
 from strawberry.types.lazy_type import LazyType
+from strawberry.types.literal import get_literal_python_type, is_literal
 from strawberry.types.private import is_private
 from strawberry.types.scalar import ScalarWrapper, scalar
 from strawberry.types.union import StrawberryUnion
@@ -1199,6 +1200,9 @@ class GraphQLCoreConverter:
             type_, self.scalar_registry
         ):  # TODO: Replace with StrawberryScalar
             return self.from_scalar(type_)
+
+        if is_literal(type_):
+            return self.from_scalar(get_literal_python_type(type_))
 
         raise TypeError(f"Unexpected type '{type_}'")
 

--- a/strawberry/types/arguments.py
+++ b/strawberry/types/arguments.py
@@ -21,6 +21,7 @@ from strawberry.types.base import (
 )
 from strawberry.types.enum import StrawberryEnumDefinition, has_enum_definition
 from strawberry.types.lazy_type import LazyType, StrawberryLazyReference
+from strawberry.types.literal import is_literal, is_valid_literal_value
 from strawberry.types.maybe import Some
 from strawberry.types.unset import UNSET
 
@@ -233,6 +234,15 @@ def convert_argument(
     if _is_leaf_type(type_, scalar_registry):
         if type_ is GlobalID:
             return GlobalID.from_id(value)  # type: ignore
+
+        return value
+
+    if is_literal(type_):
+        if not is_valid_literal_value(type_, value):
+            values = get_args(type_)
+            raise ValueError(
+                f"Expected value to be one of {values!r}; received {value!r}"
+            )
 
         return value
 

--- a/strawberry/types/literal.py
+++ b/strawberry/types/literal.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import typing
+from typing import get_args, get_origin
+
+LiteralPythonType = type[str] | type[int] | type[bool]
+
+_SUPPORTED_LITERAL_TYPES: tuple[LiteralPythonType, ...] = (str, int, bool)
+
+
+def is_literal(annotation: object) -> bool:
+    return annotation is typing.Literal or get_origin(annotation) is typing.Literal
+
+
+def get_literal_python_type(annotation: object) -> LiteralPythonType:
+    values = get_args(annotation)
+
+    if not values:
+        raise TypeError("Literal must contain at least one value")
+
+    value_types = {type(value) for value in values}
+
+    if len(value_types) != 1:
+        raise TypeError(f"Literal values must all have the same type; got {values!r}")
+
+    value_type = value_types.pop()
+
+    if value_type not in _SUPPORTED_LITERAL_TYPES:
+        raise TypeError(
+            f"Unsupported Literal values {values!r}; "
+            "only str, int, and bool values are supported"
+        )
+
+    return value_type
+
+
+def is_valid_literal_value(annotation: object, value: object) -> bool:
+    get_literal_python_type(annotation)
+
+    return any(
+        type(value) is type(expected) and value == expected
+        for expected in get_args(annotation)
+    )
+
+
+__all__ = ["get_literal_python_type", "is_literal", "is_valid_literal_value"]

--- a/tests/schema/test_literal.py
+++ b/tests/schema/test_literal.py
@@ -1,0 +1,191 @@
+from enum import Enum
+from textwrap import dedent
+from typing import Literal
+
+import pytest
+
+import strawberry
+from strawberry.types.literal import is_valid_literal_value
+
+
+def test_literal_fields_use_the_underlying_scalar_type() -> None:
+    @strawberry.type
+    class Query:
+        status: Literal["ready"]
+        priority: Literal[1, 2]
+        enabled: Literal[True]
+
+    schema = strawberry.Schema(query=Query)
+
+    assert str(schema) == dedent(
+        """\
+        type Query {
+          status: String!
+          priority: Int!
+          enabled: Boolean!
+        }"""
+    )
+
+    result = schema.execute_sync(
+        "{ status priority enabled }",
+        root_value=Query(status="ready", priority=2, enabled=True),
+    )
+
+    assert not result.errors
+    assert result.data == {"status": "ready", "priority": 2, "enabled": True}
+
+
+def test_literal_string_annotation_is_resolved() -> None:
+    @strawberry.type
+    class Query:
+        status: 'Literal["ready"]'
+
+    schema = strawberry.Schema(query=Query)
+
+    assert "status: String!" in str(schema)
+
+
+def test_literal_argument_accepts_an_allowed_value() -> None:
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def echo(self, value: Literal["one", "two"]) -> str:
+            return value
+
+    schema = strawberry.Schema(query=Query)
+    result = schema.execute_sync('{ echo(value: "two") }')
+
+    assert not result.errors
+    assert result.data == {"echo": "two"}
+
+
+def test_literal_argument_rejects_a_disallowed_value() -> None:
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def echo(self, value: Literal["one", "two"]) -> str:
+            return value
+
+    schema = strawberry.Schema(query=Query)
+    result = schema.execute_sync('{ echo(value: "three") }')
+
+    assert result.data is None
+    assert result.errors
+    assert result.errors[0].message == (
+        "Expected value to be one of ('one', 'two'); received 'three'"
+    )
+
+
+def test_literals_work_in_nested_optional_and_list_inputs() -> None:
+    @strawberry.input
+    class Settings:
+        mode: Literal["fast", "safe"]
+        retries: Literal[1, 2, 3] | None
+        flags: list[Literal[True, False]]
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def inspect_settings(self, settings: Settings) -> str:
+            return f"{settings.mode}:{settings.retries}:{settings.flags}"
+
+    schema = strawberry.Schema(query=Query)
+    result = schema.execute_sync(
+        """
+        query InspectSettings($settings: Settings!) {
+          inspectSettings(settings: $settings)
+        }
+        """,
+        variable_values={
+            "settings": {"mode": "safe", "retries": None, "flags": [True, False]}
+        },
+    )
+
+    assert not result.errors
+    assert result.data == {"inspectSettings": "safe:None:[True, False]"}
+
+
+def test_literal_validation_runs_inside_nested_lists() -> None:
+    @strawberry.input
+    class Settings:
+        modes: list[Literal["fast", "safe"]]
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def inspect_settings(self, settings: Settings) -> str:
+            return ",".join(settings.modes)
+
+    schema = strawberry.Schema(query=Query)
+    result = schema.execute_sync(
+        """
+        query InspectSettings($settings: Settings!) {
+          inspectSettings(settings: $settings)
+        }
+        """,
+        variable_values={"settings": {"modes": ["fast", "invalid"]}},
+    )
+
+    assert result.data is None
+    assert result.errors
+    assert result.errors[0].message == (
+        "Expected value to be one of ('fast', 'safe'); received 'invalid'"
+    )
+
+
+def test_literal_values_must_have_the_same_type() -> None:
+    @strawberry.type
+    class Query:
+        value: Literal[1, True]
+
+    with pytest.raises(
+        TypeError,
+        match=r"Literal values must all have the same type; got \(1, True\)",
+    ):
+        strawberry.Schema(query=Query)
+
+
+@pytest.mark.parametrize(
+    "annotation",
+    [Literal[1.0], Literal[b"value"], Literal[None]],  # noqa: PYI061
+)
+def test_unsupported_literal_types_are_rejected(annotation: object) -> None:
+    class Query:
+        __annotations__ = {"value": annotation}
+
+    query_type = strawberry.type(Query)
+
+    with pytest.raises(
+        TypeError,
+        match="only str, int, and bool values are supported",
+    ):
+        strawberry.Schema(query=query_type)
+
+
+def test_empty_literal_is_rejected() -> None:
+    @strawberry.type
+    class Query:
+        value: Literal[()]  # pyright: ignore[reportInvalidTypeForm]
+
+    with pytest.raises(TypeError, match="Literal must contain at least one value"):
+        strawberry.Schema(query=Query)
+
+
+def test_literal_validation_distinguishes_booleans_and_integers() -> None:
+    assert is_valid_literal_value(Literal[1], 1)
+    assert not is_valid_literal_value(Literal[1], True)
+
+
+def test_enum_literal_is_rejected() -> None:
+    class Status(Enum):
+        READY = "ready"
+
+    @strawberry.type
+    class Query:
+        value: Literal[Status.READY]
+
+    with pytest.raises(
+        TypeError,
+        match="only str, int, and bool values are supported",
+    ):
+        strawberry.Schema(query=Query)


### PR DESCRIPTION
To discuss if we want to magically map string literals to enums 🤔

## Summary

- map homogeneous string, integer, and boolean `typing.Literal` annotations to their underlying GraphQL scalar
- validate Literal argument values before calling resolvers, including nested inputs, lists, and optional fields
- reject mixed, empty, and unsupported Literal definitions during schema creation
- document the GraphQL introspection tradeoff and add a minor release note

## Why

Literal support is useful independently of the first-class Pydantic integration. Keeping it in Strawberry core lets that work rely on a complete, tested feature instead of carrying a Pydantic-specific schema conversion.

GraphQL introspection exposes the underlying scalar rather than the allowed values. Applications that need discoverable choices should continue to use Strawberry enums.

## Validation

- `uv run pytest tests/schema/test_literal.py tests/utils/test_arguments_converter.py tests/types/test_annotation.py -q` — 73 passed
- `uv run pytest -q` — 5,096 passed; the only local failure was the missing `ty` executable
- `uv run --with ty pytest tests/typecheckers/test_pydantic.py -q` — passed
- repository-wide Ruff — passed
- exact CI mypy command — passed across 241 source files
- focused Pyright — passed
- pre-commit hooks — passed
- AutoPub release check — passed

## Summary by Sourcery

Add core support for typing.Literal annotations, mapping supported literals to their underlying GraphQL scalar types and validating literal inputs at runtime.

New Features:
- Support typing.Literal annotations for Strawberry fields and arguments using homogeneous string, integer, and boolean values.
- Validate literal argument and input object values against their allowed set before invoking resolvers, including nested optionals and lists.

Enhancements:
- Reject empty, mixed-type, or unsupported typing.Literal definitions during schema creation to prevent invalid schemas.

Documentation:
- Document how typing.Literal annotations are handled in Strawberry, including GraphQL introspection behavior and guidance on when to use enums instead.

Tests:
- Add dedicated tests covering literal field schema mapping, input validation, nested input/list handling, and error cases for invalid literal definitions.

Chores:
- Add a minor RELEASE.md entry announcing typing.Literal support and its behavior in Strawberry.