### PR TITLE
feat: add `mask_pre_execution_errors` option to `MaskErrors`

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,49 @@
+---
+release type: minor
+social_messages:
+  x: >-
+    {project_name} {version} is out! This release adds a
+    `mask_pre_execution_errors` option to `MaskErrors`, so clients can still see
+    why their query is invalid. 🍓 https://strawberry.rocks/release/{version}
+  linkedin: >-
+    {project_name} {version} is out. This release adds a
+    `mask_pre_execution_errors` option to the `MaskErrors` extension, so syntax
+    and validation errors can reach clients while the errors your resolvers
+    raise stay masked.
+---
+
+This release adds a `mask_pre_execution_errors` option to the `MaskErrors` extension.
+
+`MaskErrors` masks every error. This includes the syntax errors of a document and the validation errors against the schema, so a client that sends an invalid query gets only the generic message. Set the new option to `False` to send these errors to the client. The errors that your resolvers raise stay masked:
+
+```python
+import strawberry
+from strawberry.extensions import MaskErrors
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def hello(self) -> str:
+        return "world"
+
+    @strawberry.field
+    def hidden_error(self) -> str:
+        raise KeyError("This error will not be visible")
+
+
+schema = strawberry.Schema(
+    Query,
+    extensions=[
+        MaskErrors(mask_pre_execution_errors=False),
+    ],
+)
+
+# "Cannot query field 'helloo' on type 'Query'. Did you mean 'hello'?"
+schema.execute_sync("{ helloo }")
+
+# "Unexpected error."
+schema.execute_sync("{ hiddenError }")
+```
+
+The default value is `True`, which keeps the current behaviour. Validation errors give the names of the fields, the arguments and the types of your schema. Thus disable the option only if the clients can know the shape of the schema.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -35,7 +35,7 @@ class Query:
 schema = strawberry.Schema(
     Query,
     extensions=[
-        MaskErrors(mask_pre_execution_errors=False),
+        lambda: MaskErrors(mask_pre_execution_errors=False),
     ],
 )
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,7 +9,8 @@ social_messages:
     {project_name} {version} is out. This release adds a
     `mask_pre_execution_errors` option to the `MaskErrors` extension, so syntax
     and validation errors can reach clients while the errors your resolvers
-    raise stay masked.
+    raise stay masked. It also fixes an error leak when one `MaskErrors`
+    instance serves concurrent operations.
 ---
 
 This release adds a `mask_pre_execution_errors` option to the `MaskErrors` extension.
@@ -47,3 +48,5 @@ schema.execute_sync("{ hiddenError }")
 ```
 
 The default value is `True`, which keeps the current behaviour. Validation errors give the names of the fields, the arguments and the types of your schema. Thus disable the option only if the clients can know the shape of the schema.
+
+This release also fixes an error leak in `MaskErrors`. The extension kept some of its state on the instance. When one instance served more than one operation at the same time – which the deprecated `extensions=[MaskErrors()]` form does – a frame of an open stream could stop the extension from masking the errors of another operation, and the message of the original exception reached the client. `MaskErrors` now keeps this state per operation.

--- a/docs/extensions/mask-errors.md
+++ b/docs/extensions/mask-errors.md
@@ -156,7 +156,7 @@ class Query:
 schema = strawberry.Schema(
     Query,
     extensions=[
-        MaskErrors(mask_pre_execution_errors=False),
+        lambda: MaskErrors(mask_pre_execution_errors=False),
     ],
 )
 

--- a/docs/extensions/mask-errors.md
+++ b/docs/extensions/mask-errors.md
@@ -35,7 +35,9 @@ schema = strawberry.Schema(
 
 ```python
 class MaskErrors(
-    should_mask_error=default_should_mask_error, error_message="Unexpected error."
+    should_mask_error=default_should_mask_error,
+    error_message="Unexpected error.",
+    mask_pre_execution_errors=True,
 ): ...
 ```
 
@@ -54,6 +56,13 @@ The `default_should_mask_error` function always returns `True`.
 #### `error_message: str = "Unexpected error."`
 
 The error message to display to the client when there is an error.
+
+#### `mask_pre_execution_errors: bool = True`
+
+Mask the errors that occur before the execution step. These are the syntax
+errors of a document and the validation errors against the schema. Set the
+option to `False` to send these errors to the client. The extension continues to
+mask the errors that resolvers raise.
 
 ## More examples:
 
@@ -117,5 +126,54 @@ schema = strawberry.Schema(
     ],
 )
 ```
+
+</details>
+
+<details>
+  <summary>Keep syntax and validation errors visible</summary>
+
+By default, the extension also masks the errors that occur before execution. A
+client that sends a malformed document thus gets only the generic message. Set
+`mask_pre_execution_errors` to `False` to send these errors to the client. The
+errors that resolvers raise stay masked.
+
+```python
+import strawberry
+from strawberry.extensions import MaskErrors
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def hello(self) -> str:
+        return "world"
+
+    @strawberry.field
+    def hidden_error(self) -> str:
+        raise KeyError("This error will not be visible")
+
+
+schema = strawberry.Schema(
+    Query,
+    extensions=[
+        MaskErrors(mask_pre_execution_errors=False),
+    ],
+)
+
+# "Cannot query field 'helloo' on type 'Query'. Did you mean 'hello'?"
+schema.execute_sync("{ helloo }")
+
+# "Unexpected error."
+schema.execute_sync("{ hiddenError }")
+```
+
+<Note>
+
+Validation errors give the names of the fields, the arguments and the types of
+your schema. They can also suggest a name that is close to the name that the
+client sent. Disable this option only if the clients can know the shape of the
+schema.
+
+</Note>
 
 </details>

--- a/strawberry/extensions/mask_errors.py
+++ b/strawberry/extensions/mask_errors.py
@@ -24,15 +24,31 @@ def default_should_mask_error(_: GraphQLError) -> bool:
 class MaskErrors(SchemaExtension):
     should_mask_error: Callable[[GraphQLError], bool]
     error_message: str
+    mask_pre_execution_errors: bool
 
     def __init__(
         self,
         should_mask_error: Callable[[GraphQLError], bool] = default_should_mask_error,
         error_message: str = "Unexpected error.",
+        mask_pre_execution_errors: bool = True,
     ) -> None:
+        """Initialize the MaskErrors extension.
+
+        Args:
+            should_mask_error: A function that tells if the extension must mask
+                an error. Use the `original_error` attribute to examine the
+                error that the resolver raised.
+            error_message: The message that the client gets for a masked error.
+            mask_pre_execution_errors: Mask the errors of the parse step and of
+                the validation step. Set it to `False` to send the syntax errors
+                and the validation errors of a document to the client. The
+                extension continues to mask the errors of the execution step.
+        """
         self.should_mask_error = should_mask_error
         self.error_message = error_message
+        self.mask_pre_execution_errors = mask_pre_execution_errors
         self._stream_result_processed = False
+        self._in_pre_execution_phase = False
 
     def anonymise_error(self, error: GraphQLError) -> GraphQLError:
         return GraphQLError(
@@ -55,6 +71,17 @@ class MaskErrors(SchemaExtension):
 
         return processed_errors
 
+    @property
+    def _masking_enabled(self) -> bool:
+        """Return `True` if the extension must mask the errors of this phase.
+
+        Parse errors and validation errors describe the document that the client
+        sent, and they can show the shape of the schema. This is a different
+        concern from the errors that resolvers raise. Thus the extension masks
+        them only when `mask_pre_execution_errors` is `True`.
+        """
+        return self.mask_pre_execution_errors or not self._in_pre_execution_phase
+
     def _process_result(self, result: object) -> None:
         if isinstance(result, _ResultWithErrors) and result.errors:
             result.errors = self._process_errors(result.errors)
@@ -68,13 +95,30 @@ class MaskErrors(SchemaExtension):
         for completed_result in getattr(result, "completed", None) or ():
             self._process_result(completed_result)
 
+    def on_parse(self) -> Iterator[None]:
+        self._in_pre_execution_phase = True
+        yield
+
+    def on_execute(self) -> Iterator[None]:
+        # The parse step and the validation step always run before this hook.
+        # Thus an operation that comes here did not fail in those steps.
+        self._in_pre_execution_phase = False
+        yield
+
     def on_operation(self) -> Iterator[None]:
         self._stream_result_processed = False
+        # An error that occurs before the parse step, a missing query for
+        # example, does not come from the document. The extension always masks
+        # these errors.
+        self._in_pre_execution_phase = False
         yield
 
         # Streaming operations are handled result-by-result before each frame is
         # yielded. Avoid processing the last result again when the stream closes.
         if self._stream_result_processed:
+            return
+
+        if not self._masking_enabled:
             return
 
         result = self.execution_context.result
@@ -87,5 +131,8 @@ class MaskErrors(SchemaExtension):
     def on_stream_result(self, result: StreamExecutionResult) -> Iterator[None]:
         """Mask errors before a streamed execution result reaches the client."""
         self._stream_result_processed = True
-        self._process_stream_result(result)
+
+        if self._masking_enabled:
+            self._process_stream_result(result)
+
         yield None

--- a/strawberry/extensions/mask_errors.py
+++ b/strawberry/extensions/mask_errors.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable, Iterator
+from contextvars import ContextVar
 from typing import Protocol, runtime_checkable
 
 from graphql import ExecutionResult as GraphQLExecutionResult
@@ -19,6 +20,17 @@ class _ResultWithErrors(Protocol):
 def default_should_mask_error(_: GraphQLError) -> bool:
     # Mask all errors
     return True
+
+
+# This state belongs to one operation, not to the extension instance. A context
+# variable keeps concurrent operations apart, also when the same instance serves
+# more than one of them, and `on_operation` resets it when the operation ends.
+_in_pre_execution_phase: ContextVar[bool] = ContextVar(
+    "strawberry_mask_errors_in_pre_execution_phase", default=False
+)
+_stream_result_processed: ContextVar[bool] = ContextVar(
+    "strawberry_mask_errors_stream_result_processed", default=False
+)
 
 
 class MaskErrors(SchemaExtension):
@@ -47,8 +59,6 @@ class MaskErrors(SchemaExtension):
         self.should_mask_error = should_mask_error
         self.error_message = error_message
         self.mask_pre_execution_errors = mask_pre_execution_errors
-        self._stream_result_processed = False
-        self._in_pre_execution_phase = False
 
     def anonymise_error(self, error: GraphQLError) -> GraphQLError:
         return GraphQLError(
@@ -80,7 +90,7 @@ class MaskErrors(SchemaExtension):
         concern from the errors that resolvers raise. Thus the extension masks
         them only when `mask_pre_execution_errors` is `True`.
         """
-        return self.mask_pre_execution_errors or not self._in_pre_execution_phase
+        return self.mask_pre_execution_errors or not _in_pre_execution_phase.get()
 
     def _process_result(self, result: object) -> None:
         if isinstance(result, _ResultWithErrors) and result.errors:
@@ -96,41 +106,48 @@ class MaskErrors(SchemaExtension):
             self._process_result(completed_result)
 
     def on_parse(self) -> Iterator[None]:
-        self._in_pre_execution_phase = True
+        _in_pre_execution_phase.set(True)
         yield
 
     def on_execute(self) -> Iterator[None]:
         # The parse step and the validation step always run before this hook.
         # Thus an operation that comes here did not fail in those steps.
-        self._in_pre_execution_phase = False
+        _in_pre_execution_phase.set(False)
         yield
 
     def on_operation(self) -> Iterator[None]:
-        self._stream_result_processed = False
+        stream_token = _stream_result_processed.set(False)
         # An error that occurs before the parse step, a missing query for
         # example, does not come from the document. The extension always masks
         # these errors.
-        self._in_pre_execution_phase = False
-        yield
+        phase_token = _in_pre_execution_phase.set(False)
 
-        # Streaming operations are handled result-by-result before each frame is
-        # yielded. Avoid processing the last result again when the stream closes.
-        if self._stream_result_processed:
-            return
+        try:
+            yield
 
-        if not self._masking_enabled:
-            return
+            # Streaming operations are handled result-by-result before each
+            # frame is yielded. Avoid processing the last result again when the
+            # stream closes.
+            if _stream_result_processed.get():
+                return
 
-        result = self.execution_context.result
+            if not self._masking_enabled:
+                return
 
-        if isinstance(result, (GraphQLExecutionResult, StrawberryExecutionResult)):
-            self._process_result(result)
-        elif initial_result := getattr(result, "initial_result", None):
-            self._process_result(initial_result)
+            result = self.execution_context.result
+
+            if isinstance(result, (GraphQLExecutionResult, StrawberryExecutionResult)):
+                self._process_result(result)
+            elif initial_result := getattr(result, "initial_result", None):
+                self._process_result(initial_result)
+        finally:
+            # This state must not outlive the operation that set it.
+            _in_pre_execution_phase.reset(phase_token)
+            _stream_result_processed.reset(stream_token)
 
     def on_stream_result(self, result: StreamExecutionResult) -> Iterator[None]:
         """Mask errors before a streamed execution result reaches the client."""
-        self._stream_result_processed = True
+        _stream_result_processed.set(True)
 
         if self._masking_enabled:
             self._process_stream_result(result)

--- a/tests/schema/extensions/test_mask_errors.py
+++ b/tests/schema/extensions/test_mask_errors.py
@@ -7,6 +7,30 @@ import strawberry
 from strawberry.extensions import MaskErrors, ValidationCache
 
 
+@strawberry.type
+class Query:
+    """Shared schema for the `mask_pre_execution_errors` tests."""
+
+    @strawberry.field
+    def test_field(self) -> str:
+        return "TestField"
+
+    @strawberry.field
+    def hidden_error(self) -> str:
+        raise KeyError("This error is not visible")
+
+
+# What `MaskErrors(mask_pre_execution_errors=False)` does with a document that
+# fails to parse, with one that fails to validate, and with one that makes a
+# resolver raise: the message the client gets, and how many times the extension
+# asks `should_mask_error` about it.
+KEEP_PRE_EXECUTION_ERRORS = [
+    ("query { testField( }", "Syntax Error: Expected Name, found '}'.", 0),
+    ("query { missingField }", "Cannot query field 'missingField' on type 'Query'.", 0),
+    ("query { hiddenError }", "Unexpected error.", 1),
+]
+
+
 @pytest.mark.parametrize(
     "query",
     [
@@ -314,3 +338,54 @@ async def test_mask_errors_selective_async():
             "path": ["visibleError"],
         }
     ]
+
+
+@pytest.mark.parametrize(
+    ("query", "expected_message", "expected_calls"), KEEP_PRE_EXECUTION_ERRORS
+)
+def test_keep_pre_execution_errors_sync(
+    query: str, expected_message: str, expected_calls: int
+):
+    should_mask_error = Mock(return_value=True)
+    schema = strawberry.Schema(
+        query=Query,
+        extensions=[
+            lambda: MaskErrors(
+                should_mask_error=should_mask_error,
+                mask_pre_execution_errors=False,
+            )
+        ],
+    )
+
+    result = schema.execute_sync(query)
+
+    assert result.data is None
+    assert result.errors is not None
+    assert [error.message for error in result.errors] == [expected_message]
+    assert should_mask_error.call_count == expected_calls
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("query", "expected_message", "expected_calls"), KEEP_PRE_EXECUTION_ERRORS
+)
+async def test_keep_pre_execution_errors_async(
+    query: str, expected_message: str, expected_calls: int
+):
+    should_mask_error = Mock(return_value=True)
+    schema = strawberry.Schema(
+        query=Query,
+        extensions=[
+            lambda: MaskErrors(
+                should_mask_error=should_mask_error,
+                mask_pre_execution_errors=False,
+            )
+        ],
+    )
+
+    result = await schema.execute(query)
+
+    assert result.data is None
+    assert result.errors is not None
+    assert [error.message for error in result.errors] == [expected_message]
+    assert should_mask_error.call_count == expected_calls

--- a/tests/schema/extensions/test_stream_result.py
+++ b/tests/schema/extensions/test_stream_result.py
@@ -306,3 +306,47 @@ async def test_mask_errors_before_streaming_pre_execution_error(
         assert [error.message for error in result.errors] == ["Unexpected error."]
     finally:
         await results.aclose()
+
+
+async def first_stream_result(
+    schema: strawberry.Schema, operation: str | None
+) -> ExecutionResult:
+    """Return the first frame of a stream, then close the stream."""
+    results = await schema.stream(operation)
+    try:
+        result = await anext(results)
+        assert isinstance(result, ExecutionResult)
+        assert result.errors
+        return result
+    finally:
+        await results.aclose()
+
+
+@pytest.mark.asyncio
+async def test_keep_pre_execution_errors_before_streaming() -> None:
+    schema = strawberry.Schema(
+        query=Query,
+        extensions=[lambda: MaskErrors(mask_pre_execution_errors=False)],
+    )
+
+    kept = await first_stream_result(schema, "{ missingField }")
+    assert [error.message for error in kept.errors] == [
+        "Cannot query field 'missingField' on type 'Query'."
+    ]
+
+    masked = await first_stream_result(schema, "{ dangerousQuery }")
+    assert [error.message for error in masked.errors] == ["Unexpected error."]
+
+
+@pytest.mark.asyncio
+async def test_mask_errors_forgets_the_phase_of_the_previous_operation() -> None:
+    """An extension instance can be shared between operations."""
+    extension = MaskErrors(mask_pre_execution_errors=False)
+    schema = strawberry.Schema(query=Query, extensions=[lambda: extension])
+
+    # This operation stops in the validation step.
+    await first_stream_result(schema, "{ missingField }")
+
+    # This one stops before the parse step, so the extension must mask it.
+    result = await first_stream_result(schema, None)
+    assert [error.message for error in result.errors] == ["Unexpected error."]

--- a/tests/schema/extensions/test_stream_result.py
+++ b/tests/schema/extensions/test_stream_result.py
@@ -350,3 +350,74 @@ async def test_mask_errors_forgets_the_phase_of_the_previous_operation() -> None
     # This one stops before the parse step, so the extension must mask it.
     result = await first_stream_result(schema, None)
     assert [error.message for error in result.errors] == ["Unexpected error."]
+
+
+@pytest.mark.asyncio
+async def test_mask_errors_masks_an_operation_that_overlaps_a_stream() -> None:
+    """One extension instance can serve two operations at the same time.
+
+    A frame of an open stream must not stop the extension from masking the
+    error of another operation that runs at the same time.
+    """
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    @strawberry.type
+    class GatedQuery:
+        @strawberry.field
+        async def gated_error(self) -> str:
+            started.set()
+            await release.wait()
+            raise RuntimeError("Secret query error")
+
+    extension = MaskErrors()
+    schema = strawberry.Schema(
+        query=GatedQuery, subscription=Subscription, extensions=[lambda: extension]
+    )
+
+    stream = await schema.stream("subscription { count }")
+    try:
+        await anext(stream)
+
+        overlapping = asyncio.create_task(schema.execute("{ gatedError }"))
+        await started.wait()
+
+        # The stream reports a frame while the other operation is in its resolver.
+        await anext(stream)
+        release.set()
+
+        result = await overlapping
+        assert result.errors
+        assert [error.message for error in result.errors] == ["Unexpected error."]
+    finally:
+        await stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_mask_errors_phase_does_not_outlive_its_operation() -> None:
+    """The phase behind `mask_pre_execution_errors` belongs to one operation.
+
+    A second operation that stops in the validation step must not stop the
+    extension from masking the error of a resolver in a stream that is still
+    open.
+    """
+    extension = MaskErrors(mask_pre_execution_errors=False)
+    schema = strawberry.Schema(
+        query=Query, subscription=Subscription, extensions=[lambda: extension]
+    )
+
+    results = await schema.stream("subscription { dangerousStream }")
+    try:
+        first_result = await anext(results)
+        assert isinstance(first_result, ExecutionResult)
+        assert first_result.data == {"dangerousStream": 1}
+
+        # This operation stops in the validation step of its own document.
+        await schema.execute("{ missingField }")
+
+        error_result = await anext(results)
+        assert isinstance(error_result, ExecutionResult)
+        assert error_result.errors
+        assert [error.message for error in error_result.errors] == ["Unexpected error."]
+    finally:
+        await results.aclose()


### PR DESCRIPTION
## Description

The original report – that `MaskErrors` does not mask validation errors – was already fixed by #3968 and #4330. `MaskErrors` masks parse errors and validation errors in every execution path today.

What is still open is the option that @erikwrede and @patrick91 asked for in that thread. There are two separate concerns: hide what the resolvers raise, and hide the shape of the schema. You cannot ask for the first one alone, so a client that sends a malformed document only gets `Unexpected error.` and cannot correct its query.

This PR adds `mask_pre_execution_errors` to the `MaskErrors` constructor. It defaults to `True`, so the behaviour does not change for anybody.

```python
schema = strawberry.Schema(
    Query,
    extensions=[lambda: MaskErrors(mask_pre_execution_errors=False)],
)

# "Cannot query field 'helloo' on type 'Query'. Did you mean 'hello'?"
schema.execute_sync("{ helloo }")

# "Unexpected error."
schema.execute_sync("{ hiddenError }")
```

### How it works

The extension masks the errors of `execution_context.result` and of each streamed frame. At that point it cannot tell which phase produced them. It now tracks the phase with the existing lifecycle hooks: `on_parse` sets a private flag and `on_execute` clears it. Every execution path enters `parsing()` before `executing()`, so an operation that reaches `on_execute` did not fail to parse or to validate. `on_operation` and `on_stream_result` both consult the flag, which keeps the sync, async, streaming, subscription and incremental paths consistent.

Errors that occur before the parse step, a missing query for example, stay masked. `Schema.process_errors` still receives the original errors, so logs do not change.

### Validation

- `uv run pytest` – 5122 passed. The single failure, `tests/typecheckers/test_pydantic.py::test_pydantic_type`, also fails on a clean checkout here, because a local binary is missing.
- `uv run mypy --config-file mypy.ini` – clean, 240 source files.
- `uv run ruff check .` and `uv run ruff format --check .` – clean.
- The 8 new test cases fail before the change and pass after it.
- I then broke the new logic seven ways – dropped each hook, dropped each guard, and forced the phase check to a constant – and confirmed that the tests catch every one.
- Manual checks of the sync, async and streaming paths, and of the example in the documentation.
- `RELEASE.md` included, release type `minor`.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

* Closes #3326

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Add a configurable option to the MaskErrors extension to control whether syntax and validation errors are masked before execution while keeping resolver-raised errors masked by default.

New Features:
- Introduce the mask_pre_execution_errors option on the MaskErrors extension to let clients see pre-execution syntax and validation errors when desired.

Enhancements:
- Track execution phase within MaskErrors so masking behavior can differ between pre-execution and execution errors without affecting logging.
- Extend MaskErrors to handle phase-aware masking for streaming operations and multiple operations sharing the same extension instance.

Documentation:
- Document the new mask_pre_execution_errors option in the MaskErrors extension guide, including examples and guidance on schema visibility implications.

Tests:
- Add sync, async, and streaming tests verifying mask_pre_execution_errors behavior for parse, validation, and resolver errors, and phase handling across multiple operations.

Chores:
- Add a minor release note describing the new mask_pre_execution_errors option and its default behavior.