### PR TITLE
Fix type checkers rejecting custom comparison methods on Strawberry types

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,22 @@
+---
+release type: patch
+social_messages:
+  x: >-
+    🍓 Strawberry {version} is out! This release fixes type checkers rejecting
+    custom comparison methods like __gt__ on Strawberry types.
+    https://strawberry.rocks/release/{version}
+  linkedin: >-
+    Strawberry {version} is out. This release fixes type checkers incorrectly
+    rejecting custom comparison methods such as __gt__ on Strawberry types,
+    which are not ordered dataclasses.
+---
+
+This release fixes type checkers incorrectly rejecting custom comparison
+methods on Strawberry types.
+
+The `type`, `input`, `interface` and federation decorators declared
+`order_default=True` in their `dataclass_transform`, so type checkers assumed an
+auto-generated ordering and flagged a user-defined `__gt__` (or another rich
+comparison method) as conflicting. Strawberry builds these dataclasses without
+`order`, so this is now `order_default=False` and defining your own comparison
+operators no longer raises a false positive.

--- a/strawberry/federation/object_type.py
+++ b/strawberry/federation/object_type.py
@@ -58,7 +58,7 @@ def _impl_type(
 
 @overload
 @dataclass_transform(
-    order_default=True,
+    order_default=False,
     kw_only_default=True,
     field_specifiers=(base_field, field, StrawberryField),
 )
@@ -74,7 +74,7 @@ def type(
 
 @overload
 @dataclass_transform(
-    order_default=True,
+    order_default=False,
     kw_only_default=True,
     field_specifiers=(base_field, field, StrawberryField),
 )
@@ -106,7 +106,7 @@ def type(
 
 @overload
 @dataclass_transform(
-    order_default=True,
+    order_default=False,
     kw_only_default=True,
     field_specifiers=(base_field, field, StrawberryField),
 )
@@ -124,7 +124,7 @@ def input(
 
 @overload
 @dataclass_transform(
-    order_default=True,
+    order_default=False,
     kw_only_default=True,
     field_specifiers=(base_field, field, StrawberryField),
 )
@@ -163,7 +163,7 @@ def input(
 
 @overload
 @dataclass_transform(
-    order_default=True,
+    order_default=False,
     kw_only_default=True,
     field_specifiers=(base_field, field, StrawberryField),
 )
@@ -179,7 +179,7 @@ def interface(
 
 @overload
 @dataclass_transform(
-    order_default=True,
+    order_default=False,
     kw_only_default=True,
     field_specifiers=(base_field, field, StrawberryField),
 )
@@ -212,7 +212,7 @@ def interface(
 
 @overload
 @dataclass_transform(
-    order_default=True,
+    order_default=False,
     kw_only_default=True,
     field_specifiers=(base_field, field, StrawberryField),
 )
@@ -228,7 +228,7 @@ def interface_object(
 
 @overload
 @dataclass_transform(
-    order_default=True,
+    order_default=False,
     kw_only_default=True,
     field_specifiers=(base_field, field, StrawberryField),
 )

--- a/strawberry/federation/schema_directive.py
+++ b/strawberry/federation/schema_directive.py
@@ -24,7 +24,7 @@ T = TypeVar("T", bound=type)
 
 
 @dataclass_transform(
-    order_default=True,
+    order_default=False,
     kw_only_default=True,
     field_specifiers=(directive_field, field, StrawberryField),
 )

--- a/strawberry/schema_directive.py
+++ b/strawberry/schema_directive.py
@@ -41,7 +41,7 @@ T = TypeVar("T", bound=type)
 
 
 @dataclass_transform(
-    order_default=True,
+    order_default=False,
     kw_only_default=True,
     field_specifiers=(directive_field, field, StrawberryField),
 )

--- a/strawberry/types/object_type.py
+++ b/strawberry/types/object_type.py
@@ -192,7 +192,7 @@ def _process_type(
 
 @overload
 @dataclass_transform(
-    order_default=True, kw_only_default=True, field_specifiers=(field, StrawberryField)
+    order_default=False, kw_only_default=True, field_specifiers=(field, StrawberryField)
 )
 def type(
     cls: T,
@@ -208,7 +208,7 @@ def type(
 
 @overload
 @dataclass_transform(
-    order_default=True, kw_only_default=True, field_specifiers=(field, StrawberryField)
+    order_default=False, kw_only_default=True, field_specifiers=(field, StrawberryField)
 )
 def type(
     *,
@@ -222,7 +222,7 @@ def type(
 
 
 @dataclass_transform(
-    order_default=True, kw_only_default=True, field_specifiers=(field, StrawberryField)
+    order_default=False, kw_only_default=True, field_specifiers=(field, StrawberryField)
 )
 def type(
     cls: T | None = None,
@@ -317,7 +317,7 @@ def type(
 
 @overload
 @dataclass_transform(
-    order_default=True, kw_only_default=True, field_specifiers=(field, StrawberryField)
+    order_default=False, kw_only_default=True, field_specifiers=(field, StrawberryField)
 )
 def input(
     cls: T,
@@ -331,7 +331,7 @@ def input(
 
 @overload
 @dataclass_transform(
-    order_default=True, kw_only_default=True, field_specifiers=(field, StrawberryField)
+    order_default=False, kw_only_default=True, field_specifiers=(field, StrawberryField)
 )
 def input(
     *,
@@ -343,7 +343,7 @@ def input(
 
 
 @dataclass_transform(
-    order_default=True, kw_only_default=True, field_specifiers=(field, StrawberryField)
+    order_default=False, kw_only_default=True, field_specifiers=(field, StrawberryField)
 )
 def input(
     cls: T | None = None,
@@ -399,7 +399,7 @@ def input(
 
 @overload
 @dataclass_transform(
-    order_default=True, kw_only_default=True, field_specifiers=(field, StrawberryField)
+    order_default=False, kw_only_default=True, field_specifiers=(field, StrawberryField)
 )
 def interface(
     cls: T,
@@ -412,7 +412,7 @@ def interface(
 
 @overload
 @dataclass_transform(
-    order_default=True, kw_only_default=True, field_specifiers=(field, StrawberryField)
+    order_default=False, kw_only_default=True, field_specifiers=(field, StrawberryField)
 )
 def interface(
     *,
@@ -423,7 +423,7 @@ def interface(
 
 
 @dataclass_transform(
-    order_default=True, kw_only_default=True, field_specifiers=(field, StrawberryField)
+    order_default=False, kw_only_default=True, field_specifiers=(field, StrawberryField)
 )
 def interface(
     cls: T | None = None,

--- a/tests/typecheckers/test_order.py
+++ b/tests/typecheckers/test_order.py
@@ -1,0 +1,29 @@
+from inline_snapshot import snapshot
+
+from .utils.marks import requires_mypy, requires_pyright, requires_ty, skip_on_windows
+from .utils.typecheck import typecheck
+
+pytestmark = [skip_on_windows, requires_pyright, requires_mypy, requires_ty]
+
+
+# Strawberry types are not ordered dataclasses, so defining a custom comparison
+# operator must not be reported as conflicting with a generated one.
+CODE = """
+import strawberry
+
+
+@strawberry.type
+class Fruit:
+    weight: int
+
+    def __gt__(self, other: "Fruit") -> bool:
+        return self.weight > other.weight
+"""
+
+
+def test():
+    results = typecheck(CODE)
+
+    assert results.pyright == snapshot([])
+    assert results.mypy == snapshot([])
+    assert results.ty == snapshot([])

--- a/tests/typecheckers/utils/mypy.py
+++ b/tests/typecheckers/utils/mypy.py
@@ -81,6 +81,9 @@ def run_mypy(
 
         try:
             for line in full_output.split("\n"):
+                # mypy emits nothing when a snippet has no diagnostics.
+                if not line.strip():
+                    continue
                 mypy_result = json.loads(line)
 
                 results.append(


### PR DESCRIPTION
## Description 🍓

Strawberry types are not ordered dataclasses, but the `type`, `input`,
`interface` and federation decorators declared `order_default=True` in their
`@dataclass_transform`. Type checkers therefore assumed an auto-generated
ordering and rejected a user-defined rich comparison method:

```python
import strawberry

@strawberry.type
class Fruit:
    weight: int

    def __gt__(self, other: "Fruit") -> bool:  # error: may not have a custom "__gt__" when "order" is True
        return self.weight > other.weight
```

`_wrap_dataclass` builds these with `dataclasses.dataclass(kw_only=True)` (no
`order`), so `order_default` is now `False` across those decorators and defining
your own comparison operators no longer raises a false positive. `kw_only_default`
is unchanged. 🍓

## Tests 🍓

Added `tests/typecheckers/test_order.py`, which asserts mypy, pyright and ty all
accept a custom `__gt__` on a Strawberry type (it fails against the previous
`order_default=True`). The mypy type-check helper also now tolerates a snippet
that produces no diagnostics, which this test needs. 🍓

Closes #3790

## Summary by Sourcery

Adjust Strawberry decorators and related utilities so type checkers no longer treat Strawberry types as ordered dataclasses, allowing custom comparison methods without false positives.

Bug Fixes:
- Set dataclass_transform order_default=False for Strawberry type, input, interface, schema directive, and federation decorators to prevent type checkers from assuming auto-generated ordering and rejecting user-defined comparison methods.

Enhancements:
- Add a typechecker test ensuring mypy, pyright, and ty accept custom comparison operators on Strawberry types and update the mypy helper to handle snippets with no diagnostics.
- Introduce a RELEASE.md entry documenting the patch release and the fix for typechecker behavior around custom comparison methods on Strawberry types.