### PR TITLE
fix(printer): convert list-valued custom-scalar defaults instead of crashing

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,21 @@
+---
+release type: patch
+social_messages:
+  x: >-
+    🍓 Strawberry {version} is out! This release fixes a crash when printing a
+    schema whose custom-scalar (e.g. JSON) input default is a list.
+    https://strawberry.rocks/release/{version}
+  linkedin: >-
+    Strawberry {version} is out. This release fixes a crash when printing a
+    schema whose custom-scalar (e.g. JSON) input default is or contains a list,
+    so SDL export and snapshot tests keep working for list-valued defaults.
+---
+
+This release fixes a crash when printing a schema whose custom-scalar (e.g.
+`JSON`) input field has a list-valued default.
+
+`ast_from_leaf_type` handled `dict`/`str`/number defaults but had no branch for
+lists, so a field like
+`j: JSON = strawberry.field(default_factory=lambda: [1, 2, 3])` — or a list
+nested inside a dict default — raised `TypeError: Cannot convert value to AST`
+when the schema was printed. Lists (and tuples) are now converted correctly.

--- a/strawberry/printer/ast_from_value.py
+++ b/strawberry/printer/ast_from_value.py
@@ -82,6 +82,11 @@ def ast_from_leaf_type(serialized: object, type_: GraphQLInputType | None) -> Va
             )
         )
 
+    if isinstance(serialized, (list, tuple)):
+        return ListValueNode(
+            values=tuple(ast_from_leaf_type(item, None) for item in serialized)
+        )
+
     raise TypeError(
         f"Cannot convert value to AST: {inspect(serialized)}."
     )  # pragma: no cover

--- a/tests/test_printer/test_basic.py
+++ b/tests/test_printer/test_basic.py
@@ -265,6 +265,33 @@ def test_input_defaults_scalars():
     assert print_schema(schema) == textwrap.dedent(expected_type).strip()
 
 
+def test_input_defaults_scalars_with_lists():
+    # Regression: a list-valued custom-scalar (JSON) default — at the top level or
+    # nested inside a dict — used to raise TypeError when printing the schema, because
+    # ast_from_leaf_type had branches for dict/str/int/... but none for list/tuple.
+    # (List *literal* formatting is stable across graphql-core versions, unlike the
+    # ObjectValueNode spacing that gates test_input_defaults_scalars, so this asserts
+    # on substrings rather than an exact SDL match.)
+    @strawberry.input
+    class MyInput:
+        j: JSON = strawberry.field(default_factory=lambda: [1, 2, 3])
+        j2: JSON = strawberry.field(default_factory=lambda: {"tags": ["a", "b"]})
+        j3: JSON = strawberry.field(default_factory=lambda: [{"x": 1}, {"y": 2}])
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def search(self, input: MyInput) -> JSON:
+            return input.j
+
+    # The regression is a crash; getting a string back at all (having also printed the
+    # list-of-dicts default j3) is the core assertion. The two substrings below use only
+    # list-literal formatting, which is stable across graphql-core versions.
+    printed = print_schema(strawberry.Schema(query=Query))
+    assert "j: JSON! = [1, 2, 3]" in printed
+    assert '["a", "b"]' in printed  # list nested inside a dict default
+
+
 @skip_if_gql_32("formatting is different in gql 3.2")
 def test_arguments_scalar():
     @strawberry.input


### PR DESCRIPTION
## Description

`ast_from_leaf_type` (in `strawberry/printer/ast_from_value.py`) converts serialized custom-scalar values — the `JSON` scalar feature it exists for — into AST nodes. It has branches for `bool`, `int`, `float`, `str`, and `dict` (recursing into dict values), but **no branch for `list`/`tuple`**, so any list value falls through to the `raise TypeError(...)` that is even marked `# pragma: no cover` (assumed unreachable).

It is reachable: a `JSON`-typed input field/argument whose default is — or contains — a list. Printing such a schema raises instead of emitting SDL.

### Reproduction

```python
import strawberry
from strawberry.scalars import JSON

@strawberry.input
class MyInput:
    j: JSON = strawberry.field(default_factory=lambda: [1, 2, 3])

@strawberry.type
class Query:
    @strawberry.field
    def search(self, input: MyInput) -> JSON:
        return {}

print(strawberry.Schema(query=Query))
# TypeError: Cannot convert value to AST: [1, 2, 3].
```

A list nested inside a dict default (e.g. `{"tags": ["a", "b"]}`) breaks the same way, while plain dict defaults already print fine.

## Fix

Add a `list`/`tuple` branch that recurses via `ast_from_leaf_type` into a `ListValueNode` (already imported), mirroring the existing `dict` branch and matching graphql-core’s own `ast_from_value`, which handles iterables.

## Test

Added `test_input_defaults_scalars_with_lists` (top-level list default + list nested in a dict default + list of dicts). It asserts on list-literal substrings rather than an exact SDL match, since `ObjectValueNode` spacing varies across graphql-core versions (the reason the sibling `test_input_defaults_scalars` is `skip_if_gql_32`). Full `tests/test_printer/` passes (32), and `ruff format/check` is clean on the touched files.

## Summary by Sourcery

Fix schema printing for custom-scalar input defaults that are lists or contain lists by converting these values to AST list nodes and document the patch release.

Bug Fixes:
- Handle list- and tuple-valued custom scalar (e.g. JSON) input defaults when converting values to AST, avoiding printer crashes on schema export.

Documentation:
- Add RELEASE notes describing the fix for crashes when printing schemas with list-valued custom-scalar defaults.

Tests:
- Add regression test covering list-valued JSON input defaults, including nested lists and lists of dicts, to ensure schema printing remains stable.