### PR TITLE
fix: correct dataclass transform ordering metadata

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,17 @@
+---
+release type: patch
+social_messages:
+  x: >-
+    {project_name} {version} is out! This release fixes dataclass transform
+    metadata so custom ordering methods are correctly accepted by type checkers. 🍓
+    https://strawberry.rocks/release/{version}
+  linkedin: >-
+    {project_name} {version} is out. This release fixes dataclass transform
+    metadata so custom ordering methods are correctly accepted by type checkers.
+---
+
+This release fixes incorrect dataclass transform ordering metadata.
+
+Strawberry decorators now correctly declare that ordering methods are not generated
+by default, matching their runtime dataclass behavior and allowing custom ordering
+methods such as `__gt__` to be used without type-checking errors.

--- a/strawberry/federation/object_type.py
+++ b/strawberry/federation/object_type.py
@@ -58,7 +58,7 @@ def _impl_type(
 
 @overload
 @dataclass_transform(
-    order_default=True,
+    order_default=False,
     kw_only_default=True,
     field_specifiers=(base_field, field, StrawberryField),
 )
@@ -74,7 +74,7 @@ def type(
 
 @overload
 @dataclass_transform(
-    order_default=True,
+    order_default=False,
     kw_only_default=True,
     field_specifiers=(base_field, field, StrawberryField),
 )
@@ -106,7 +106,7 @@ def type(
 
 @overload
 @dataclass_transform(
-    order_default=True,
+    order_default=False,
     kw_only_default=True,
     field_specifiers=(base_field, field, StrawberryField),
 )
@@ -124,7 +124,7 @@ def input(
 
 @overload
 @dataclass_transform(
-    order_default=True,
+    order_default=False,
     kw_only_default=True,
     field_specifiers=(base_field, field, StrawberryField),
 )
@@ -163,7 +163,7 @@ def input(
 
 @overload
 @dataclass_transform(
-    order_default=True,
+    order_default=False,
     kw_only_default=True,
     field_specifiers=(base_field, field, StrawberryField),
 )
@@ -179,7 +179,7 @@ def interface(
 
 @overload
 @dataclass_transform(
-    order_default=True,
+    order_default=False,
     kw_only_default=True,
     field_specifiers=(base_field, field, StrawberryField),
 )
@@ -212,7 +212,7 @@ def interface(
 
 @overload
 @dataclass_transform(
-    order_default=True,
+    order_default=False,
     kw_only_default=True,
     field_specifiers=(base_field, field, StrawberryField),
 )
@@ -228,7 +228,7 @@ def interface_object(
 
 @overload
 @dataclass_transform(
-    order_default=True,
+    order_default=False,
     kw_only_default=True,
     field_specifiers=(base_field, field, StrawberryField),
 )

--- a/strawberry/federation/schema_directive.py
+++ b/strawberry/federation/schema_directive.py
@@ -24,7 +24,7 @@ T = TypeVar("T", bound=type)
 
 
 @dataclass_transform(
-    order_default=True,
+    order_default=False,
     kw_only_default=True,
     field_specifiers=(directive_field, field, StrawberryField),
 )

--- a/strawberry/schema_directive.py
+++ b/strawberry/schema_directive.py
@@ -41,7 +41,7 @@ T = TypeVar("T", bound=type)
 
 
 @dataclass_transform(
-    order_default=True,
+    order_default=False,
     kw_only_default=True,
     field_specifiers=(directive_field, field, StrawberryField),
 )

--- a/strawberry/types/object_type.py
+++ b/strawberry/types/object_type.py
@@ -191,7 +191,7 @@ def _process_type(
 
 @overload
 @dataclass_transform(
-    order_default=True, kw_only_default=True, field_specifiers=(field, StrawberryField)
+    order_default=False, kw_only_default=True, field_specifiers=(field, StrawberryField)
 )
 def type(
     cls: T,
@@ -207,7 +207,7 @@ def type(
 
 @overload
 @dataclass_transform(
-    order_default=True, kw_only_default=True, field_specifiers=(field, StrawberryField)
+    order_default=False, kw_only_default=True, field_specifiers=(field, StrawberryField)
 )
 def type(
     *,
@@ -221,7 +221,7 @@ def type(
 
 
 @dataclass_transform(
-    order_default=True, kw_only_default=True, field_specifiers=(field, StrawberryField)
+    order_default=False, kw_only_default=True, field_specifiers=(field, StrawberryField)
 )
 def type(
     cls: T | None = None,
@@ -316,7 +316,7 @@ def type(
 
 @overload
 @dataclass_transform(
-    order_default=True, kw_only_default=True, field_specifiers=(field, StrawberryField)
+    order_default=False, kw_only_default=True, field_specifiers=(field, StrawberryField)
 )
 def input(
     cls: T,
@@ -330,7 +330,7 @@ def input(
 
 @overload
 @dataclass_transform(
-    order_default=True, kw_only_default=True, field_specifiers=(field, StrawberryField)
+    order_default=False, kw_only_default=True, field_specifiers=(field, StrawberryField)
 )
 def input(
     *,
@@ -342,7 +342,7 @@ def input(
 
 
 @dataclass_transform(
-    order_default=True, kw_only_default=True, field_specifiers=(field, StrawberryField)
+    order_default=False, kw_only_default=True, field_specifiers=(field, StrawberryField)
 )
 def input(
     cls: T | None = None,
@@ -398,7 +398,7 @@ def input(
 
 @overload
 @dataclass_transform(
-    order_default=True, kw_only_default=True, field_specifiers=(field, StrawberryField)
+    order_default=False, kw_only_default=True, field_specifiers=(field, StrawberryField)
 )
 def interface(
     cls: T,
@@ -411,7 +411,7 @@ def interface(
 
 @overload
 @dataclass_transform(
-    order_default=True, kw_only_default=True, field_specifiers=(field, StrawberryField)
+    order_default=False, kw_only_default=True, field_specifiers=(field, StrawberryField)
 )
 def interface(
     *,
@@ -422,7 +422,7 @@ def interface(
 
 
 @dataclass_transform(
-    order_default=True, kw_only_default=True, field_specifiers=(field, StrawberryField)
+    order_default=False, kw_only_default=True, field_specifiers=(field, StrawberryField)
 )
 def interface(
     cls: T | None = None,

--- a/tests/typecheckers/test_directives.py
+++ b/tests/typecheckers/test_directives.py
@@ -58,3 +58,104 @@ def test():
             ),
         ]
     )
+
+
+def test_schema_directive_custom_ordering_method():
+    code = """
+from strawberry.schema_directive import Location, schema_directive
+
+
+@schema_directive(locations=[Location.OBJECT])
+class UserDirective:
+    name: str
+
+    def __gt__(self, other: "UserDirective") -> bool:
+        return self.name > other.name
+
+
+reveal_type(UserDirective)
+"""
+
+    results = typecheck(code)
+
+    assert results.pyright == snapshot(
+        [
+            Result(
+                type="information",
+                message='Type of "UserDirective" is "type[UserDirective]"',
+                line=13,
+                column=13,
+            )
+        ]
+    )
+    assert results.mypy == snapshot(
+        [
+            Result(
+                type="note",
+                message='Revealed type is "def (*, name: str) -> mypy_test.UserDirective"',
+                line=13,
+                column=13,
+            )
+        ]
+    )
+    assert results.ty == snapshot(
+        [
+            Result(
+                type="information",
+                message="Revealed type: `<class 'UserDirective'>`",
+                line=13,
+                column=13,
+            )
+        ]
+    )
+
+
+def test_federation_schema_directive_custom_ordering_method():
+    code = """
+from strawberry.federation.schema_directive import schema_directive
+from strawberry.schema_directive import Location
+
+
+@schema_directive(locations=[Location.OBJECT])
+class UserDirective:
+    name: str
+
+    def __gt__(self, other: "UserDirective") -> bool:
+        return self.name > other.name
+
+
+reveal_type(UserDirective)
+"""
+
+    results = typecheck(code)
+
+    assert results.pyright == snapshot(
+        [
+            Result(
+                type="information",
+                message='Type of "UserDirective" is "type[UserDirective]"',
+                line=14,
+                column=13,
+            )
+        ]
+    )
+    assert results.mypy == snapshot(
+        [
+            Result(
+                type="note",
+                message='Revealed type is "def (*, name: str) -> mypy_test.UserDirective"',
+                line=14,
+                column=13,
+            )
+        ]
+    )
+    assert results.ty == snapshot(
+        [
+            Result(
+                type="information",
+                message="Revealed type: `<class 'UserDirective'>`",
+                line=14,
+                column=13,
+            )
+        ]
+    )

--- a/tests/typecheckers/test_federation.py
+++ b/tests/typecheckers/test_federation.py
@@ -352,3 +352,53 @@ def test_federation_scalar():
             )
         ]
     )
+
+
+def test_federation_custom_ordering_method():
+    code = """
+import strawberry
+
+
+@strawberry.federation.type
+class User:
+    name: str
+
+    def __gt__(self, other: "User") -> bool:
+        return self.name > other.name
+
+
+reveal_type(User)
+"""
+
+    results = typecheck(code)
+
+    assert results.pyright == snapshot(
+        [
+            Result(
+                type="information",
+                message='Type of "User" is "type[User]"',
+                line=13,
+                column=13,
+            )
+        ]
+    )
+    assert results.mypy == snapshot(
+        [
+            Result(
+                type="note",
+                message='Revealed type is "def (*, name: str) -> mypy_test.User"',
+                line=13,
+                column=13,
+            )
+        ]
+    )
+    assert results.ty == snapshot(
+        [
+            Result(
+                type="information",
+                message="Revealed type: `<class 'User'>`",
+                line=13,
+                column=13,
+            )
+        ]
+    )

--- a/tests/typecheckers/test_type.py
+++ b/tests/typecheckers/test_type.py
@@ -186,3 +186,53 @@ def test():
             ),
         ]
     )
+
+
+def test_custom_ordering_method():
+    code = """
+import strawberry
+
+
+@strawberry.type
+class User:
+    name: str
+
+    def __gt__(self, other: "User") -> bool:
+        return self.name > other.name
+
+
+reveal_type(User)
+"""
+
+    results = typecheck(code)
+
+    assert results.pyright == snapshot(
+        [
+            Result(
+                type="information",
+                message='Type of "User" is "type[User]"',
+                line=13,
+                column=13,
+            )
+        ]
+    )
+    assert results.mypy == snapshot(
+        [
+            Result(
+                type="note",
+                message='Revealed type is "def (*, name: str) -> mypy_test.User"',
+                line=13,
+                column=13,
+            )
+        ]
+    )
+    assert results.ty == snapshot(
+        [
+            Result(
+                type="information",
+                message="Revealed type: `<class 'User'>`",
+                line=13,
+                column=13,
+            )
+        ]
+    )


### PR DESCRIPTION
## Summary

Align Strawberry's `dataclass_transform` ordering metadata with its actual runtime dataclass behavior.

Strawberry ultimately wraps these decorated classes with `dataclasses.dataclass(kw_only=True)`, which uses Python's default `order=False`. The corresponding `dataclass_transform` declarations, however, advertised `order_default=True`.

That mismatch causes type checkers such as mypy and ty to model Strawberry-decorated classes as if ordering methods were generated by default, incorrectly rejecting valid user-defined comparison methods such as `__gt__`.

## Root cause

At runtime, Strawberry's dataclass wrapping is equivalent to:

```python
@dataclasses.dataclass(kw_only=True)
class Example:
    ...
```

Because `dataclasses.dataclass` defaults to `order=False`, defining a custom ordering method is valid.

The static typing metadata instead declared:

```python
@dataclass_transform(
    order_default=True,
    kw_only_default=True,
    ...,
)
```

Under PEP 681, this tells type checkers to assume `order=True` when interpreting classes produced by the decorator. That does not match Strawberry's runtime behavior.

For example:

```python
@strawberry.type
class User:
    name: str

    def __gt__(self, other: "User") -> bool:
        return self.name > other.name
```

Before this change, mypy rejects the custom `__gt__` because it assumes ordering is enabled, and ty reports the equivalent conflict. The class is valid at runtime because Strawberry does not enable dataclass ordering.

## Changes

- Set `order_default=False` in Strawberry's dataclass-transform metadata so static typing matches runtime behavior.
- Apply the correction consistently to related decorators that use the same dataclass semantics:
  - core `type`, `input`, and `interface`
  - federation `type`, `input`, `interface`, and `interface_object`
  - schema directives
  - federation schema directives
- Add regression coverage for custom ordering methods on:
  - `@strawberry.type`
  - `@strawberry.federation.type`
  - `@schema_directive`
  - federation `@schema_directive`
- Add the required `RELEASE.md` entry.

This is a typing-metadata correction only; it does not change Strawberry's runtime dataclass behavior.

## Validation

The issue was reproduced before the fix with a custom `__gt__` method:

- mypy reported that a custom `__gt__` is not allowed when `order` is `True`
- ty reported the equivalent ordering conflict
- pyright did not report an ordering error

After correcting the metadata, the same examples type-check without ordering errors.

Focused type-checker tests:

```bash
uv run pytest \
  tests/typecheckers/test_type.py \
  tests/typecheckers/test_federation.py \
  tests/typecheckers/test_directives.py \
  -q
```

Result:

```text
10 passed
```

Formatting and repository checks also passed:

```bash
uv run pre-commit run --files \
  strawberry/types/object_type.py \
  strawberry/federation/object_type.py \
  strawberry/schema_directive.py \
  strawberry/federation/schema_directive.py \
  tests/typecheckers/test_type.py \
  tests/typecheckers/test_federation.py \
  tests/typecheckers/test_directives.py \
  RELEASE.md

git diff --check
```

Fixes #3790

## Summary by Sourcery

Align Strawberry's dataclass transform metadata with its runtime behavior by disabling default ordering in all applicable decorators.

Bug Fixes:
- Correct dataclass transform ordering metadata so Strawberry-decorated classes are accurately modeled by type checkers and can define custom comparison methods such as `__gt__`.
- Apply the metadata correction consistently across core, federation, and schema directive decorators.

Tests:
- Add type-checker regression coverage for custom ordering methods on core and federation types and schema directives.