### PR TITLE
Type custom scalar callables with graphql-core aliases

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,9 @@
+---
+release type: patch
+---
+
+This release improves type annotations for custom scalars: `serialize`,
+`parse_value` and `parse_literal` are now typed with graphql-core's
+`GraphQLScalarSerializer`, `GraphQLScalarValueParser` and
+`GraphQLScalarLiteralParser` aliases instead of bare `Callable`, so
+`strawberry.scalar(...)` calls type-check cleanly under strict type checkers.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,8 +1,19 @@
 ---
 release type: patch
+social_messages:
+  x: >-
+    {project_name} {version} is out! Custom scalar `serialize`/`parse_value`/`parse_literal`
+    are now typed with graphql-core's aliases, so `strawberry.scalar(...)` type-checks
+    cleanly under strict checkers. 🍓 https://strawberry.rocks/release/{version}
+  linkedin: >-
+    {project_name} {version} is out. Custom scalar callables (`serialize`, `parse_value`,
+    `parse_literal`) are now typed with graphql-core's `GraphQLScalarSerializer`,
+    `GraphQLScalarValueParser` and `GraphQLScalarLiteralParser` aliases instead of bare
+    `Callable`, so `strawberry.scalar(...)` calls type-check cleanly under strict type
+    checkers.
 ---
 
-This release improves type annotations for custom scalars: `serialize`,
+This release adds precise type annotations for custom scalars: `serialize`,
 `parse_value` and `parse_literal` are now typed with graphql-core's
 `GraphQLScalarSerializer`, `GraphQLScalarValueParser` and
 `GraphQLScalarLiteralParser` aliases instead of bare `Callable`, so

--- a/strawberry/federation/scalar.py
+++ b/strawberry/federation/scalar.py
@@ -6,6 +6,12 @@ from typing import (
     overload,
 )
 
+from graphql import (
+    GraphQLScalarLiteralParser,
+    GraphQLScalarSerializer,
+    GraphQLScalarValueParser,
+)
+
 from strawberry.types.scalar import ScalarWrapper, _process_scalar
 
 _T = TypeVar("_T", bound=type | NewType)
@@ -21,9 +27,9 @@ def scalar(
     name: str | None = None,
     description: str | None = None,
     specified_by_url: str | None = None,
-    serialize: Callable = identity,
-    parse_value: Callable | None = None,
-    parse_literal: Callable | None = None,
+    serialize: GraphQLScalarSerializer = identity,
+    parse_value: GraphQLScalarValueParser | None = None,
+    parse_literal: GraphQLScalarLiteralParser | None = None,
     directives: Iterable[object] = (),
     authenticated: bool = False,
     inaccessible: bool = False,
@@ -40,9 +46,9 @@ def scalar(
     name: str | None = None,
     description: str | None = None,
     specified_by_url: str | None = None,
-    serialize: Callable = identity,
-    parse_value: Callable | None = None,
-    parse_literal: Callable | None = None,
+    serialize: GraphQLScalarSerializer = identity,
+    parse_value: GraphQLScalarValueParser | None = None,
+    parse_literal: GraphQLScalarLiteralParser | None = None,
     directives: Iterable[object] = (),
     authenticated: bool = False,
     inaccessible: bool = False,
@@ -58,9 +64,9 @@ def scalar(
     name: str | None = None,
     description: str | None = None,
     specified_by_url: str | None = None,
-    serialize: Callable = identity,
-    parse_value: Callable | None = None,
-    parse_literal: Callable | None = None,
+    serialize: GraphQLScalarSerializer = identity,
+    parse_value: GraphQLScalarValueParser | None = None,
+    parse_literal: GraphQLScalarLiteralParser | None = None,
     directives: Iterable[object] = (),
     authenticated: bool = False,
     inaccessible: bool = False,

--- a/strawberry/types/scalar.py
+++ b/strawberry/types/scalar.py
@@ -18,7 +18,12 @@ from strawberry.utils.str_converters import to_camel_case
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Mapping
 
-    from graphql import GraphQLScalarType
+    from graphql import (
+        GraphQLScalarLiteralParser,
+        GraphQLScalarSerializer,
+        GraphQLScalarType,
+        GraphQLScalarValueParser,
+    )
 
 
 _T = TypeVar("_T", bound=type | NewType)
@@ -33,9 +38,9 @@ class ScalarDefinition(StrawberryType):
     name: str
     description: str | None
     specified_by_url: str | None
-    serialize: Callable | None
-    parse_value: Callable | None
-    parse_literal: Callable | None
+    serialize: GraphQLScalarSerializer | None
+    parse_value: GraphQLScalarValueParser | None
+    parse_literal: GraphQLScalarLiteralParser | None
     directives: Iterable[object] = ()
     origin: GraphQLScalarType | type | None = None
 
@@ -83,9 +88,9 @@ def _process_scalar(
     name: str | None = None,
     description: str | None = None,
     specified_by_url: str | None = None,
-    serialize: Callable | None = None,
-    parse_value: Callable | None = None,
-    parse_literal: Callable | None = None,
+    serialize: GraphQLScalarSerializer | None = None,
+    parse_value: GraphQLScalarValueParser | None = None,
+    parse_literal: GraphQLScalarLiteralParser | None = None,
     directives: Iterable[object] = (),
 ) -> ScalarWrapper:
     from strawberry.exceptions.handler import should_use_rich_exceptions
@@ -125,9 +130,9 @@ def scalar(
     name: str,
     description: str | None = None,
     specified_by_url: str | None = None,
-    serialize: Callable = identity,
-    parse_value: Callable | None = None,
-    parse_literal: Callable | None = None,
+    serialize: GraphQLScalarSerializer = identity,
+    parse_value: GraphQLScalarValueParser | None = None,
+    parse_literal: GraphQLScalarLiteralParser | None = None,
     directives: Iterable[object] = (),
 ) -> ScalarDefinition: ...
 
@@ -139,9 +144,9 @@ def scalar(
     name: None = None,
     description: str | None = None,
     specified_by_url: str | None = None,
-    serialize: Callable = identity,
-    parse_value: Callable | None = None,
-    parse_literal: Callable | None = None,
+    serialize: GraphQLScalarSerializer = identity,
+    parse_value: GraphQLScalarValueParser | None = None,
+    parse_literal: GraphQLScalarLiteralParser | None = None,
     directives: Iterable[object] = (),
 ) -> Callable[[_T], _T]: ...
 
@@ -153,9 +158,9 @@ def scalar(
     name: str | None = None,
     description: str | None = None,
     specified_by_url: str | None = None,
-    serialize: Callable = identity,
-    parse_value: Callable | None = None,
-    parse_literal: Callable | None = None,
+    serialize: GraphQLScalarSerializer = identity,
+    parse_value: GraphQLScalarValueParser | None = None,
+    parse_literal: GraphQLScalarLiteralParser | None = None,
     directives: Iterable[object] = (),
 ) -> _T: ...
 
@@ -169,9 +174,9 @@ def scalar(
     name: str | None = None,
     description: str | None = None,
     specified_by_url: str | None = None,
-    serialize: Callable = identity,
-    parse_value: Callable | None = None,
-    parse_literal: Callable | None = None,
+    serialize: GraphQLScalarSerializer = identity,
+    parse_value: GraphQLScalarValueParser | None = None,
+    parse_literal: GraphQLScalarLiteralParser | None = None,
     directives: Iterable[object] = (),
 ) -> Any:
     """Annotates a class or type as a GraphQL custom scalar.

--- a/tests/typecheckers/test_federation.py
+++ b/tests/typecheckers/test_federation.py
@@ -294,3 +294,61 @@ def test_federation_input():
             ),
         ]
     )
+
+
+CODE_SCALAR = """
+import strawberry
+from datetime import datetime
+from graphql.language import ast
+
+def parse_epoch_literal(
+    node: ast.ValueNode, variables: dict[str, object] | None = None
+) -> datetime:
+    assert isinstance(node, ast.IntValueNode)
+    return datetime.fromtimestamp(int(node.value))
+
+EpochDateTime = strawberry.federation.scalar(
+    datetime,
+    name="EpochDateTime",
+    serialize=lambda value: int(value.timestamp()),
+    parse_value=lambda value: datetime.fromtimestamp(int(value)),
+    parse_literal=parse_epoch_literal,
+)
+
+reveal_type(EpochDateTime)
+"""
+
+
+def test_federation_scalar():
+    results = typecheck(CODE_SCALAR)
+
+    assert results.pyright == snapshot(
+        [
+            Result(
+                type="information",
+                message='Type of "EpochDateTime" is "type[datetime]"',
+                line=20,
+                column=13,
+            )
+        ]
+    )
+    assert results.mypy == snapshot(
+        [
+            Result(
+                type="note",
+                message='Revealed type is "def (year: typing.SupportsIndex, month: typing.SupportsIndex, day: typing.SupportsIndex, hour: typing.SupportsIndex =, minute: typing.SupportsIndex =, second: typing.SupportsIndex =, microsecond: typing.SupportsIndex =, tzinfo: datetime.tzinfo | None =, *, fold: int =) -> datetime.datetime"',
+                line=20,
+                column=13,
+            )
+        ]
+    )
+    assert results.ty == snapshot(
+        [
+            Result(
+                type="information",
+                message="Revealed type: `<class 'datetime'>`",
+                line=20,
+                column=13,
+            )
+        ]
+    )

--- a/tests/typecheckers/test_scalars.py
+++ b/tests/typecheckers/test_scalars.py
@@ -149,7 +149,7 @@ def test():
 
 CODE_SCHEMA_OVERRIDES = """
 import strawberry
-from datetime import datetime, timezone
+from datetime import datetime
 
 EpochDateTime = strawberry.scalar(
     datetime,
@@ -168,15 +168,14 @@ reveal_type(EpochDateTime)
 
 
 def test_schema_overrides():
-    # TODO: change strict to true when we improve type hints for scalar
-    results = typecheck(CODE_SCHEMA_OVERRIDES, strict=False)
+    results = typecheck(CODE_SCHEMA_OVERRIDES)
 
     assert results.pyright == snapshot(
         [
             Result(
                 type="information",
                 message='Type of "EpochDateTime" is "type[datetime]"',
-                line=16,
+                line=17,
                 column=13,
             )
         ]
@@ -232,20 +231,20 @@ reveal_type(MyString("test"))
 
 
 def test_scalar_map():
-    results = typecheck(CODE_SCALAR_MAP, strict=False)
+    results = typecheck(CODE_SCALAR_MAP)
 
     assert results.pyright == snapshot(
         [
             Result(
                 type="information",
                 message='Type of "MyString" is "type[MyString]"',
-                line=23,
+                line=24,
                 column=13,
             ),
             Result(
                 type="information",
                 message='Type of "MyString("test")" is "MyString"',
-                line=24,
+                line=25,
                 column=13,
             ),
         ]


### PR DESCRIPTION
## Description

The `serialize`, `parse_value` and `parse_literal` arguments of `strawberry.scalar` (and the corresponding `ScalarDefinition` fields) are annotated as bare `Callable`, which type checkers treat as partially unknown.
Under strict checking (e.g. pyright/basedpyright with `reportUnknownMemberType`), every `strawberry.scalar(...)` call in user code is reported:

error: Type of "scalar" is partially unknown (reportUnknownMemberType)

These callables flow unchanged into `GraphQLScalarType` (`_make_scalar_type`), and `_make_scalar_definition` already assigns graphql-core's typed attributes back into `ScalarDefinition`, so graphql-core's own aliases are the factual contract:

- `serialize: GraphQLScalarSerializer` (= `Callable[[Any], Any]`)
- `parse_value: GraphQLScalarValueParser` (= `Callable[[Any], Any]`)
- `parse_literal: GraphQLScalarLiteralParser` (= `Callable[[ValueNode, dict[str, Any] | None], Any]`)

The change is annotation-only — no runtime behavior is affected. As a bonus, `parse_literal` now documents its real two-argument call contract (graphql-core invokes it with `(node, variables)`), so single-argument parsers that would fail at runtime are caught by the type checker.

Applied to `strawberry.types.scalar` (`ScalarDefinition` fields, `_process_scalar`, all `scalar()` overloads) and
`strawberry.federation.scalar`.

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* None

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Align custom scalar typing with graphql-core scalar callables to improve static type checking without changing runtime behavior.

Enhancements:
- Type ScalarDefinition and scalar() callable parameters using GraphQLScalarSerializer, GraphQLScalarValueParser, and GraphQLScalarLiteralParser instead of untyped Callable.
- Apply the same typed scalar callable annotations to federation scalar helpers to reflect the actual parse_literal two-argument calling convention.