### PR TITLE
Add workflow for ai PRs

### DIFF
--- a/.github/workflows/issue-manager.yml
+++ b/.github/workflows/issue-manager.yml
@@ -9,18 +9,20 @@ on:
   issues:
     types:
       - labeled
-  # `pull_request_target` would make this workflow run with elevated privileges
-  # on PR events, which `zizmor` correctly flags as unsafe. PRs are still
-  # handled on the daily schedule and whenever new comments are added.
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
+    types:
+      - labeled
   workflow_dispatch:
 
-permissions:
-  issues: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   issue-manager:
+    if: github.repository_owner == 'strawberry-graphql'
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: tiangolo/issue-manager@dc846170c36eb62fb434b3d943b36399fe240fb5 # 0.8.1
         with:
@@ -30,5 +32,9 @@ jobs:
               "info-needed": {
                 "delay": "P14D",
                 "message": "Hi, this issue requires extra info to be actionable. We're closing this issue because it has not been actionable for a while now. Feel free to provide the requested information and we'll happily open it again! 😊"
+              },
+              "maybe-ai": {
+                "delay": 0,
+                "message": "This was marked as potentially AI generated and will be closed now. If this is an error, please provide additional details, make sure to read the docs about contributing and AI."
               }
             }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,6 +146,25 @@ present, your code will not be merged.
 - If your changes warrant a documentation change, the pull request must also
   update the documentation.
 
+##### AI-assisted contributions
+
+You are welcome to use AI and other automated tools when contributing. However,
+every contribution must include meaningful human judgment and be work that you
+understand, have reviewed, and can explain.
+
+Please do not submit generated code, descriptions, or comments without carefully
+checking them. If reviewing a contribution would require more maintainer effort
+than the contributor put into understanding and validating it, it is not ready
+to be submitted.
+
+Maintainers may apply the `maybe-ai` label to pull requests that appear to be
+substantially generated and lack that human ownership. The pull request will be
+closed automatically. If the label was applied in error, comment with additional
+context about your approach, validation, and understanding of the change so a
+maintainer can reconsider it.
+
+Repeated low-effort or automated submissions may be treated as spam.
+
 ##### RELEASE.md files
 
 When you submit a PR, make sure to include a RELEASE.md file. We use that to


### PR DESCRIPTION
<!-- shortcake:start -->
## Stack [🍰](https://shortcake.patrick.wtf)

- **#4542** (`2026-07-23-add-workflow-for-ai-prs`) <-- this PR
<!-- shortcake:end -->

## Summary by Sourcery

Clarify expectations for AI-assisted contributions and integrate automated handling for potentially AI-generated pull requests.

CI:
- Update the issue-manager workflow to react to labels on pull requests, scope permissions to the job, and automatically close PRs labeled as potentially AI-generated via the new `maybe-ai` rule.

Documentation:
- Add contribution guidelines explaining required human oversight and review for AI-assisted work, and how maintainers will handle low-effort automated submissions.