### PR TITLE
Raise an error for nested Strawberry field metadata

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,39 @@
+---
+release type: patch
+social_messages:
+  x: >-
+    {project_name} {version} is out! This release reports misplaced nested
+    strawberry.field() metadata instead of silently ignoring it.
+    https://strawberry.rocks/release/{version}
+  linkedin: >-
+    {project_name} {version} is out. This release reports misplaced nested
+    strawberry.field() metadata with a clear error instead of silently ignoring it.
+---
+
+This release fixes silently ignored `strawberry.field()` metadata in nested type
+annotations.
+
+Strawberry now raises a clear error when field metadata is placed below the
+class-field annotation, such as on a list item, and explains that it must be moved
+to the outermost `Annotated` metadata for the field.
+
+For example, Strawberry now reports this misplaced metadata:
+
+```python
+from typing import Annotated
+
+import strawberry
+
+
+@strawberry.type
+class Query:
+    names: list[Annotated[str, strawberry.field(description="A name")]]
+```
+
+Move `strawberry.field()` to the field's outermost `Annotated` metadata:
+
+```python
+@strawberry.type
+class Query:
+    names: Annotated[list[str], strawberry.field(description="The names")]
+```

--- a/docs/errors/invalid-strawberry-field-annotation.md
+++ b/docs/errors/invalid-strawberry-field-annotation.md
@@ -1,0 +1,40 @@
+---
+title: Invalid Strawberry Field Annotation Error
+---
+
+# Invalid Strawberry Field Annotation Error
+
+## Description
+
+This error is raised when `strawberry.field()` is nested inside another type in
+a class-field annotation. For example, this attempts to configure a list item,
+which is not a GraphQL field:
+
+```python
+from typing import Annotated
+
+import strawberry
+
+
+@strawberry.type
+class Query:
+    names: list[Annotated[str, strawberry.field(description="A name")]]
+```
+
+Strawberry only uses `strawberry.field()` metadata from the outermost
+`Annotated` type because that node represents the class field.
+
+## How to fix this error
+
+Move `strawberry.field()` to the outermost `Annotated` metadata for the field:
+
+```python
+from typing import Annotated
+
+import strawberry
+
+
+@strawberry.type
+class Query:
+    names: Annotated[list[str], strawberry.field(description="The names")]
+```

--- a/docs/types/object-types.md
+++ b/docs/types/object-types.md
@@ -158,6 +158,18 @@ Use only one `strawberry.field()` for each field. You can alternatively use the
 equivalent assignment syntax, such as
 `name: str = strawberry.field(description="The displayed name")`.
 
+`strawberry.field()` must be metadata on the field's outermost `Annotated` type.
+Placing it inside a wrapper configures no GraphQL field, so Strawberry raises an
+error instead of silently ignoring it:
+
+```python
+# Incorrect: strawberry.field() describes the list item, not `names`.
+names: list[Annotated[str, strawberry.field(description="A name")]]
+
+# Correct: strawberry.field() describes `names`.
+names: Annotated[list[str], strawberry.field(description="The names")]
+```
+
 ## API
 
 `@strawberry.type(name: str = None, description: str = None)`

--- a/strawberry/annotation.py
+++ b/strawberry/annotation.py
@@ -39,8 +39,6 @@ from strawberry.types.unset import UNSET
 from strawberry.utils.typing import eval_type, is_generic, is_type_var
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-
     from strawberry.types.base import StrawberryType
     from strawberry.types.field import StrawberryField
     from strawberry.types.union import StrawberryUnion
@@ -125,6 +123,12 @@ class StrawberryAnnotation:
 
         return eval_type(annotation, self.namespace, None)
 
+    def _get_evaluated_annotation(self) -> object:
+        if self.__evaluated_cache__ is _NOT_EVALUATED:
+            self.__evaluated_cache__ = self.evaluate()
+
+        return self.__evaluated_cache__
+
     def _get_type_with_args(
         self, evaled_type: type[Any]
     ) -> tuple[type[Any], list[Any]]:
@@ -142,14 +146,11 @@ class StrawberryAnnotation:
         self,
         *,
         type_definition: StrawberryObjectDefinition | None = None,
-        _validate: Callable[[object], None] | None = None,
     ) -> StrawberryType | type:
         """Return resolved (transformed) annotation."""
         if (resolved := self.__resolve_cache__) is None:
-            resolved = self._resolve(_validate=_validate)
+            resolved = self._resolve()
             self.__resolve_cache__ = resolved
-        elif _validate is not None and self.__evaluated_cache__ is not _NOT_EVALUATED:
-            _validate(self.__evaluated_cache__)
 
         # If this is a generic field, try to resolve it using its origin's
         # specialized type_var_map
@@ -174,14 +175,8 @@ class StrawberryAnnotation:
 
         return resolved
 
-    def _resolve(
-        self,
-        _validate: Callable[[object], None] | None = None,
-    ) -> StrawberryType | type:
-        evaled_type = cast("Any", self.evaluate())
-        self.__evaluated_cache__ = evaled_type
-        if _validate is not None:
-            _validate(evaled_type)
+    def _resolve(self) -> StrawberryType | type:
+        evaled_type = cast("Any", self._get_evaluated_annotation())
         return self._resolve_evaled_type(evaled_type)
 
     def _resolve_evaled_type(self, evaled_type: Any) -> StrawberryType | type:
@@ -228,6 +223,7 @@ class StrawberryAnnotation:
         module = sys.modules[field.origin.__module__]
         self.namespace = module.__dict__
 
+        self.__evaluated_cache__ = _NOT_EVALUATED
         self.__resolve_cache__ = None  # Invalidate cache to allow re-evaluation
 
     def create_concrete_type(self, evaled_type: type) -> type:

--- a/strawberry/annotation.py
+++ b/strawberry/annotation.py
@@ -123,7 +123,8 @@ class StrawberryAnnotation:
 
         return eval_type(annotation, self.namespace, None)
 
-    def _get_evaluated_annotation(self) -> object:
+    @property
+    def _evaluated_annotation(self) -> object:
         if self.__evaluated_cache__ is _NOT_EVALUATED:
             self.__evaluated_cache__ = self.evaluate()
 
@@ -176,7 +177,7 @@ class StrawberryAnnotation:
         return resolved
 
     def _resolve(self) -> StrawberryType | type:
-        evaled_type = cast("Any", self._get_evaluated_annotation())
+        evaled_type = cast("Any", self._evaluated_annotation)
         return self._resolve_evaled_type(evaled_type)
 
     def _resolve_evaled_type(self, evaled_type: Any) -> StrawberryType | type:

--- a/strawberry/annotation.py
+++ b/strawberry/annotation.py
@@ -101,7 +101,7 @@ class StrawberryAnnotation:
     def annotation(self) -> object | str:
         """Return evaluated type on success or fallback to raw (string) annotation."""
         try:
-            return self.evaluate()
+            return self._evaluated_annotation
         except NameError:
             # Evaluation failures can happen when importing types within a TYPE_CHECKING
             # block or if the type is declared later on in a module.

--- a/strawberry/annotation.py
+++ b/strawberry/annotation.py
@@ -39,6 +39,8 @@ from strawberry.types.unset import UNSET
 from strawberry.utils.typing import eval_type, is_generic, is_type_var
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from strawberry.types.base import StrawberryType
     from strawberry.types.field import StrawberryField
     from strawberry.types.union import StrawberryUnion
@@ -54,9 +56,16 @@ ASYNC_TYPES = (
     typing.AsyncIterator,
 )
 
+_NOT_EVALUATED = object()
+
 
 class StrawberryAnnotation:
-    __slots__ = "__resolve_cache__", "namespace", "raw_annotation"
+    __slots__ = (
+        "__evaluated_cache__",
+        "__resolve_cache__",
+        "namespace",
+        "raw_annotation",
+    )
 
     def __init__(
         self,
@@ -67,6 +76,7 @@ class StrawberryAnnotation:
         self.raw_annotation = annotation
         self.namespace = namespace
 
+        self.__evaluated_cache__: object = _NOT_EVALUATED
         self.__resolve_cache__: StrawberryType | type | None = None
 
     def __eq__(self, other: object) -> bool:
@@ -103,6 +113,7 @@ class StrawberryAnnotation:
     def annotation(self, value: object | str) -> None:
         self.raw_annotation = value
 
+        self.__evaluated_cache__ = _NOT_EVALUATED
         self.__resolve_cache__ = None
 
     def evaluate(self) -> type:
@@ -131,11 +142,14 @@ class StrawberryAnnotation:
         self,
         *,
         type_definition: StrawberryObjectDefinition | None = None,
+        _validate: Callable[[object], None] | None = None,
     ) -> StrawberryType | type:
         """Return resolved (transformed) annotation."""
         if (resolved := self.__resolve_cache__) is None:
-            resolved = self._resolve()
+            resolved = self._resolve(_validate=_validate)
             self.__resolve_cache__ = resolved
+        elif _validate is not None and self.__evaluated_cache__ is not _NOT_EVALUATED:
+            _validate(self.__evaluated_cache__)
 
         # If this is a generic field, try to resolve it using its origin's
         # specialized type_var_map
@@ -160,8 +174,14 @@ class StrawberryAnnotation:
 
         return resolved
 
-    def _resolve(self) -> StrawberryType | type:
+    def _resolve(
+        self,
+        _validate: Callable[[object], None] | None = None,
+    ) -> StrawberryType | type:
         evaled_type = cast("Any", self.evaluate())
+        self.__evaluated_cache__ = evaled_type
+        if _validate is not None:
+            _validate(evaled_type)
         return self._resolve_evaled_type(evaled_type)
 
     def _resolve_evaled_type(self, evaled_type: Any) -> StrawberryType | type:

--- a/strawberry/exceptions/__init__.py
+++ b/strawberry/exceptions/__init__.py
@@ -10,6 +10,7 @@ from .duplicated_type_name import DuplicatedTypeName
 from .exception import StrawberryException, UnableToFindExceptionSource
 from .handler import setup_exception_handler
 from .invalid_argument_type import InvalidArgumentTypeError
+from .invalid_strawberry_field_annotation import InvalidStrawberryFieldAnnotationError
 from .invalid_superclass_interface import InvalidSuperclassInterfaceError
 from .invalid_union_type import InvalidTypeForUnionMergeError, InvalidUnionTypeError
 from .missing_arguments_annotations import MissingArgumentsAnnotationsError
@@ -176,6 +177,7 @@ __all__ = [
     "InvalidArgumentTypeError",
     "InvalidCustomContext",
     "InvalidDefaultFactoryError",
+    "InvalidStrawberryFieldAnnotationError",
     "InvalidSuperclassInterfaceError",
     "InvalidTypeForUnionMergeError",
     "InvalidUnionTypeError",

--- a/strawberry/exceptions/invalid_strawberry_field_annotation.py
+++ b/strawberry/exceptions/invalid_strawberry_field_annotation.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from functools import cached_property
+from typing import TYPE_CHECKING
+
+from .exception import StrawberryException
+from .utils.source_finder import SourceFinder
+
+if TYPE_CHECKING:
+    from .exception_source import ExceptionSource
+
+
+class InvalidStrawberryFieldAnnotationError(StrawberryException):
+    def __init__(self, field_name: str, cls: type) -> None:
+        self.cls = cls
+        self.field_name = field_name
+
+        self.message = (
+            f"`strawberry.field()` for field `{field_name}` on type `{cls.__name__}` "
+            "must be placed at the top level of the field annotation"
+        )
+        self.rich_message = (
+            f"`strawberry.field()` for field `[underline]{field_name}[/]` on type "
+            f"`[underline]{cls.__name__}[/]` cannot be nested inside another type"
+        )
+        self.annotation_message = "strawberry.field() is nested inside another type"
+        self.suggestion = (
+            "To fix this error, move `strawberry.field()` to the outermost "
+            "`Annotated` metadata for the field."
+        )
+
+        super().__init__(self.message)
+
+    @cached_property
+    def exception_source(self) -> ExceptionSource | None:
+        source_finder = SourceFinder()
+
+        return source_finder.find_class_attribute_from_object(self.cls, self.field_name)

--- a/strawberry/types/field.py
+++ b/strawberry/types/field.py
@@ -131,6 +131,7 @@ class StrawberryField(dataclasses.Field):
             self.python_name = python_name
 
         self.type_annotation = type_annotation
+        self._validated_type_annotation: StrawberryAnnotation | None = None
 
         self.description: str | None = description
         self.origin = origin
@@ -352,10 +353,14 @@ class StrawberryField(dataclasses.Field):
         with contextlib.suppress(NameError):
             # Prioritise the field type over the resolver return type
             if self.type_annotation is not None:
-                self._validate_type_annotation(
-                    self.type_annotation._evaluated_annotation
-                )
-                resolved = self.type_annotation.resolve(type_definition=type_definition)
+                type_annotation = self.type_annotation
+                if type_annotation is not self._validated_type_annotation:
+                    self._validate_type_annotation(
+                        type_annotation._evaluated_annotation
+                    )
+
+                resolved = type_annotation.resolve(type_definition=type_definition)
+                self._validated_type_annotation = type_annotation
             elif self.base_resolver is not None and self.base_resolver.type is not None:
                 # Handle unannotated functions (such as lambdas)
                 # Generics will raise MissingTypesForGenericError later

--- a/strawberry/types/field.py
+++ b/strawberry/types/field.py
@@ -369,10 +369,7 @@ class StrawberryField(dataclasses.Field):
         if (
             self.python_name is not None
             and isinstance(self.origin, type)
-            and _contains_strawberry_field(
-                annotation,
-                at_field_annotation_root=True,
-            )
+            and _contains_strawberry_field(annotation)
         ):
             raise InvalidStrawberryFieldAnnotationError(
                 field_name=self.python_name,
@@ -422,7 +419,7 @@ class StrawberryField(dataclasses.Field):
 def _contains_strawberry_field(
     annotation: object,
     *,
-    at_field_annotation_root: bool = False,
+    at_field_annotation_root: bool = True,
 ) -> bool:
     if get_origin(annotation) is Annotated:
         annotation, *metadata = get_args(annotation)

--- a/strawberry/types/field.py
+++ b/strawberry/types/field.py
@@ -131,6 +131,8 @@ class StrawberryField(dataclasses.Field):
             self.python_name = python_name
 
         self.type_annotation = type_annotation
+        # Cache the exact annotation object after successful validation and
+        # resolution so replacing `type_annotation` automatically revalidates it.
         self._validated_type_annotation: StrawberryAnnotation | None = None
 
         self.description: str | None = description

--- a/strawberry/types/field.py
+++ b/strawberry/types/field.py
@@ -353,7 +353,7 @@ class StrawberryField(dataclasses.Field):
             # Prioritise the field type over the resolver return type
             if self.type_annotation is not None:
                 self._validate_type_annotation(
-                    self.type_annotation._get_evaluated_annotation()
+                    self.type_annotation._evaluated_annotation
                 )
                 resolved = self.type_annotation.resolve(type_definition=type_definition)
             elif self.base_resolver is not None and self.base_resolver.type is not None:

--- a/strawberry/types/field.py
+++ b/strawberry/types/field.py
@@ -352,10 +352,10 @@ class StrawberryField(dataclasses.Field):
         with contextlib.suppress(NameError):
             # Prioritise the field type over the resolver return type
             if self.type_annotation is not None:
-                resolved = self.type_annotation.resolve(
-                    type_definition=type_definition,
-                    _validate=self._validate_type_annotation,
+                self._validate_type_annotation(
+                    self.type_annotation._get_evaluated_annotation()
                 )
+                resolved = self.type_annotation.resolve(type_definition=type_definition)
             elif self.base_resolver is not None and self.base_resolver.type is not None:
                 # Handle unannotated functions (such as lambdas)
                 # Generics will raise MissingTypesForGenericError later

--- a/strawberry/types/field.py
+++ b/strawberry/types/field.py
@@ -8,16 +8,23 @@ from collections.abc import Awaitable, Callable, Coroutine, Mapping, Sequence
 from functools import cached_property
 from typing import (
     TYPE_CHECKING,
+    Annotated,
     Any,
     NoReturn,
     TypeAlias,
     TypeVar,
     Union,
+    get_args,
+    get_origin,
     overload,
 )
 
 from strawberry.annotation import StrawberryAnnotation
-from strawberry.exceptions import InvalidArgumentTypeError, InvalidDefaultFactoryError
+from strawberry.exceptions import (
+    InvalidArgumentTypeError,
+    InvalidDefaultFactoryError,
+    InvalidStrawberryFieldAnnotationError,
+)
 from strawberry.types.base import (
     StrawberryType,
     WithStrawberryObjectDefinition,
@@ -345,7 +352,10 @@ class StrawberryField(dataclasses.Field):
         with contextlib.suppress(NameError):
             # Prioritise the field type over the resolver return type
             if self.type_annotation is not None:
-                resolved = self.type_annotation.resolve(type_definition=type_definition)
+                resolved = self.type_annotation.resolve(
+                    type_definition=type_definition,
+                    _validate=self._validate_type_annotation,
+                )
             elif self.base_resolver is not None and self.base_resolver.type is not None:
                 # Handle unannotated functions (such as lambdas)
                 # Generics will raise MissingTypesForGenericError later
@@ -354,6 +364,20 @@ class StrawberryField(dataclasses.Field):
                 resolved = self.base_resolver.type
 
         return resolved
+
+    def _validate_type_annotation(self, annotation: object) -> None:
+        if (
+            self.python_name is not None
+            and isinstance(self.origin, type)
+            and _contains_strawberry_field(
+                annotation,
+                allow_field_metadata=True,
+            )
+        ):
+            raise InvalidStrawberryFieldAnnotationError(
+                field_name=self.python_name,
+                cls=self.origin,
+            )
 
     def copy_with(
         self, type_var_map: Mapping[str, StrawberryType | builtins.type]
@@ -393,6 +417,29 @@ class StrawberryField(dataclasses.Field):
     @cached_property
     def is_async(self) -> bool:
         return self._has_async_base_resolver
+
+
+def _contains_strawberry_field(
+    annotation: object,
+    *,
+    allow_field_metadata: bool = False,
+) -> bool:
+    if get_origin(annotation) is Annotated:
+        annotation, *metadata = get_args(annotation)
+        if not allow_field_metadata and any(
+            isinstance(item, StrawberryField) for item in metadata
+        ):
+            return True
+
+        return _contains_strawberry_field(
+            annotation,
+            allow_field_metadata=allow_field_metadata,
+        )
+
+    return any(
+        _contains_strawberry_field(arg, allow_field_metadata=False)
+        for arg in get_args(annotation)
+    )
 
 
 # NOTE: we are separating the sync and async resolvers because using both

--- a/strawberry/types/field.py
+++ b/strawberry/types/field.py
@@ -371,7 +371,7 @@ class StrawberryField(dataclasses.Field):
             and isinstance(self.origin, type)
             and _contains_strawberry_field(
                 annotation,
-                allow_field_metadata=True,
+                at_field_annotation_root=True,
             )
         ):
             raise InvalidStrawberryFieldAnnotationError(
@@ -422,22 +422,22 @@ class StrawberryField(dataclasses.Field):
 def _contains_strawberry_field(
     annotation: object,
     *,
-    allow_field_metadata: bool = False,
+    at_field_annotation_root: bool = False,
 ) -> bool:
     if get_origin(annotation) is Annotated:
         annotation, *metadata = get_args(annotation)
-        if not allow_field_metadata and any(
+        if not at_field_annotation_root and any(
             isinstance(item, StrawberryField) for item in metadata
         ):
             return True
 
         return _contains_strawberry_field(
             annotation,
-            allow_field_metadata=allow_field_metadata,
+            at_field_annotation_root=at_field_annotation_root,
         )
 
     return any(
-        _contains_strawberry_field(arg, allow_field_metadata=False)
+        _contains_strawberry_field(arg, at_field_annotation_root=False)
         for arg in get_args(annotation)
     )
 

--- a/strawberry/types/fields/resolver.py
+++ b/strawberry/types/fields/resolver.py
@@ -120,13 +120,13 @@ class ReservedType(NamedTuple):
             annotation = resolver.strawberry_annotations[parameter]
             if isinstance(annotation, StrawberryAnnotation):
                 try:
-                    evaled_annotation: Any = annotation.evaluate()
+                    evaled_annotation: Any = annotation._evaluated_annotation
                 except NameError:
                     # If we fail to evaluate, check if the raw annotation string
                     # matches this reserved type. This handles cases where types
                     # are imported under TYPE_CHECKING or use forward references
                     # like "strawberry.Info".
-                    raw = annotation.annotation
+                    raw = annotation.raw_annotation
                     if isinstance(raw, str):
                         evaled_annotation = raw
                     else:

--- a/strawberry/types/object_type.py
+++ b/strawberry/types/object_type.py
@@ -37,19 +37,10 @@ from strawberry.types.unset import UNSET
 from strawberry.utils.str_converters import to_camel_case
 
 from .base import StrawberryObjectDefinition
-from .field import StrawberryField, field
+from .field import StrawberryField, _contains_strawberry_field, field
 from .type_resolver import _get_fields
 
 T = TypeVar("T", bound=builtins.type)
-
-
-def _contains_strawberry_field(annotation: object) -> bool:
-    if get_origin(annotation) is Annotated:
-        annotation, *metadata = get_args(annotation)
-        if any(isinstance(item, StrawberryField) for item in metadata):
-            return True
-
-    return any(_contains_strawberry_field(arg) for arg in get_args(annotation))
 
 
 def _process_annotated_fields(cls: T) -> dict[str, StrawberryAnnotation]:
@@ -94,7 +85,10 @@ def _process_annotated_fields(cls: T) -> dict[str, StrawberryAnnotation]:
         ):
             raise MultipleStrawberryFieldsError(field_name=field_name, cls=cls)
 
-        if _contains_strawberry_field(first):
+        if _contains_strawberry_field(
+            annotation,
+            allow_field_metadata=True,
+        ):
             raise InvalidStrawberryFieldAnnotationError(
                 field_name=field_name,
                 cls=cls,

--- a/strawberry/types/object_type.py
+++ b/strawberry/types/object_type.py
@@ -24,6 +24,7 @@ from typing_extensions import (
 
 from strawberry.annotation import StrawberryAnnotation
 from strawberry.exceptions import (
+    InvalidStrawberryFieldAnnotationError,
     InvalidSuperclassInterfaceError,
     MissingFieldAnnotationError,
     MissingReturnAnnotationError,
@@ -40,6 +41,15 @@ from .field import StrawberryField, field
 from .type_resolver import _get_fields
 
 T = TypeVar("T", bound=builtins.type)
+
+
+def _contains_strawberry_field(annotation: object) -> bool:
+    if get_origin(annotation) is Annotated:
+        annotation, *metadata = get_args(annotation)
+        if any(isinstance(item, StrawberryField) for item in metadata):
+            return True
+
+    return any(_contains_strawberry_field(arg) for arg in get_args(annotation))
 
 
 def _process_annotated_fields(cls: T) -> dict[str, StrawberryAnnotation]:
@@ -70,10 +80,12 @@ def _process_annotated_fields(cls: T) -> dict[str, StrawberryAnnotation]:
         else:
             annotation = raw_annotation
 
-        if get_origin(annotation) is not Annotated:
-            continue
+        if get_origin(annotation) is Annotated:
+            first, *rest = get_args(annotation)
+        else:
+            first = annotation
+            rest = []
 
-        first, *rest = get_args(annotation)
         strawberry_fields = [arg for arg in rest if isinstance(arg, StrawberryField)]
 
         if len(strawberry_fields) > 1 or (
@@ -81,6 +93,12 @@ def _process_annotated_fields(cls: T) -> dict[str, StrawberryAnnotation]:
             and isinstance(cls.__dict__.get(field_name), StrawberryField)
         ):
             raise MultipleStrawberryFieldsError(field_name=field_name, cls=cls)
+
+        if _contains_strawberry_field(first):
+            raise InvalidStrawberryFieldAnnotationError(
+                field_name=field_name,
+                cls=cls,
+            )
 
         if not strawberry_fields:
             continue

--- a/strawberry/types/object_type.py
+++ b/strawberry/types/object_type.py
@@ -85,10 +85,7 @@ def _process_annotated_fields(cls: T) -> dict[str, StrawberryAnnotation]:
         ):
             raise MultipleStrawberryFieldsError(field_name=field_name, cls=cls)
 
-        if _contains_strawberry_field(
-            annotation,
-            at_field_annotation_root=True,
-        ):
+        if _contains_strawberry_field(annotation):
             raise InvalidStrawberryFieldAnnotationError(
                 field_name=field_name,
                 cls=cls,

--- a/strawberry/types/object_type.py
+++ b/strawberry/types/object_type.py
@@ -87,7 +87,7 @@ def _process_annotated_fields(cls: T) -> dict[str, StrawberryAnnotation]:
 
         if _contains_strawberry_field(
             annotation,
-            allow_field_metadata=True,
+            at_field_annotation_root=True,
         ):
             raise InvalidStrawberryFieldAnnotationError(
                 field_name=field_name,

--- a/tests/types/test_annotated_fields_future_annotations.py
+++ b/tests/types/test_annotated_fields_future_annotations.py
@@ -236,9 +236,8 @@ def test_nested_annotated_field_raises_error():
 
 
 def test_nested_annotated_field_with_later_forward_reference_raises_error():
-    global LaterWithNestedField
-
-    try:
+    def create_schema() -> None:
+        global LaterWithNestedField
 
         @strawberry.type
         class Query:
@@ -253,6 +252,9 @@ def test_nested_annotated_field_with_later_forward_reference_raises_error():
         class LaterWithNestedField:
             value: str
 
+        strawberry.Schema(query=Query)
+
+    try:
         with pytest.raises(
             InvalidStrawberryFieldAnnotationError,
             match=(
@@ -260,20 +262,30 @@ def test_nested_annotated_field_with_later_forward_reference_raises_error():
                 r"must be placed at the top level of the field annotation"
             ),
         ):
-            strawberry.Schema(query=Query)
+            create_schema()
     finally:
-        del LaterWithNestedField
+        globals().pop("LaterWithNestedField", None)
 
 
 def test_nested_annotated_field_with_unresolvable_type_raises_unresolved_error():
-    @strawberry.type
-    class Query:
-        values: list[
-            Annotated[UnresolvableType, strawberry.field(description="Nested")]
-        ]
+    if sys.version_info >= (3, 14):
+        with pytest.raises(InvalidStrawberryFieldAnnotationError):
 
-    with pytest.raises(UnresolvedFieldTypeError):
-        strawberry.Schema(query=Query)
+            @strawberry.type
+            class Query:
+                values: list[
+                    Annotated[UnresolvableType, strawberry.field(description="Nested")]
+                ]
+    else:
+
+        @strawberry.type
+        class Query:
+            values: list[
+                Annotated[UnresolvableType, strawberry.field(description="Nested")]
+            ]
+
+        with pytest.raises(UnresolvedFieldTypeError):
+            strawberry.Schema(query=Query)
 
 
 def test_field_owned_metadata_with_unresolved_forward_reference_is_not_rejected():

--- a/tests/types/test_annotated_fields_future_annotations.py
+++ b/tests/types/test_annotated_fields_future_annotations.py
@@ -11,6 +11,7 @@ from strawberry.exceptions import (
     InvalidStrawberryFieldAnnotationError,
     MultipleStrawberryFieldsError,
     PrivateStrawberryFieldError,
+    UnresolvedFieldTypeError,
 )
 from strawberry.extensions import FieldExtension
 from strawberry.permission import BasePermission, PermissionExtension
@@ -20,6 +21,7 @@ from strawberry.types.lazy_type import LazyType
 
 if TYPE_CHECKING:
     from tests.schema.test_lazy.type_c import TypeC
+    from tests.schema.test_lazy.type_c import TypeC as UnresolvableType
 
 
 class AllowAll(BasePermission):
@@ -231,6 +233,60 @@ def test_nested_annotated_field_raises_error():
     @strawberry.type
     class Query:
         values: list[Annotated[str, strawberry.field(description="Not the list field")]]
+
+
+def test_nested_annotated_field_with_later_forward_reference_raises_error():
+    global LaterWithNestedField
+
+    try:
+
+        @strawberry.type
+        class Query:
+            values: list[
+                Annotated[
+                    LaterWithNestedField,
+                    strawberry.field(description="Not the list field"),
+                ]
+            ]
+
+        @strawberry.type
+        class LaterWithNestedField:
+            value: str
+
+        with pytest.raises(
+            InvalidStrawberryFieldAnnotationError,
+            match=(
+                r"`strawberry.field\(\)` for field `values` on type `Query` "
+                r"must be placed at the top level of the field annotation"
+            ),
+        ):
+            strawberry.Schema(query=Query)
+    finally:
+        del LaterWithNestedField
+
+
+def test_nested_annotated_field_with_unresolvable_type_raises_unresolved_error():
+    @strawberry.type
+    class Query:
+        values: list[
+            Annotated[UnresolvableType, strawberry.field(description="Nested")]
+        ]
+
+    with pytest.raises(UnresolvedFieldTypeError):
+        strawberry.Schema(query=Query)
+
+
+def test_field_owned_metadata_with_unresolved_forward_reference_is_not_rejected():
+    @strawberry.type
+    class Query:
+        values: Annotated[
+            list[TypeC],
+            strawberry.field(description="The list field"),
+        ]
+
+    field = get_object_definition(Query).fields[0]
+
+    assert field.python_name == "values"
 
 
 def test_nested_lazy_metadata_is_preserved():

--- a/tests/types/test_annotated_fields_future_annotations.py
+++ b/tests/types/test_annotated_fields_future_annotations.py
@@ -8,6 +8,7 @@ import pytest
 
 import strawberry
 from strawberry.exceptions import (
+    InvalidStrawberryFieldAnnotationError,
     MultipleStrawberryFieldsError,
     PrivateStrawberryFieldError,
 )
@@ -217,6 +218,34 @@ def test_multiple_annotated_fields_raise_error():
                 strawberry.field(description="First"),
                 strawberry.field(description="Second"),
             ]
+
+
+@pytest.mark.raises_strawberry_exception(
+    InvalidStrawberryFieldAnnotationError,
+    match=(
+        r"`strawberry.field\(\)` for field `values` on type `Query` "
+        r"must be placed at the top level of the field annotation"
+    ),
+)
+def test_nested_annotated_field_raises_error():
+    @strawberry.type
+    class Query:
+        values: list[Annotated[str, strawberry.field(description="Not the list field")]]
+
+
+def test_nested_lazy_metadata_is_preserved():
+    @strawberry.type
+    class Query:
+        children: Annotated[
+            list[Annotated[TypeC, strawberry.lazy("tests.schema.test_lazy.type_c")]],
+            strawberry.field(description="The children"),
+        ]
+
+    field = get_object_definition(Query).fields[0]
+
+    assert field.description == "The children"
+    assert isinstance(field.type.of_type, LazyType)
+    assert field.type.of_type.resolve_type().__name__ == "TypeC"
 
 
 @pytest.mark.skipif(

--- a/tests/types/test_annotation.py
+++ b/tests/types/test_annotation.py
@@ -73,3 +73,18 @@ def test_set_anntation():
     annotation.annotation = str
 
     assert annotation.annotation is str
+
+
+def test_evaluation_is_cached_between_annotation_and_resolve():
+    class CountingAnnotation(StrawberryAnnotation):
+        evaluations = 0
+
+        def evaluate(self) -> type:
+            self.evaluations += 1
+            return super().evaluate()
+
+    annotation = CountingAnnotation("int")
+
+    assert annotation.annotation is int
+    assert annotation.resolve() is int
+    assert annotation.evaluations == 1

--- a/tests/types/test_field_types.py
+++ b/tests/types/test_field_types.py
@@ -49,6 +49,27 @@ def test_literal():
     assert field.type is bool
 
 
+def test_field_annotation_validation_is_cached(mocker):
+    contains_strawberry_field = mocker.patch(
+        "strawberry.types.field._contains_strawberry_field",
+        return_value=False,
+    )
+    field = StrawberryField(
+        python_name="value",
+        type_annotation=StrawberryAnnotation(str),
+        origin=object,
+    )
+
+    assert field.resolve_type() is str
+    assert field.resolve_type() is str
+    contains_strawberry_field.assert_called_once_with(str)
+
+    field.type_annotation = StrawberryAnnotation(int)
+
+    assert field.resolve_type() is int
+    assert contains_strawberry_field.call_count == 2
+
+
 def test_object():
     @strawberry.type
     class TypeyType:

--- a/tests/types/test_object_types.py
+++ b/tests/types/test_object_types.py
@@ -7,7 +7,10 @@ from typing import Annotated, Optional, TypeVar
 import pytest
 
 import strawberry
-from strawberry.exceptions import MultipleStrawberryFieldsError
+from strawberry.exceptions import (
+    InvalidStrawberryFieldAnnotationError,
+    MultipleStrawberryFieldsError,
+)
 from strawberry.types.base import get_object_definition, has_object_definition
 from strawberry.types.field import StrawberryField
 
@@ -448,6 +451,60 @@ def test_annotated_field_with_other_annotations():
 
     assert field.python_name == "name"
     assert field.type is str
+
+
+@pytest.mark.parametrize(
+    "annotation",
+    [
+        list[Annotated[str, strawberry.field(description="List item")]],
+        Optional[Annotated[str, strawberry.field(description="Optional value")]],
+        list[
+            Optional[
+                Annotated[str, strawberry.field(description="Nested optional value")]
+            ]
+        ],
+    ],
+    ids=["list", "optional", "nested-wrappers"],
+)
+def test_nested_annotated_field_raises_error(annotation: object):
+    with pytest.raises(
+        InvalidStrawberryFieldAnnotationError,
+        match=(
+            r"`strawberry.field\(\)` for field `values` on type `Query` "
+            r"must be placed at the top level of the field annotation"
+        ),
+    ):
+
+        @strawberry.type
+        class Query:
+            values: annotation
+
+
+def test_nested_non_field_metadata_is_preserved():
+    class Colour(Enum):
+        RED = "red"
+
+    @strawberry.type
+    class Success:
+        value: str
+
+    @strawberry.type
+    class Failure:
+        message: str
+
+    @strawberry.type
+    class Query:
+        results: Annotated[
+            list[Annotated[Success | Failure, strawberry.union("NestedResult")]],
+            strawberry.field(description="The results"),
+        ]
+        colours: list[Annotated[Colour, strawberry.enum(name="NestedColour")]]
+
+    fields = {field.python_name: field for field in get_object_definition(Query).fields}
+
+    assert fields["results"].description == "The results"
+    assert fields["results"].type.of_type.graphql_name == "NestedResult"
+    assert fields["colours"].type.of_type.name == "NestedColour"
 
 
 def test_annotated_field_preserves_union_metadata():


### PR DESCRIPTION
## Summary

- reject `strawberry.field()` metadata nested below the owning class-field annotation
- preserve valid root field metadata and nested lazy, union, and enum metadata
- add a source-aware Strawberry exception, documentation, tests, and release-note examples

## Testing

- `uv run pytest tests/types -q`
- `uv run pytest tests/types/test_annotated_fields_future_annotations.py tests/types/test_object_types.py -q`
- `uv run pytest tests/fields/test_arguments.py tests/fields/test_resolvers.py -q`
- `uv run pytest tests/schema/test_schema_generation.py tests/schema/test_directives.py -q`
- `uv run mypy --config-file mypy.ini strawberry/types/object_type.py strawberry/exceptions/invalid_strawberry_field_annotation.py`
- `uv run pre-commit run --files RELEASE.md docs/types/object-types.md docs/errors/invalid-strawberry-field-annotation.md strawberry/exceptions/__init__.py strawberry/exceptions/invalid_strawberry_field_annotation.py strawberry/types/object_type.py tests/types/test_object_types.py tests/types/test_annotated_fields_future_annotations.py`

## Summary by Sourcery

Reject nested `strawberry.field()` metadata with actionable diagnostics while preserving valid annotation metadata.

Bug Fixes:
- Raise a clear, source-aware error when `strawberry.field()` metadata is nested inside a class-field annotation instead of silently ignoring it.

Enhancements:
- Preserve valid root field metadata and nested lazy, union, and enum metadata while caching annotation evaluation and validation.

Documentation:
- Document the invalid nested field metadata error and show how to place `strawberry.field()` on the outermost annotation.

Tests:
- Add coverage for nested field metadata, forward references, unresolved types, metadata preservation, and validation caching.