### PR TITLE
Fix pydantic unions that annotate the None member

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,24 @@
+---
+release type: patch
+social_messages:
+  x: >-
+    {project_name} {version} is out! Annotate the `None` member of a union in
+    your Pydantic model, like `Union[str, SkipJsonSchema[None]]`, and your
+    schema builds instead of raising InvalidUnionTypeError. 🍓
+    https://strawberry.rocks/release/{version}
+  linkedin: >-
+    {project_name} {version} is out. If you annotate the `None` member of a
+    union in a Pydantic model, for example `Union[str, SkipJsonSchema[None]]`,
+    Strawberry now reads that field as an optional field and builds your schema
+    instead of raising InvalidUnionTypeError.
+---
+
+This release fixes Pydantic fields that annotate the `None` member of a union.
+
+Write `field_a: Union[str, SkipJsonSchema[None]]` in your model and Strawberry
+now gives you a nullable `String`. Before, the `Annotated` wrapper hid the
+`NoneType` that marks a field optional, so Strawberry read the field as a real
+GraphQL union and raised `InvalidUnionTypeError`, telling you that `str` cannot
+be used in a GraphQL union. Strawberry unwraps that `None` member now, and
+leaves the metadata on every other member alone, so `strawberry.lazy` references and
+`strawberry.union` names keep working.

--- a/strawberry/experimental/pydantic/fields.py
+++ b/strawberry/experimental/pydantic/fields.py
@@ -28,6 +28,23 @@ def replace_pydantic_types(type_: Any, is_input: bool) -> Any:
     return type_
 
 
+def _unwrap_annotated_none(type_: Any) -> Any:
+    """Return `None` for union members that are `None` behind an `Annotated`.
+
+    Pydantic lets you annotate the `None` member of a union, for example
+    `Union[str, SkipJsonSchema[None]]`. That hides the `NoneType` that tells
+    strawberry the field is optional, so the field is read as a union of `str`
+    and `Annotated[None, ...]` instead. Metadata on `None` says nothing about
+    the GraphQL type, while metadata on any other member can (a
+    `strawberry.lazy` reference or a `strawberry.union` name), so only the
+    `None` member loses its metadata here.
+    """
+    if get_origin(type_) is Annotated and get_args(type_)[0] is type(None):
+        return type(None)
+
+    return type_
+
+
 def replace_types_recursively(
     type_: Any, is_input: bool, compat: PydanticCompat
 ) -> Any:
@@ -47,8 +64,8 @@ def replace_types_recursively(
 
     if isinstance(replaced_type, TypingGenericAlias):
         return TypingGenericAlias(origin, converted)
-    if isinstance(replaced_type, UnionType):
-        return Union[converted]  # noqa: UP007
+    if origin is Union or isinstance(replaced_type, UnionType):
+        return Union[tuple(_unwrap_annotated_none(t) for t in converted)]  # noqa: UP007
 
     # TODO: investigate if we could move the check for annotated to the top
     if origin is Annotated and converted:

--- a/tests/experimental/pydantic/schema/test_basic.py
+++ b/tests/experimental/pydantic/schema/test_basic.py
@@ -1,10 +1,11 @@
 import textwrap
 from enum import Enum
+from typing import Union
 
 import pydantic
 
 import strawberry
-from tests.experimental.pydantic.utils import needs_pydantic_v1
+from tests.experimental.pydantic.utils import needs_pydantic_v1, needs_pydantic_v2
 
 
 def test_basic_type_field_list():
@@ -556,3 +557,42 @@ def test_basic_type_with_constrained_list():
 
     assert not result.errors
     assert result.data["user"]["friendNames"] == ["A", "B"]
+
+
+@needs_pydantic_v2
+def test_basic_type_with_skip_json_schema_none_union():
+    from pydantic.json_schema import SkipJsonSchema
+
+    class UserModel(pydantic.BaseModel):
+        age: int
+        password: Union[str, SkipJsonSchema[None]] = None
+
+    @strawberry.experimental.pydantic.type(UserModel, all_fields=True)
+    class User:
+        pass
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def user(self) -> User:
+            return User(age=1, password="ABC")
+
+    schema = strawberry.Schema(query=Query)
+
+    expected_schema = """
+    type Query {
+      user: User!
+    }
+
+    type User {
+      age: Int!
+      password: String
+    }
+    """
+
+    assert str(schema) == textwrap.dedent(expected_schema).strip()
+
+    result = schema.execute_sync("{ user { age password } }")
+
+    assert not result.errors
+    assert result.data["user"] == {"age": 1, "password": "ABC"}

--- a/tests/experimental/pydantic/test_basic.py
+++ b/tests/experimental/pydantic/test_basic.py
@@ -1,7 +1,7 @@
 import dataclasses
 import warnings
 from enum import Enum
-from typing import Annotated, Any
+from typing import Annotated, Any, Union
 
 import pydantic
 import pytest
@@ -16,6 +16,7 @@ from strawberry.types.base import (
 )
 from strawberry.types.enum import StrawberryEnumDefinition
 from strawberry.types.union import StrawberryUnion
+from tests.experimental.pydantic.utils import needs_pydantic_v2
 
 
 def test_basic_type_all_fields():
@@ -939,3 +940,79 @@ def test_nested_annotated():
     assert isinstance(field_b.type, StrawberryOptional)
     assert isinstance(field_b.type.of_type, StrawberryList)
     assert field_b.type.of_type.of_type is int
+
+
+def test_annotated_none_in_union():
+    class User(pydantic.BaseModel):
+        a: Union[int, Annotated[None, "metadata"]] = None
+        b: Union[int, str, Annotated[None, "metadata"]] = None
+
+    @strawberry.experimental.pydantic.input(User, all_fields=True)
+    class UserType:
+        pass
+
+    definition: StrawberryObjectDefinition = UserType.__strawberry_definition__
+    assert definition.name == "UserType"
+
+    [field_a, field_b] = definition.fields
+    assert field_a.python_name == "a"
+    assert isinstance(field_a.type, StrawberryOptional)
+    assert field_a.type.of_type is int
+
+    assert field_b.python_name == "b"
+    assert isinstance(field_b.type, StrawberryOptional)
+    assert isinstance(field_b.type.of_type, StrawberryUnion)
+    assert field_b.type.of_type.types == (int, str)
+
+
+@needs_pydantic_v2
+def test_skip_json_schema_none_in_union():
+    from pydantic.json_schema import SkipJsonSchema
+
+    class User(pydantic.BaseModel):
+        a: Union[str, SkipJsonSchema[None]] = None
+        b: Union[list[str], SkipJsonSchema[None]] = None
+
+    @strawberry.experimental.pydantic.type(User, all_fields=True)
+    class UserType:
+        pass
+
+    definition: StrawberryObjectDefinition = UserType.__strawberry_definition__
+    assert definition.name == "UserType"
+
+    [field_a, field_b] = definition.fields
+    assert field_a.python_name == "a"
+    assert isinstance(field_a.type, StrawberryOptional)
+    assert field_a.type.of_type is str
+
+    assert field_b.python_name == "b"
+    assert isinstance(field_b.type, StrawberryOptional)
+    assert isinstance(field_b.type.of_type, StrawberryList)
+    assert field_b.type.of_type.of_type is str
+
+
+def test_annotated_union_member_keeps_metadata():
+    @strawberry.type
+    class Cat:
+        name: str
+
+    @strawberry.type
+    class Dog:
+        name: str
+
+    AnimalUnion = Annotated[Union[Cat, Dog], strawberry.union("AnimalUnion")]
+
+    class User(pydantic.BaseModel):
+        pet: Union[AnimalUnion, Annotated[None, "metadata"]] = None
+
+    @strawberry.experimental.pydantic.type(User, all_fields=True)
+    class UserType:
+        pass
+
+    definition: StrawberryObjectDefinition = UserType.__strawberry_definition__
+
+    [field] = definition.fields
+    assert field.python_name == "pet"
+    assert isinstance(field.type, StrawberryOptional)
+    assert isinstance(field.type.of_type, StrawberryUnion)
+    assert field.type.of_type.graphql_name == "AnimalUnion"


### PR DESCRIPTION
## Repro

A pydantic model that annotates the `None` member of a union kills schema construction:

```python
from typing import Union

from pydantic import BaseModel
from pydantic.json_schema import SkipJsonSchema

import strawberry


class ModelA(BaseModel):
    field_a: Union[str, SkipJsonSchema[None]] = None


@strawberry.experimental.pydantic.type(model=ModelA, all_fields=True)
class TypeA:
    pass


@strawberry.type
class Query:
    a: TypeA


schema = strawberry.Schema(query=Query)
```

```
strawberry.exceptions.invalid_union_type.InvalidUnionTypeError: Type `str` cannot be used in a GraphQL Union
```

I hit this on main at 34e9707, pydantic 2.13.4, Python 3.13.

## Root cause

`replace_types_recursively` in `strawberry/experimental/pydantic/fields.py` rebuilds the union member by member. Each member keeps its `Annotated` wrapper, so `Union[str, Annotated[None, SkipJsonSchema()]]` comes out the other side unchanged. Python does not collapse that to `Optional[str]`, because the union holds no bare `NoneType`.

`StrawberryAnnotation._is_optional` looks for that bare `NoneType`. It does not find one, so strawberry classifies the field as a real GraphQL union and hands `str` to `from_union`. Scalars are not valid union members, so you get `InvalidUnionTypeError`.

Nothing here is specific to `SkipJsonSchema`. Any `Annotated[None, ...]` union member breaks the same way.

## Fix

I unwrap union members that are `None` behind an `Annotated`, right where the union gets rebuilt:

```python
def _unwrap_annotated_none(type_: Any) -> Any:
    if get_origin(type_) is Annotated and get_args(type_)[0] is type(None):
        return type(None)

    return type_
```

The union branch now also catches `typing.Union`, not only PEP 604 `UnionType`. That matters because `int | Annotated[None, "m"]` evaluates to `typing.Union` at runtime, not `types.UnionType`, so the old `isinstance(replaced_type, UnionType)` branch never saw the broken case. The `typing.Union` path used to fall through to `copy_with`, which is `Union[args]` under the hood, so the rebuild itself behaves the same.

## What it does not change

Only the `None` member loses its metadata. Metadata on `None` says nothing about the GraphQL type. Metadata on any other member can, and it survives untouched:

- `strawberry.lazy` puts a `StrawberryLazyReference` in `Annotated` metadata, read by `StrawberryAnnotation._get_type_with_args`.
- `strawberry.union` puts a `StrawberryUnion` in `Annotated` metadata, which names the union in the schema.

I added a test for the second one: a `strawberry.union("AnimalUnion")` inside an optional field still prints as `AnimalUnion`.

Optional detection past this point is unchanged. `create_optional` still filters `NoneType` and `UNSET` and rebuilds the child type the same way.

## Test evidence

New tests, all failing before the fix and passing after:

- `tests/experimental/pydantic/test_basic.py::test_annotated_none_in_union` covers a plain `Annotated[None, "metadata"]` member, both a two member and a three member union.
- `tests/experimental/pydantic/test_basic.py::test_skip_json_schema_none_in_union` covers `SkipJsonSchema[None]`, scalar and list.
- `tests/experimental/pydantic/test_basic.py::test_annotated_union_member_keeps_metadata` pins the metadata that must survive.
- `tests/experimental/pydantic/schema/test_basic.py::test_basic_type_with_skip_json_schema_none_union` builds the schema from the issue and asserts the printed SDL plus a query result.

Counts from my runs:

- `tests/experimental/pydantic` on pydantic 2.13.4, before: 4 failed, 154 passed, 11 skipped, 1 xfailed. After: 158 passed, 11 skipped, 1 xfailed.
- `tests/experimental/pydantic` on pydantic 1.10.26, before: 2 failed, 167 passed, 10 skipped, 1 xfailed. After: 169 passed, 10 skipped, 1 xfailed. The two `SkipJsonSchema` tests skip on v1.
- Union and optional and annotated tests repo wide: 330 passed, 3 skipped, 1 xfailed, 5315 deselected.
- Full suite minus the mypy, pyright and cli dirs: 4928 passed, 339 skipped, 207 deselected, 112 xfailed, 23 xpassed, 1 failed. The one failure is `tests/typecheckers/test_pydantic.py::test_pydantic_type`, which raises `FileNotFoundError: [Errno 2] No such file or directory: 'ty'` on my machine. It fails identically with my change reverted.
- `uv run mypy strawberry/experimental/pydantic/fields.py`: no issues.
- `uv run ruff check` and `ruff format --check` on the changed files: clean.

Fixes #3992

I used AI assistance on this change and reviewed everything.

## Summary by Sourcery

Normalize Annotated None union members in Pydantic integration so Strawberry correctly treats these fields as optional while preserving metadata on other union members, and document the change with accompanying tests and release notes.

Bug Fixes:
- Handle Pydantic union fields that annotate the None member as optional GraphQL fields instead of invalid unions

Enhancements:
- Preserve Annotated metadata for non-None union members while normalizing None to support optional detection
- Support both typing.Union and PEP 604 unions in the recursive type replacement logic

Documentation:
- Add release notes describing the fix for Pydantic unions that annotate the None member and its impact on schema generation

Tests:
- Add tests covering Annotated[None] in unions, SkipJsonSchema[None] in unions, and ensuring Annotated union members retain metadata and correct SDL/query behavior