### PR TITLE
Fix operation directive argument coercion

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,22 @@
+---
+release type: patch
+social_messages:
+  x: >-
+    {project_name} {version} is out! Operation directive resolvers now receive
+    correctly typed arguments, including inputs, enums, custom scalars, and
+    defaults. 🍓 https://strawberry.rocks/release/{version}
+  linkedin: >-
+    {project_name} {version} is out. Operation directive arguments now behave
+    like field arguments, with standard GraphQL coercion and Strawberry input
+    conversion for literals, variables, defaults, and explicit null values. 🍓
+---
+
+This release fixes argument handling for operation directive resolvers.
+
+Arguments passed to operation directives now use GraphQL's standard coercion before
+your resolver runs. Directive resolvers receive Python numeric values, Strawberry
+enum members and nested input objects, and values parsed by custom scalars, whether
+clients use literals or variables.
+
+When a client omits a variable, Strawberry now applies the directive argument's
+default. Explicit `null` continues to reach nullable arguments as `None`.

--- a/docs/types/operation-directives.md
+++ b/docs/types/operation-directives.md
@@ -98,11 +98,11 @@ query People($identified: Boolean!) {
   person {
     name @turnUppercase
   }
-  jess: person {
-    name @replace(old: "Jess", new: "Jessica")
+  duck: person {
+    name @replace(old: "Duck", new: "Duck")
   }
   johnDoe: person {
-    name @replace(old: "Jess", new: "John") @include(if: $identified)
+    name @replace(old: "Duck", new: "John") @include(if: $identified)
   }
 }
 ```

--- a/strawberry/extensions/directives.py
+++ b/strawberry/extensions/directives.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from graphql import get_argument_values
+
 from strawberry.extensions import SchemaExtension
-from strawberry.types.nodes import convert_arguments
+from strawberry.types.arguments import convert_arguments
+from strawberry.utils import IS_GQL_33
 from strawberry.utils.await_maybe import await_maybe
 
 if TYPE_CHECKING:
@@ -76,7 +79,25 @@ def process_directive(
     strawberry_directive = schema.get_directive_by_name(directive_name)
     assert strawberry_directive is not None, f"Directive {directive_name} not found"
 
-    arguments = convert_arguments(info=info, nodes=directive.arguments)
+    directive_definition = info.schema.get_directive(directive_name)
+    assert directive_definition is not None, f"Directive {directive_name} not found"
+
+    variable_values: Any = info.variable_values
+    if IS_GQL_33 and not hasattr(variable_values, "coerced"):
+        # Strawberry exposes a plain dict, while graphql-core 3.3 expects its
+        # VariableValues container when coercing arguments.
+        from graphql.execution import values as execution_values
+
+        variable_values_type = vars(execution_values)["VariableValues"]
+        variable_values = variable_values_type({}, variable_values)
+
+    arguments = get_argument_values(directive_definition, directive, variable_values)
+    arguments = convert_arguments(
+        arguments,
+        strawberry_directive.arguments,
+        scalar_registry=schema.schema_converter.scalar_registry,
+        config=schema.config,
+    )
     resolver = strawberry_directive.resolver
 
     info_parameter = resolver.info_parameter

--- a/tests/schema/extensions/schema_extensions/conftest.py
+++ b/tests/schema/extensions/schema_extensions/conftest.py
@@ -47,7 +47,7 @@ class ExampleExtension(SchemaExtension):
 def default_query_types_and_query() -> SchemaHelper:
     @strawberry.type
     class Person:
-        name: str = "Jess"
+        name: str = "Duck"
 
     @strawberry.type
     class Query:

--- a/tests/schema/extensions/schema_extensions/test_extensions.py
+++ b/tests/schema/extensions/schema_extensions/test_extensions.py
@@ -18,7 +18,7 @@ from .conftest import ExampleExtension, ExecType, SchemaHelper, hook_wrap
 def test_base_extension():
     @strawberry.type
     class Person:
-        name: str = "Jess"
+        name: str = "Duck"
 
     @strawberry.type
     class Query:
@@ -62,7 +62,7 @@ def test_called_only_if_overriden(monkeypatch: pytest.MonkeyPatch):
 
     @strawberry.type
     class Person:
-        name: str = "Jess"
+        name: str = "Duck"
 
     @strawberry.type
     class Query:
@@ -100,7 +100,7 @@ def test_extension_access_to_parsed_document():
 
     @strawberry.type
     class Person:
-        name: str = "Jess"
+        name: str = "Duck"
 
     @strawberry.type
     class Query:
@@ -135,7 +135,7 @@ def test_extension_access_to_errors():
 
     @strawberry.type
     class Person:
-        name: str = "Jess"
+        name: str = "Duck"
 
     @strawberry.type
     class Query:
@@ -288,7 +288,7 @@ async def test_mixed_sync_and_async_extension_hooks(
 
     @strawberry.type
     class Person:
-        name: str = "Jess"
+        name: str = "Duck"
 
     @strawberry.type
     class Query:

--- a/tests/schema/extensions/test_apollo.py
+++ b/tests/schema/extensions/test_apollo.py
@@ -21,7 +21,7 @@ def test_tracing_sync(mocker):
 
     @strawberry.type
     class Person:
-        name: str = "Jess"
+        name: str = "Duck"
 
     @strawberry.type
     class Query:
@@ -76,7 +76,7 @@ async def test_tracing_async(mocker):
 
     @strawberry.type
     class Person:
-        name: str = "Jess"
+        name: str = "Duck"
 
     @strawberry.type
     class Query:
@@ -143,7 +143,7 @@ def test_should_not_trace_introspection_sync_queries(mocker):
 
     @strawberry.type
     class Person:
-        name: str = "Jess"
+        name: str = "Duck"
 
     @strawberry.type
     class Query:
@@ -178,7 +178,7 @@ async def test_should_not_trace_introspection_async_queries(mocker):
 
     @strawberry.type
     class Person:
-        name: str = "Jess"
+        name: str = "Duck"
 
     @strawberry.type
     class Query:

--- a/tests/schema/extensions/test_opentelemetry.py
+++ b/tests/schema/extensions/test_opentelemetry.py
@@ -19,7 +19,7 @@ def global_tracer_mock(mocker: MockerFixture) -> MagicMock:
 
 @strawberry.type
 class Person:
-    name: str = "Jess"
+    name: str = "Duck"
 
 
 @strawberry.type

--- a/tests/schema/test_directives.py
+++ b/tests/schema/test_directives.py
@@ -16,7 +16,7 @@ from strawberry.utils.await_maybe import await_maybe
 def test_supports_default_directives():
     @strawberry.type
     class Person:
-        name: str = "Jess"
+        name: str = "Duck"
         points: int = 2000
 
     @strawberry.type
@@ -41,7 +41,7 @@ def test_supports_default_directives():
 
     assert not result.errors
     assert result.data
-    assert result.data["person"] == {"name": "Jess"}
+    assert result.data["person"] == {"name": "Duck"}
 
     query = """query ($skipPoints: Boolean!){
         person {
@@ -55,14 +55,14 @@ def test_supports_default_directives():
 
     assert not result.errors
     assert result.data
-    assert result.data["person"] == {"name": "Jess", "points": 2000}
+    assert result.data["person"] == {"name": "Duck", "points": 2000}
 
 
 @pytest.mark.asyncio
 async def test_supports_default_directives_async():
     @strawberry.type
     class Person:
-        name: str = "Jess"
+        name: str = "Duck"
         points: int = 2000
 
     @strawberry.type
@@ -83,7 +83,7 @@ async def test_supports_default_directives_async():
 
     assert not result.errors
     assert result.data
-    assert result.data["person"] == {"name": "Jess"}
+    assert result.data["person"] == {"name": "Duck"}
 
     query = """query ($skipPoints: Boolean!){
         person {
@@ -97,7 +97,7 @@ async def test_supports_default_directives_async():
 
     assert not result.errors
     assert result.data
-    assert result.data["person"] == {"name": "Jess", "points": 2000}
+    assert result.data["person"] == {"name": "Duck", "points": 2000}
 
 
 def test_can_declare_directives():
@@ -170,7 +170,7 @@ def test_directive_arguments_without_value_param():
 def test_runs_directives():
     @strawberry.type
     class Person:
-        name: str = "Jess"
+        name: str = "Duck"
 
     @strawberry.type
     class Query:
@@ -194,11 +194,14 @@ def test_runs_directives():
         person {
             name @turnUppercase
         }
-        jess: person {
-            name @replace(old: "Jess", new: "Jessica")
+        duck: person {
+            name @replace(old: "Duck", new: "Duck")
+        }
+        duckUpper: person {
+            name @replace(old: "Duck", new: "Duck") @turnUppercase
         }
         johnDoe: person {
-            name @replace(old: "Jess", new: "John") @include(if: $identified)
+            name @replace(old: "Duck", new: "John") @include(if: $identified)
         }
     }"""
 
@@ -206,15 +209,16 @@ def test_runs_directives():
 
     assert not result.errors
     assert result.data
-    assert result.data["person"]["name"] == "JESS"
-    assert result.data["jess"]["name"] == "Jessica"
+    assert result.data["person"]["name"] == "DUCK"
+    assert result.data["duck"]["name"] == "Duck"
+    assert result.data["duckUpper"]["name"] == "DUCK"
     assert result.data["johnDoe"].get("name") is None
 
 
 def test_runs_directives_camel_case_off():
     @strawberry.type
     class Person:
-        name: str = "Jess"
+        name: str = "Duck"
 
     @strawberry.type
     class Query:
@@ -242,11 +246,11 @@ def test_runs_directives_camel_case_off():
         person {
             name @turn_uppercase
         }
-        jess: person {
-            name @replace(old: "Jess", new: "Jessica")
+        duck: person {
+            name @replace(old: "Duck", new: "Duck")
         }
         johnDoe: person {
-            name @replace(old: "Jess", new: "John") @include(if: $identified)
+            name @replace(old: "Duck", new: "John") @include(if: $identified)
         }
     }"""
 
@@ -254,8 +258,8 @@ def test_runs_directives_camel_case_off():
 
     assert not result.errors
     assert result.data
-    assert result.data["person"]["name"] == "JESS"
-    assert result.data["jess"]["name"] == "Jessica"
+    assert result.data["person"]["name"] == "DUCK"
+    assert result.data["duck"]["name"] == "Duck"
     assert result.data["johnDoe"].get("name") is None
 
 
@@ -263,7 +267,7 @@ def test_runs_directives_camel_case_off():
 async def test_runs_directives_async():
     @strawberry.type
     class Person:
-        name: str = "Jess"
+        name: str = "Duck"
 
     @strawberry.type
     class Query:
@@ -289,14 +293,14 @@ async def test_runs_directives_async():
 
     assert not result.errors
     assert result.data
-    assert result.data["person"]["name"] == "JESS"
+    assert result.data["person"]["name"] == "DUCK"
 
 
 @pytest.mark.xfail
 def test_runs_directives_with_list_params():
     @strawberry.type
     class Person:
-        name: str = "Jess"
+        name: str = "Duck"
 
     @strawberry.type
     class Query:
@@ -323,13 +327,13 @@ def test_runs_directives_with_list_params():
 
     assert not result.errors
     assert result.data
-    assert result.data["person"]["name"] == "JESS"
+    assert result.data["person"]["name"] == "DUCK"
 
 
 def test_runs_directives_with_extensions():
     @strawberry.type
     class Person:
-        name: str = "Jess"
+        name: str = "Duck"
 
     @strawberry.type
     class Query:
@@ -361,14 +365,14 @@ def test_runs_directives_with_extensions():
 
     assert not result.errors
     assert result.data
-    assert result.data["person"]["name"] == "JESS"
+    assert result.data["person"]["name"] == "DUCK"
 
 
 @pytest.mark.asyncio
 async def test_runs_directives_with_extensions_async():
     @strawberry.type
     class Person:
-        name: str = "Jess"
+        name: str = "Duck"
 
     @strawberry.type
     class Query:
@@ -400,7 +404,7 @@ async def test_runs_directives_with_extensions_async():
 
     assert not result.errors
     assert result.data
-    assert result.data["person"]["name"] == "JESS"
+    assert result.data["person"]["name"] == "DUCK"
 
 
 @pytest.fixture
@@ -594,6 +598,162 @@ async def test_directive_list_argument() -> NoReturn:
     assert result.errors is None
     assert result.data
     assert result.data["greeting"] == "Hi foo, bar"
+
+
+@pytest.mark.parametrize(
+    ("query", "variable_values"),
+    [
+        (
+            """
+            query {
+                greeting @inspectArguments(
+                    inputValue: {
+                        integer: 3
+                        floatingPoint: 1.5
+                        flavor: VANILLA
+                        nestedInput: { snakeCaseValue: 7 }
+                        parsed: "raw"
+                        integers: [1, 2]
+                    }
+                )
+            }
+            """,
+            None,
+        ),
+        (
+            """
+            query InspectArguments($inputValue: DirectiveInput!) {
+                greeting @inspectArguments(
+                    inputValue: $inputValue
+                )
+            }
+            """,
+            {
+                "inputValue": {
+                    "integer": 3,
+                    "floatingPoint": 1.5,
+                    "flavor": "VANILLA",
+                    "nestedInput": {"snakeCaseValue": 7},
+                    "parsed": "raw",
+                    "integers": [1, 2],
+                },
+            },
+        ),
+    ],
+)
+def test_directive_arguments_are_coerced_and_converted(
+    query: str, variable_values: dict[str, Any] | None
+) -> None:
+    @strawberry.enum
+    class Flavor(Enum):
+        VANILLA = "vanilla"
+        CHOCOLATE = "chocolate"
+
+    ParsedScalar = strawberry.scalar(
+        str,
+        name="ParsedScalar",
+        serialize=str,
+        parse_value=lambda value: f"parsed:{value}",
+    )
+
+    @strawberry.input
+    class NestedDirectiveInput:
+        snake_case_value: int
+
+    @strawberry.input
+    class DirectiveInput:
+        integer: int
+        floating_point: float
+        flavor: Flavor
+        nested_input: NestedDirectiveInput
+        parsed: ParsedScalar
+        integers: list[int]
+
+    received_arguments: list[DirectiveInput] = []
+
+    @strawberry.directive(locations=[DirectiveLocation.FIELD])
+    def inspect_arguments(
+        value: DirectiveValue[str],
+        input_value: DirectiveInput,
+    ) -> str:
+        received_arguments.append(input_value)
+        return value
+
+    @strawberry.type
+    class Query:
+        greeting: str = "Hi"
+
+    schema = strawberry.Schema(query=Query, directives=[inspect_arguments])
+    result = schema.execute_sync(
+        query, root_value=Query(), variable_values=variable_values
+    )
+
+    assert result.errors is None
+    assert result.data == {"greeting": "Hi"}
+    assert received_arguments == [
+        DirectiveInput(
+            integer=3,
+            floating_point=1.5,
+            flavor=Flavor.VANILLA,
+            nested_input=NestedDirectiveInput(snake_case_value=7),
+            parsed="parsed:raw",
+            integers=[1, 2],
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    ("query", "variable_values", "expected"),
+    [
+        ("{ greeting @captureDefault }", None, "fallback"),
+        (
+            "query($label: String) { greeting @captureDefault(label: $label) }",
+            {},
+            "fallback",
+        ),
+        (
+            """
+            query($label: String = "variable default") {
+                greeting @captureDefault(label: $label)
+            }
+            """,
+            {},
+            "variable default",
+        ),
+        ("{ greeting @captureDefault(label: null) }", None, None),
+        (
+            "query($label: String) { greeting @captureDefault(label: $label) }",
+            {"label": None},
+            None,
+        ),
+    ],
+)
+def test_directive_argument_defaults_distinguish_omitted_values_from_null(
+    query: str,
+    variable_values: dict[str, Any] | None,
+    expected: str | None,
+) -> None:
+    received_labels: list[str | None] = []
+
+    @strawberry.directive(locations=[DirectiveLocation.FIELD])
+    def capture_default(
+        value: DirectiveValue[str], label: str | None = "fallback"
+    ) -> str:
+        received_labels.append(label)
+        return value
+
+    @strawberry.type
+    class Query:
+        greeting: str = "Hi"
+
+    schema = strawberry.Schema(query=Query, directives=[capture_default])
+    result = schema.execute_sync(
+        query, root_value=Query(), variable_values=variable_values
+    )
+
+    assert result.errors is None
+    assert result.data == {"greeting": "Hi"}
+    assert received_labels == [expected]
 
 
 def test_directives_with_custom_types():


### PR DESCRIPTION
## Summary

- coerce operation directive arguments with graphql-core before invoking resolvers
- convert coerced values through Strawberry's normal argument conversion path so resolvers receive Python numeric values, enum members, nested input objects, and parsed custom scalars
- apply directive defaults for omitted variables while preserving explicit null values
- cover literal and variable inputs, lists, directive chaining, and graphql-core 3.2/3.3 compatibility
- update directive examples and related test fixtures to use Duck

## Testing

- `uv run pytest tests/schema/test_directives.py tests/schema/extensions/schema_extensions tests/schema/extensions/test_apollo.py tests/schema/extensions/test_opentelemetry.py -q` (88 passed, 7 skipped, 1 existing xfailed)
- `uv run --with graphql-core==3.3.0rc0 --no-sync pytest tests/schema/test_directives.py -q` (26 passed, 1 existing xfailed)
- mypy under graphql-core 3.2.11 and 3.3.0rc0
- ruff check and format
- pre-commit hooks for all changed files

## Summary by Sourcery

Fix operation directive argument coercion so directive resolvers receive correctly typed values and preserve GraphQL default and null semantics.

Bug Fixes:
- Correct operation directive argument handling so resolvers receive GraphQL-coerced and Strawberry-converted values for literals, variables, lists, enums, nested inputs, custom scalars, defaults, and explicit nulls.

Enhancements:
- Maintain operation directive argument coercion compatibility across graphql-core 3.2 and 3.3.

Documentation:
- Update operation directive examples and release notes to document correctly typed arguments and default handling.

Tests:
- Add coverage for directive argument coercion, nested values, custom scalars, directive chaining, variables, defaults, and explicit null values.

Chores:
- Update related directive and extension fixtures to use Duck consistently.