### PR TITLE
feat: add sort_schema option for lexicographic schema sorting

### DIFF
--- a/strawberry/printer/printer.py
+++ b/strawberry/printer/printer.py
@@ -597,6 +597,12 @@ def print_schema(schema: BaseSchema) -> str:
         "GraphQLSchema",
         schema._schema,  # type: ignore
     )
+
+    if getattr(schema.config, "sort_schema", False):
+        from graphql.utilities import lexicographic_sort_schema
+
+        graphql_core_schema = lexicographic_sort_schema(graphql_core_schema)
+
     extras = PrintExtras()
 
     filtered_directives = [

--- a/strawberry/schema/config.py
+++ b/strawberry/schema/config.py
@@ -30,6 +30,9 @@ class StrawberryConfig:
         disable_field_suggestions: Disable field suggestions in error messages.
         info_class: Custom Info class to use.
         enable_experimental_incremental_execution: Enable @defer/@stream support.
+        sort_schema: Whether to lexicographically sort the schema when printing.
+            When enabled, types, fields, arguments, and enum values are sorted
+            alphabetically using graphql-core's lexicographicSortSchema.
         scalar_map: A mapping of types to their scalar definitions. This allows
             any type (including NewType) to be used as a GraphQL scalar with
             proper type checking support.
@@ -44,6 +47,7 @@ class StrawberryConfig:
     disable_field_suggestions: bool = False
     info_class: type[Info] = Info
     enable_experimental_incremental_execution: bool = False
+    sort_schema: bool = False
     _unsafe_disable_same_type_validation: bool = False
     scalar_map: Mapping[object, ScalarDefinition] = field(default_factory=dict)
     batching_config: BatchingConfig | None = None

--- a/tests/test_printer/test_basic.py
+++ b/tests/test_printer/test_basic.py
@@ -544,9 +544,7 @@ def test_sort_schema_lexicographic():
     field_lines = [line.strip() for line in lines if "_field" in line]
     field_names = [line.split(":")[0] for line in field_lines if ":" in line]
 
-    assert field_names == sorted(field_names), (
-        f"Fields not sorted: {field_names}"
-    )
+    assert field_names == sorted(field_names), f"Fields not sorted: {field_names}"
 
 
 def test_sort_schema_disabled_by_default():

--- a/tests/test_printer/test_basic.py
+++ b/tests/test_printer/test_basic.py
@@ -521,3 +521,48 @@ def test_input_with_renamed_maybe_some_none_default_gql_33():
     """).strip()
 
     assert sdl == expected
+
+
+def test_sort_schema_lexicographic():
+    """Test that sort_schema config option lexicographically sorts the schema."""
+
+    @strawberry.type
+    class Query:
+        zebra_field: str
+        alpha_field: str
+        middle_field: str
+
+    schema = strawberry.Schema(
+        query=Query,
+        config=StrawberryConfig(sort_schema=True),
+    )
+
+    sdl = print_schema(schema)
+
+    # Fields should be sorted alphabetically
+    lines = sdl.split("\n")
+    field_lines = [line.strip() for line in lines if "_field" in line]
+    field_names = [line.split(":")[0] for line in field_lines if ":" in line]
+
+    assert field_names == sorted(field_names), (
+        f"Fields not sorted: {field_names}"
+    )
+
+
+def test_sort_schema_disabled_by_default():
+    """Test that sort_schema is disabled by default (fields keep definition order)."""
+
+    @strawberry.type
+    class Query:
+        zebra_field: str
+        alpha_field: str
+        middle_field: str
+
+    schema = strawberry.Schema(query=Query)
+
+    sdl = print_schema(schema)
+
+    # Without sort_schema, fields should be in definition order
+    assert "zebra_field" in sdl
+    assert "alpha_field" in sdl
+    assert "middle_field" in sdl


### PR DESCRIPTION
## Summary

This PR adds a new `sort_schema` configuration option to `StrawberryConfig` that enables lexicographic sorting of the GraphQL schema when printing. Fixes #3149.

## Changes

- **`strawberry/schema/config.py`**: Added `sort_schema: bool = False` to `StrawberryConfig` with docstring
- **`strawberry/printer/printer.py`**: Apply `lexicographic_sort_schema` from graphql-core when `sort_schema=True`
- **`tests/test_printer/test_basic.py`**: Added 2 tests for enabled and disabled behavior

## Usage

```python
import strawberry
from strawberry.schema.config import StrawberryConfig

schema = strawberry.Schema(
    query=Query,
    config=StrawberryConfig(sort_schema=True),
)
```

When `sort_schema=True`, the output schema will have all types, fields, arguments, and enum values sorted alphabetically using graphql-core's `lexicographicSortSchema`.

## Design Decisions

- **Off by default**: `sort_schema` defaults to `False` to avoid breaking existing behavior
- **Non-breaking**: Users who don't set this option see no change
- **Leverages graphql-core**: Uses the battle-tested `lexicographicSortSchema` from graphql-core rather than implementing custom sorting
- **Works with all export paths**: Affects `schema.as_str()`, `print_schema()`, CLI `export-schema`, and federation SDL

## Tests

Verified locally that:
- Without `sort_schema`: fields maintain definition order (zebra, alpha, middle)
- With `sort_schema=True`: fields are sorted alphabetically (alpha, middle, zebra)

Fixes #3149

## Summary by Sourcery

Add a configuration option to control lexicographic sorting of printed GraphQL schemas and ensure default behavior remains unchanged.

New Features:
- Introduce a sort_schema boolean option on StrawberryConfig to enable lexicographic sorting of the schema when printing.
- Apply graphql-core's lexicographic_sort_schema when sort_schema is enabled so printed SDL is alphabetically ordered.

Tests:
- Add tests verifying that sort_schema lexicographically sorts fields when enabled and preserves definition order when left at its default value.