### PR TITLE
fix(codegen): keep GraphQL field names that don't survive camel-casing

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,35 @@
+---
+release type: patch
+social_messages:
+  x: >-
+    Strawberry {version} is out! This release fixes schema codegen silently
+    renaming fields whose GraphQL names don't survive camel-casing. 🍓
+    https://strawberry.rocks/release/{version}
+  linkedin: >-
+    Strawberry {version} is out. This release fixes schema codegen so that
+    GraphQL field names such as `some_field` or `allowCustomExportURL` keep
+    their original names in the generated schema instead of being silently
+    renamed.
+---
+
+This release fixes schema codegen silently renaming fields whose GraphQL names
+are not reproduced by camel-casing.
+
+Strawberry derives the GraphQL name of a field by camel-casing its Python name,
+so generating `some_field` from a GraphQL field named `some_field` produced a
+schema exposing `someField` instead. The same happened to names containing
+acronyms, such as `allowCustomExportURL`, which came back as
+`allowCustomExportUrl`.
+
+Codegen now adds an explicit alias whenever camel-casing would not give the
+original name back:
+
+```python
+@strawberry.type
+class Example:
+    some_field: int | None = strawberry.field(name="some_field")
+    allow_custom_export_url: bool = strawberry.field(name="allowCustomExportURL")
+```
+
+Fields whose GraphQL names convert to the same Python name (for example
+`someField` and `some_field`) are also no longer silently dropped.

--- a/strawberry/schema_codegen/__init__.py
+++ b/strawberry/schema_codegen/__init__.py
@@ -332,6 +332,21 @@ def _get_field_value(
     return None
 
 
+def _make_unique_name(name: str, used_names: set[str]) -> str:
+    """Return a variant of *name* not in *used_names*, and reserve it.
+
+    Two GraphQL names can convert to the same Python name (e.g. `someField` and
+    `some_field`); appending underscores stops the later one from silently
+    overwriting the earlier one.
+    """
+    while name in used_names:
+        name += "_"
+
+    used_names.add(name)
+
+    return name
+
+
 def _get_field(
     field: FieldDefinitionNode | InputValueDefinitionNode,
     is_apollo_federation: bool,
@@ -346,12 +361,7 @@ def _get_field(
     if keyword.iskeyword(name):
         name = f"{name}_"
 
-    # Two GraphQL names can convert to the same Python name (e.g. `someField`
-    # and `some_field`), which would silently overwrite the previous field.
-    while name in used_names:
-        name += "_"
-
-    used_names.add(name)
+    name = _make_unique_name(name, used_names)
 
     # Strawberry derives the GraphQL name by camel-casing the Python name, so an
     # explicit alias is needed whenever that would not give the original name

--- a/strawberry/schema_codegen/__init__.py
+++ b/strawberry/schema_codegen/__init__.py
@@ -39,7 +39,7 @@ from graphql.language.ast import (
     NullValueNode,
 )
 
-from strawberry.utils.str_converters import to_snake_case
+from strawberry.utils.str_converters import to_camel_case, to_snake_case
 
 if TYPE_CHECKING:
     from graphql.language.ast import ConstDirectiveNode
@@ -338,13 +338,25 @@ def _get_field(
     imports: set[Import],
     *,
     is_input_field: bool = False,
+    used_names: set[str],
 ) -> cst.SimpleStatementLine:
-    name = to_snake_case(field.name.value)
-    alias: str | None = None
+    graphql_name = field.name.value
+    name = to_snake_case(graphql_name)
 
     if keyword.iskeyword(name):
         name = f"{name}_"
-        alias = field.name.value
+
+    # Two GraphQL names can convert to the same Python name (e.g. `someField`
+    # and `some_field`), which would silently overwrite the previous field.
+    while name in used_names:
+        name += "_"
+
+    used_names.add(name)
+
+    # Strawberry derives the GraphQL name by camel-casing the Python name, so an
+    # explicit alias is needed whenever that would not give the original name
+    # back, e.g. for `some_field`, `URL` or names aliased above.
+    alias = graphql_name if to_camel_case(name) != graphql_name else None
 
     # For input types, wrap nullable fields in strawberry.Maybe[...]
     wrap_in_maybe = is_input_field and _is_nullable(field.type)
@@ -571,6 +583,7 @@ def _get_class_definition(
 
     is_input_type = isinstance(definition, InputObjectTypeDefinitionNode)
 
+    used_names: set[str] = set()
     class_definition = cst.ClassDef(
         name=cst.Name(definition.name.value),
         body=cst.IndentedBlock(
@@ -580,6 +593,7 @@ def _get_class_definition(
                     is_apollo_federation,
                     imports,
                     is_input_field=is_input_type,
+                    used_names=used_names,
                 )
                 for field in definition.fields
             ]

--- a/tests/schema_codegen/test_names.py
+++ b/tests/schema_codegen/test_names.py
@@ -48,8 +48,58 @@ def test_converts_names_to_snake_case():
         @strawberry.type
         class Example:
             some_field: str
-            allow_custom_export_url: bool
-            allow_insecure_tls: bool
+            allow_custom_export_url: bool = strawberry.field(name="allowCustomExportURL")
+            allow_insecure_tls: bool = strawberry.field(name="allowInsecureTLS")
+        """
+    ).strip()
+
+    assert codegen(schema).strip() == expected
+
+
+def test_keeps_graphql_names_that_do_not_survive_camel_casing():
+    # Strawberry camel-cases Python names to get the GraphQL name, so names that
+    # are not reproduced by that conversion need an explicit alias.
+    schema = """
+    type Example {
+        some_field: Int
+        URL: String
+    }
+    """
+
+    expected = textwrap.dedent(
+        """
+        from __future__ import annotations
+        import strawberry
+
+        @strawberry.type
+        class Example:
+            some_field: int | None = strawberry.field(name="some_field")
+            url: str | None = strawberry.field(name="URL")
+        """
+    ).strip()
+
+    assert codegen(schema).strip() == expected
+
+
+def test_handles_names_converting_to_the_same_python_name():
+    # `someField` and `some_field` both convert to `some_field`; the second one
+    # must not overwrite the first.
+    schema = """
+    type Example {
+        someField: String
+        some_field: Int
+    }
+    """
+
+    expected = textwrap.dedent(
+        """
+        from __future__ import annotations
+        import strawberry
+
+        @strawberry.type
+        class Example:
+            some_field: str | None
+            some_field_: int | None = strawberry.field(name="some_field")
         """
     ).strip()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

`schema-codegen` generated code that produces a *different* schema than the SDL it
was given. Strawberry derives a field's GraphQL name by camel-casing its Python
name, but codegen only added an explicit `name=` alias for Python keywords. Any
name that isn't reproduced by camel-casing was silently renamed:

| SDL in | Schema produced by generated code |
|---|---|
| `some_field: Int` | `someField: Int` |
| `allowCustomExportURL: Boolean!` | `allowCustomExportUrl: Boolean!` |
| `URL: String` | `url: String` |

Additionally, two GraphQL names converting to the same Python name (e.g.
`someField` and `some_field`) produced a duplicate attribute, silently dropping
one field.

Codegen now adds an alias whenever camel-casing wouldn't give the original name
back, and makes colliding Python names unique.

Note: this updates `test_converts_names_to_snake_case`, which asserted the
previous (incorrect) output for `allowCustomExportURL` / `allowInsecureTLS` —
those generated `allowCustomExportUrl` / `allowInsecureTls` in the resulting
schema.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* N/A

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Ensure schema codegen preserves original GraphQL field names and avoids silently dropping fields when names collide after conversion to Python identifiers.

Bug Fixes:
- Prevent schema codegen from silently renaming GraphQL fields whose names are not reproduced by camel-casing their Python counterparts.
- Avoid losing fields when multiple GraphQL names convert to the same Python attribute name by generating unique Python names.

Documentation:
- Add a release note describing the schema codegen bug with camel-cased field names and the fix for preserving original GraphQL names.

Tests:
- Update existing name-conversion test to assert the corrected generated schema for fields with acronyms and add new tests covering non-camel-case GraphQL names and colliding name conversions.