### PR TITLE
fix: coerce non-string input for built-in scalars into clean errors

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+The built-in `UUID`, `Date`, `DateTime`, and `Time` scalars now reject non-string variable values with a standard coercion error, matching the existing `Decimal` behavior, instead of raising an unhandled `AttributeError`/`TypeError` inside the parser. Previously a value like `{"id": 469610.0}` sent into a `UUID` position crashed with `'float' object has no attribute 'replace'` and surfaced in error trackers as a server-side exception.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,24 @@
-Release type: patch
+---
+release type: patch
+social_messages:
+  x: >-
+    {project_name} {version} is out! This release fixes the built-in UUID,
+    Date, DateTime and Time scalars to reject non-string values with a proper
+    coercion error instead of crashing with an unhandled exception. 🍓
+    https://strawberry.rocks/release/{version}
+  linkedin: >-
+    {project_name} {version} is out. The built-in UUID, Date, DateTime and
+    Time scalars now reject non-string variable values with a standard GraphQL
+    coercion error instead of raising an unhandled AttributeError or
+    TypeError, keeping plain bad client input out of server-side error
+    tracking.
+---
 
-The built-in `UUID`, `Date`, `DateTime`, and `Time` scalars now reject non-string variable values with a standard coercion error, matching the existing `Decimal` behavior, instead of raising an unhandled `AttributeError`/`TypeError` inside the parser. Previously a value like `{"id": 469610.0}` sent into a `UUID` position crashed with `'float' object has no attribute 'replace'` and surfaced in error trackers as a server-side exception.
+This release fixes the built-in `UUID`, `Date`, `DateTime`, and `Time` scalars
+to reject non-string variable values with a standard coercion error instead of
+raising an unhandled `AttributeError`/`TypeError` inside the parser.
+
+Previously a value like `{"id": 469610.0}` sent into a `UUID` position crashed
+with `'float' object has no attribute 'replace'` and surfaced in error
+trackers as a server-side exception. The `Decimal` scalar keeps accepting
+numeric input by stringifying it, as before.

--- a/strawberry/schema/types/base_scalars.py
+++ b/strawberry/schema/types/base_scalars.py
@@ -15,18 +15,26 @@ def wrap_parser(
     type_: str,
     exceptions: tuple[type[Exception], ...] = (ValueError,),
     include_error: bool = True,
+    accept_non_string: bool = False,
 ) -> Callable[[object], object]:
     """Wrap a string parser so any invalid input becomes a clean coercion error.
 
-    The value is stringified before parsing so that non-string input (e.g. a
-    numeric id sent by a client) takes the same ``GraphQLError`` path as a
-    malformed string, instead of raising ``AttributeError``/``TypeError``
-    inside the parser and surfacing as a server-side crash.
+    Non-string input is rejected up front so the parser can never crash with
+    ``AttributeError``/``TypeError`` on unexpected value types and surface as
+    a server-side error. ``accept_non_string`` stringifies non-string input
+    instead of rejecting it, for scalars that accept it by design (``Decimal``
+    accepts numeric input this way).
     """
 
     def inner(value: object) -> object:
+        if not isinstance(value, str):
+            if not accept_non_string:
+                raise GraphQLError(
+                    f'Value cannot represent a {type_}: "{value}". Expected a string.'
+                )
+            value = str(value)
         try:
-            return parser(str(value))
+            return parser(value)
         except exceptions as e:
             detail = f" {e}" if include_error else ""
             raise GraphQLError(
@@ -79,6 +87,7 @@ DecimalDefinition: ScalarDefinition = ScalarDefinition(
         "Decimal",
         exceptions=(decimal.DecimalException,),
         include_error=False,
+        accept_non_string=True,
     ),
     parse_literal=None,
     origin=decimal.Decimal,

--- a/strawberry/schema/types/base_scalars.py
+++ b/strawberry/schema/types/base_scalars.py
@@ -10,23 +10,30 @@ from graphql import GraphQLError
 from strawberry.types.scalar import ScalarDefinition
 
 
-def wrap_parser(parser: Callable, type_: str) -> Callable:
-    def inner(value: str) -> object:
+def wrap_parser(
+    parser: Callable[[str], object],
+    type_: str,
+    exceptions: tuple[type[Exception], ...] = (ValueError,),
+    include_error: bool = True,
+) -> Callable[[object], object]:
+    """Wrap a string parser so any invalid input becomes a clean coercion error.
+
+    The value is stringified before parsing so that non-string input (e.g. a
+    numeric id sent by a client) takes the same ``GraphQLError`` path as a
+    malformed string, instead of raising ``AttributeError``/``TypeError``
+    inside the parser and surfacing as a server-side crash.
+    """
+
+    def inner(value: object) -> object:
         try:
-            return parser(value)
-        except ValueError as e:
-            raise GraphQLError(  # noqa: B904
-                f'Value cannot represent a {type_}: "{value}". {e}'
-            )
+            return parser(str(value))
+        except exceptions as e:
+            detail = f" {e}" if include_error else ""
+            raise GraphQLError(
+                f'Value cannot represent a {type_}: "{value}".{detail}'
+            ) from None
 
     return inner
-
-
-def parse_decimal(value: object) -> decimal.Decimal:
-    try:
-        return decimal.Decimal(str(value))
-    except decimal.DecimalException:
-        raise GraphQLError(f'Value cannot represent a Decimal: "{value}".')  # noqa: B904
 
 
 isoformat = methodcaller("isoformat")
@@ -67,7 +74,12 @@ DecimalDefinition: ScalarDefinition = ScalarDefinition(
     description="Decimal (fixed-point)",
     specified_by_url=None,
     serialize=str,
-    parse_value=parse_decimal,
+    parse_value=wrap_parser(
+        decimal.Decimal,
+        "Decimal",
+        exceptions=(decimal.DecimalException,),
+        include_error=False,
+    ),
     parse_literal=None,
     origin=decimal.Decimal,
 )

--- a/tests/schema/types/test_date.py
+++ b/tests/schema/types/test_date.py
@@ -134,4 +134,7 @@ def test_parsing_of_non_string_value(value):
     result = execute_mutation(value)
     assert result.errors
     assert isinstance(result.errors[0], GraphQLError)
-    assert f'Value cannot represent a Date: "{value}".' in result.errors[0].message
+    assert (
+        f'Value cannot represent a Date: "{value}". Expected a string.'
+        in result.errors[0].message
+    )

--- a/tests/schema/types/test_date.py
+++ b/tests/schema/types/test_date.py
@@ -124,3 +124,14 @@ def test_serialization_error_message_for_incorrect_date_string():
     assert result.errors[0].message.startswith(
         expected_message,
     )
+
+
+@pytest.mark.parametrize("value", [1.5, 10, True])
+def test_parsing_of_non_string_value(value):
+    """Test GraphQLError is raised for a non-string value.
+    The parser must not leak a TypeError from ``fromisoformat``.
+    """
+    result = execute_mutation(value)
+    assert result.errors
+    assert isinstance(result.errors[0], GraphQLError)
+    assert f'Value cannot represent a Date: "{value}".' in result.errors[0].message

--- a/tests/schema/types/test_datetime.py
+++ b/tests/schema/types/test_datetime.py
@@ -184,4 +184,7 @@ def test_parsing_of_non_string_value(value):
     result = execute_mutation(value)
     assert result.errors
     assert isinstance(result.errors[0], GraphQLError)
-    assert f'Value cannot represent a DateTime: "{value}".' in result.errors[0].message
+    assert (
+        f'Value cannot represent a DateTime: "{value}". Expected a string.'
+        in result.errors[0].message
+    )

--- a/tests/schema/types/test_datetime.py
+++ b/tests/schema/types/test_datetime.py
@@ -174,3 +174,14 @@ def test_serialization_error_message_for_incorrect_datetime_string():
     assert result.errors[0].message.startswith(
         expected_message,
     )
+
+
+@pytest.mark.parametrize("value", [1.5, 10, True])
+def test_parsing_of_non_string_value(value):
+    """Test GraphQLError is raised for a non-string value.
+    The parser must not leak a TypeError from ``dateutil``.
+    """
+    result = execute_mutation(value)
+    assert result.errors
+    assert isinstance(result.errors[0], GraphQLError)
+    assert f'Value cannot represent a DateTime: "{value}".' in result.errors[0].message

--- a/tests/schema/types/test_decimal.py
+++ b/tests/schema/types/test_decimal.py
@@ -110,3 +110,6 @@ def test_parsing_of_non_decimal_value():
         'Decimal: "True".'
     )
     assert result.errors[0].message == expected_message
+    original_error = result.errors[0].original_error
+    assert isinstance(original_error, GraphQLError)
+    assert original_error.original_error is None

--- a/tests/schema/types/test_decimal.py
+++ b/tests/schema/types/test_decimal.py
@@ -72,3 +72,41 @@ def test_serialization_of_incorrect_decimal_string():
         'Decimal: "fail".'
     )
     assert result.errors[0].message == expected_message
+
+
+def test_parsing_of_non_decimal_value():
+    """Test GraphQLError is raised for a value ``Decimal`` cannot parse.
+    The error should exclude "original_error".
+    """
+
+    @strawberry.type
+    class Query:
+        ok: bool
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        def decimal_input(self, decimal_input: Decimal) -> Decimal:
+            return decimal_input
+
+    schema = strawberry.Schema(query=Query, mutation=Mutation)
+
+    result = schema.execute_sync(
+        """
+            mutation decimalInput($value: Decimal!) {
+                decimalInput(decimalInput: $value)
+            }
+        """,
+        variable_values={"value": True},
+    )
+
+    assert result.errors
+    assert isinstance(result.errors[0], GraphQLError)
+    expected_message = (
+        "Variable '$value' got invalid value True; Value cannot represent a "
+        'Decimal: "True".'
+        if IS_GQL_32
+        else "Variable '$value' has invalid value: Value cannot represent a "
+        'Decimal: "True".'
+    )
+    assert result.errors[0].message == expected_message

--- a/tests/schema/types/test_time.py
+++ b/tests/schema/types/test_time.py
@@ -125,7 +125,7 @@ def test_serialization_error_message_for_incorrect_time_string():
     )
 
 
-@pytest.mark.parametrize("value", [1.5, 99, True])
+@pytest.mark.parametrize("value", [1.5, 10, True])
 def test_parsing_of_non_string_value(value):
     """Test GraphQLError is raised for a non-string value.
     The parser must not leak a TypeError from ``fromisoformat``.
@@ -133,4 +133,7 @@ def test_parsing_of_non_string_value(value):
     result = execute_mutation(value)
     assert result.errors
     assert isinstance(result.errors[0], GraphQLError)
-    assert f'Value cannot represent a Time: "{value}".' in result.errors[0].message
+    assert (
+        f'Value cannot represent a Time: "{value}". Expected a string.'
+        in result.errors[0].message
+    )

--- a/tests/schema/types/test_time.py
+++ b/tests/schema/types/test_time.py
@@ -123,3 +123,14 @@ def test_serialization_error_message_for_incorrect_time_string():
     assert result.errors[0].message.startswith(
         expected_message,
     )
+
+
+@pytest.mark.parametrize("value", [1.5, 99, True])
+def test_parsing_of_non_string_value(value):
+    """Test GraphQLError is raised for a non-string value.
+    The parser must not leak a TypeError from ``fromisoformat``.
+    """
+    result = execute_mutation(value)
+    assert result.errors
+    assert isinstance(result.errors[0], GraphQLError)
+    assert f'Value cannot represent a Time: "{value}".' in result.errors[0].message

--- a/tests/schema/types/test_uuid.py
+++ b/tests/schema/types/test_uuid.py
@@ -72,3 +72,41 @@ def test_serialization_of_incorrect_uuid_string():
         'UUID: "fail". badly formed hexadecimal UUID string'
     )
     assert result.errors[0].message == expected_message
+
+
+def test_parsing_of_non_string_value():
+    """Test GraphQLError is raised for a non-string value.
+    The parser must not leak an AttributeError from ``uuid.UUID``.
+    """
+
+    @strawberry.type
+    class Query:
+        ok: bool
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        def uuid_input(self, uuid_input: uuid.UUID) -> uuid.UUID:
+            return uuid_input
+
+    schema = strawberry.Schema(query=Query, mutation=Mutation)
+
+    result = schema.execute_sync(
+        """
+            mutation uuidInput($value: UUID!) {
+                uuidInput(uuidInput: $value)
+            }
+        """,
+        variable_values={"value": 469610.0},
+    )
+
+    assert result.errors
+    assert isinstance(result.errors[0], GraphQLError)
+    expected_message = (
+        "Variable '$value' got invalid value 469610.0; Value cannot represent a "
+        'UUID: "469610.0". badly formed hexadecimal UUID string'
+        if IS_GQL_32
+        else "Variable '$value' has invalid value: Value cannot represent a "
+        'UUID: "469610.0". badly formed hexadecimal UUID string'
+    )
+    assert result.errors[0].message == expected_message

--- a/tests/schema/types/test_uuid.py
+++ b/tests/schema/types/test_uuid.py
@@ -1,5 +1,6 @@
 import uuid
 
+import pytest
 from graphql import GraphQLError
 
 import strawberry
@@ -74,9 +75,20 @@ def test_serialization_of_incorrect_uuid_string():
     assert result.errors[0].message == expected_message
 
 
-def test_parsing_of_non_string_value():
+@pytest.mark.parametrize(
+    "value",
+    [
+        469610.0,
+        # would stringify into 32 valid hexadecimal characters, so it must be
+        # rejected by type, not by parsing
+        10000000000000000000000000000000,
+        True,
+    ],
+)
+def test_parsing_of_non_string_value(value):
     """Test GraphQLError is raised for a non-string value.
-    The parser must not leak an AttributeError from ``uuid.UUID``.
+    The parser must not leak an AttributeError from ``uuid.UUID``, and the
+    string form of the value must not be accepted either.
     """
 
     @strawberry.type
@@ -97,16 +109,14 @@ def test_parsing_of_non_string_value():
                 uuidInput(uuidInput: $value)
             }
         """,
-        variable_values={"value": 469610.0},
+        variable_values={"value": value},
     )
 
     assert result.errors
-    assert isinstance(result.errors[0], GraphQLError)
-    expected_message = (
-        "Variable '$value' got invalid value 469610.0; Value cannot represent a "
-        'UUID: "469610.0". badly formed hexadecimal UUID string'
-        if IS_GQL_32
-        else "Variable '$value' has invalid value: Value cannot represent a "
-        'UUID: "469610.0". badly formed hexadecimal UUID string'
+    error = result.errors[0]
+    assert isinstance(error, GraphQLError)
+    assert (
+        f'Value cannot represent a UUID: "{value}". Expected a string.' in error.message
     )
-    assert result.errors[0].message == expected_message
+    assert isinstance(error.original_error, GraphQLError)
+    assert error.original_error.original_error is None


### PR DESCRIPTION
## Description

Non-string variable values sent into the built-in `UUID`, `Date`, `DateTime`, and `Time` scalars raised `AttributeError`/`TypeError` inside the parser (e.g. `'float' object has no attribute 'replace'` from `uuid.UUID`), which graphql-core re-raises with the original stack trace attached, so error trackers report plain invalid client input as a server-side crash (see #4524 for a full repro).

As discussed in the issue, this makes `wrap_parser` generic instead of adding more small per-scalar functions:

- Non-string input is rejected up front with a clean coercion error (`Value cannot represent a UUID: "469610.0". Expected a string.`), so the wrapped parser can never crash on unexpected value types. Rejecting by type (rather than stringifying) also means a value like the integer `10000000000000000000000000000000`, whose string form happens to be 32 valid hex characters, cannot slip through as a UUID.
- `wrap_parser` takes the exception type(s) to catch as a parameter (default `(ValueError,)`), which lets `Decimal` go through it too with `exceptions=(decimal.DecimalException,)`, and `parse_decimal` is removed.
- `Decimal` keeps its existing behavior of accepting numeric input via `accept_non_string=True` (stringify instead of reject), and `include_error=False` preserves its bare error message (`decimal.InvalidOperation`'s message is the unhelpful `[<class 'decimal.ConversionSyntax'>]`, which is why #1507 left it out).
- The parse-failure path now uses `raise ... from None` so no implicit exception context leaks into the chain, and tests assert that the raised `GraphQLError` carries no `original_error`.

Error messages for string input are unchanged for all five scalars.

New tests cover non-string input for all five built-in scalars; the full `tests/schema/` suite passes.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #4524
* Closes #1507

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
