### PR TITLE
Default FastAPI router subclasses to supported context types

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,23 @@
+---
+release type: patch
+social_messages:
+  x: >-
+    {project_name} {version} is out! FastAPI GraphQLRouter subclasses now accept
+    valid custom context getters without extra generic annotations. 🍓
+    https://strawberry.rocks/release/{version}
+  linkedin: >-
+    {project_name} {version} is out. FastAPI GraphQLRouter subclasses now
+    type-check with valid custom context getters even when they omit explicit
+    generic parameters.
+---
+
+This release fixes type checking for FastAPI `GraphQLRouter` subclasses that
+provide a custom context getter without explicit generic parameters.
+
+Bare subclasses now default to the context types supported by the FastAPI
+integration, so valid context getters are accepted by type checkers. Explicitly
+using `GraphQLRouter[MyContext]` is still available when the precise context
+type needs to be preserved on the subclass.
+
+The minimum supported `typing-extensions` version is now 4.14.0, ensuring these
+default generic parameters work across Strawberry's supported Python versions.

--- a/docs/integrations/fastapi.md
+++ b/docs/integrations/fastapi.md
@@ -290,6 +290,22 @@ following methods:
 - `async def render_graphql_ide(self, request: Request) -> HTMLResponse`
 - `async def on_ws_connect(self, context: Context) -> Union[UnsetType, None, Dict[str, object]]`
 
+`GraphQLRouter` is generic over the context and root value types. Type checkers
+can usually infer these types when the router is instantiated directly. When
+subclassing the router, specify any custom context or root value types on the
+base class to preserve their precise types:
+
+```python
+class MyGraphQLRouter(GraphQLRouter[MyContext, MyRootValue]):
+    pass
+```
+
+The context defaults to the context types supported by the FastAPI integration,
+while the root value defaults to `None`. You can therefore omit the root value
+type when only the context is customized: `GraphQLRouter[MyContext]`. Apply the
+same type arguments to explicit `GraphQLRouter` variable annotations, or omit
+the redundant annotation and let the type checker infer the concrete subclass.
+
 ### process_result
 
 The `process_result` option allows you to customize and/or process results
@@ -395,14 +411,17 @@ provide a custom error payload that will be sent to the client when the legacy
 GraphQL over WebSocket protocol is used.
 
 ```python
-from typing import Dict
 from strawberry.exceptions import ConnectionRejectionError
-from strawberry.fastapi import GraphQLRouter
+from strawberry.fastapi import BaseContext, GraphQLRouter
 
 
-class MyGraphQLRouter(GraphQLRouter):
-    async def on_ws_connect(self, context: Dict[str, object]):
-        connection_params = context["connection_params"]
+class Context(BaseContext):
+    pass
+
+
+class MyGraphQLRouter(GraphQLRouter[Context]):
+    async def on_ws_connect(self, context: Context):
+        connection_params = context.connection_params
 
         if not isinstance(connection_params, dict):
             # Reject without a custom graphql-ws error payload

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 requires-python = ">=3.10,<4.0"
 dependencies = [
   "graphql-core>=3.2.0,<3.4.0",
-  "typing-extensions>=4.5.0",
+  "typing-extensions>=4.14.0",
   "python-dateutil>=2.7",
   "packaging>=23",
   "cross-web>=0.6.0",

--- a/strawberry/fastapi/router.py
+++ b/strawberry/fastapi/router.py
@@ -8,6 +8,7 @@ from typing import (
     TypeGuard,
     cast,
 )
+from typing_extensions import TypeVar
 
 from cross_web import HTTPException, StarletteRequestAdapter
 from fastapi import APIRouter, Depends, params
@@ -30,8 +31,10 @@ from strawberry.asgi import ASGIWebSocketAdapter
 from strawberry.exceptions import InvalidCustomContext
 from strawberry.fastapi.context import BaseContext, CustomContext
 from strawberry.http.async_base_view import AsyncBaseHTTPView
-from strawberry.http.typevars import Context, RootValue
+from strawberry.http.typevars import RootValue
 from strawberry.subscriptions import GRAPHQL_TRANSPORT_WS_PROTOCOL, GRAPHQL_WS_PROTOCOL
+
+Context = TypeVar("Context", default=CustomContext)
 
 if TYPE_CHECKING:
     from collections.abc import (

--- a/tests/typecheckers/test_fastapi.py
+++ b/tests/typecheckers/test_fastapi.py
@@ -72,6 +72,76 @@ def test_router_with_context():
     )
 
 
+CODE_ROUTER_SUBCLASS_WITH_CONTEXT = """
+import strawberry
+
+from fastapi import Depends
+from strawberry.fastapi import GraphQLRouter, BaseContext
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def hello(self) -> str:
+        return "Hello World"
+
+
+class Context(BaseContext):
+    pass
+
+
+class CustomGraphQLRouter(GraphQLRouter):
+    pass
+
+
+def get_context(context: Context = Depends(Context)) -> Context:
+    return context
+
+
+router: GraphQLRouter = CustomGraphQLRouter(
+    strawberry.Schema(query=Query),
+    context_getter=get_context,
+)
+
+reveal_type(router)
+"""
+
+
+def test_router_subclass_with_context():
+    results = typecheck(CODE_ROUTER_SUBCLASS_WITH_CONTEXT)
+
+    assert results.pyright == snapshot(
+        [
+            Result(
+                type="information",
+                message='Type of "router" is "CustomGraphQLRouter"',
+                line=32,
+                column=13,
+            )
+        ]
+    )
+    assert results.mypy == snapshot(
+        [
+            Result(
+                type="note",
+                message='Revealed type is "strawberry.fastapi.router.GraphQLRouter[strawberry.fastapi.context.BaseContext | dict[str, Any], None]"',
+                line=32,
+                column=13,
+            )
+        ]
+    )
+    assert results.ty == snapshot(
+        [
+            Result(
+                type="information",
+                message="Revealed type: `CustomGraphQLRouter`",
+                line=32,
+                column=13,
+            )
+        ]
+    )
+
+
 CODE_ROUTER_WITH_ASYNC_CONTEXT = """
 import strawberry
 

--- a/uv.lock
+++ b/uv.lock
@@ -4085,7 +4085,7 @@ requires-dist = [
     { name = "starlette", marker = "extra == 'asgi'", specifier = ">=0.18.0" },
     { name = "starlette", marker = "extra == 'cli'", specifier = ">=0.18.0" },
     { name = "typer", marker = "extra == 'cli'", specifier = ">=0.12.4" },
-    { name = "typing-extensions", specifier = ">=4.5.0" },
+    { name = "typing-extensions", specifier = ">=4.14.0" },
     { name = "uvicorn", marker = "extra == 'cli'", specifier = ">=0.11.6" },
     { name = "websockets", marker = "extra == 'cli'", specifier = ">=15.0.1,<17" },
 ]


### PR DESCRIPTION
<!-- shortcake:start -->
## Stack [🍰](https://shortcake.patrick.wtf)

- **#4540** (`2026-07-22-default-fastapi-router-subclasses-to-supported-con`) <-- this PR
<!-- shortcake:end -->

## Summary by Sourcery

Adjust FastAPI GraphQLRouter typing so subclasses default to supported context types and update docs and tests accordingly.

Bug Fixes:
- Fix type checking for FastAPI GraphQLRouter subclasses that use a custom context getter without explicit generic parameters.

Documentation:
- Document GraphQLRouter generics for context and root value types and update FastAPI WebSocket example to use a typed context subclass.

Tests:
- Add a type-checking test that validates router subclasses accept supported context types by default.

Chores:
- Add a patch release note describing the FastAPI GraphQLRouter typing fix and its impact.