### PR TITLE
Support Annotated field configuration everywhere

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,19 @@
+---
+release type: patch
+social_messages:
+  x: >-
+    {project_name} {version} is out! This release fixes Annotated field
+    configuration with postponed annotations, defaults, and combined metadata.
+    🍓 https://strawberry.rocks/release/{version}
+  linkedin: >-
+    {project_name} {version} is out. This release fixes Annotated field
+    configuration with postponed annotations, dataclass defaults, and combined
+    Strawberry metadata.
+---
+
+This release fixes fields configured with `strawberry.field()` inside
+`typing.Annotated`.
+
+Field options now work with postponed annotations, `default` and
+`default_factory` configure the generated dataclass constructor, and other
+Annotated metadata such as named unions is preserved.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,7 +4,7 @@ social_messages:
   x: >-
     {project_name} {version} is out! This release fixes Annotated field
     configuration with postponed annotations, defaults, and combined metadata.
-    🍓 https://strawberry.rocks/release/{version}
+    https://strawberry.rocks/release/{version}
   linkedin: >-
     {project_name} {version} is out. This release fixes Annotated field
     configuration with postponed annotations, dataclass defaults, and combined

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,18 +2,39 @@
 release type: patch
 social_messages:
   x: >-
-    {project_name} {version} is out! This release fixes Annotated field
-    configuration with postponed annotations, defaults, and combined metadata.
+    {project_name} {version} is out! Fields defined with typing.Annotated now
+    support the full strawberry.field API across object, input, and interface
+    types.
     https://strawberry.rocks/release/{version}
   linkedin: >-
-    {project_name} {version} is out. This release fixes Annotated field
-    configuration with postponed annotations, dataclass defaults, and combined
-    Strawberry metadata.
+    {project_name} {version} is out. You can now configure fields with
+    strawberry.field inside typing.Annotated consistently across object, input,
+    and interface types, including defaults and combined metadata.
 ---
 
 This release fixes fields configured with `strawberry.field()` inside
 `typing.Annotated`.
 
-Field options now work with postponed annotations, `default` and
-`default_factory` configure the generated dataclass constructor, and other
-Annotated metadata such as named unions is preserved.
+You can now use this syntax consistently on object types, input types, and
+interfaces, including in projects that use `from __future__ import annotations`:
+
+```python
+from typing import Annotated
+
+import strawberry
+
+Name = Annotated[
+    str,
+    strawberry.field(name="displayName", default="Anonymous"),
+]
+
+
+@strawberry.type
+class User:
+    name: Name
+```
+
+All `strawberry.field()` options are supported. Fields with `default` or
+`default_factory` can be omitted when creating an instance, and field
+configuration can be combined with other Strawberry metadata such as named
+unions.

--- a/docs/types/object-types.md
+++ b/docs/types/object-types.md
@@ -116,6 +116,31 @@ All `strawberry.field()` options are supported. In particular, `default` and
 `default_factory` also configure the generated dataclass constructor, so
 `User(name="Patrick")` in the example above gets a new empty `tags` list.
 
+On Python 3.10 through 3.13, use `strawberry.lazy()` when the field type is only
+imported under `TYPE_CHECKING` or otherwise unavailable at runtime. This form
+works together with field metadata:
+
+```python
+from typing import TYPE_CHECKING, Annotated
+
+import strawberry
+
+if TYPE_CHECKING:
+    from .users import User
+
+
+@strawberry.type
+class Post:
+    author: Annotated[
+        "User",
+        strawberry.lazy(".users"),
+        strawberry.field(description="The post author"),
+    ]
+```
+
+Python 3.14 and newer can also preserve the field metadata on a direct
+unresolved reference without `strawberry.lazy()`.
+
 The field configuration can be combined with other Strawberry metadata. The
 order of the metadata does not matter:
 

--- a/docs/types/object-types.md
+++ b/docs/types/object-types.md
@@ -90,6 +90,49 @@ type Book {
 
 </CodeGrid>
 
+## Customizing fields with `Annotated`
+
+You can configure fields by adding `strawberry.field()` to
+[`typing.Annotated`](https://docs.python.org/3/library/typing.html#typing.Annotated).
+This syntax works on object types, input types, and interfaces, including when
+using `from __future__ import annotations`:
+
+```python
+from typing import Annotated
+
+import strawberry
+
+
+@strawberry.type
+class User:
+    name: Annotated[
+        str,
+        strawberry.field(name="displayName", description="The displayed name"),
+    ]
+    tags: Annotated[list[str], strawberry.field(default_factory=list)]
+```
+
+All `strawberry.field()` options are supported. In particular, `default` and
+`default_factory` also configure the generated dataclass constructor, so
+`User(name="Patrick")` in the example above gets a new empty `tags` list.
+
+The field configuration can be combined with other Strawberry metadata. The
+order of the metadata does not matter:
+
+```python
+@strawberry.type
+class Query:
+    result: Annotated[
+        Success | Failure,
+        strawberry.union("Result"),
+        strawberry.field(description="The operation result"),
+    ]
+```
+
+Use only one `strawberry.field()` for each field. You can alternatively use the
+equivalent assignment syntax, such as
+`name: str = strawberry.field(description="The displayed name")`.
+
 ## API
 
 `@strawberry.type(name: str = None, description: str = None)`

--- a/strawberry/types/field.py
+++ b/strawberry/types/field.py
@@ -174,17 +174,16 @@ class StrawberryField(dataclasses.Field):
             is_subscription=self.is_subscription,
             description=self.description,
             base_resolver=self.base_resolver,
-            permission_classes=(
-                self.permission_classes[:]
-                if self.permission_classes is not None
-                else []
-            ),
-            default=self.default_value,
+            permission_classes=[],
+            default=self.default,
             default_factory=self.default_factory,
             metadata=self.metadata.copy() if self.metadata is not None else None,
             deprecation_reason=self.deprecation_reason,
             directives=self.directives[:] if self.directives is not None else [],
             extensions=self.extensions[:] if self.extensions is not None else [],
+        )
+        new_field.permission_classes = (
+            self.permission_classes[:] if self.permission_classes is not None else []
         )
         new_field._arguments = (
             self._arguments[:] if self._arguments is not None else None

--- a/strawberry/types/object_type.py
+++ b/strawberry/types/object_type.py
@@ -2,20 +2,32 @@ import builtins
 import copy
 import dataclasses
 import inspect
+import sys
 import types
 from collections.abc import Callable, Sequence
 from typing import (
+    Annotated,
     Any,
+    ForwardRef,
     TypeVar,
     cast,
+    get_args,
+    get_origin,
     overload,
 )
-from typing_extensions import dataclass_transform, get_annotations
+from typing_extensions import (
+    Format,
+    dataclass_transform,
+    evaluate_forward_ref,
+    get_annotations,
+)
 
+from strawberry.annotation import StrawberryAnnotation
 from strawberry.exceptions import (
     InvalidSuperclassInterfaceError,
     MissingFieldAnnotationError,
     MissingReturnAnnotationError,
+    MultipleStrawberryFieldsError,
     ObjectIsNotClassError,
 )
 from strawberry.types.base import get_object_definition
@@ -28,6 +40,87 @@ from .field import StrawberryField, field
 from .type_resolver import _get_fields
 
 T = TypeVar("T", bound=builtins.type)
+
+
+def _process_annotated_fields(cls: T) -> dict[str, StrawberryAnnotation]:
+    """Make StrawberryFields in Annotated available to dataclasses."""
+    module_namespace = sys.modules[cls.__module__].__dict__
+    type_annotations: dict[str, StrawberryAnnotation] = {}
+
+    annotations = get_annotations(cls, format=Format.FORWARDREF)
+
+    for field_name, raw_annotation in annotations.items():
+        annotation: object
+        if isinstance(raw_annotation, str):
+            try:
+                annotation = evaluate_forward_ref(
+                    ForwardRef(raw_annotation),
+                    owner=cls,
+                    globals=module_namespace,
+                    locals=dict(vars(cls)),
+                    format=Format.FORWARDREF,
+                )
+                if isinstance(annotation, ForwardRef):
+                    annotation = StrawberryAnnotation(
+                        raw_annotation,
+                        namespace=module_namespace,
+                    ).evaluate()
+            except (NameError, TypeError):
+                continue
+        else:
+            annotation = raw_annotation
+
+        if get_origin(annotation) is not Annotated:
+            continue
+
+        first, *rest = get_args(annotation)
+        strawberry_fields = [arg for arg in rest if isinstance(arg, StrawberryField)]
+
+        if len(strawberry_fields) > 1 or (
+            strawberry_fields
+            and isinstance(cls.__dict__.get(field_name), StrawberryField)
+        ):
+            raise MultipleStrawberryFieldsError(field_name=field_name, cls=cls)
+
+        if not strawberry_fields:
+            continue
+
+        source_field = strawberry_fields[0]
+        field = copy.copy(source_field)
+
+        default = cls.__dict__.get(field_name, dataclasses.MISSING)
+        if (
+            field.default is dataclasses.MISSING
+            and field.default_factory is dataclasses.MISSING
+            and default is not dataclasses.MISSING
+        ):
+            if isinstance(default, dataclasses.Field):
+                field.default = default.default
+                field.default_factory = default.default_factory
+                if default.default is not dataclasses.MISSING:
+                    field.default_value = default.default
+                elif callable(default.default_factory):
+                    field.default_value = default.default_factory()
+            else:
+                field.default = default
+                field.default_value = default
+
+        remaining_metadata = [
+            arg for arg in rest if not isinstance(arg, StrawberryField)
+        ]
+        field_type = (
+            Annotated[(first, *remaining_metadata)] if remaining_metadata else first
+        )
+        type_annotation = field.type_annotation or StrawberryAnnotation(
+            field_type,
+            namespace=module_namespace,
+        )
+        field.type_annotation = type_annotation
+
+        setattr(cls, field_name, field)
+        type_annotations[field_name] = type_annotation
+
+    return type_annotations
 
 
 def _get_interfaces(cls: builtins.type[Any]) -> list[StrawberryObjectDefinition]:
@@ -108,9 +201,19 @@ def _check_field_annotations(cls: builtins.type[Any]) -> None:
 
 def _wrap_dataclass(cls: T) -> T:
     """Wrap a strawberry.type class with a dataclass and check for any issues before doing so."""
+    annotated_field_types = _process_annotated_fields(cls)
+
     # Ensure all Fields have been properly type-annotated
     _check_field_annotations(cls)
-    return cast("T", dataclasses.dataclass(kw_only=True)(cls))
+    wrapped = cast("T", dataclasses.dataclass(kw_only=True)(cls))
+
+    # dataclasses replaces each StrawberryField's type with the class annotation.
+    # Restore the type with only the StrawberryField metadata removed, keeping any
+    # other Annotated metadata and explicit graphql_type override intact.
+    for field_name, type_annotation in annotated_field_types.items():
+        wrapped.__dataclass_fields__[field_name].type_annotation = type_annotation  # type: ignore[attr-defined]
+
+    return wrapped
 
 
 def _inject_default_for_maybe_annotations(cls: T, annotations: dict[str, Any]) -> None:

--- a/strawberry/types/object_type.py
+++ b/strawberry/types/object_type.py
@@ -109,11 +109,27 @@ def _process_annotated_fields(cls: T) -> dict[str, StrawberryAnnotation]:
             arg for arg in rest if not isinstance(arg, StrawberryField)
         ]
         field_type = (
-            Annotated[(first, *remaining_metadata)] if remaining_metadata else first
+            field.type_annotation.raw_annotation
+            if field.type_annotation is not None
+            else first
         )
-        type_annotation = field.type_annotation or StrawberryAnnotation(
-            field_type,
-            namespace=module_namespace,
+        field_type = (
+            Annotated[(field_type, *remaining_metadata)]
+            if remaining_metadata
+            else field_type
+        )
+        type_annotation = (
+            field.type_annotation
+            if field.type_annotation is not None and not remaining_metadata
+            else StrawberryAnnotation(
+                field_type,
+                namespace=(
+                    field.type_annotation.namespace
+                    if field.type_annotation is not None
+                    and field.type_annotation.namespace is not None
+                    else module_namespace
+                ),
+            )
         )
         field.type_annotation = type_annotation
 

--- a/strawberry/types/type_resolver.py
+++ b/strawberry/types/type_resolver.py
@@ -1,64 +1,19 @@
 from __future__ import annotations
 
-import copy
 import dataclasses
 import sys
-from typing import Annotated, Any, get_args, get_origin
+from typing import Any
 
 from strawberry.annotation import StrawberryAnnotation
 from strawberry.exceptions import (
     FieldWithResolverAndDefaultFactoryError,
     FieldWithResolverAndDefaultValueError,
-    MultipleStrawberryFieldsError,
     PrivateStrawberryFieldError,
 )
 from strawberry.types.base import has_object_definition
 from strawberry.types.field import StrawberryField
 from strawberry.types.private import is_private
 from strawberry.types.unset import UNSET
-
-
-def _get_field_from_annotated(
-    field: dataclasses.Field,
-    origin: type,
-    module_namespace: dict[str, Any],
-    cls: type,
-) -> StrawberryField | None:
-    """Extract a StrawberryField from an Annotated type annotation.
-
-    Returns a configured StrawberryField if the annotation contains one,
-    or None if no StrawberryField is found in the Annotated args.
-    Raises MultipleStrawberryFieldsError if more than one is found.
-    """
-    field_type = field.type
-
-    if get_origin(field_type) is not Annotated:
-        return None
-
-    first, *rest = get_args(field_type)
-
-    strawberry_fields = [arg for arg in rest if isinstance(arg, StrawberryField)]
-
-    if len(strawberry_fields) > 1:
-        raise MultipleStrawberryFieldsError(field_name=field.name, cls=cls)
-
-    if not strawberry_fields:
-        return None
-
-    result = copy.copy(strawberry_fields[0])
-    result.python_name = field.name
-    result.type_annotation = StrawberryAnnotation(
-        annotation=first,
-        namespace=module_namespace,
-    )
-    result.origin = origin
-
-    # Transfer default from dataclass field if not set in strawberry.field()
-    if result.default is dataclasses.MISSING:
-        result.default = field.default
-        result.default_value = field.default
-
-    return result
 
 
 def _get_fields(
@@ -127,19 +82,6 @@ def _get_fields(
     # then we can proceed with finding the fields for the current class
     for field in dataclasses.fields(cls):  # type: ignore
         if isinstance(field, StrawberryField):
-            # Check for conflict: strawberry.field in both Annotated and assignment
-            annotation = (
-                field.type_annotation.annotation
-                if isinstance(field.type_annotation, StrawberryAnnotation)
-                else field.type
-            )
-            if get_origin(annotation) is Annotated:
-                annotated_args = get_args(annotation)
-                if any(isinstance(arg, StrawberryField) for arg in annotated_args[1:]):
-                    raise MultipleStrawberryFieldsError(
-                        field_name=field.python_name or field.name, cls=cls
-                    )
-
             # Check that the field type is not Private
             if is_private(field.type):
                 raise PrivateStrawberryFieldError(field.python_name, cls)
@@ -198,23 +140,16 @@ def _get_fields(
             origin = origins.get(field.name, cls)
             module = sys.modules[origin.__module__]
 
-            annotated_field = _get_field_from_annotated(
-                field, origin, module.__dict__, cls
+            field = StrawberryField(  # noqa: PLW2901
+                python_name=field.name,
+                graphql_name=None,
+                type_annotation=StrawberryAnnotation(
+                    annotation=field.type,
+                    namespace=module.__dict__,
+                ),
+                origin=origin,
+                default=getattr(cls, field.name, dataclasses.MISSING),
             )
-
-            if annotated_field is not None:
-                field = annotated_field  # noqa: PLW2901
-            else:
-                field = StrawberryField(  # noqa: PLW2901
-                    python_name=field.name,
-                    graphql_name=None,
-                    type_annotation=StrawberryAnnotation(
-                        annotation=field.type,
-                        namespace=module.__dict__,
-                    ),
-                    origin=origin,
-                    default=getattr(cls, field.name, dataclasses.MISSING),
-                )
 
         field_name = field.python_name
 

--- a/tests/federation/test_types.py
+++ b/tests/federation/test_types.py
@@ -1,4 +1,8 @@
+from typing import Annotated
+
 import strawberry
+from strawberry.federation.schema_directives import External
+from strawberry.types import get_object_definition
 
 
 def test_type():
@@ -32,3 +36,17 @@ def test_type_and_override_with_resolver():
     location = Location(id=strawberry.ID("1"))
 
     assert location.id == "1"
+
+
+def test_annotated_federation_field():
+    @strawberry.federation.type
+    class Product:
+        sku: Annotated[
+            str,
+            strawberry.federation.field(external=True, default="default-sku"),
+        ]
+
+    field = get_object_definition(Product).fields[0]
+
+    assert Product().sku == "default-sku"
+    assert any(isinstance(directive, External) for directive in field.directives)

--- a/tests/relay/test_fields.py
+++ b/tests/relay/test_fields.py
@@ -2,6 +2,7 @@ import dataclasses
 import textwrap
 import warnings
 from collections.abc import Iterable
+from typing import Annotated
 from typing_extensions import Self
 
 import pytest
@@ -10,8 +11,9 @@ from pytest_mock import MockerFixture
 import strawberry
 from strawberry import relay
 from strawberry.annotation import StrawberryAnnotation
-from strawberry.relay.fields import ConnectionExtension
+from strawberry.relay.fields import ConnectionExtension, NodeExtension
 from strawberry.relay.utils import to_base64
+from strawberry.types import get_object_definition
 from strawberry.types.arguments import StrawberryArgument
 from strawberry.types.field import StrawberryField
 from strawberry.types.fields.resolver import StrawberryResolver
@@ -1749,3 +1751,43 @@ def test_relay_node_on_nested_type():
     )
     assert result.errors is None
     assert result.data == {"nested": {"__typename": "NestedType"}}
+
+
+def test_annotated_relay_fields():
+    @strawberry.type
+    class Fruit(relay.Node):
+        code: relay.NodeID[str]
+
+    def resolve_fruits() -> list[Fruit]:
+        return []
+
+    @strawberry.type
+    class Query:
+        node: Annotated[
+            relay.Node,
+            relay.node(description="A node"),
+        ]
+        fruits: Annotated[
+            relay.ListConnection[Fruit],
+            relay.connection(
+                resolver=resolve_fruits,
+                description="Some fruit",
+            ),
+        ]
+
+    fields = {field.python_name: field for field in get_object_definition(Query).fields}
+
+    assert Query().node is strawberry.UNSET
+    assert fields["node"].description == "A node"
+    assert (
+        sum(isinstance(item, NodeExtension) for item in fields["node"].extensions) == 1
+    )
+    assert fields["fruits"].description == "Some fruit"
+    assert (
+        sum(
+            isinstance(item, ConnectionExtension)
+            for item in fields["fruits"].extensions
+        )
+        == 1
+    )
+    assert "fruits(" in str(strawberry.Schema(query=Query, types=[Fruit]))

--- a/tests/test_printer/test_schema_directives.py
+++ b/tests/test_printer/test_schema_directives.py
@@ -176,6 +176,21 @@ def test_using_different_names_for_directive_field():
     assert print_schema(schema) == textwrap.dedent(expected_output).strip()
 
 
+def test_annotated_directive_field_configures_constructor():
+    @strawberry.schema_directive(locations=[Location.FIELD_DEFINITION])
+    class Sensitive:
+        reason: Annotated[
+            str,
+            strawberry.directive_field(name="why", default="classified"),
+        ]
+
+    field = Sensitive.__strawberry_directive__.fields[0]
+
+    assert Sensitive().reason == "classified"
+    assert field.graphql_name == "why"
+    assert field.default == "classified"
+
+
 def test_respects_schema_config_for_names():
     @strawberry.schema_directive(locations=[Location.FIELD_DEFINITION])
     class Sensitive:

--- a/tests/types/test_annotated_fields_future_annotations.py
+++ b/tests/types/test_annotated_fields_future_annotations.py
@@ -144,14 +144,26 @@ def test_annotated_field_preserves_union_metadata():
             strawberry.union("NamedResult"),
             strawberry.field(description="The result"),
         ]
+        overridden_result: Annotated[
+            bool,
+            strawberry.field(
+                graphql_type=Success | Failure,
+                description="The overridden result",
+            ),
+            strawberry.union("NamedOverriddenResult"),
+        ]
 
-    field = get_object_definition(Query).fields[0]
+    fields = {field.python_name: field for field in get_object_definition(Query).fields}
 
-    assert field.description == "The result"
-    assert field.type.graphql_name == "NamedResult"
-    assert "union NamedResult = Success | Failure" in str(
-        strawberry.Schema(query=Query)
-    )
+    assert fields["result"].description == "The result"
+    assert fields["result"].type.graphql_name == "NamedResult"
+    assert fields["overridden_result"].description == "The overridden result"
+    assert fields["overridden_result"].type.graphql_name == "NamedOverriddenResult"
+
+    schema = str(strawberry.Schema(query=Query))
+
+    assert "union NamedResult = Success | Failure" in schema
+    assert "union NamedOverriddenResult = Success | Failure" in schema
 
 
 def test_annotated_field_preserves_other_type_metadata():

--- a/tests/types/test_annotated_fields_future_annotations.py
+++ b/tests/types/test_annotated_fields_future_annotations.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import sys
+from enum import Enum
+from typing import TYPE_CHECKING, Annotated, Any
+
+import pytest
+
+import strawberry
+from strawberry.exceptions import (
+    MultipleStrawberryFieldsError,
+    PrivateStrawberryFieldError,
+)
+from strawberry.extensions import FieldExtension
+from strawberry.permission import BasePermission, PermissionExtension
+from strawberry.types import get_object_definition
+from strawberry.types.auto import StrawberryAuto
+from strawberry.types.lazy_type import LazyType
+
+if TYPE_CHECKING:
+    from tests.schema.test_lazy.type_c import TypeC
+
+
+class AllowAll(BasePermission):
+    def has_permission(self, source: Any, info: strawberry.Info, **kwargs: Any) -> bool:
+        return True
+
+
+class MarkerExtension(FieldExtension):
+    pass
+
+
+class Colour(Enum):
+    RED = "red"
+
+
+DIRECTIVE = object()
+EXTENSION = MarkerExtension()
+
+ConfiguredName = Annotated[
+    str,
+    strawberry.field(
+        name="displayName",
+        description="The displayed name",
+        default="Anonymous",
+    ),
+]
+Tags = Annotated[list[str], strawberry.field(default_factory=list)]
+
+
+@strawberry.type
+class Success:
+    value: str
+
+
+@strawberry.type
+class Failure:
+    message: str
+
+
+def resolve_value() -> str:
+    return "resolved"
+
+
+def test_annotated_fields_on_all_type_definitions():
+    @strawberry.type
+    class ObjectType:
+        name: ConfiguredName
+        tags: Tags
+
+    @strawberry.input
+    class InputType:
+        name: ConfiguredName
+        tags: Tags
+
+    @strawberry.interface
+    class InterfaceType:
+        name: ConfiguredName
+        tags: Tags
+
+    for type_ in (ObjectType, InputType, InterfaceType):
+        fields = {
+            field.python_name: field for field in get_object_definition(type_).fields
+        }
+        instance = type_()
+
+        assert fields["name"].graphql_name == "displayName"
+        assert fields["name"].description == "The displayed name"
+        assert fields["name"].default == "Anonymous"
+        assert fields["tags"].default_factory is list
+        assert instance.name == "Anonymous"
+        assert instance.tags == []
+        assert instance.tags is not type_().tags
+
+
+def test_annotated_field_supports_all_options():
+    @strawberry.type
+    class Query:
+        value: Annotated[
+            str,
+            strawberry.field(
+                name="renamed",
+                is_subscription=True,
+                description="A value",
+                permission_classes=[AllowAll],
+                deprecation_reason="Use another field",
+                default="default",
+                metadata={"key": "value"},
+                directives=[DIRECTIVE],
+                extensions=[EXTENSION],
+            ),
+        ]
+        graphql_type_override: Annotated[
+            bool,
+            strawberry.field(graphql_type=int, default=True),
+        ]
+        resolved: Annotated[str, strawberry.field(resolver=resolve_value)]
+
+    fields = {field.python_name: field for field in get_object_definition(Query).fields}
+    field = fields["value"]
+    instance = Query()
+
+    assert field.graphql_name == "renamed"
+    assert field.is_subscription is True
+    assert field.description == "A value"
+    assert field.permission_classes == [AllowAll]
+    assert field.deprecation_reason == "Use another field"
+    assert field.default == "default"
+    assert field.metadata == {"key": "value"}
+    assert field.directives == [DIRECTIVE]
+    assert field.extensions.count(EXTENSION) == 1
+    assert sum(isinstance(item, PermissionExtension) for item in field.extensions) == 1
+    assert fields["graphql_type_override"].type is int
+    assert fields["resolved"].base_resolver is not None
+    assert instance.value == "default"
+    assert instance.graphql_type_override is True
+
+
+def test_annotated_field_preserves_union_metadata():
+    @strawberry.type
+    class Query:
+        result: Annotated[
+            Success | Failure,
+            strawberry.union("NamedResult"),
+            strawberry.field(description="The result"),
+        ]
+
+    field = get_object_definition(Query).fields[0]
+
+    assert field.description == "The result"
+    assert field.type.graphql_name == "NamedResult"
+    assert "union NamedResult = Success | Failure" in str(
+        strawberry.Schema(query=Query)
+    )
+
+
+def test_annotated_field_preserves_other_type_metadata():
+    @strawberry.type
+    class Query:
+        colour: Annotated[
+            Colour,
+            strawberry.enum(name="AnnotatedColour", description="A colour"),
+            strawberry.field(description="The selected colour"),
+        ]
+        child: Annotated[
+            TypeC,
+            strawberry.lazy("tests.schema.test_lazy.type_c"),
+            strawberry.field(description="A lazy child"),
+        ]
+        inferred: Annotated[
+            strawberry.auto,
+            strawberry.field(description="An inferred field"),
+        ]
+
+    fields = {field.python_name: field for field in get_object_definition(Query).fields}
+
+    assert fields["colour"].description == "The selected colour"
+    assert fields["colour"].type.name == "AnnotatedColour"
+    assert fields["colour"].type.description == "A colour"
+    assert fields["child"].description == "A lazy child"
+    assert isinstance(fields["child"].type, LazyType)
+    assert fields["child"].type.resolve_type().__name__ == "TypeC"
+    assert fields["inferred"].description == "An inferred field"
+    assert isinstance(fields["inferred"].type_annotation, StrawberryAuto)
+
+
+def test_annotated_field_preserves_private_metadata():
+    with pytest.raises(PrivateStrawberryFieldError):
+
+        @strawberry.type
+        class Query:
+            secret: Annotated[
+                strawberry.Private[str],
+                strawberry.field(description="A secret"),
+            ]
+
+
+def test_multiple_annotated_fields_raise_error():
+    with pytest.raises(MultipleStrawberryFieldsError):
+
+        @strawberry.type
+        class Query:
+            value: Annotated[
+                str,
+                strawberry.field(description="First"),
+                strawberry.field(description="Second"),
+            ]
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 14),
+    reason="partial forward-reference evaluation requires Python 3.14",
+)
+def test_annotated_field_with_unresolved_forward_reference():
+    global Later
+
+    try:
+
+        @strawberry.type
+        class Query:
+            later: Annotated[Later, strawberry.field(description="Defined later")]
+
+        @strawberry.type
+        class Later:
+            value: str
+
+        field = get_object_definition(Query).fields[0]
+
+        assert field.description == "Defined later"
+        assert field.type is Later
+        assert "later: Later!" in str(strawberry.Schema(query=Query))
+    finally:
+        del Later

--- a/tests/types/test_object_types.py
+++ b/tests/types/test_object_types.py
@@ -306,6 +306,57 @@ def test_annotated_field_with_default_value():
     assert query.name == "default"
 
 
+def test_annotated_field_defaults_on_all_type_definitions():
+    ConfiguredName = Annotated[
+        str,
+        strawberry.field(
+            name="displayName",
+            description="The displayed name",
+            default="Anonymous",
+        ),
+    ]
+    Tags = Annotated[list[str], strawberry.field(default_factory=list)]
+
+    @strawberry.type
+    class ObjectType:
+        name: ConfiguredName
+        tags: Tags
+
+    @strawberry.input
+    class InputType:
+        name: ConfiguredName
+        tags: Tags
+
+    @strawberry.interface
+    class InterfaceType:
+        name: ConfiguredName
+        tags: Tags
+
+    for type_ in (ObjectType, InputType, InterfaceType):
+        fields = {
+            field.python_name: field for field in get_object_definition(type_).fields
+        }
+        instance = type_()
+
+        assert fields["name"].graphql_name == "displayName"
+        assert fields["name"].description == "The displayed name"
+        assert fields["name"].default == "Anonymous"
+        assert fields["tags"].default_factory is list
+        assert instance.name == "Anonymous"
+        assert instance.tags == []
+        assert instance.tags is not type_().tags
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def use_input(self, input: InputType) -> str:
+            return input.name
+
+    schema = strawberry.Schema(query=Query)
+
+    assert 'displayName: String! = "Anonymous"' in str(schema)
+
+
 def test_annotated_field_with_list_type():
     @strawberry.type
     class Query:
@@ -397,6 +448,29 @@ def test_annotated_field_with_other_annotations():
 
     assert field.python_name == "name"
     assert field.type is str
+
+
+def test_annotated_field_preserves_union_metadata():
+    @strawberry.type
+    class Success:
+        value: str
+
+    @strawberry.type
+    class Failure:
+        message: str
+
+    @strawberry.type
+    class Query:
+        result: Annotated[
+            Success | Failure,
+            strawberry.field(description="The result"),
+            strawberry.union("NamedResult"),
+        ]
+
+    field = get_object_definition(Query).fields[0]
+
+    assert field.description == "The result"
+    assert field.type.graphql_name == "NamedResult"
 
 
 def test_annotated_field_mixed_with_regular_field():


### PR DESCRIPTION
## Summary

- process `Annotated[..., strawberry.field(...)]` before dataclass generation so field defaults and factories configure constructors
- support eager and postponed annotations across object, input, and interface definitions
- preserve sibling Strawberry metadata such as named unions, enums, lazy references, `auto`, and private markers
- retain all field options, explicit GraphQL type overrides, resolvers, permissions, directives, extensions, and metadata
- cover StrawberryField-producing APIs including federation fields, Relay node/connection fields, and directive fields
- add permanent user documentation and release notes

## Implementation notes

Annotation evaluation uses the public `Format.FORWARDREF` APIs first. On Python 3.10–3.13, Strawberry's existing lazy-aware evaluator is used only when the backport leaves the complete expression unresolved. No new annotation parser is introduced.

Directly unresolved postponed expressions such as `Annotated[Later, strawberry.field(...)]` rely on Python 3.14's PEP 649/749 support. Resolvable postponed annotations and Strawberry lazy references remain supported on all Strawberry Python versions.

## Validation

- `uv run pytest tests/types tests/test_printer/test_schema_directives.py tests/federation/test_types.py tests/relay/test_fields.py -q` — 530 passed, 5 skipped, 1 xfailed
- `uv run pytest tests/federation/test_types.py tests/relay/test_fields.py -q` — 237 passed
- `uv run --isolated --python 3.14 pytest tests/types/test_annotated_fields_future_annotations.py tests/test_printer/test_schema_directives.py -q` — 29 passed, 4 skipped
- `uv run --isolated --python 3.15 pytest tests/types/test_annotated_fields_future_annotations.py tests/test_printer/test_schema_directives.py -q` — 29 passed, 4 skipped
- `uv run mypy --config-file mypy.ini strawberry/types/object_type.py strawberry/types/type_resolver.py strawberry/types/field.py`
- targeted pre-commit hooks across all changed files

Closes #4241

## Summary by Sourcery

Enable full Strawberry field configuration through `typing.Annotated` across supported type and field definitions.

New Features:
- Support configuring object, input, and interface fields with `strawberry.field()` inside `typing.Annotated`, including defaults and factories.
- Extend Annotated field configuration to federation, Relay, directive fields, and combinations with other Strawberry metadata.

Bug Fixes:
- Preserve field options, GraphQL type overrides, resolvers, permissions, directives, extensions, and metadata when processing Annotated fields.
- Support eager and postponed annotations while retaining lazy references, named unions, enums, auto fields, and private-field validation.

Documentation:
- Add user documentation covering Annotated field configuration, defaults, postponed annotations, lazy references, and metadata composition.
- Add patch release notes for the expanded Annotated field support.

Tests:
- Add coverage for Annotated fields across core type definitions, federation, Relay, schema directives, metadata combinations, validation, and forward references.
