### PR TITLE
Add input clean methods

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,16 @@
+---
+release type: minor
+social_messages:
+  x: >-
+    {project_name} {version} is out! This release adds lifecycle hooks for input
+    objects. 🍓 https://strawberry.rocks/release/{version}
+  linkedin: >-
+    {project_name} {version} is out. This release adds lifecycle hooks for input
+    objects so inputs can validate and prepare request-scoped data before resolvers run.
+---
+
+This release adds lifecycle hooks for input objects.
+
+Input objects can now define a synchronous or asynchronous `clean` method that
+receives the resolver `Info` object after GraphQL input coercion and before
+resolver execution.

--- a/docs/types/input-types.md
+++ b/docs/types/input-types.md
@@ -89,6 +89,84 @@ completely absent (common in update operations), you can use `strawberry.Maybe`.
 See the [Maybe documentation](./maybe.md) for comprehensive examples and usage
 patterns.
 
+## Clean methods
+
+Input types can prepare or validate coerced values before the resolver runs.
+Define `clean` as either a regular or async method; it receives the resolver's
+`Info` object. Nested input clean methods run before the method of their
+containing input.
+
+### Normalize input values
+
+Use a synchronous `clean` method for local normalization and validation.
+
+```python
+import strawberry
+from strawberry.types import Info
+
+
+@strawberry.input
+class CreateUserInput:
+    email: str
+
+    def clean(self, info: Info) -> None:
+        self.email = self.email.strip().lower()
+```
+
+### Load request data asynchronously
+
+Use an async `clean` method when preparation needs request-scoped resources such
+as dataloaders.
+
+```python
+import strawberry
+from strawberry.dataloader import DataLoader
+from strawberry.types import Info
+
+
+class RequestContext:
+    project_loader: DataLoader[strawberry.ID, object]
+
+
+@strawberry.input
+class ProjectInput:
+    project_id: strawberry.ID
+    project: strawberry.Private[object | None] = None
+
+    async def clean(self, info: Info) -> None:
+        self.project = await info.context.project_loader.load(self.project_id)
+```
+
+Asynchronous clean methods require asynchronous execution with
+`await schema.execute(...)`.
+
+### Clean nested inputs
+
+Nested input clean methods run before the clean method of their containing
+input. This lets a parent validate normalized nested values.
+
+```python
+import strawberry
+from strawberry.types import Info
+
+
+@strawberry.input
+class AddressInput:
+    country: str
+
+    def clean(self, info: Info) -> None:
+        self.country = self.country.upper()
+
+
+@strawberry.input
+class ShippingInput:
+    address: AddressInput
+
+    def clean(self, info: Info) -> None:
+        if self.address.country not in info.context.shipping_countries:
+            raise ValueError("Shipping is not available in this country")
+```
+
 ## API
 
 `@strawberry.input(name: str = None, description: str = None)`

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -75,7 +75,10 @@ from strawberry.types.base import (
 from strawberry.types.cast import get_strawberry_type_cast
 from strawberry.types.enum import StrawberryEnumDefinition, has_enum_definition
 from strawberry.types.field import UNRESOLVED
-from strawberry.types.input import run_input_clean_methods
+from strawberry.types.input import (
+    run_input_clean_methods,
+    type_has_input_clean_method,
+)
 from strawberry.types.lazy_type import LazyType
 from strawberry.types.private import is_private
 from strawberry.types.scalar import ScalarWrapper, scalar
@@ -995,6 +998,10 @@ class GraphQLCoreConverter:
             # that type-changing extensions are reflected before handlers are
             # matched; here we only need to build the resolver chain.
             extension_functions = build_field_extension_resolvers(field)
+            has_input_clean_methods = any(
+                type_has_input_clean_method(argument.type)
+                for argument in field.arguments
+            )
 
             def extension_resolver(
                 _source: Any,
@@ -1019,8 +1026,10 @@ class GraphQLCoreConverter:
                     # explicitly to the extensions
                     field_kwargs.pop("info")
 
-                input_clean_methods = run_input_clean_methods(
-                    [*field_args, *field_kwargs.values()], info
+                input_clean_methods = (
+                    run_input_clean_methods([*field_args, *field_kwargs.values()], info)
+                    if has_input_clean_methods
+                    else None
                 )
 
                 # `_get_result` expects `field_args` and `field_kwargs` as

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -59,7 +59,10 @@ from strawberry.schema.types.scalar import (
     DEFAULT_SCALAR_REGISTRY,
     _make_scalar_type,
 )
-from strawberry.types.arguments import StrawberryArgument, convert_arguments
+from strawberry.types.arguments import (
+    StrawberryArgument,
+    convert_arguments,
+)
 from strawberry.types.base import (
     StrawberryList,
     StrawberryMaybe,
@@ -72,6 +75,7 @@ from strawberry.types.base import (
 from strawberry.types.cast import get_strawberry_type_cast
 from strawberry.types.enum import StrawberryEnumDefinition, has_enum_definition
 from strawberry.types.field import UNRESOLVED
+from strawberry.types.input import run_input_clean_methods
 from strawberry.types.lazy_type import LazyType
 from strawberry.types.private import is_private
 from strawberry.types.scalar import ScalarWrapper, scalar
@@ -1015,6 +1019,10 @@ class GraphQLCoreConverter:
                     # explicitly to the extensions
                     field_kwargs.pop("info")
 
+                input_clean_methods = run_input_clean_methods(
+                    [*field_args, *field_kwargs.values()], info
+                )
+
                 # `_get_result` expects `field_args` and `field_kwargs` as
                 # separate arguments so we have to wrap the function so that we
                 # can pass them in
@@ -1032,11 +1040,20 @@ class GraphQLCoreConverter:
                     )
 
                 # combine all the extension resolvers
-                return reduce(
+                resolver = reduce(
                     lambda chained_fn, next_fn: partial(next_fn, chained_fn),
                     extension_functions,
                     wrapped_get_result,
-                )(_source, info, **field_kwargs)
+                )
+
+                if input_clean_methods is None:
+                    return resolver(_source, info, **field_kwargs)
+
+                async def run_resolver() -> Any:
+                    await input_clean_methods
+                    return await await_maybe(resolver(_source, info, **field_kwargs))
+
+                return run_resolver()
 
             return extension_resolver
 

--- a/strawberry/types/input.py
+++ b/strawberry/types/input.py
@@ -5,12 +5,47 @@ from collections.abc import Awaitable, Callable, Iterable, Iterator
 from functools import partial
 from typing import TypeAlias
 
-from strawberry.types.base import StrawberryObjectDefinition, get_object_definition
+from strawberry.types.base import (
+    StrawberryContainer,
+    StrawberryObjectDefinition,
+    StrawberryType,
+    get_object_definition,
+)
 from strawberry.types.maybe import Some
 from strawberry.utils.await_maybe import await_maybe
 
 CleanOperation: TypeAlias = Callable[[], object]
 MaybeAwaitable: TypeAlias = Awaitable[None] | None
+
+
+def type_has_input_clean_method(type_: StrawberryType | type) -> bool:
+    """Return whether an input type graph contains a `clean` method.
+
+    This runs while creating a schema so regular resolvers do not pay for input
+    traversal when none of their declared input types supports lifecycle hooks.
+    """
+    return _type_has_input_clean_method(type_, set())
+
+
+def _type_has_input_clean_method(
+    type_: StrawberryType | type,
+    visited: set[StrawberryObjectDefinition],
+) -> bool:
+    if isinstance(type_, StrawberryContainer):
+        return _type_has_input_clean_method(type_.of_type, visited)
+
+    definition = get_object_definition(type_)
+    if definition is None or not definition.is_input or definition in visited:
+        return False
+
+    visited.add(definition)
+
+    if callable(getattr(definition.origin, "clean", None)):
+        return True
+
+    return any(
+        _type_has_input_clean_method(field.type, visited) for field in definition.fields
+    )
 
 
 def run_input_clean_methods(values: Iterable[object], info: object) -> MaybeAwaitable:

--- a/strawberry/types/input.py
+++ b/strawberry/types/input.py
@@ -35,10 +35,10 @@ def _run_clean_operations(operations: Iterable[CleanOperation]) -> MaybeAwaitabl
 
 
 async def _await_remaining(
-    first: Awaitable[object], remaining: Iterator[CleanOperation]
+    pending: Awaitable[object], remaining: Iterator[CleanOperation]
 ) -> None:
     """Await clean operations sequentially to preserve child-before-parent order."""
-    await first
+    await pending
     for operation in remaining:
         await await_maybe(operation())
 

--- a/strawberry/types/input.py
+++ b/strawberry/types/input.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import inspect
+from collections.abc import Awaitable, Callable, Iterable, Iterator
+from functools import partial
+from typing import TypeAlias
+
+from strawberry.types.base import StrawberryObjectDefinition, get_object_definition
+from strawberry.types.maybe import Some
+from strawberry.utils.await_maybe import await_maybe
+
+CleanOperation: TypeAlias = Callable[[], object]
+MaybeAwaitable: TypeAlias = Awaitable[None] | None
+
+
+def run_input_clean_methods(values: Iterable[object], info: object) -> MaybeAwaitable:
+    """Run clean methods on coerced input objects.
+
+    Nested inputs are visited before their containing input. Synchronous methods run
+    immediately; an awaitable is returned only when a method returns an awaitable.
+    """
+    return _run_clean_operations(partial(_visit_input, value, info) for value in values)
+
+
+def _run_clean_operations(operations: Iterable[CleanOperation]) -> MaybeAwaitable:
+    """Run clean operations until one requires asynchronous continuation."""
+    iterator = iter(operations)
+
+    for operation in iterator:
+        result = operation()
+        if inspect.isawaitable(result):
+            return _await_remaining(result, iterator)
+
+    return None
+
+
+async def _await_remaining(
+    first: Awaitable[object], remaining: Iterator[CleanOperation]
+) -> None:
+    """Await clean operations sequentially to preserve child-before-parent order."""
+    await first
+    for operation in remaining:
+        await await_maybe(operation())
+
+
+def _visit_input(value: object, info: object) -> MaybeAwaitable:
+    """Traverse an input value and run its nested lifecycle hooks."""
+    if isinstance(value, Some):
+        return _visit_input(value.value, info)
+
+    if isinstance(value, (list, tuple)):
+        return _run_clean_operations(
+            partial(_visit_input, item, info) for item in value
+        )
+
+    definition = get_object_definition(value)
+    if definition is None or not definition.is_input:
+        return None
+
+    return _run_clean_operations(_iter_clean_operations(value, definition, info))
+
+
+def _iter_clean_operations(
+    value: object,
+    definition: StrawberryObjectDefinition,
+    info: object,
+) -> Iterator[CleanOperation]:
+    """Yield nested-input visits followed by this input's clean hook."""
+    for field in definition.fields:
+        assert field.python_name is not None
+        field_value = getattr(value, field.python_name)
+        yield partial(_visit_input, field_value, info)
+
+    clean = getattr(value, "clean", None)
+    if callable(clean):
+        yield partial(clean, info)

--- a/tests/schema/test_input.py
+++ b/tests/schema/test_input.py
@@ -8,6 +8,7 @@ import strawberry
 from strawberry.dataloader import DataLoader
 from strawberry.exceptions import InvalidSuperclassInterfaceError
 from strawberry.printer import print_schema
+from strawberry.schema import schema_converter
 from strawberry.types import Info
 from tests.conftest import skip_if_gql_32
 
@@ -191,6 +192,32 @@ def test_input_clean_runs_after_coercion_and_before_resolver():
         call.parent_clean("ONE", "TWO"),
         call.resolver("ONE", "TWO"),
     ]
+
+
+def test_input_without_clean_skips_input_clean_traversal(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    run_input_clean_methods = Mock(wraps=schema_converter.run_input_clean_methods)
+    monkeypatch.setattr(
+        schema_converter, "run_input_clean_methods", run_input_clean_methods
+    )
+
+    @strawberry.input
+    class Input:
+        value: str
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def value(self, data: Input) -> str:
+            return data.value
+
+    schema = strawberry.Schema(query=Query)
+    result = schema.execute_sync('query { value(data: { value: "project" }) }')
+
+    assert result.errors is None
+    assert result.data == {"value": "project"}
+    run_input_clean_methods.assert_not_called()
 
 
 async def test_input_async_clean_runs_before_containing_clean_and_resolver():

--- a/tests/schema/test_input.py
+++ b/tests/schema/test_input.py
@@ -1,11 +1,14 @@
 import re
 import textwrap
+from unittest.mock import Mock, call
 
 import pytest
 
 import strawberry
+from strawberry.dataloader import DataLoader
 from strawberry.exceptions import InvalidSuperclassInterfaceError
 from strawberry.printer import print_schema
+from strawberry.types import Info
 from tests.conftest import skip_if_gql_32
 
 
@@ -141,3 +144,237 @@ def test_input_cannot_inherit_from_interfaces():
     @strawberry.input
     class SomeOtherInput(SomeInterface, SomeOtherInterface):
         another_arg: str
+
+
+def test_input_clean_runs_after_coercion_and_before_resolver():
+    hooks = Mock()
+
+    @strawberry.input
+    class ChildInput:
+        value: str
+
+        def clean(self, info: Info) -> None:
+            hooks.child_clean(info.context["prefix"], self.value)
+            self.value = self.value.upper()
+
+    @strawberry.input
+    class ParentInput:
+        child: ChildInput
+        children: list[ChildInput]
+
+        def clean(self, info: Info) -> None:
+            hooks.parent_clean(self.child.value, self.children[0].value)
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def values(self, data: ParentInput) -> str:
+            hooks.resolver(data.child.value, data.children[0].value)
+            return f"{data.child.value},{data.children[0].value}"
+
+    schema = strawberry.Schema(query=Query)
+
+    result = schema.execute_sync(
+        """
+        query {
+            values(data: { child: { value: "one" }, children: [{ value: "two" }] })
+        }
+        """,
+        context_value={"prefix": "request"},
+    )
+
+    assert result.errors is None
+    assert result.data == {"values": "ONE,TWO"}
+    assert hooks.mock_calls == [
+        call.child_clean("request", "one"),
+        call.child_clean("request", "two"),
+        call.parent_clean("ONE", "TWO"),
+        call.resolver("ONE", "TWO"),
+    ]
+
+
+async def test_input_async_clean_runs_before_containing_clean_and_resolver():
+    hooks = Mock()
+
+    @strawberry.input
+    class ChildInput:
+        value: str
+
+        async def clean(self, info: Info) -> None:
+            hooks.child_clean(info.context["suffix"], self.value)
+            self.value += info.context["suffix"]
+
+    @strawberry.input
+    class ParentInput:
+        child: ChildInput
+
+        def clean(self, info: Info) -> None:
+            hooks.parent_clean(self.child.value)
+            self.child.value = self.child.value.upper()
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def value(self, data: ParentInput) -> str:
+            hooks.resolver(data.child.value)
+            return data.child.value
+
+    schema = strawberry.Schema(query=Query)
+
+    result = await schema.execute(
+        'query { value(data: { child: { value: "project" } }) }',
+        context_value={"suffix": "-1"},
+    )
+
+    assert result.errors is None
+    assert result.data == {"value": "PROJECT-1"}
+    assert hooks.mock_calls == [
+        call.child_clean("-1", "project"),
+        call.parent_clean("project-1"),
+        call.resolver("PROJECT-1"),
+    ]
+
+
+async def test_input_async_clean_runs_after_contained_clean():
+    hooks = Mock()
+
+    @strawberry.input
+    class ChildInput:
+        value: str
+
+        def clean(self, info: Info) -> None:
+            hooks.child_clean(self.value)
+            self.value = self.value.upper()
+
+    @strawberry.input
+    class ParentInput:
+        child: ChildInput
+
+        async def clean(self, info: Info) -> None:
+            hooks.parent_clean(self.child.value)
+            self.child.value += info.context["suffix"]
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def value(self, data: ParentInput) -> str:
+            hooks.resolver(data.child.value)
+            return data.child.value
+
+    schema = strawberry.Schema(query=Query)
+
+    result = await schema.execute(
+        'query { value(data: { child: { value: "project" } }) }',
+        context_value={"suffix": "-1"},
+    )
+
+    assert result.errors is None
+    assert result.data == {"value": "PROJECT-1"}
+    assert hooks.mock_calls == [
+        call.child_clean("project"),
+        call.parent_clean("PROJECT"),
+        call.resolver("PROJECT-1"),
+    ]
+
+
+def test_input_clean_error_prevents_resolver_execution():
+    resolver = Mock()
+
+    @strawberry.input
+    class Input:
+        value: str
+
+        def clean(self, info: Info) -> None:
+            raise ValueError("Invalid input")
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def value(self, data: Input) -> str:
+            resolver(data)
+            return data.value
+
+    schema = strawberry.Schema(query=Query)
+
+    result = schema.execute_sync('query { value(data: { value: "project" }) }')
+
+    assert result.data is None
+    assert result.errors is not None
+    assert result.errors[0].message == "Invalid input"
+    resolver.assert_not_called()
+
+
+async def test_input_clean_can_use_dataloader():
+    async def load_projects(keys: list[str]) -> list[str]:
+        return [f"project:{key}" for key in keys]
+
+    project_loader = Mock(side_effect=load_projects)
+
+    @strawberry.input
+    class ProjectInput:
+        project_id: strawberry.ID
+        project: strawberry.Private[str | None] = None
+
+        async def clean(self, info: Info) -> None:
+            self.project = await info.context["project_loader"].load(self.project_id)
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def project(self, data: ProjectInput) -> str:
+            assert data.project is not None
+            return data.project
+
+    schema = strawberry.Schema(query=Query)
+    loader = DataLoader(load_fn=project_loader)
+
+    result = await schema.execute(
+        'query { project(data: { projectId: "one" }) }',
+        context_value={"project_loader": loader},
+    )
+
+    assert result.errors is None
+    assert result.data == {"project": "project:one"}
+    project_loader.assert_called_once_with(["one"])
+
+
+async def test_input_clean_preserves_mutation_field_order():
+    hooks = Mock()
+
+    @strawberry.input
+    class Input:
+        value: str
+
+        async def clean(self, info: Info) -> None:
+            hooks.clean(self.value)
+
+    @strawberry.type
+    class Query:
+        value: str = "query"
+
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        async def first(self, data: Input) -> str:
+            hooks.resolver("first", data.value)
+            return data.value
+
+        @strawberry.mutation
+        async def second(self, data: Input) -> str:
+            hooks.resolver("second", data.value)
+            return data.value
+
+    schema = strawberry.Schema(query=Query, mutation=Mutation)
+
+    result = await schema.execute(
+        'mutation { first(data: { value: "one" }) second(data: { value: "two" }) }'
+    )
+
+    assert result.errors is None
+    assert result.data == {"first": "one", "second": "two"}
+    assert hooks.mock_calls == [
+        call.clean("one"),
+        call.resolver("first", "one"),
+        call.clean("two"),
+        call.resolver("second", "two"),
+    ]


### PR DESCRIPTION
## Description

Adds opt-in `clean(info)` methods for Strawberry input types. Clean methods run after input coercion and before field extensions and resolver execution. They support both synchronous and asynchronous implementations, receive the resolver `Info`, and process nested inputs before their containing input.

Also adds documentation for synchronous normalization, async request-scoped DataLoader hydration, and nested input validation.

## Types of Changes

- [x] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

Fixes #4552

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Introduce lifecycle clean hooks for input objects that run between input coercion and resolver execution.

New Features:
- Allow input object types to define synchronous or asynchronous clean methods that receive resolver Info and run before resolvers and field extensions.
- Support nested input clean execution in child-before-parent order, including for collections and Maybe values.

Build:
- Add a release note entry describing the new input clean lifecycle hooks.

Documentation:
- Document how to use input clean methods for synchronous normalization, async DataLoader hydration, and nested input validation.

Tests:
- Add tests covering clean method ordering, async behavior, error handling, DataLoader integration, and mutation field ordering.