### PR TITLE
Fix schema codegen generating invalid Python for keyword enum values

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,44 @@
+---
+release type: patch
+social_messages:
+  x: >-
+    Strawberry {version} is out! This release fixes schema codegen generating
+    invalid Python when a GraphQL enum value is a Python keyword. 🍓
+    https://strawberry.rocks/release/{version}
+  linkedin: >-
+    Strawberry {version} is out. This release fixes schema codegen so that
+    GraphQL enum values that are Python keywords (like `class` or `import`) now
+    generate valid Python instead of code that fails to import.
+---
+
+This release fixes schema codegen generating invalid Python when a GraphQL enum
+value is a Python keyword.
+
+Previously, an enum such as:
+
+```graphql
+enum Example {
+  class
+  import
+}
+```
+
+generated Python that could not be imported, because `class` and `import` are
+reserved keywords:
+
+```python
+@strawberry.enum
+class Example(Enum):
+    class = "class"  # SyntaxError
+    import = "import"
+```
+
+Strawberry now aliases these members and preserves the original GraphQL name via
+`strawberry.enum_value`, matching how keyword field names are already handled:
+
+```python
+@strawberry.enum
+class Example(Enum):
+    class_ = strawberry.enum_value("class", name="class")
+    import_ = strawberry.enum_value("import", name="import")
+```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,8 +11,8 @@ social_messages:
     generate valid Python instead of code that fails to import.
 ---
 
-This release fixes schema codegen generating invalid Python when a GraphQL enum
-value is a Python keyword.
+This release fixes schema codegen that generated invalid Python when a GraphQL
+enum value is a Python keyword.
 
 Previously, an enum such as:
 

--- a/strawberry/schema_codegen/__init__.py
+++ b/strawberry/schema_codegen/__init__.py
@@ -594,6 +594,27 @@ def _get_class_definition(
 def _get_enum_value(enum_value: EnumValueDefinitionNode) -> cst.SimpleStatementLine:
     name = enum_value.name.value
 
+    if keyword.iskeyword(name):
+        # A Python keyword can't be used as an enum member name, so alias the
+        # member and keep the original GraphQL name via `strawberry.enum_value`.
+        return cst.SimpleStatementLine(
+            body=[
+                cst.Assign(
+                    targets=[cst.AssignTarget(cst.Name(f"{name}_"))],
+                    value=cst.Call(
+                        func=cst.Attribute(
+                            value=cst.Name("strawberry"),
+                            attr=cst.Name("enum_value"),
+                        ),
+                        args=[
+                            cst.Arg(cst.SimpleString(f'"{name}"')),
+                            _get_argument("name", name),
+                        ],
+                    ),
+                )
+            ]
+        )
+
     return cst.SimpleStatementLine(
         body=[
             cst.Assign(

--- a/strawberry/schema_codegen/__init__.py
+++ b/strawberry/schema_codegen/__init__.py
@@ -591,16 +591,29 @@ def _get_class_definition(
     return Definition(class_definition, interfaces, definition.name.value)
 
 
-def _get_enum_value(enum_value: EnumValueDefinitionNode) -> cst.SimpleStatementLine:
+def _get_enum_value(
+    enum_value: EnumValueDefinitionNode, used_names: set[str]
+) -> cst.SimpleStatementLine:
     name = enum_value.name.value
 
-    if keyword.iskeyword(name):
-        # A Python keyword can't be used as an enum member name, so alias the
-        # member and keep the original GraphQL name via `strawberry.enum_value`.
+    # A Python keyword can't be used as an enum member name. Neither can a name
+    # that collides with an alias we already generated for another member (e.g.
+    # an enum with both `class` and `class_`). In those cases we alias the member
+    # with trailing underscore(s) until it is unique, and keep the original
+    # GraphQL name via `strawberry.enum_value`.
+    member_name = name
+    if keyword.iskeyword(name) or name in used_names:
+        member_name = f"{name}_"
+        while member_name in used_names:
+            member_name += "_"
+
+    used_names.add(member_name)
+
+    if member_name != name:
         return cst.SimpleStatementLine(
             body=[
                 cst.Assign(
-                    targets=[cst.AssignTarget(cst.Name(f"{name}_"))],
+                    targets=[cst.AssignTarget(cst.Name(member_name))],
                     value=cst.Call(
                         func=cst.Attribute(
                             value=cst.Name("strawberry"),
@@ -633,11 +646,12 @@ def _get_enum_definition(definition: EnumTypeDefinitionNode) -> Definition:
         ),
     )
 
+    used_names: set[str] = set()
     class_definition = cst.ClassDef(
         name=cst.Name(definition.name.value),
         bases=[cst.Arg(cst.Name("Enum"))],
         body=cst.IndentedBlock(
-            body=[_get_enum_value(value) for value in definition.values]
+            body=[_get_enum_value(value, used_names) for value in definition.values]
         ),
         decorators=[decorator],
     )

--- a/tests/schema_codegen/test_enum.py
+++ b/tests/schema_codegen/test_enum.py
@@ -1,4 +1,7 @@
+import keyword
 import textwrap
+
+import pytest
 
 from strawberry.schema_codegen import codegen
 
@@ -23,6 +26,29 @@ def test_enum():
             AUTH_BROWSER_LAUNCHED = "AUTH_BROWSER_LAUNCHED"
             AUTH_COULD_NOT_LAUNCH_BROWSER = "AUTH_COULD_NOT_LAUNCH_BROWSER"
             AUTH_ERROR_DURING_LOGIN = "AUTH_ERROR_DURING_LOGIN"
+        """
+    ).strip()
+
+    assert codegen(schema).strip() == expected
+
+
+@pytest.mark.parametrize("name", keyword.kwlist)
+def test_handles_keyword_enum_values(name: str):
+    schema = f"""
+    enum Example {{
+        {name}
+    }}
+    """
+
+    expected = textwrap.dedent(
+        f"""
+        from __future__ import annotations
+        import strawberry
+        from enum import Enum
+
+        @strawberry.enum
+        class Example(Enum):
+            {name}_ = strawberry.enum_value("{name}", name="{name}")
         """
     ).strip()
 

--- a/tests/schema_codegen/test_enum.py
+++ b/tests/schema_codegen/test_enum.py
@@ -55,6 +55,36 @@ def test_handles_keyword_enum_values(name: str):
     assert codegen(schema).strip() == expected
 
 
+def test_mixed_keyword_and_non_keyword_enum_values():
+    # Only keyword values are aliased; non-keyword values are left as-is and the
+    # original ordering is preserved.
+    schema = """
+    enum Example {
+        RED
+        class
+        BLUE
+        import
+    }
+    """
+
+    expected = textwrap.dedent(
+        """
+        from __future__ import annotations
+        import strawberry
+        from enum import Enum
+
+        @strawberry.enum
+        class Example(Enum):
+            RED = "RED"
+            class_ = strawberry.enum_value("class", name="class")
+            BLUE = "BLUE"
+            import_ = strawberry.enum_value("import", name="import")
+        """
+    ).strip()
+
+    assert codegen(schema).strip() == expected
+
+
 def test_keyword_enum_value_alias_does_not_collide():
     # An enum can contain both a keyword value and its underscore-suffixed
     # counterpart; the generated aliases must stay unique so the generated

--- a/tests/schema_codegen/test_enum.py
+++ b/tests/schema_codegen/test_enum.py
@@ -55,6 +55,33 @@ def test_handles_keyword_enum_values(name: str):
     assert codegen(schema).strip() == expected
 
 
+def test_keyword_enum_value_alias_does_not_collide():
+    # An enum can contain both a keyword value and its underscore-suffixed
+    # counterpart; the generated aliases must stay unique so the generated
+    # Enum can be imported.
+    schema = """
+    enum Example {
+        class
+        class_
+    }
+    """
+
+    expected = textwrap.dedent(
+        """
+        from __future__ import annotations
+        import strawberry
+        from enum import Enum
+
+        @strawberry.enum
+        class Example(Enum):
+            class_ = strawberry.enum_value("class", name="class")
+            class__ = strawberry.enum_value("class_", name="class_")
+        """
+    ).strip()
+
+    assert codegen(schema).strip() == expected
+
+
 # TODO: descriptions
 def test_multiple_enums_single_import():
     schema = """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
`schema-codegen` produced invalid Python when a GraphQL enum value is a Python keyword (e.g. `class`, `import`, `None`) — the generated `class = "class"` fails to import. Keyword field names were already aliased; enum values weren't. This applies the same handling, aliasing the member and preserving the GraphQL name via `strawberry.enum_value`. Added a parametrized regression test over all Python keywords (fails without the change) and a `RELEASE.md`. 

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* N/A — found via code review while working on relay pagination ([#4516](https://github.com/dottxt-ai/outlines/issues/4516)); no existing issue.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Fix schema code generation for GraphQL enums whose values are Python keywords so that generated code is importable and consistent with existing keyword handling.

Bug Fixes:
- Ensure enum values that are Python keywords are aliased in generated Python while preserving their original GraphQL names via strawberry.enum_value.

Documentation:
- Add RELEASE.md entry describing the fix for keyword enum values in schema code generation.

Tests:
- Add parametrized regression test verifying schema codegen handles all Python keyword enum values correctly.