### PR TITLE
fix(federation): run @key/@requires/@provides field sets and resolve_reference kwargs through the name converter (#591)

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,16 @@
 ---
 release type: patch
+social_messages:
+  x: >-
+    {project_name} {version} is out! This release makes federation @key,
+    @requires and @provides field sets follow the schema's name converter,
+    fixing subgraph composition for snake_case fields. 🍓
+    https://strawberry.rocks/release/{version}
+  linkedin: >-
+    {project_name} {version} is out. Federation @key, @requires and @provides
+    field sets and resolve_reference keyword arguments now follow the schema's
+    configured name converter, fixing Apollo Federation subgraph composition
+    for snake_case fields.
 ---
 
 This release fixes federation `@key`, `@requires` and `@provides` directives

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,39 @@
+---
+release type: patch
+---
+
+This release fixes federation `@key`, `@requires` and `@provides` directives
+to use the schema's configured name converter, so the field names inside
+them line up with the field names actually printed in the SDL.
+
+Previously, `fields` selections on these directives were emitted as-is,
+regardless of any name conversion applied to the fields themselves. With the
+default camelCase conversion, this meant a snake_case Python field like
+`my_key` was printed as `myKey` in the type but referenced as `my_key` in
+`@key(fields: "my_key")` -- a mismatch that Apollo Federation composition
+rejects.
+
+`resolve_reference` now also receives keyword arguments matching each
+field's Python name (e.g. `my_key`) instead of its GraphQL name (e.g.
+`myKey`), matching how every other resolver in Strawberry receives its
+arguments.
+
+```python
+@strawberry.federation.type(keys=["my_key"])
+class Product:
+    my_key: str
+
+    @classmethod
+    def resolve_reference(cls, my_key: str) -> "Product":
+        return Product(my_key=my_key)
+```
+
+now prints `type Product @key(fields: "myKey")` (matching the `myKey` field
+that's actually defined) and calls `resolve_reference(my_key=...)` instead
+of raising `TypeError: resolve_reference() got an unexpected keyword
+argument 'myKey'`.
+
+If you were working around either of these bugs -- e.g. by writing
+`keys=["myKey"]` directly, or by naming your `resolve_reference` parameters
+after the GraphQL name instead of the Python name -- you'll need to update
+those to use the field's Python name instead, as shown above.

--- a/strawberry/federation/field_set.py
+++ b/strawberry/federation/field_set.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+from graphql import GraphQLError, parse
+from graphql.language import FieldNode, FragmentSpreadNode, InlineFragmentNode
+from graphql.language.printer import print_ast
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from graphql.language import (
+        OperationDefinitionNode,
+        SelectionNode,
+        SelectionSetNode,
+    )
+
+
+def apply_name_converter(field_set: str, name_converter: Callable[[str], str]) -> str:
+    """Apply ``name_converter`` to every field name in a federation FieldSet.
+
+    A FieldSet (used by the ``@key``, ``@requires`` and ``@provides``
+    directives) is a GraphQL selection set given as a string, e.g.
+    ``"upc"`` or ``"organization { id } upc"``. Field names inside it are
+    not automatically renamed by the schema's name converter the way
+    regular fields are, so without this, a snake_case Python field ends up
+    referenced by its Python name in the directive even though the field
+    itself is printed under its (e.g. camelCased) GraphQL name -- producing
+    a FieldSet that points at a field that doesn't exist.
+
+    Arguments and fragment spreads inside the selection set are left
+    untouched. If ``field_set`` can't be parsed as a selection set, it's
+    returned unchanged rather than raising, since callers may hold FieldSet
+    values that predate this validation.
+    """
+    try:
+        document = parse(f"{{ {field_set} }}")
+    except GraphQLError:
+        return field_set
+
+    operation = cast("OperationDefinitionNode", document.definitions[0])
+
+    return _print_selection_set(operation.selection_set, name_converter)
+
+
+def _print_selection_set(
+    selection_set: SelectionSetNode, name_converter: Callable[[str], str]
+) -> str:
+    return " ".join(
+        _print_selection(selection, name_converter)
+        for selection in selection_set.selections
+    )
+
+
+def _print_selection(
+    selection: SelectionNode, name_converter: Callable[[str], str]
+) -> str:
+    if isinstance(selection, FieldNode):
+        printed = name_converter(selection.name.value)
+
+        if selection.arguments:
+            args = ", ".join(
+                f"{argument.name.value}: {print_ast(argument.value)}"
+                for argument in selection.arguments
+            )
+            printed += f"({args})"
+
+        if selection.selection_set is not None:
+            nested = _print_selection_set(selection.selection_set, name_converter)
+            printed += f" {{ {nested} }}"
+
+        return printed
+
+    if isinstance(selection, InlineFragmentNode):
+        type_condition = (
+            f" on {selection.type_condition.name.value}"
+            if selection.type_condition
+            else ""
+        )
+        nested = (
+            _print_selection_set(selection.selection_set, name_converter)
+            if selection.selection_set is not None
+            else ""
+        )
+        return f"...{type_condition} {{ {nested} }}"
+
+    if isinstance(selection, FragmentSpreadNode):
+        return f"...{selection.name.value}"
+
+    return print_ast(selection)  # pragma: no cover
+
+
+__all__ = ["apply_name_converter"]

--- a/strawberry/federation/schema.py
+++ b/strawberry/federation/schema.py
@@ -26,6 +26,7 @@ from strawberry.types.scalar import ScalarDefinition, ScalarWrapper, scalar
 from strawberry.types.union import StrawberryUnion
 from strawberry.utils.inspect import get_func_args
 
+from .field_set import apply_name_converter as apply_name_converter_to_field_set
 from .schema_directive import StrawberryFederationSchemaDirective
 from .types import FieldSet, LinkImport
 from .versions import format_version, parse_version
@@ -93,7 +94,11 @@ class Schema(BaseSchema):
             FederationAny: scalar(
                 name="_Any", serialize=lambda v: v, parse_value=lambda v: v
             ),
-            FieldSet: scalar(name="_FieldSet", serialize=lambda v: v, parse_value=str),
+            FieldSet: scalar(
+                name="_FieldSet",
+                serialize=self._serialize_field_set,
+                parse_value=str,
+            ),
             LinkImport: scalar(
                 name="link__Import", serialize=lambda v: v, parse_value=lambda v: v
             ),
@@ -122,6 +127,16 @@ class Schema(BaseSchema):
 
         composed_directives = self._add_compose_directives()
         self._add_link_directives(composed_directives)  # type: ignore
+
+    def _serialize_field_set(self, value: str) -> str:
+        # FieldSet values (used by @key, @requires and @provides) are given
+        # as plain strings, so they don't go through the same field-renaming
+        # applied to the rest of the schema. Run them through the schema's
+        # name converter here so the field names they reference line up with
+        # the field names actually printed in the SDL.
+        return apply_name_converter_to_field_set(
+            value, self.config.name_converter.apply_naming_config
+        )
 
     def _get_federation_query_type(
         self,
@@ -204,14 +219,22 @@ class Schema(BaseSchema):
                 resolve_reference = definition.origin.resolve_reference
 
                 func_args = get_func_args(resolve_reference)
-                kwargs = representation
 
-                # TODO: use the same logic we use for other resolvers
+                # `representation` is keyed by GraphQL field name (e.g. the
+                # camelCased name a name converter produces), but
+                # `resolve_reference` is a plain Python callable, so its
+                # keyword arguments are expected to match the field's Python
+                # name instead.
+                kwargs: dict[str, Any] = {}
+                for key, value in representation.items():  # type: ignore[attr-defined]
+                    field = self.get_field_for_type(key, type_name)
+                    kwargs[field.python_name if field is not None else key] = value
+
                 if "info" in func_args:
-                    kwargs["info"] = info  # type: ignore[index]
+                    kwargs["info"] = info
 
                 try:
-                    result = resolve_reference(**kwargs)  # type: ignore[arg-type]
+                    result = resolve_reference(**kwargs)
                 except Exception as e:  # noqa: BLE001
                     result = e
             else:

--- a/tests/federation/printer/test_keys.py
+++ b/tests/federation/printer/test_keys.py
@@ -70,3 +70,142 @@ def test_keys_federation_2():
     assert schema.as_str() == textwrap.dedent(expected).strip()
 
     del Review
+
+
+def test_keys_use_the_name_converter_for_field_names():
+    # https://github.com/strawberry-graphql/strawberry/issues/591
+    # `fields` on `@key` is a plain string, so it isn't renamed the same way
+    # a real field is; without running it through the name converter, the
+    # printed directive references a field name (`my_key`) that doesn't
+    # match the one actually printed for the field (`myKey`).
+    @strawberry.federation.type(keys=["my_key"])
+    class Product:
+        my_key: str
+
+    @strawberry.federation.type
+    class Query:
+        @strawberry.field
+        def product(self) -> Product:  # pragma: no cover
+            return Product(my_key="1")
+
+    schema = strawberry.federation.Schema(query=Query)
+
+    expected = """
+        schema @link(url: "https://specs.apollo.dev/federation/v2.11", import: ["@key"]) {
+          query: Query
+        }
+
+        type Product @key(fields: "myKey") {
+          myKey: String!
+        }
+
+        type Query {
+          _entities(representations: [_Any!]!): [_Entity]!
+          _service: _Service!
+          product: Product!
+        }
+
+        scalar _Any
+
+        union _Entity = Product
+
+        type _Service {
+          sdl: String!
+        }
+    """
+
+    assert schema.as_str() == textwrap.dedent(expected).strip()
+
+
+def test_keys_use_the_name_converter_for_nested_field_names():
+    @strawberry.federation.type(keys=["org_id"])
+    class Organization:
+        org_id: str
+
+    @strawberry.federation.type(keys=["my_key organization { org_id }"])
+    class Product:
+        my_key: str
+        organization: Organization
+
+    @strawberry.federation.type
+    class Query:
+        @strawberry.field
+        def product(self) -> Product:  # pragma: no cover
+            return Product(my_key="1", organization=Organization(org_id="1"))
+
+    schema = strawberry.federation.Schema(query=Query)
+
+    expected = """
+        schema @link(url: "https://specs.apollo.dev/federation/v2.11", import: ["@key"]) {
+          query: Query
+        }
+
+        type Organization @key(fields: "orgId") {
+          orgId: String!
+        }
+
+        type Product @key(fields: "myKey organization { orgId }") {
+          myKey: String!
+          organization: Organization!
+        }
+
+        type Query {
+          _entities(representations: [_Any!]!): [_Entity]!
+          _service: _Service!
+          product: Product!
+        }
+
+        scalar _Any
+
+        union _Entity = Organization | Product
+
+        type _Service {
+          sdl: String!
+        }
+    """
+
+    assert schema.as_str() == textwrap.dedent(expected).strip()
+
+
+def test_keys_are_not_renamed_when_auto_camel_case_is_off():
+    from strawberry.schema.config import StrawberryConfig
+
+    @strawberry.federation.type(keys=["my_key"])
+    class Product:
+        my_key: str
+
+    @strawberry.federation.type
+    class Query:
+        @strawberry.field
+        def product(self) -> Product:  # pragma: no cover
+            return Product(my_key="1")
+
+    schema = strawberry.federation.Schema(
+        query=Query, config=StrawberryConfig(auto_camel_case=False)
+    )
+
+    expected = """
+        schema @link(url: "https://specs.apollo.dev/federation/v2.11", import: ["@key"]) {
+          query: Query
+        }
+
+        type Product @key(fields: "my_key") {
+          my_key: String!
+        }
+
+        type Query {
+          _entities(representations: [_Any!]!): [_Entity]!
+          _service: _Service!
+          product: Product!
+        }
+
+        scalar _Any
+
+        union _Entity = Product
+
+        type _Service {
+          sdl: String!
+        }
+    """
+
+    assert schema.as_str() == textwrap.dedent(expected).strip()

--- a/tests/federation/printer/test_requires.py
+++ b/tests/federation/printer/test_requires.py
@@ -78,3 +78,52 @@ def test_fields_requires_are_printed_correctly():
     assert schema.as_str() == textwrap.dedent(expected).strip()
 
     del Review
+
+
+def test_fields_requires_use_the_name_converter_for_field_names():
+    # Same underlying bug as https://github.com/strawberry-graphql/strawberry/issues/591,
+    # but for @requires instead of @key.
+    @strawberry.federation.type(keys=["upc"], extend=True)
+    class Product:
+        upc: str = strawberry.federation.field(external=True)
+        the_field: str = strawberry.federation.field(external=True)
+
+        @strawberry.federation.field(requires=["the_field"])
+        def computed(self) -> str:  # pragma: no cover
+            return ""
+
+    @strawberry.federation.type
+    class Query:
+        @strawberry.field
+        def top_products(self, first: int) -> list[Product]:  # pragma: no cover
+            return []
+
+    schema = strawberry.federation.Schema(query=Query)
+
+    expected = """
+        schema @link(url: "https://specs.apollo.dev/federation/v2.11", import: ["@external", "@key", "@requires"]) {
+          query: Query
+        }
+
+        extend type Product @key(fields: "upc") {
+          upc: String! @external
+          theField: String! @external
+          computed: String! @requires(fields: "theField")
+        }
+
+        type Query {
+          _entities(representations: [_Any!]!): [_Entity]!
+          _service: _Service!
+          topProducts(first: Int!): [Product!]!
+        }
+
+        scalar _Any
+
+        union _Entity = Product
+
+        type _Service {
+          sdl: String!
+        }
+    """
+
+    assert schema.as_str() == textwrap.dedent(expected).strip()

--- a/tests/federation/test_entities.py
+++ b/tests/federation/test_entities.py
@@ -43,6 +43,49 @@ def test_fetch_entities():
     assert result.data == {"_entities": [{"upc": "B00005N5PF"}]}
 
 
+def test_resolve_reference_receives_python_field_names():
+    # https://github.com/strawberry-graphql/strawberry/issues/591
+    # The representation sent by the router is keyed by GraphQL field name
+    # (myKey), but resolve_reference is a plain Python callable, so its
+    # keyword arguments should match the field's Python name (my_key).
+    @strawberry.federation.type(keys=["my_key"])
+    class Product:
+        my_key: str
+
+        @classmethod
+        def resolve_reference(cls, my_key: str) -> "Product":
+            return Product(my_key=my_key)
+
+    @strawberry.federation.type(extend=True)
+    class Query:
+        @strawberry.field
+        def top_products(self, first: int) -> list[Product]:  # pragma: no cover
+            return []
+
+    schema = strawberry.federation.Schema(query=Query)
+
+    query = """
+        query ($representations: [_Any!]!) {
+            _entities(representations: $representations) {
+                ... on Product {
+                    myKey
+                }
+            }
+        }
+    """
+
+    result = schema.execute_sync(
+        query,
+        variable_values={
+            "representations": [{"__typename": "Product", "myKey": "B00005N5PF"}]
+        },
+    )
+
+    assert not result.errors
+
+    assert result.data == {"_entities": [{"myKey": "B00005N5PF"}]}
+
+
 def test_info_param_in_resolve_reference():
     @strawberry.federation.type(keys=["upc"])
     class Product:


### PR DESCRIPTION
<!-- PR title: fix(federation): run @key/@requires/@provides field sets and resolve_reference kwargs through the name converter (#591) -->

**You set the work.** #591: with a name converter configured, `@key(fields:)` (and `@requires`/`@provides`) still print the raw Python field name instead of the wire name — `@key(fields: "my_key")` next to `myKey: ID!`, which real Apollo Federation subgraph composition rejects. `resolve_reference` has the same problem in reverse: it receives wire-named kwargs and throws `TypeError: unexpected keyword argument 'myKey'`.

**It's done.** Both are fixed at the one place FieldSet strings are printed and parsed — every field name now runs through the same name converter as everything else. Five regression tests written before the fix: snake_case `@key`, nested composite keys, `@requires`, `resolve_reference` kwarg mapping, and a guard proving the *converter* drives this, not blanket camelCasing.

**Here's the evidence.**

- Fresh clone at `34e97078`, patch applied, dependencies installed, then the network was disconnected.
- Full suite in a clean `python:3.12-bookworm` container: **5,120 pass**, 0 fail (348 skipped / 120 xfailed / 24 xpassed — identical to base).
- mypy and ruff clean; the Apollo `federation-compatibility` reference SDL is byte-identical before and after.
- Stashing just the fix: 4 of the 5 new tests fail with the exact errors from your issue.
- **Worth weighing before merging:** this is an unguarded behaviour change. Anyone who worked around the bug — hardcoding `keys=["myKey"]`, or naming `resolve_reference` params after the wire name — will need to switch to the Python form after upgrading. Written up in `RELEASE.md`; happy to gate it behind a flag instead if you'd rather.

<details>
<summary><b>Audit trail</b> — an independently checkable record that these checks ran, in this order, before this PR existed</summary>

| | |
|---|---|
| Base commit | `34e9707833f99100086d2736980d5471dde054ce` |
| Container | `python:3.12-bookworm@sha256:9bed8554…` (linux/arm64), network off during tests |
| The patch, content-addressed | [record](https://gateway.autonolas.tech/ipfs/f0155122093d9c48a23c9ca9d648ee6ff6562afcf8ba06221de4d7d23efec9d76d1e8328e) |
| The verification result, signed by a second key | [record](https://gateway.autonolas.tech/ipfs/f01551220184f0dfe2b0375f42c91ecc21c8275877732f0d4e7d0ee3b81f1628da75f287c) |
| Timestamped sequence | [work assigned](https://sepolia.basescan.org/tx/0xe8ddad4075956eb6865b587e2c05b14131dba9c9f87715f6d05f76fd524e2e2d) → [work delivered](https://sepolia.basescan.org/tx/0x241174808bba8c6189a1e4d3a577557d466c4ae26ae0beffe4655d5d7a5a91f6) → [checks passed](https://sepolia.basescan.org/tx/0xdbbfb77bb19daf060b9a5e2984f71648bedd64d5fb0351e2ed62b4dd2daf1222) |

What this proves: the checks ran, in that order, on exactly this patch, before this PR was opened — none of it can be backdated or swapped afterwards. What it doesn't prove: that the fix is *right*. The two signing keys are distinct but run by the same project, and the record lives on a test network. Correctness is your judgement, which is the point.

</details>

Written by an AI agent; reviewed and sent by a human who answers the review. We're testing whether work checked this way is useful to maintainers — blunt feedback welcome, including "don't".

---

## Everything below is written by Claude

Fixes #591 — both halves of which are still live on current main.

**The fix**, confined to `strawberry/federation/` (the core printer stays federation-agnostic):

- New `federation/field_set.py` parses a FieldSet string as a GraphQL selection set and re-prints it with each field name run through the configured name converter — recursing into nested/composite keys (`"a { b c }"`), leaving arguments and fragment spreads untouched, falling back to the original string on parse failure.
- The `_FieldSet` scalar's serialize hook applies it, so `@key`, `@requires`, and `@provides` are fixed uniformly. `entities_resolver` maps representation keys to `field.python_name` via the existing `get_field_for_type()`, resolving the `# TODO: use the same logic we use for other resolvers` in the code.

## Summary by Sourcery

Fix federation field set handling and reference resolution to respect the configured name converter for field names.

Bug Fixes:
- Ensure @key, @requires and @provides FieldSet strings use the schema's name converter so directive field names match the printed SDL.
- Map _entities representations from GraphQL field names to Python attribute names before calling resolve_reference, preventing unexpected keyword argument errors when a name converter is used.

Enhancements:
- Introduce a FieldSet helper to parse and reprint selection sets with converted field names while preserving arguments and fragments.

Documentation:
- Document the federation behaviour change and migration notes in RELEASE.md, including the impact on existing workarounds for the previous bug.

Tests:
- Add regression tests covering name conversion in @key (including nested/composite keys) and @requires directives, as well as resolve_reference receiving Python-style keyword arguments.