### PR TITLE
Make input coercion errors classifiable

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,20 @@
+---
+release type: patch
+social_messages:
+  x: >-
+    {project_name} {version} is out! This release makes built-in scalar and
+    OneOf input errors classifiable without changing GraphQL responses.
+    https://strawberry.rocks/release/{version}
+  linkedin: >-
+    {project_name} {version} is out. This release makes built-in scalar and
+    OneOf input errors classifiable for more accurate error monitoring without
+    changing GraphQL responses.
+---
+
+This release fixes classification of built-in scalar and OneOf input errors.
+
+Strawberry now raises `StrawberryInputCoercionError` for these client input
+errors, allowing server-side error handling and monitoring to distinguish them
+from server faults without changing error messages or serialized responses.
+Custom scalar parsers can raise the same exception for expected conversion
+errors.

--- a/docs/extensions/sentry-tracing.md
+++ b/docs/extensions/sentry-tracing.md
@@ -17,3 +17,37 @@ For more details, please refer to the
 [documentation for the official Sentry Strawberry integration](https://docs.sentry.io/platforms/python/integrations/strawberry/).
 
 </Warning>
+
+## Filtering input coercion errors
+
+The official Sentry integration captures all errors returned in a GraphQL
+response. If invalid client input should not be reported, use Sentry's
+`before_send` callback to filter `StrawberryInputCoercionError`:
+
+```python
+from typing import Any
+
+import sentry_sdk
+
+from strawberry.exceptions import StrawberryInputCoercionError
+
+
+def before_send(event: dict[str, Any], hint: dict[str, Any]) -> dict[str, Any] | None:
+    exc_info = hint.get("exc_info")
+    error = exc_info[1] if exc_info else None
+
+    if isinstance(error, StrawberryInputCoercionError) or isinstance(
+        getattr(error, "original_error", None), StrawberryInputCoercionError
+    ):
+        return None
+
+    return event
+
+
+sentry_sdk.init(before_send=before_send)
+```
+
+Checking `original_error` is necessary because graphql-core wraps scalar errors
+raised while coercing variables in another `GraphQLError`. For this reason,
+Sentry's `ignore_errors` option alone does not filter every input coercion
+error.

--- a/docs/guides/errors.md
+++ b/docs/guides/errors.md
@@ -56,6 +56,29 @@ Strawberry, so there’s not really a way to customize this behavior. You can
 disable all validation by using the
 [DisableValidation](../extensions/disable-validation) extension.
 
+### Strawberry input coercion errors
+
+When Strawberry cannot coerce a value provided for one of its built-in `Date`,
+`DateTime`, `Time`, `Decimal`, or `UUID` scalars, or for a OneOf input object,
+it raises `StrawberryInputCoercionError`. This exception lets server-side error
+handling distinguish these client input errors without changing the serialized
+GraphQL response.
+
+graphql-core wraps scalar errors raised while coercing variables, so error
+handlers should also check `original_error`:
+
+```python
+from graphql import GraphQLError
+
+from strawberry.exceptions import StrawberryInputCoercionError
+
+
+def is_strawberry_input_error(error: GraphQLError) -> bool:
+    return isinstance(error, StrawberryInputCoercionError) or isinstance(
+        error.original_error, StrawberryInputCoercionError
+    )
+```
+
 ## GraphQL type errors
 
 When a query is executed each field must resolve to the correct type. For

--- a/docs/types/scalars.md
+++ b/docs/types/scalars.md
@@ -170,6 +170,46 @@ from strawberry.scalars import Base16, Base32, Base64
 
 </Note>
 
+### Classifying invalid custom scalar input
+
+Strawberry cannot determine whether an arbitrary exception from a custom
+`parse_value` function represents invalid client input or a bug in the parser.
+To make an expected conversion error identifiable by server-side error handling,
+raise `StrawberryInputCoercionError` explicitly:
+
+```python
+import uuid
+from typing import NewType
+
+import strawberry
+from strawberry.exceptions import StrawberryInputCoercionError
+
+OrderID = NewType("OrderID", uuid.UUID)
+
+
+def parse_order_id(value: object) -> OrderID:
+    if not isinstance(value, str):
+        raise StrawberryInputCoercionError("OrderID must be a string")
+
+    try:
+        return OrderID(uuid.UUID(value))
+    except ValueError:
+        raise StrawberryInputCoercionError("Invalid OrderID") from None
+
+
+order_id_scalar = strawberry.scalar(
+    name="OrderID",
+    serialize=str,
+    parse_value=parse_order_id,
+)
+```
+
+The resulting scalar definition can be added to `StrawberryConfig.scalar_map`.
+Only catch exceptions that represent expected conversion errors so unexpected
+parser exceptions continue to be reported as server faults. See
+[Dealing with errors](../guides/errors#strawberry-input-coercion-errors) for how
+to identify direct and wrapped coercion errors.
+
 ## Example: Custom Object Scalar
 
 Suppose we would like to use a Pillow `Image` as a scalar that serializes

--- a/strawberry/exceptions/__init__.py
+++ b/strawberry/exceptions/__init__.py
@@ -159,6 +159,10 @@ class StrawberryGraphQLError(GraphQLError):
     """Use it when you want to override the graphql.GraphQLError in custom extensions."""
 
 
+class StrawberryInputCoercionError(StrawberryGraphQLError):
+    """Raised when Strawberry cannot coerce a client-provided input value."""
+
+
 class ConnectionRejectionError(Exception):
     """Use it when you want to reject a WebSocket connection."""
 
@@ -193,6 +197,7 @@ __all__ = [
     "ScalarAlreadyRegisteredError",
     "StrawberryException",
     "StrawberryGraphQLError",
+    "StrawberryInputCoercionError",
     "UnableToFindExceptionSource",
     "UnallowedReturnTypeForUnion",
     "UnresolvedFieldTypeError",

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -21,7 +21,6 @@ from graphql import (
     GraphQLDirective,
     GraphQLEnumType,
     GraphQLEnumValue,
-    GraphQLError,
     GraphQLField,
     GraphQLID,
     GraphQLInputField,
@@ -47,6 +46,7 @@ from strawberry.exceptions import (
     InvalidUnionTypeError,
     MissingTypesForGenericError,
     ScalarAlreadyRegisteredError,
+    StrawberryInputCoercionError,
     UnresolvedFieldTypeError,
 )
 from strawberry.extensions.field_extension import build_field_extension_resolvers
@@ -668,14 +668,14 @@ class GraphQLCoreConverter:
 
         def check_one_of(value: dict[str, Any]) -> dict[str, Any]:
             if len(value) != 1:
-                raise GraphQLError(
+                raise StrawberryInputCoercionError(
                     f"OneOf Input Object '{type_name}' must specify exactly one key."
                 )
 
             first_key, first_value = next(iter(value.items()))
 
             if first_value is None or first_value is UNSET:
-                raise GraphQLError(
+                raise StrawberryInputCoercionError(
                     f"Value for member field '{first_key}' must be non-null"
                 )
 

--- a/strawberry/schema/types/base_scalars.py
+++ b/strawberry/schema/types/base_scalars.py
@@ -5,8 +5,8 @@ from collections.abc import Callable
 from operator import methodcaller
 
 import dateutil.parser
-from graphql import GraphQLError
 
+from strawberry.exceptions import StrawberryInputCoercionError
 from strawberry.types.scalar import ScalarDefinition
 
 
@@ -29,7 +29,7 @@ def wrap_parser(
     def inner(value: object) -> object:
         if not isinstance(value, str):
             if not accept_non_string:
-                raise GraphQLError(
+                raise StrawberryInputCoercionError(
                     f'Value cannot represent a {type_}: "{value}". Expected a string.'
                 )
             value = str(value)
@@ -37,7 +37,7 @@ def wrap_parser(
             return parser(value)
         except exceptions as e:
             detail = f" {e}" if include_error else ""
-            raise GraphQLError(
+            raise StrawberryInputCoercionError(
                 f'Value cannot represent a {type_}: "{value}".{detail}'
             ) from None
 

--- a/strawberry/schema/validation_rules/one_of.py
+++ b/strawberry/schema/validation_rules/one_of.py
@@ -2,7 +2,6 @@ from typing import Any
 
 from graphql import (
     ExecutableDefinitionNode,
-    GraphQLError,
     GraphQLNamedType,
     ObjectValueNode,
     ValidationContext,
@@ -10,6 +9,8 @@ from graphql import (
     VariableDefinitionNode,
     get_named_type,
 )
+
+from strawberry.exceptions import StrawberryInputCoercionError
 
 
 class OneOfInputValidationRule(ValidationRule):
@@ -44,7 +45,7 @@ class OneOfInputValidationRule(ValidationRule):
 
         if is_not_exactly_one_field:
             self.report_error(
-                GraphQLError(
+                StrawberryInputCoercionError(
                     f"OneOf Input Object '{type.name}' must specify exactly one key.",
                     nodes=[node],
                 )
@@ -58,7 +59,7 @@ class OneOfInputValidationRule(ValidationRule):
 
         if is_null_literal:
             self.report_error(
-                GraphQLError(
+                StrawberryInputCoercionError(
                     f"Field '{type.name}.{keys[0]}' must be non-null.",
                     nodes=[node],
                 )
@@ -73,7 +74,7 @@ class OneOfInputValidationRule(ValidationRule):
 
             if is_nullable_variable:
                 self.report_error(
-                    GraphQLError(
+                    StrawberryInputCoercionError(
                         f"Variable '{variable_name}' must be non-nullable to be used for OneOf Input Object '{type.name}'.",
                         nodes=[node],
                     )

--- a/tests/schema/test_custom_scalar.py
+++ b/tests/schema/test_custom_scalar.py
@@ -2,6 +2,8 @@ import base64
 from typing import NewType
 
 import strawberry
+from strawberry.exceptions import StrawberryInputCoercionError
+from strawberry.schema.config import StrawberryConfig
 
 Base64Encoded = strawberry.scalar(
     NewType("Base64Encoded", bytes),
@@ -50,6 +52,45 @@ def test_custom_scalar_deserialization():
 
     assert not result.errors
     assert result.data["decodeBase64"] == "decoded"
+
+
+def test_custom_scalar_input_errors_can_be_classified():
+    CustomValue = NewType("CustomValue", str)
+
+    def parse_value(value: object) -> CustomValue:
+        raise StrawberryInputCoercionError(f"Invalid value: {value}")
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def parse(self, value: CustomValue) -> bool:  # pragma: no cover
+            return True
+
+    schema = strawberry.Schema(
+        Query,
+        config=StrawberryConfig(
+            scalar_map={
+                CustomValue: strawberry.scalar(
+                    name="CustomValue",
+                    serialize=str,
+                    parse_value=parse_value,
+                )
+            }
+        ),
+    )
+
+    literal_result = schema.execute_sync('{ parse(value: "invalid") }')
+    variable_result = schema.execute_sync(
+        "query($value: CustomValue!) { parse(value: $value) }",
+        variable_values={"value": "invalid"},
+    )
+
+    assert literal_result.errors
+    assert isinstance(literal_result.errors[0], StrawberryInputCoercionError)
+    assert variable_result.errors
+    assert isinstance(
+        variable_result.errors[0].original_error, StrawberryInputCoercionError
+    )
 
 
 def test_custom_scalar_decorated_class():

--- a/tests/schema/test_one_of.py
+++ b/tests/schema/test_one_of.py
@@ -3,6 +3,7 @@ from typing import Any
 import pytest
 
 import strawberry
+from strawberry.exceptions import StrawberryInputCoercionError
 from strawberry.schema_directives import OneOf
 
 
@@ -57,6 +58,8 @@ def test_must_specify_at_least_one_key_default(
 
     assert result.errors
     assert len(result.errors) == 1
+    assert isinstance(result.errors[0], StrawberryInputCoercionError)
+    assert result.errors[0].extensions == {}
     assert (
         result.errors[0].message
         == "OneOf Input Object 'ExampleInputTagged' must specify exactly one key."
@@ -108,8 +111,11 @@ def test_must_specify_at_least_one_key_literal(value: str, variables: dict[str, 
 
     assert result.errors
     assert len(result.errors) == 1
+    error = result.errors[0]
+    assert isinstance(error, StrawberryInputCoercionError)
+    assert error.extensions == {}
     assert (
-        result.errors[0].message
+        error.message
         == "OneOf Input Object 'ExampleInputTagged' must specify exactly one key."
     )
 
@@ -128,7 +134,10 @@ def test_value_must_be_non_null_input():
 
     assert result.errors
     assert len(result.errors) == 1
-    assert result.errors[0].message == "Value for member field 'a' must be non-null"
+    error = result.errors[0]
+    assert isinstance(error, StrawberryInputCoercionError)
+    assert error.extensions == {}
+    assert error.message == "Value for member field 'a' must be non-null"
 
 
 def test_value_must_be_non_null_literal():
@@ -145,6 +154,8 @@ def test_value_must_be_non_null_literal():
 
     assert result.errors
     assert len(result.errors) == 1
+    assert isinstance(result.errors[0], StrawberryInputCoercionError)
+    assert result.errors[0].extensions == {}
     assert result.errors[0].message == "Field 'ExampleInputTagged.a' must be non-null."
 
 
@@ -161,6 +172,8 @@ def test_value_must_be_non_null_variable():
 
     assert result.errors
     assert len(result.errors) == 1
+    assert isinstance(result.errors[0], StrawberryInputCoercionError)
+    assert result.errors[0].extensions == {}
     assert (
         result.errors[0].message
         == "Variable 'b' must be non-nullable to be used for OneOf Input Object 'ExampleInputTagged'."

--- a/tests/schema/types/test_date.py
+++ b/tests/schema/types/test_date.py
@@ -4,6 +4,7 @@ import pytest
 from graphql import GraphQLError
 
 import strawberry
+from strawberry.exceptions import StrawberryInputCoercionError
 from strawberry.types.execution import ExecutionResult
 from strawberry.utils import IS_GQL_32
 
@@ -65,6 +66,23 @@ def test_deserialization_with_parse_literal():
     assert Query.deserialized == datetime.date(2019, 10, 25)
 
 
+@pytest.mark.parametrize("value", ['"2021-13-01"', "12345"])
+def test_invalid_literal_is_classifiable(value: str):
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def deserialize(self, arg: datetime.date) -> bool:  # pragma: no cover
+            return True
+
+    schema = strawberry.Schema(Query)
+
+    result = schema.execute_sync(f"query {{ deserialize(arg: {value}) }}")
+
+    assert result.errors
+    assert isinstance(result.errors[0], StrawberryInputCoercionError)
+    assert result.errors[0].extensions == {}
+
+
 def execute_mutation(value) -> ExecutionResult:
     @strawberry.type
     class Query:
@@ -100,12 +118,13 @@ def execute_mutation(value) -> ExecutionResult:
     ],
 )
 def test_serialization_of_incorrect_date_string(value):
-    """Test GraphQLError is raised for incorrect date.
-    The error should exclude "original_error".
-    """
+    """Test invalid date variables retain a classifiable coercion error."""
     result = execute_mutation(value)
     assert result.errors
-    assert isinstance(result.errors[0], GraphQLError)
+    error = result.errors[0]
+    assert isinstance(error, GraphQLError)
+    assert isinstance(error.original_error, StrawberryInputCoercionError)
+    assert error.extensions == {}
 
 
 def test_serialization_error_message_for_incorrect_date_string():
@@ -133,8 +152,10 @@ def test_parsing_of_non_string_value(value):
     """
     result = execute_mutation(value)
     assert result.errors
-    assert isinstance(result.errors[0], GraphQLError)
+    error = result.errors[0]
+    assert isinstance(error, GraphQLError)
+    assert isinstance(error.original_error, StrawberryInputCoercionError)
+    assert error.extensions == {}
     assert (
-        f'Value cannot represent a Date: "{value}". Expected a string.'
-        in result.errors[0].message
+        f'Value cannot represent a Date: "{value}". Expected a string.' in error.message
     )


### PR DESCRIPTION
## Description

Adds `StrawberryInputCoercionError` so monitoring and error-handling code can distinguish invalid client input from server faults without changing GraphQL error messages or serialized responses.

- Uses the exception for built-in Date, DateTime, Time, Decimal, and UUID scalar coercion failures.
- Uses it for OneOf validation and runtime coercion failures.
- Documents direct and graphql-core-wrapped detection, custom scalar opt-in, and Sentry filtering.
- Covers literal, variable, OneOf, and custom scalar behavior with tests.

Closes #4587

## Verification

- `uv run pytest tests/schema -q` (711 passed, 14 skipped, 2 xfailed)
- `uv run pytest tests/schema/types/test_date.py tests/schema/test_one_of.py tests/schema/test_custom_scalar.py -q` (42 passed)
- Targeted Ruff lint and format checks
- Prettier, blacken-docs, and Alex documentation checks
- graphql-core 3.3.0rc0 compatibility tests (37 passed)

## Summary by Sourcery

Classify expected GraphQL input coercion failures without changing client-facing error responses.

New Features:
- Introduce `StrawberryInputCoercionError` to identify invalid client input separately from server faults.
- Apply the classification to built-in scalar, OneOf, and opt-in custom scalar coercion errors.

Enhancements:
- Preserve existing GraphQL error messages, extensions, and serialized responses while retaining the underlying coercion error for wrapped variable errors.

Documentation:
- Document direct and graphql-core-wrapped error detection, custom scalar usage, and Sentry filtering.

Tests:
- Add coverage for literal, variable, OneOf, built-in scalar, and custom scalar coercion error classification.