### PR TITLE
Add custom schema error loggers

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,16 @@
+---
+release type: minor
+social_messages:
+  x: >-
+    {project_name} {version} is out! Schemas can now use custom error loggers for
+    GraphQL execution errors. 🍓 https://strawberry.rocks/release/{version}
+  linkedin: >-
+    {project_name} {version} is out. Schemas can now use custom error loggers to
+    integrate GraphQL execution errors with application logging and observability.
+---
+
+This release adds support for custom GraphQL execution error loggers.
+
+Pass a logger object to `strawberry.Schema(logger=...)` to control how execution
+errors are reported without subclassing the schema. Existing schemas continue to
+use the `strawberry.execution` logger by default.

--- a/docs/types/schema.md
+++ b/docs/types/schema.md
@@ -114,6 +114,11 @@ List of handlers that convert expected Python exceptions into typed GraphQL
 union results. See
 [dealing with expected errors](/docs/guides/errors#mapping-expected-exceptions-to-union-results).
 
+#### `logger: Optional[StrawberryLoggerProtocol] = None`
+
+A custom logger for GraphQL execution errors. See
+[handling execution errors](#handling-execution-errors).
+
 #### `scalar_overrides: Optional[Dict[object, ScalarWrapper]] = None`
 
 Override the implementation of the built in scalars.
@@ -189,9 +194,30 @@ operation in the document will be executed.
 
 ## Handling execution errors
 
-By default Strawberry will log any errors encountered during a query execution
-to a `strawberry.execution` logger. This behaviour can be changed by overriding
-the `process_errors` function on the `strawberry.Schema` class.
+By default Strawberry logs errors encountered during query execution to the
+`strawberry.execution` logger. You can provide a custom logger when creating the
+schema. The logger must define an `error` method that accepts the GraphQL error
+and optional execution context:
+
+```python
+import strawberry
+from graphql import GraphQLError
+from strawberry.types import ExecutionContext
+
+
+class CustomLogger:
+    def error(
+        self,
+        error: GraphQLError,
+        execution_context: ExecutionContext | None = None,
+    ) -> None: ...
+
+
+schema = strawberry.Schema(query=Query, logger=CustomLogger())
+```
+
+For more extensive customisation, you can still subclass `strawberry.Schema` and
+override its `process_errors` method.
 
 The default functionality looks like this:
 
@@ -199,19 +225,17 @@ The default functionality looks like this:
 # strawberry/schema/base.py
 from strawberry.types import ExecutionContext
 
-logger = logging.getLogger("strawberry.execution")
-
 
 class BaseSchema:
     ...
 
     def process_errors(
         self,
-        errors: List[GraphQLError],
-        execution_context: Optional[ExecutionContext] = None,
+        errors: list[GraphQLError],
+        execution_context: ExecutionContext | None = None,
     ) -> None:
         for error in errors:
-            StrawberryLogger.error(error, execution_context)
+            self.logger.error(error, execution_context)
 ```
 
 ```python
@@ -226,16 +250,10 @@ class StrawberryLogger:
     def error(
         cls,
         error: GraphQLError,
-        execution_context: Optional[ExecutionContext] = None,
+        execution_context: ExecutionContext | None = None,
         # https://www.python.org/dev/peps/pep-0484/#arbitrary-argument-lists-and-default-argument-values
         **logger_kwargs: Any,
     ) -> None:
-        # "stack_info" is a boolean; check for None explicitly
-        if logger_kwargs.get("stack_info") is None:
-            logger_kwargs["stack_info"] = True
-
-        logger_kwargs["stacklevel"] = 3
-
         cls.logger.error(error, exc_info=error.original_error, **logger_kwargs)
 ```
 

--- a/strawberry/federation/schema.py
+++ b/strawberry/federation/schema.py
@@ -39,6 +39,7 @@ if TYPE_CHECKING:
     from strawberry.schema.exception_handlers import ExceptionHandler
     from strawberry.schema_directive import StrawberrySchemaDirective
     from strawberry.types.enum import StrawberryEnumDefinition
+    from strawberry.utils.logging import StrawberryLoggerProtocol
 
 
 FederationAny = NewType("FederationAny", object)
@@ -77,6 +78,7 @@ class Schema(BaseSchema):
             "2.11",
         ] = "2.11",
         exception_handlers: Iterable["ExceptionHandler[Any]"] = (),
+        logger: "StrawberryLoggerProtocol | None" = None,
     ) -> None:
         # Convert version string (e.g., "2.5") to version tuple (e.g., (2, 5))
         self.federation_version = parse_version(federation_version)
@@ -113,6 +115,7 @@ class Schema(BaseSchema):
             scalar_overrides=federation_scalar_overrides,
             schema_directives=schema_directives,
             exception_handlers=exception_handlers,
+            logger=logger,
         )
 
         self.schema_directives = list(schema_directives)

--- a/strawberry/schema/base.py
+++ b/strawberry/schema/base.py
@@ -4,8 +4,6 @@ from abc import abstractmethod
 from typing import TYPE_CHECKING, Any
 from typing_extensions import Protocol
 
-from strawberry.utils.logging import StrawberryLogger
-
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
@@ -27,6 +25,7 @@ if TYPE_CHECKING:
     from strawberry.types.graphql import OperationType
     from strawberry.types.scalar import ScalarDefinition
     from strawberry.types.union import StrawberryUnion
+    from strawberry.utils.logging import StrawberryLoggerProtocol
 
     from .config import StrawberryConfig
 
@@ -39,6 +38,7 @@ class BaseSchema(Protocol):
     subscription: type[WithStrawberryObjectDefinition] | None
     schema_directives: list[object]
     exception_handlers: tuple[ExceptionHandler[Any], ...]
+    logger: StrawberryLoggerProtocol
 
     @abstractmethod
     async def execute(
@@ -136,7 +136,7 @@ class BaseSchema(Protocol):
         execution_context: ExecutionContext | None = None,
     ) -> None:
         for error in errors:
-            StrawberryLogger.error(error, execution_context)
+            self.logger.error(error, execution_context)
 
 
 __all__ = ["BaseSchema"]

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -65,6 +65,7 @@ from strawberry.types.graphql import OperationType
 from strawberry.utils import IS_GQL_32, IS_GQL_33
 from strawberry.utils.aio import aclosing
 from strawberry.utils.await_maybe import await_maybe
+from strawberry.utils.logging import StrawberryLogger
 
 from . import compat
 from ._graphql_core import (
@@ -98,6 +99,7 @@ if TYPE_CHECKING:
     from strawberry.types.field import StrawberryField
     from strawberry.types.scalar import ScalarDefinition, ScalarWrapper
     from strawberry.types.union import StrawberryUnion
+    from strawberry.utils.logging import StrawberryLoggerProtocol
 
 
 SubscriptionResult: TypeAlias = AsyncGenerator[
@@ -273,6 +275,7 @@ class Schema(BaseSchema):
         ) = None,
         schema_directives: Iterable[object] = (),
         exception_handlers: Iterable[ExceptionHandler[Any]] = (),
+        logger: StrawberryLoggerProtocol | None = None,
     ) -> None:
         """Default Schema to be used in a Strawberry application.
 
@@ -297,6 +300,7 @@ class Schema(BaseSchema):
             schema_directives: A list of schema directives for the schema.
             exception_handlers: A list of handlers that can convert Python
                 exceptions into explicit GraphQL union return values.
+            logger: A logger used to report GraphQL execution errors.
 
         Example:
         ```python
@@ -337,6 +341,7 @@ class Schema(BaseSchema):
         )
         self.config = config or StrawberryConfig()
         self.exception_handlers = tuple(exception_handlers)
+        self.logger = logger if logger is not None else StrawberryLogger()
 
         self.schema_converter = GraphQLCoreConverter(
             self.config,

--- a/strawberry/utils/logging.py
+++ b/strawberry/utils/logging.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from typing import TYPE_CHECKING, Any
+from typing_extensions import Protocol
 
 if TYPE_CHECKING:
     from typing import Final
@@ -9,6 +10,16 @@ if TYPE_CHECKING:
     from graphql.error import GraphQLError
 
     from strawberry.types import ExecutionContext
+
+
+class StrawberryLoggerProtocol(Protocol):
+    """Interface for loggers used to report GraphQL execution errors."""
+
+    def error(
+        self,
+        error: GraphQLError,
+        execution_context: ExecutionContext | None = None,
+    ) -> None: ...
 
 
 class StrawberryLogger:
@@ -25,4 +36,4 @@ class StrawberryLogger:
         cls.logger.error(error, exc_info=error.original_error, **logger_kwargs)
 
 
-__all__ = ["StrawberryLogger"]
+__all__ = ["StrawberryLogger", "StrawberryLoggerProtocol"]

--- a/tests/federation/test_schema.py
+++ b/tests/federation/test_schema.py
@@ -321,6 +321,17 @@ def test_can_create_schema_without_query():
     )
 
 
+def test_custom_logger():
+    class CustomLogger:
+        def error(self, error, execution_context=None):
+            pass
+
+    logger = CustomLogger()
+    schema = strawberry.federation.Schema(logger=logger)
+
+    assert schema.logger is logger
+
+
 def test_federation_schema_warning():
     @strawberry.federation.type(keys=["upc"])
     class ProductFed:

--- a/tests/schema/test_execution.py
+++ b/tests/schema/test_execution.py
@@ -429,6 +429,29 @@ def test_overriding_process_errors(caplog: pytest.LogCaptureFixture):
     assert caplog.records == []
 
 
+def test_custom_logger(caplog: pytest.LogCaptureFixture):
+    @strawberry.type
+    class Query:
+        example: str = "hi"
+
+    logged_errors = []
+
+    class CustomLogger:
+        def error(self, error, execution_context=None):
+            logged_errors.append((error, execution_context))
+
+    schema = strawberry.Schema(query=Query, logger=CustomLogger())
+
+    result = schema.execute_sync("{ missingField }")
+
+    assert result.errors
+    assert len(logged_errors) == 1
+    assert logged_errors[0][0] is result.errors[0]
+    assert logged_errors[0][1] is not None
+    assert logged_errors[0][1].schema is schema
+    assert caplog.records == []
+
+
 def test_adding_custom_validation_rules():
     @strawberry.type
     class Query:


### PR DESCRIPTION
## Summary

- add a schema-scoped logger protocol for GraphQL execution errors
- allow both `strawberry.Schema` and `strawberry.federation.Schema` to accept a custom `logger`
- route the default `process_errors` implementation through the configured logger
- document the new option and add release notes and coverage

## Motivation

Strawberry currently sends every GraphQL execution error through the global
`strawberry.execution` logger. Applications that need structured logging,
redaction, or different handling for expected errors must either change global
logging configuration or subclass `Schema` solely to override `process_errors`.

This adds the per-schema composition point proposed in #2514 while preserving
the existing `StrawberryLogger.error(...)` classmethod API. Existing schemas keep
the current logging behavior by default, while custom stateful logger objects can
implement the structural `StrawberryLoggerProtocol` without inheriting from the
default logger.

Closes #2514.

## Validation

- `uv run pytest tests/schema/test_execution.py tests/utils/test_logging.py tests/federation/test_schema.py`
- `uv run mypy`
- contribution pre-commit hooks for all changed files
- full test suite: 5,103 passed; the only initial failure was the missing external `ty` executable, and that test passed when rerun with `uv run --with ty`

## Summary by Sourcery

Allow schemas to use configurable loggers for GraphQL execution errors while keeping the existing default logger behavior.

New Features:
- Support passing a custom execution error logger to both standard and federation schemas via a new logger parameter.
- Introduce a StrawberryLoggerProtocol interface for pluggable error logger implementations.

Enhancements:
- Route schema error processing through the schema’s configured logger instead of the global StrawberryLogger, preserving previous default behavior.
- Update documentation to describe custom execution error loggers and their usage, and add release notes for the change.

Tests:
- Add tests verifying that custom loggers are used during execution for both regular and federation schemas and that default logging is suppressed when a custom logger is provided.