### PR TITLE
fix: honour strawberry.cast when resolving unions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,46 @@
+---
+release type: patch
+social_messages:
+  x: >-
+    {project_name} {version} is out! This release fixes `strawberry.cast` when
+    used with unions of types that don't implement an interface. 🍓
+    https://strawberry.rocks/release/{version}
+  linkedin: >-
+    {project_name} {version} is out. This release fixes `strawberry.cast` when
+    used with unions of types that don't implement an interface, so ORM objects
+    returned from a union field now resolve to the type you cast them to.
+---
+
+This release fixes `strawberry.cast` when used with unions.
+
+`strawberry.cast` is the supported way to tell Strawberry which type an object
+should resolve to when returning something that isn't an instance of any of the
+union's types, such as a Django, Pydantic or SQLAlchemy object. It worked for
+interfaces, and for unions whose types implement an interface, but was ignored
+for unions of plain types, which failed with `WrongReturnTypeForUnion`:
+
+```python
+@strawberry.type
+class Apple:
+    name: str
+
+
+@strawberry.type
+class Banana:
+    name: str
+
+
+Fruit = Annotated[Apple | Banana, strawberry.union("Fruit")]
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def fruits(self) -> list[Fruit]:
+        return [
+            strawberry.cast(Banana, banana_model),
+            strawberry.cast(Apple, apple_model),
+        ]
+```
+
+Each item now resolves to the type it was cast to, instead of raising an error.

--- a/docs/types/union.md
+++ b/docs/types/union.md
@@ -157,6 +157,24 @@ class Query:
         )
 ```
 
+If you return an object that is not an instance of one of the union's types,
+such as a Django, Pydantic or SQLAlchemy object, Strawberry has no way to tell
+which type it should resolve to. Use `strawberry.cast` to say which one it is:
+
+```python
+from typing import Union
+import strawberry
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def latest_media(self) -> Union[Audio, Video, Image]:
+        media = MediaModel.objects.latest()
+
+        return strawberry.cast(Video, media)
+```
+
 ## Single member union
 
 Sometimes you might want to define a union with only one member. This is useful

--- a/strawberry/types/union.py
+++ b/strawberry/types/union.py
@@ -27,6 +27,7 @@ from strawberry.types.base import (
     StrawberryType,
     has_object_definition,
 )
+from strawberry.types.cast import get_strawberry_type_cast
 from strawberry.types.lazy_type import LazyType
 
 if TYPE_CHECKING:
@@ -172,6 +173,29 @@ class StrawberryUnion(StrawberryType):
             assert isinstance(type_, GraphQLUnionType)
 
             from strawberry.types.base import StrawberryObjectDefinition
+
+            # An explicit `strawberry.cast` is the documented way to disambiguate
+            # when returning an object that isn't an instance of any of the union's
+            # types, such as a Django, Pydantic or SQLAlchemy object. Types that
+            # implement an interface get an `is_type_of` that already honours it,
+            # but types without interfaces have none, so check it here as well.
+            if (type_cast := get_strawberry_type_cast(root)) is not None:
+                for inner_type in type_.types:
+                    concrete_type = type_map.get(inner_type.name)
+
+                    if concrete_type is None:  # pragma: no cover
+                        continue
+
+                    definition = concrete_type.definition
+
+                    if (
+                        isinstance(definition, StrawberryObjectDefinition)
+                        and definition.origin is type_cast
+                    ):
+                        return inner_type.name
+
+                # The object was cast to something that isn't a member of this
+                # union, fall back to the checks below to keep the error the same
 
             # If the type given is not an Object type, try resolving using `is_type_of`
             # defined on the union's inner types

--- a/tests/schema/test_union.py
+++ b/tests/schema/test_union.py
@@ -531,6 +531,148 @@ def test_union_explicit_type_resolution():
     assert result.data == {"myField": {"__typename": "A", "a": 1}}
 
 
+def test_union_resolution_with_strawberry_cast():
+    """`strawberry.cast` should disambiguate a union of types without interfaces."""
+
+    @dataclass
+    class Row:
+        name: str
+
+    @strawberry.type
+    class A:
+        name: str
+
+    @strawberry.type
+    class B:
+        name: str
+
+    MyUnion = Annotated[A | B, strawberry.union("MyUnion")]
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def my_field(self) -> MyUnion:
+            return strawberry.cast(B, Row(name="hi"))  # type: ignore
+
+    schema = strawberry.Schema(query=Query)
+
+    query = "{ myField { __typename, ... on A { name }, ... on B { name } } }"
+    result = schema.execute_sync(query)
+
+    assert not result.errors
+    assert result.data == {"myField": {"__typename": "B", "name": "hi"}}
+
+
+def test_union_resolution_with_strawberry_cast_in_list():
+    """Each item of a list of unions should resolve to its own cast type."""
+
+    @dataclass
+    class Row:
+        name: str
+
+    @strawberry.type
+    class A:
+        name: str
+
+    @strawberry.type
+    class B:
+        name: str
+
+    MyUnion = Annotated[A | B, strawberry.union("MyUnion")]
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def my_field(self) -> list[MyUnion]:
+            return [
+                strawberry.cast(B, Row(name="b")),  # type: ignore
+                strawberry.cast(A, Row(name="a")),  # type: ignore
+            ]
+
+    schema = strawberry.Schema(query=Query)
+
+    query = "{ myField { __typename, ... on A { name }, ... on B { name } } }"
+    result = schema.execute_sync(query)
+
+    assert not result.errors
+    assert result.data == {
+        "myField": [
+            {"__typename": "B", "name": "b"},
+            {"__typename": "A", "name": "a"},
+        ]
+    }
+
+
+def test_union_resolution_with_strawberry_cast_and_interfaces():
+    """Casting keeps working when the union's types implement an interface."""
+
+    @dataclass
+    class Row:
+        name: str
+
+    @strawberry.interface
+    class Node:
+        name: str
+
+    @strawberry.type
+    class A(Node): ...
+
+    @strawberry.type
+    class B(Node): ...
+
+    MyUnion = Annotated[A | B, strawberry.union("MyUnion")]
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def my_field(self) -> MyUnion:
+            return strawberry.cast(B, Row(name="hi"))  # type: ignore
+
+    schema = strawberry.Schema(query=Query, types=[A, B])
+
+    query = "{ myField { __typename, ... on Node { name } } }"
+    result = schema.execute_sync(query)
+
+    assert not result.errors
+    assert result.data == {"myField": {"__typename": "B", "name": "hi"}}
+
+
+def test_union_resolution_with_strawberry_cast_outside_union():
+    """Casting to a type that isn't part of the union keeps the existing error."""
+
+    @dataclass
+    class Row:
+        name: str
+
+    @strawberry.type
+    class A:
+        name: str
+
+    @strawberry.type
+    class B:
+        name: str
+
+    @strawberry.type
+    class C:
+        name: str
+
+    MyUnion = Annotated[A | B, strawberry.union("MyUnion")]
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def my_field(self) -> MyUnion:
+            return strawberry.cast(C, Row(name="hi"))  # type: ignore
+
+    schema = strawberry.Schema(query=Query, types=[C])
+
+    query = "{ myField { __typename, ... on A { name }, ... on B { name } } }"
+    result = schema.execute_sync(query)
+
+    assert result.errors
+    assert "cannot be resolved for the field" in result.errors[0].message
+
+
 def test_union_optional_with_or_operator():
     """Verify that the `|` operator is supported when annotating unions as
     optional in schemas.


### PR DESCRIPTION
`strawberry.cast` is documented as the way to pick a type when returning an object that is not an instance of any of a union's types, such as a Django, Pydantic or SQLAlchemy object. It was ignored for unions whose types do not implement an interface, and those queries failed with `WrongReturnTypeForUnion`.

The cast was only ever honoured by accident: `_get_is_type_of` returns `None` for types without interfaces, so the synthesised `is_type_of` that checks the cast did not exist for them, and the union resolver never looked at the cast itself. Check it directly in the union resolver so it no longer depends on a type implementing an interface.

A cast to a type outside the union falls through to the existing checks, so unrelated behaviour and error messages are unchanged.

Refs #3980

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Ensure union resolution respects explicit strawberry.cast annotations when resolving non-instance objects and document this behavior.

Bug Fixes:
- Fix union resolution to honor strawberry.cast for unions whose member types do not implement interfaces, avoiding WrongReturnTypeForUnion for cast ORM-like objects.
- Preserve existing error behavior when casting to a type that is not part of the union.

Documentation:
- Document how to use strawberry.cast to disambiguate union member types when returning non-instance objects.

Tests:
- Add union resolution tests covering strawberry.cast usage for plain unions, list-of-union fields, interface-based unions, and casts to non-union members.

Chores:
- Add a patch-level release note describing the strawberry.cast union resolution fix and associated behavior.