### PR TITLE
Support optional info parameters in resolvers

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,46 @@
+---
+release type: minor
+social_messages:
+  x: >-
+    {project_name} {version} is out! This release adds support for optional
+    `info` parameters in resolvers, so `info: strawberry.Info | None = None`
+    now works and keeps type checkers happy. 🍓
+    {{https://strawberry.rocks/release/{version}}}
+  linkedin: >-
+    {project_name} {version} is out. This release adds support for optional
+    `info` parameters in resolvers. Annotating a resolver with
+    `info: strawberry.Info | None = None` now injects the execution info as
+    usual, so resolvers that are also called directly from Python no longer
+    need an annotation that every type checker rejects.
+---
+
+This release adds support for optional `info` parameters in resolvers.
+
+Previously only a bare `strawberry.Info` annotation was recognized, so a
+resolver that is also called directly from Python had to be written as
+`info: strawberry.Info = None` — an annotation every type checker rejects.
+
+```python
+import strawberry
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def hello(self, info: strawberry.Info | None = None) -> str:
+        return "from graphql" if info else "standalone"
+```
+
+`Optional[Info]`, `Union[Info, None]`, generic forms such as
+`Info[Context, RootValue] | None`, subclasses of `Info` used with
+`StrawberryConfig(info_class=...)`, type aliases, and qualified string or
+forward reference annotations such as `"strawberry.Info | None"` are all
+recognized.
+
+Unions with more than one non-`None` member, such as `Info | str | None`, are
+still rejected, and this change does not affect the `Parent` or
+`DirectiveValue` reserved parameters.
+
+An optional `info` parameter is now always injected by Strawberry and never
+appears as a field argument in the schema, including when a scalar override is
+registered for `Info`.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -28,7 +28,7 @@ import strawberry
 class Query:
     @strawberry.field
     def hello(self, info: strawberry.Info | None = None) -> str:
-        return "from graphql" if info else "standalone"
+        return "from GraphQL" if info else "standalone"
 ```
 
 `Optional[Info]`, `Union[Info, None]`, generic forms such as

--- a/strawberry/types/fields/resolver.py
+++ b/strawberry/types/fields/resolver.py
@@ -1,5 +1,6 @@
 from __future__ import annotations as _
 
+import ast
 import asyncio
 import inspect
 import sys
@@ -27,7 +28,11 @@ from strawberry.parent import StrawberryParent, resolve_parent_forward_arg
 from strawberry.types.arguments import StrawberryArgument
 from strawberry.types.base import StrawberryType, has_object_definition
 from strawberry.types.info import Info
-from strawberry.utils.typing import type_has_annotation
+from strawberry.utils.typing import (
+    get_optional_annotation,
+    is_optional,
+    type_has_annotation,
+)
 
 if TYPE_CHECKING:
     import builtins
@@ -107,6 +112,7 @@ class ReservedType(NamedTuple):
     name: str | None
     type: type
     alias: str | None = None
+    allow_optional: bool = False
 
     def find(
         self,
@@ -159,7 +165,12 @@ class ReservedType(NamedTuple):
         # Handle TypeAliasType (Python 3.12+ `type X = ...` syntax)
         # We need to unwrap the alias to get the actual type
         if hasattr(other, "__value__"):
-            other = other.__value__
+            return self.is_reserved_type(other.__value__)
+
+        # Optional[T] and T | None describe the value accepted by direct Python
+        # calls, but GraphQL still needs to inject reserved parameters as T.
+        if self.allow_optional and is_optional(other):
+            return self.is_reserved_type(get_optional_annotation(other))
 
         origin = cast("type", get_origin(other)) or other
         if origin is Annotated:
@@ -188,13 +199,88 @@ class ReservedType(NamedTuple):
         if self.alias:
             valid_names.add(f"strawberry.{self.alias}")
 
-        return base_annotation in valid_names
+        if base_annotation in valid_names:
+            return True
+
+        # Unresolvable annotations can still be optional, e.g. when the type is
+        # imported under TYPE_CHECKING and written as "strawberry.Info | None".
+        if not self.allow_optional:
+            return False
+
+        inner = _unwrap_optional_str(annotation)
+        return inner is not None and inner in valid_names
+
+
+def _is_none_node(node: ast.expr) -> bool:
+    return isinstance(node, ast.Constant) and node.value is None
+
+
+def _dotted_name(node: ast.expr) -> str | None:
+    """Return the dotted name for a Name/Attribute chain, if it is one."""
+    parts: list[str] = []
+    current: ast.expr = node
+    while isinstance(current, ast.Attribute):
+        parts.append(current.attr)
+        current = current.value
+    if not isinstance(current, ast.Name):
+        return None
+    parts.append(current.id)
+    return ".".join(reversed(parts))
+
+
+def _union_members(node: ast.expr) -> list[ast.expr] | None:
+    """Flatten a union annotation node, or return None if it is not a union."""
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+        return (_union_members(node.left) or [node.left]) + (
+            _union_members(node.right) or [node.right]
+        )
+
+    if isinstance(node, ast.Subscript):
+        name = _dotted_name(node.value)
+        tail = name.rsplit(".", maxsplit=1)[-1] if name else None
+        if tail == "Optional":
+            return [node.slice, ast.Constant(value=None)]
+        if tail == "Union":
+            if not isinstance(node.slice, ast.Tuple):
+                return [node.slice]
+            members: list[ast.expr] = []
+            for element in node.slice.elts:
+                members.extend(_union_members(element) or [element])
+            return members
+
+    return None
+
+
+def _unwrap_optional_str(annotation: str) -> str | None:
+    """Return the base name of the sole non-None member of an optional string.
+
+    The annotation is parsed structurally, never evaluated. ``None`` is returned
+    when the annotation is not a union, is not optional, or has more than one
+    non-``None`` member.
+    """
+    try:
+        node = ast.parse(annotation.strip(), mode="eval").body
+    except SyntaxError:
+        return None
+
+    members = _union_members(node)
+    if members is None:
+        return None
+
+    non_none = [member for member in members if not _is_none_node(member)]
+    if len(non_none) != 1 or len(non_none) == len(members):
+        return None
+
+    inner = non_none[0]
+    if isinstance(inner, ast.Subscript):
+        inner = inner.value
+    return _dotted_name(inner)
 
 
 SELF_PARAMSPEC = ReservedNameBoundParameter("self")
 CLS_PARAMSPEC = ReservedNameBoundParameter("cls")
 ROOT_PARAMSPEC = ReservedName("root")
-INFO_PARAMSPEC = ReservedType("info", Info)
+INFO_PARAMSPEC = ReservedType("info", Info, allow_optional=True)
 PARENT_PARAMSPEC = ReservedType(name=None, type=StrawberryParent, alias="Parent")
 
 T = TypeVar("T")

--- a/tests/fields/test_resolvers.py
+++ b/tests/fields/test_resolvers.py
@@ -1,12 +1,13 @@
 import dataclasses
 import textwrap
 import types
-from typing import Any, ClassVar, ForwardRef, no_type_check
+from typing import Any, ClassVar, ForwardRef, Optional, Union, no_type_check
 
 import pytest
 
 import strawberry
 from strawberry.exceptions import (
+    ConflictingArgumentsError,
     MissingArgumentsAnnotationsError,
     MissingFieldAnnotationError,
     MissingReturnAnnotationError,
@@ -15,6 +16,7 @@ from strawberry.parent import Parent
 from strawberry.scalars import JSON
 from strawberry.types.fields.resolver import (
     INFO_PARAMSPEC,
+    PARENT_PARAMSPEC,
     Signature,
     StrawberryResolver,
     UncallableResolverError,
@@ -685,6 +687,131 @@ def test_info_annotation_with_type_alias():
     result = schema.execute_sync("query { hello }")
     assert result.errors is None
     assert result.data == {"hello": "Hello World"}
+
+
+def test_optional_info_is_reserved_type():
+    """Optional Info annotations are recognized as the info parameter (#4389)."""
+    assert INFO_PARAMSPEC.is_reserved_type(Optional[strawberry.Info]) is True
+    assert INFO_PARAMSPEC.is_reserved_type(Union[strawberry.Info, None]) is True
+    assert INFO_PARAMSPEC.is_reserved_type(strawberry.Info | None) is True
+    assert INFO_PARAMSPEC.is_reserved_type(None | strawberry.Info) is True
+    assert INFO_PARAMSPEC.is_reserved_type(strawberry.Info[None, None] | None) is True
+
+
+def test_optional_info_type_alias_is_reserved_type():
+    """TypeAliasType wrapping or wrapped by Optional is unwrapped recursively."""
+    from typing_extensions import TypeAliasType
+
+    AliasedInfo = TypeAliasType("AliasedInfo", strawberry.Info[None, None])
+    OptionalAliasedInfo = TypeAliasType(
+        "OptionalAliasedInfo", Optional[strawberry.Info[None, None]]
+    )
+
+    assert INFO_PARAMSPEC.is_reserved_type(AliasedInfo | None) is True
+    assert INFO_PARAMSPEC.is_reserved_type(OptionalAliasedInfo) is True
+
+
+def test_non_optional_info_unions_are_not_reserved_types():
+    """Only unions of exactly one Info and None are matched."""
+    assert INFO_PARAMSPEC.is_reserved_type(strawberry.Info | str) is False
+    assert INFO_PARAMSPEC.is_reserved_type(strawberry.Info | str | None) is False
+    assert INFO_PARAMSPEC.is_reserved_type(list[strawberry.Info] | None) is False
+    assert INFO_PARAMSPEC.is_reserved_type(Optional[str]) is False
+    assert INFO_PARAMSPEC.is_reserved_type(str) is False
+
+
+def test_optional_parent_annotation_is_not_reserved_type():
+    """Only ``Info`` opts into optional matching; ``Parent`` is unchanged."""
+    assert PARENT_PARAMSPEC.is_reserved_type(Parent[str]) is True
+    assert PARENT_PARAMSPEC.is_reserved_type(Optional[Parent[str]]) is False
+    assert PARENT_PARAMSPEC.is_reserved_type("strawberry.Parent") is True
+    assert PARENT_PARAMSPEC.is_reserved_type("strawberry.Parent | None") is False
+
+
+def test_optional_info_forward_reference_string():
+    """Qualified optional strings match too, for TYPE_CHECKING-only imports."""
+    assert INFO_PARAMSPEC.is_reserved_type("strawberry.Info | None") is True
+    assert INFO_PARAMSPEC.is_reserved_type("None | strawberry.Info") is True
+    assert INFO_PARAMSPEC.is_reserved_type("Optional[strawberry.Info]") is True
+    assert INFO_PARAMSPEC.is_reserved_type("typing.Optional[strawberry.Info]") is True
+    assert INFO_PARAMSPEC.is_reserved_type("Union[strawberry.Info, None]") is True
+    assert INFO_PARAMSPEC.is_reserved_type("strawberry.types.info.Info | None") is True
+    assert (
+        INFO_PARAMSPEC.is_reserved_type("strawberry.Info[Context, None] | None") is True
+    )
+    assert INFO_PARAMSPEC.is_reserved_type(ForwardRef("strawberry.Info | None")) is True
+
+    # Unqualified names and multi-member unions still do not match
+    assert INFO_PARAMSPEC.is_reserved_type("Info | None") is False
+    assert INFO_PARAMSPEC.is_reserved_type("MyInfo | None") is False
+    assert INFO_PARAMSPEC.is_reserved_type("strawberry.Info | str") is False
+    assert INFO_PARAMSPEC.is_reserved_type("strawberry.Info | str | None") is False
+    assert INFO_PARAMSPEC.is_reserved_type("list[strawberry.Info] | None") is False
+    assert INFO_PARAMSPEC.is_reserved_type("strawberry.Info |") is False
+
+
+def test_optional_info_annotation_supports_graphql_and_direct_calls():
+    """Regression test for issue #4389."""
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def hello(self, request_info: strawberry.Info | None = None) -> str:
+            return "injected" if request_info is not None else "standalone"
+
+    # The resolver stays usable as a plain Python function
+    assert Query().hello() == "standalone"
+
+    field = Query.__strawberry_definition__.fields[0]
+    assert field.arguments == []
+    assert field.base_resolver.info_parameter.name == "request_info"
+
+    result = strawberry.Schema(query=Query).execute_sync("{ hello }")
+    assert result.errors is None
+    assert result.data == {"hello": "injected"}
+
+
+async def test_optional_info_annotation_with_async_resolver():
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        async def hello(self, request_info: strawberry.Info | None = None) -> str:
+            return "injected" if request_info is not None else "standalone"
+
+    assert await Query().hello() == "standalone"
+
+    result = await strawberry.Schema(query=Query).execute("{ hello }")
+    assert result.errors is None
+    assert result.data == {"hello": "injected"}
+
+
+def test_optional_generic_info_annotation_builds_schema():
+    """``Info[Ctx, Root] | None`` used to fail at decoration time."""
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def hello(self, info: strawberry.Info[None, None] | None = None) -> str:
+            return "injected" if info is not None else "standalone"
+
+    result = strawberry.Schema(query=Query).execute_sync("{ hello }")
+    assert result.errors is None
+    assert result.data == {"hello": "injected"}
+
+
+def test_conflicting_optional_info_arguments():
+    """Two optional Info parameters conflict, like two plain Info parameters."""
+    with pytest.raises(ConflictingArgumentsError):
+
+        @strawberry.type
+        class Query:
+            @strawberry.field
+            def hello(
+                self,
+                first: strawberry.Info | None = None,
+                second: strawberry.Info | None = None,
+            ) -> str:
+                return "hi"
 
 
 def test_info_forward_reference_string():

--- a/tests/typecheckers/test_info.py
+++ b/tests/typecheckers/test_info.py
@@ -157,3 +157,46 @@ def example(info: strawberry.Info) -> None:
             ),
         ]
     )
+
+
+def test_optional_info():
+    CODE = """
+import strawberry
+
+
+def example(info: strawberry.Info | None = None) -> None:
+    reveal_type(info)
+"""
+
+    results = typecheck(CODE)
+
+    assert results.pyright == snapshot(
+        [
+            Result(
+                type="information",
+                message='Type of "info" is "Info[Any, Any] | None"',
+                line=6,
+                column=17,
+            ),
+        ]
+    )
+    assert results.mypy == snapshot(
+        [
+            Result(
+                type="note",
+                message='Revealed type is "strawberry.types.info.Info[Any, Any] | None"',
+                line=6,
+                column=17,
+            ),
+        ]
+    )
+    assert results.ty == snapshot(
+        [
+            Result(
+                type="information",
+                message="Revealed type: `Info[Any, Any] | None`",
+                line=6,
+                column=17,
+            ),
+        ]
+    )

--- a/tests/types/test_argument_types.py
+++ b/tests/types/test_argument_types.py
@@ -109,10 +109,19 @@ class CustomInfo(Info[ContextType, RootValueType]):
 
 @pytest.mark.parametrize(
     "annotation",
-    [CustomInfo, CustomInfo[None, None], Info, Info[None, None]],
+    [
+        CustomInfo,
+        CustomInfo[None, None],
+        Info,
+        Info[None, None],
+        CustomInfo | None,
+        CustomInfo[None, None] | None,
+        Info | None,
+        Info[None, None] | None,
+    ],
 )
 def test_custom_info(annotation):
-    """Test to ensure that subclassed Info does not raise warning."""
+    """Test that concrete, generic, and optional Info types are injected."""
     with warnings.catch_warnings():
         warnings.filterwarnings("error")
 


### PR DESCRIPTION
Fixes #4389

## Problem

Annotating `info` as optional makes schema construction fail:

```python
@strawberry.type
class Query:
    @strawberry.field
    def hello(self, info: strawberry.Info | None = None) -> str:
        return "hi"

# TypeError: Unexpected type '<class 'strawberry.types.info.Info'>'
```

There is currently no spelling that keeps both sides happy. Drop the default and type checkers flag every call site that omits `info`. Keep it and Strawberry treats `info` as a GraphQL argument, so the schema does not build.

## Cause

`ReservedType.is_reserved_type` matches a bare class, a generic alias, an `Annotated` form, a string, a `ForwardRef` and a `TypeAliasType`. An `Optional` or union wrapper matches none of those, so the parameter is never classified as reserved and falls through to the argument path.

That gap is old. A second matching path was hiding it. Until 0.295.0, `ReservedType.find` fell back to matching by parameter name whenever type matching failed, and `INFO_PARAMSPEC` carries the name `"info"`. A resolver written the usual way failed type matching, hit the name fallback, and worked anyway.

Because the fallback keyed on the parameter name rather than the annotation, the bug was already reachable on 0.295.0 under any other name:

```python
# 0.295.0
def a(self, info: strawberry.Info | None = None) -> str: ...          # worked, through the name fallback
def b(self, request_info: strawberry.Info | None = None) -> str: ...  # already failed
```

The fallback and its deprecation warning came in with #1713 (52dcfb50), first released in 0.115.0. #4224 removed them, first released in 0.296.0. So #4224 did not introduce this. It took away the cover for a gap that had been in the type-based matcher all along.

## Why the tests did not catch it

Every test that exercises reserved-parameter classification annotates a bare `strawberry.Info` on a parameter named `info`. The fallback covered exactly that spelling, so removing it could not fail any of them.

Optional `Info` does appear in the suite, in `resolve_nodes` and `resolve_connection` in `tests/relay/schema.py` and `tests/relay/test_fields.py`. Those hooks are called directly by the relay code and never go through `StrawberryResolver`, so they never reach `ReservedType.find`. The annotation was present and exercised at runtime while the classification path stayed untested.

## Solution

`ReservedType` gains an opt-in `allow_optional` field, set only on `INFO_PARAMSPEC`. When it is set, `is_reserved_type` unwraps a single optional layer and re-checks the inner annotation. `TypeAliasType.__value__` unwrapping becomes recursive so an alias still resolves when it is wrapped.

String annotations, from `from __future__ import annotations` or `TYPE_CHECKING` imports, go through `_is_reserved_type_str`. That now parses the annotation with `ast.parse(..., mode="eval")` and matches the union structurally. It only parses, it never evaluates.

Accepted:

```python
info: strawberry.Info | None = None
info: Optional[strawberry.Info] = None
info: Union[strawberry.Info, None] = None
info: strawberry.Info[Context, RootValue] | None = None
info: "strawberry.Info | None" = None
type MyInfo = strawberry.Info   # then info: MyInfo | None = None
```

Still rejected, deliberately:

```python
info: strawberry.Info | str            # union with a non-None member
parent: strawberry.Parent[str] | None  # Parent keeps strict matching
value: DirectiveValue[str] | None      # DirectiveValue keeps strict matching
```

`Parent` and `DirectiveValue` do not set the flag, so nothing about them changes.

## Behavior changes

Two parameters that both annotate an optional `Info` now raise `ConflictingArgumentsError` at decoration time instead of quietly exposing one of them as a GraphQL argument.

With `scalar_overrides={Info: MyScalar}`, an optional `info` parameter is now treated as reserved. It no longer appears as a GraphQL argument and receives the real `Info` object. Before this change it showed up in the SDL and execution failed with "got multiple values for argument 'info'".

## Testing

13 new tests plus 4 parametrised cases. 11 of them fail on main. Two are guards that check the matcher does not over-match, covering unions with a non-None member and optional `Parent`.

They cover sync and async resolvers, generic `Info`, `TypeAliasType`, string and forward-reference annotations, direct calls alongside GraphQL execution, and the conflict error. `tests/typecheckers/test_info.py` gets a case showing mypy, pyright and ty all resolve `strawberry.Info | None` with no error.

Full suite on the patched tree: 5109 passed, 405 skipped, 120 xfailed, 24 xpassed. That is main plus the new tests, with nothing else changing. I also ran it on Python 3.10 and 3.11, and against graphql-core 3.3.0rc0.

## Risk

The change is contained to reserved-parameter classification. Nothing else opts into `allow_optional`, so `self`, `cls`, `root`, `Parent` and `DirectiveValue` match exactly as before.

The two behavior changes above are the only user-visible differences beyond the fix. Both read as correct to me, but say the word if you would rather keep either one as it was.