### PR TITLE
fix: validate Upload scalar inputs

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -23,9 +23,9 @@ mutation {
 }
 ```
 
-Files can only be provided through a multipart request, so `Upload` now rejects
-values that come from the JSON body of the request, whether they are passed as
-variables or inline literals, including inside input types and lists:
+Files can only be provided through a multipart request, so `Upload` will now
+reject values that come from the JSON body of the request, whether they are
+passed as variables or inline literals, including inside input types and lists:
 
 ```json
 {

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,41 @@
+---
+release type: patch
+social_messages:
+  x: >-
+    {project_name} {version} is out! This release fixes validation of the
+    `Upload` scalar, so non-file values are rejected before your resolver runs.
+    🍓 https://strawberry.rocks/release/{version}
+  linkedin: >-
+    {project_name} {version} is out. This release fixes validation of the
+    `Upload` scalar. Sending a string, number or object where a file is expected
+    now fails validation with a clear error instead of reaching your resolver.
+---
+
+This release fixes validation of the `Upload` scalar.
+
+Previously the `Upload` scalar accepted any value, so a client could send a
+plain JSON value where a file was expected and the resolver would run with it,
+usually failing later with a confusing internal error:
+
+```graphql
+mutation {
+  readFile(file: "not a file")
+}
+```
+
+Files can only be provided through a multipart request, so `Upload` now rejects
+values that come from the JSON body of the request, whether they are passed as
+variables or inline literals, including inside input types and lists:
+
+```json
+{
+  "errors": [
+    {
+      "message": "Upload cannot represent a non-file value: 'not a file'"
+    }
+  ]
+}
+```
+
+The file objects provided by every integration are still accepted, and nullable
+`Upload` fields still accept `null`.

--- a/docs/guides/file-upload.md
+++ b/docs/guides/file-upload.md
@@ -69,7 +69,7 @@ This gives you proper IDE autocomplete and type checking, since the type
 annotation matches the actual runtime type.
 
 A file can only be provided through a multipart request, so the `Upload` scalar
-rejects any value that comes from the JSON body of the request. Passing a
+will reject any value that comes from the JSON body of the request. Passing a
 string, number, boolean, list or object where a file is expected fails
 validation and the resolver is never called:
 

--- a/docs/guides/file-upload.md
+++ b/docs/guides/file-upload.md
@@ -68,6 +68,21 @@ class Mutation:
 This gives you proper IDE autocomplete and type checking, since the type
 annotation matches the actual runtime type.
 
+A file can only be provided through a multipart request, so the `Upload` scalar
+rejects any value that comes from the JSON body of the request. Passing a
+string, number, boolean, list or object where a file is expected fails
+validation and the resolver is never called:
+
+```json
+{
+  "errors": [
+    {
+      "message": "Variable '$file' got invalid value 'not a file'; Upload cannot represent a non-file value: 'not a file'"
+    }
+  ]
+}
+```
+
 ## ASGI / FastAPI / Starlette
 
 Since these integrations use asyncio for communication, the resolver _must_ be

--- a/strawberry/file_uploads/scalars.py
+++ b/strawberry/file_uploads/scalars.py
@@ -1,14 +1,36 @@
-from typing import NewType
+from typing import Any, NewType
+
+from graphql import GraphQLError
+from graphql.pyutils import inspect
 
 from strawberry.types.scalar import scalar
 
 Upload = NewType("Upload", bytes)
 
+# Values reach the `Upload` scalar from one of two places: the JSON body of the
+# request (variables and inline literals), or the multipart request handling,
+# which replaces file placeholders with the file objects provided by the web
+# framework. Only the latter is a valid upload, so rejecting the types a JSON
+# decoder can produce keeps this framework agnostic: every file object is
+# accepted (Django's `UploadedFile`, Starlette's `UploadFile`, Sanic's `File`
+# named tuple, a plain `BytesIO`, ...) without knowing about any of them.
+_JSON_TYPES = (bool, int, float, str, list, dict)
+
+
+def parse_upload_value(value: Any) -> Any:
+    if isinstance(value, _JSON_TYPES):
+        raise GraphQLError(
+            f"Upload cannot represent a non-file value: {inspect(value)}"
+        )
+
+    return value
+
+
 UploadDefinition = scalar(
     name="Upload",
     description="Represents a file upload.",
     serialize=lambda v: v,
-    parse_value=lambda v: v,
+    parse_value=parse_upload_value,
 )
 
 __all__ = ["Upload", "UploadDefinition"]

--- a/tests/file_uploads/test_scalars.py
+++ b/tests/file_uploads/test_scalars.py
@@ -1,0 +1,129 @@
+from io import BytesIO
+from typing import NamedTuple
+
+import pytest
+
+import strawberry
+from strawberry.file_uploads import Upload
+
+
+@strawberry.type
+class Query:
+    hello: str = "world"
+
+
+@strawberry.input
+class FolderInput:
+    file: Upload
+
+
+@strawberry.type
+class Mutation:
+    @strawberry.mutation
+    def read_file(self, file: Upload) -> str:
+        return type(file).__name__
+
+    @strawberry.mutation
+    def read_files(self, files: list[Upload]) -> list[str]:
+        return [type(file).__name__ for file in files]
+
+    @strawberry.mutation
+    def read_folder(self, folder: FolderInput) -> str:
+        return type(folder.file).__name__
+
+    @strawberry.mutation
+    def read_optional_file(self, file: Upload | None = None) -> str:
+        return type(file).__name__
+
+
+schema = strawberry.Schema(query=Query, mutation=Mutation)
+
+
+class SanicFile(NamedTuple):
+    """Mirrors `sanic.request.File`, which is a named tuple rather than a file."""
+
+    type: str
+    body: bytes
+    name: str
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "not a file",
+        42,
+        3.14,
+        True,
+        {"not": "a file"},
+        ["not a file"],
+    ],
+)
+def test_upload_rejects_non_file_variables(value):
+    result = schema.execute_sync(
+        "mutation($file: Upload!) { readFile(file: $file) }",
+        variable_values={"file": value},
+    )
+
+    assert result.data is None
+    assert result.errors is not None
+    assert "Upload cannot represent a non-file value" in result.errors[0].message
+
+
+def test_upload_rejects_non_file_literals():
+    result = schema.execute_sync('mutation { readFile(file: "not a file") }')
+
+    assert result.data is None
+    assert result.errors is not None
+    assert "Upload cannot represent a non-file value" in result.errors[0].message
+
+
+def test_upload_rejects_non_file_inside_input_type():
+    result = schema.execute_sync(
+        "mutation($folder: FolderInput!) { readFolder(folder: $folder) }",
+        variable_values={"folder": {"file": "not a file"}},
+    )
+
+    assert result.data is None
+    assert result.errors is not None
+    assert "Upload cannot represent a non-file value" in result.errors[0].message
+
+
+def test_upload_rejects_non_file_inside_list():
+    result = schema.execute_sync(
+        "mutation($files: [Upload!]!) { readFiles(files: $files) }",
+        variable_values={"files": [BytesIO(b"strawberry"), "not a file"]},
+    )
+
+    assert result.data is None
+    assert result.errors is not None
+    assert "Upload cannot represent a non-file value" in result.errors[0].message
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (BytesIO(b"strawberry"), "BytesIO"),
+        (b"strawberry", "bytes"),
+        # Integrations hand over their own file objects, so anything that isn't
+        # a value a JSON decoder could have produced has to be accepted.
+        (SanicFile("text/plain", b"strawberry", "file.txt"), "SanicFile"),
+    ],
+)
+def test_upload_accepts_file_objects(value, expected):
+    result = schema.execute_sync(
+        "mutation($file: Upload!) { readFile(file: $file) }",
+        variable_values={"file": value},
+    )
+
+    assert result.errors is None
+    assert result.data == {"readFile": expected}
+
+
+def test_upload_still_accepts_null_when_nullable():
+    result = schema.execute_sync(
+        "mutation($file: Upload) { readOptionalFile(file: $file) }",
+        variable_values={"file": None},
+    )
+
+    assert result.errors is None
+    assert result.data == {"readOptionalFile": "NoneType"}

--- a/tests/http/test_upload.py
+++ b/tests/http/test_upload.py
@@ -108,6 +108,29 @@ async def test_upload(enabled_http_client: HttpClient):
     assert response.json["data"] == {"readText": "strawberry"}
 
 
+async def test_upload_variable_without_a_file_is_rejected(
+    enabled_http_client: HttpClient,
+):
+    """A plain JSON request cannot carry a file, so it must not reach the resolver."""
+    query = """
+    mutation($textFile: Upload!) {
+        readText(textFile: $textFile)
+    }
+    """
+
+    response = await enabled_http_client.query(
+        query,
+        variables={"textFile": "not a file"},
+    )
+
+    assert response.status_code == 200
+    assert response.json["data"] is None
+    assert (
+        "Upload cannot represent a non-file value"
+        in response.json["errors"][0]["message"]
+    )
+
+
 async def test_file_list_upload(enabled_http_client: HttpClient):
     query = "mutation($files: [Upload!]!) { readFiles(files: $files) }"
     file1 = BytesIO(b"strawberry1")


### PR DESCRIPTION
The `Upload` scalar was defined with `parse_value=lambda v: v`, so it accepted any value. A client could send a plain JSON value where a file was expected and the resolver would run with it, typically failing later with a confusing internal error instead of a validation error.

Files can only be provided through a multipart request, so values that come from the JSON body of the request are now rejected, whether they are passed as variables or inline literals, including inside input types and lists.

Validating by rejecting the types a JSON decoder can produce keeps this framework agnostic. An allow list is not workable here: valid uploads are framework specific, and duck typing on `read` would reject Sanic's `File`, which is a named tuple. Values only reach this scalar either from the JSON body, which is always invalid, or from the multipart handling, which always substitutes a framework file object.

Fixes #3567

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Validate GraphQL Upload scalar inputs to reject JSON-derived non-file values and ensure only framework-provided file objects reach resolvers.

Bug Fixes:
- Prevent non-file JSON values from being accepted by the Upload scalar, returning a clear validation error instead of failing later in resolvers.

Enhancements:
- Document Upload scalar validation behavior and add release notes describing the change in file upload handling.

Documentation:
- Explain that the Upload scalar rejects values coming from the JSON body and show the resulting validation error response.

Tests:
- Add schema-level and HTTP tests to verify Upload rejects non-file variables, literals, nested inputs, and lists while still accepting framework file objects and nullable null values.

Chores:
- Add a patch release note file announcing the Upload scalar validation fix and its user-visible impact.