### PR TITLE
fix: preserve None annotations on explicit fields

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,14 @@
+---
+release type: patch
+social_messages:
+  x: >-
+    {project_name} {version} is out! Fields annotated with `None` now work with
+    `strawberry.field()`. 🍓 https://strawberry.rocks/release/{version}
+  linkedin: >-
+    {project_name} {version} is out. Fields annotated with `None` now work when
+    declared with `strawberry.field()`, matching other Void field declarations.
+---
+
+This release fixes schema generation for fields annotated with `None` and declared
+with `strawberry.field()`. They now produce the `Void` scalar instead of raising
+`UnresolvedFieldTypeError`.

--- a/strawberry/types/type_resolver.py
+++ b/strawberry/types/type_resolver.py
@@ -127,6 +127,17 @@ def _get_fields(
     # then we can proceed with finding the fields for the current class
     for field in dataclasses.fields(cls):  # type: ignore
         if isinstance(field, StrawberryField):
+            # ``dataclasses`` assigns annotations through ``StrawberryField.type``.
+            # A literal ``None`` is otherwise mistaken for its initialization value.
+            if (
+                field.type_annotation is None
+                and field.name is not None
+                and field.name in cls.__annotations__
+            ):
+                field.type_annotation = StrawberryAnnotation(
+                    annotation=cls.__annotations__[field.name]
+                )
+
             # Check for conflict: strawberry.field in both Annotated and assignment
             annotation = (
                 field.type_annotation.annotation

--- a/tests/schema/test_scalars.py
+++ b/tests/schema/test_scalars.py
@@ -66,6 +66,32 @@ def test_void_function():
     assert result.errors
 
 
+def test_void_field_with_strawberry_field():
+    @strawberry.type
+    class Query:
+        value: None = strawberry.field()
+
+    schema = strawberry.Schema(query=Query)
+
+    assert (
+        str(schema)
+        == dedent(
+            '''
+      type Query {
+        value: Void
+      }
+
+      """Represents NULL values"""
+      scalar Void
+    '''
+        ).strip()
+    )
+
+    result = schema.execute_sync("query { value }", root_value=Query(value=None))
+    assert not result.errors
+    assert result.data == {"value": None}
+
+
 def test_uuid_field_string_value():
     @strawberry.type
     class Query:


### PR DESCRIPTION
Fixes #3493.

A literal `None` annotation was dropped when `dataclasses` initialized an explicit `strawberry.field()`, leaving the field unresolved. Restore the annotation from the class before field resolution so it maps to `Void`, matching plain and resolver-backed fields; regression coverage verifies schema generation and execution.

## Summary by Sourcery

Preserve literal None annotations on explicit strawberry.field declarations so they resolve to the Void scalar instead of remaining unresolved.

Bug Fixes:
- Restore type annotations for dataclass fields backed by strawberry.field when the annotation is literally None, ensuring they resolve to the Void scalar rather than causing UnresolvedFieldTypeError.

Documentation:
- Add release notes describing the fix for None-annotated fields declared with strawberry.field and their mapping to the Void scalar.

Tests:
- Add regression test ensuring fields annotated with None and declared via strawberry.field generate the Void scalar and execute successfully.