### PR TITLE
Add strawberry.Info support to schema extensions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,23 @@
+---
+release type: minor
+social_messages:
+  x: >-
+    {project_name} {version} is out! Schema extensions can now use
+    strawberry.Info, with a compatibility warning and codemod for legacy
+    GraphQLResolveInfo hooks. 🍓 https://strawberry.rocks/release/{version}
+  linkedin: >-
+    {project_name} {version} is out. Schema extension resolvers can now opt into
+    strawberry.Info, including custom Info classes, while a codemod provides a
+    behavior-preserving migration from GraphQLResolveInfo.
+---
+
+This release adds `strawberry.Info` support to schema extension resolvers.
+
+Annotating `SchemaExtension.resolve` with `strawberry.Info` now passes the same
+configured Info type used by field resolvers. Existing unannotated and
+`GraphQLResolveInfo` extension resolvers continue to receive the graphql-core
+object, with a deprecation warning ahead of Strawberry 2.
+
+Run `strawberry upgrade schema-extension-info .` to opt direct schema extension
+subclasses into Strawberry Info while preserving their existing raw Info
+behavior.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,7 +16,7 @@ This release adds `strawberry.Info` support to schema extension resolvers.
 Annotating `SchemaExtension.resolve` with `strawberry.Info` now passes the same
 configured Info type used by field resolvers. Existing unannotated and
 `GraphQLResolveInfo` extension resolvers continue to receive the graphql-core
-object, with a deprecation warning ahead of Strawberry 2.
+object, with a deprecation warning ahead of Strawberry 1.0.
 
 Run `strawberry upgrade schema-extension-info .` to opt direct schema extension
 subclasses into Strawberry Info while preserving their existing raw Info

--- a/docs/guides/custom-extensions.md
+++ b/docs/guides/custom-extensions.md
@@ -103,8 +103,8 @@ Because those fields have no Strawberry return type, `return_type` raises a
 
 An unannotated `info` parameter, or one annotated as `GraphQLResolveInfo`, keeps
 the previous runtime behavior for compatibility but emits a
-`DeprecationWarning`. This compatibility behavior will be removed in
-Strawberry 2.
+`DeprecationWarning`. This compatibility behavior will be removed in Strawberry
+1.0.
 
 The upgrade command opts direct `SchemaExtension` subclasses into
 `strawberry.Info` while preserving their existing use of the raw object:

--- a/docs/guides/custom-extensions.md
+++ b/docs/guides/custom-extensions.md
@@ -80,13 +80,68 @@ check out [field extensions](field-extensions.md).
 Note that `resolve` can also be implemented asynchronously.
 
 ```python
-from graphql import GraphQLResolveInfo
+import strawberry
 from strawberry.extensions import SchemaExtension
 
 
 class MyExtension(SchemaExtension):
-    def resolve(self, _next, root, info: GraphQLResolveInfo, *args, **kwargs):
+    def resolve(self, _next, root, info: strawberry.Info, *args, **kwargs):
         return _next(root, info, *args, **kwargs)
+```
+
+Annotating `info` with `strawberry.Info` opts the extension into Strawberry's
+Info API, including a custom `info_class` configured on the schema. Access the
+underlying graphql-core object with `info._raw_info` when integrating with an
+API that requires `GraphQLResolveInfo`.
+
+For graphql-core-only fields such as introspection fields, `python_name` falls
+back to the GraphQL field name and `get_argument_definition` returns `None`.
+Because those fields have no Strawberry return type, `return_type` raises a
+`ValueError`; use `info._raw_info.return_type` when handling them.
+
+#### Migrating from `GraphQLResolveInfo`
+
+An unannotated `info` parameter, or one annotated as `GraphQLResolveInfo`, keeps
+the previous runtime behavior for compatibility but emits a
+`DeprecationWarning`. This compatibility behavior will be removed in
+Strawberry 2.
+
+The upgrade command opts direct `SchemaExtension` subclasses into
+`strawberry.Info` while preserving their existing use of the raw object:
+
+```shell
+strawberry upgrade schema-extension-info .
+```
+
+For example, the codemod renames the new parameter and retains `info` as an
+alias for the graphql-core object. This makes the automated change
+behavior-preserving and leaves semantic cleanup to a follow-up review:
+
+```python
+class MyExtension(SchemaExtension):
+    def resolve(self, _next, root, strawberry_info: strawberry.Info, **kwargs):
+        info = strawberry_info._raw_info
+        return _next(root, info, **kwargs)
+```
+
+Indirect subclasses must be reviewed manually; unrecognized annotations on
+direct subclasses are reported by the codemod. The following prompt can be given
+to a coding agent after running the codemod:
+
+```text
+Find all SchemaExtension subclasses that override resolve. Ensure the Info
+parameter is annotated as strawberry.Info and preserve every _next call.
+
+Replace access through info._raw_info with Strawberry Info properties when they
+are equivalent: field_name, context, root_value, variable_values, operation,
+and path. Review schema and return_type carefully because Strawberry and
+graphql-core expose different objects for those properties. Keep _raw_info for
+parent_type, field_nodes, fragments, is_awaitable, graphql-core helpers, and
+APIs that explicitly require GraphQLResolveInfo.
+
+Do not modify FieldExtension classes. Run the affected sync and async extension
+tests, including custom info_class, mixed legacy/new extension chains, and
+introspection queries.
 ```
 
 ### Get results

--- a/strawberry/cli/commands/upgrade/__init__.py
+++ b/strawberry/cli/commands/upgrade/__init__.py
@@ -12,6 +12,7 @@ from strawberry.cli.app import app
 from strawberry.codemods.annotated_unions import ConvertUnionToAnnotatedUnion
 from strawberry.codemods.maybe_optional import ConvertMaybeToOptional
 from strawberry.codemods.replace_scalar_wrappers import ReplaceScalarWrappers
+from strawberry.codemods.schema_extension_info import ConvertSchemaExtensionInfo
 from strawberry.codemods.update_imports import UpdateImportsCodemod
 
 from ._run_codemod import run_codemod
@@ -21,6 +22,7 @@ codemods = {
     "update-imports": UpdateImportsCodemod,
     "maybe-optional": ConvertMaybeToOptional,
     "replace-scalar-wrappers": ReplaceScalarWrappers,
+    "schema-extension-info": ConvertSchemaExtensionInfo,
 }
 
 
@@ -55,6 +57,7 @@ def upgrade(
         | ReplaceScalarWrappers
         | ConvertMaybeToOptional
         | ConvertUnionToAnnotatedUnion
+        | ConvertSchemaExtensionInfo
     )
 
     if codemod == "update-imports":
@@ -63,6 +66,8 @@ def upgrade(
         transformer = ReplaceScalarWrappers(context=context)
     elif codemod == "maybe-optional":
         transformer = ConvertMaybeToOptional(context=context)
+    elif codemod == "schema-extension-info":
+        transformer = ConvertSchemaExtensionInfo(context=context)
     else:
         transformer = ConvertUnionToAnnotatedUnion(
             context,
@@ -83,6 +88,17 @@ def upgrade(
 
     results = list(run_codemod(transformer, files))
     changed = [result for result in results if result.changed]
+    warnings = [
+        (result.filename, warning)
+        for result in results
+        for warning in result.transform_result.warning_messages
+    ]
+
+    if warnings:
+        rich.print()
+        rich.print("[yellow]Warnings:")
+        for filename, warning in warnings:
+            rich.print(f"  - {filename}: {warning}")
 
     rich.print()
     rich.print("[green]Upgrade completed successfully, here's a summary:")

--- a/strawberry/codemods/__init__.py
+++ b/strawberry/codemods/__init__.py
@@ -1,10 +1,12 @@
 from .annotated_unions import ConvertUnionToAnnotatedUnion
 from .maybe_optional import ConvertMaybeToOptional
 from .replace_scalar_wrappers import ReplaceScalarWrappers
+from .schema_extension_info import ConvertSchemaExtensionInfo
 from .update_imports import UpdateImportsCodemod
 
 __all__ = [
     "ConvertMaybeToOptional",
+    "ConvertSchemaExtensionInfo",
     "ConvertUnionToAnnotatedUnion",
     "ReplaceScalarWrappers",
     "UpdateImportsCodemod",

--- a/strawberry/codemods/schema_extension_info.py
+++ b/strawberry/codemods/schema_extension_info.py
@@ -1,0 +1,299 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import libcst as cst
+from libcst.codemod import CodemodContext, VisitorBasedCodemodCommand
+from libcst.codemod.visitors import AddImportsVisitor, RemoveImportsVisitor
+from libcst.helpers import get_full_name_for_node
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+def _imported_name(alias: cst.ImportAlias) -> str | None:
+    if alias.asname and isinstance(alias.asname.name, cst.Name):
+        return alias.asname.name.value
+    if isinstance(alias.name, cst.Name):
+        return alias.name.value
+    return None
+
+
+class _NameCollector(cst.CSTVisitor):
+    def __init__(self) -> None:
+        self.names: set[str] = set()
+
+    def visit_Name(self, node: cst.Name) -> None:  # noqa: N802
+        self.names.add(node.value)
+
+
+class ConvertSchemaExtensionInfo(VisitorBasedCodemodCommand):
+    DESCRIPTION = (
+        "Opts SchemaExtension.resolve into strawberry.Info while preserving its "
+        "existing graphql-core Info behavior."
+    )
+
+    def __init__(self, context: CodemodContext) -> None:
+        super().__init__(context)
+        self._schema_extension_names: set[str] = set()
+        self._strawberry_info_names: set[str] = set()
+        self._graphql_info_names: set[str] = {"GraphQLResolveInfo"}
+        self._graphql_info_imports: dict[str, tuple[str, str | None]] = {}
+        self._strawberry_module_names: set[str] = {"strawberry"}
+        self._class_stack: list[bool] = []
+        self._class_function_depths: list[int] = []
+        self._function_depth = 0
+
+    def visit_Import(self, node: cst.Import) -> None:  # noqa: N802
+        for alias in node.names:
+            imported_module = get_full_name_for_node(alias.name)
+            if imported_module == "strawberry":
+                self._strawberry_module_names.add(_imported_name(alias) or "strawberry")
+            elif (
+                imported_module
+                in {
+                    "strawberry.extensions",
+                    "strawberry.extensions.base_extension",
+                }
+                and alias.asname
+            ):
+                imported_name = _imported_name(alias)
+                if imported_name:
+                    self._schema_extension_names.add(f"{imported_name}.SchemaExtension")
+
+    def visit_ImportFrom(self, node: cst.ImportFrom) -> None:  # noqa: N802
+        module_name = get_full_name_for_node(node.module) if node.module else None
+        if isinstance(node.names, cst.ImportStar):
+            return
+
+        for alias in node.names:
+            original_name = get_full_name_for_node(alias.name)
+            imported_name = _imported_name(alias)
+            if original_name is None or imported_name is None:
+                continue
+
+            if (
+                module_name
+                in {
+                    "strawberry.extensions",
+                    "strawberry.extensions.base_extension",
+                }
+                and original_name == "SchemaExtension"
+            ):
+                self._schema_extension_names.add(imported_name)
+            elif (
+                module_name
+                in {"strawberry", "strawberry.types", "strawberry.types.info"}
+                and original_name == "Info"
+            ):
+                self._strawberry_info_names.add(imported_name)
+            elif (
+                module_name in {"graphql", "graphql.type"}
+                and original_name == "GraphQLResolveInfo"
+            ):
+                self._graphql_info_names.add(imported_name)
+                self._graphql_info_imports[imported_name] = (
+                    module_name,
+                    imported_name if imported_name != original_name else None,
+                )
+
+    def visit_ClassDef(self, node: cst.ClassDef) -> None:  # noqa: N802
+        self._class_stack.append(
+            any(self._is_schema_extension_base(base.value) for base in node.bases)
+        )
+        self._class_function_depths.append(self._function_depth)
+
+    def leave_ClassDef(  # noqa: N802
+        self, original_node: cst.ClassDef, updated_node: cst.ClassDef
+    ) -> cst.ClassDef:
+        self._class_stack.pop()
+        self._class_function_depths.pop()
+        return updated_node
+
+    def visit_FunctionDef(self, node: cst.FunctionDef) -> None:  # noqa: N802
+        self._function_depth += 1
+
+    def leave_FunctionDef(  # noqa: N802
+        self, original_node: cst.FunctionDef, updated_node: cst.FunctionDef
+    ) -> cst.FunctionDef:
+        is_direct_class_method = (
+            bool(self._class_function_depths)
+            and self._function_depth == self._class_function_depths[-1] + 1
+        )
+        self._function_depth -= 1
+        if (
+            not self._class_stack
+            or not self._class_stack[-1]
+            or not is_direct_class_method
+            or original_node.name.value != "resolve"
+        ):
+            return updated_node
+
+        parameter = self._find_info_parameter(updated_node.params)
+        if parameter is None:
+            self.warn(
+                "Skipped SchemaExtension.resolve because its info parameter "
+                "could not be identified."
+            )
+            return updated_node
+
+        annotation_kind = self._annotation_kind(parameter.annotation)
+        if annotation_kind == "strawberry":
+            return updated_node
+        if annotation_kind == "unknown":
+            self.warn(
+                f"Skipped {original_node.name.value}: the annotation on "
+                f"`{parameter.name.value}` is not a recognized graphql-core Info type."
+            )
+            return updated_node
+
+        collector = _NameCollector()
+        updated_node.visit(collector)
+        strawberry_info_name = "strawberry_info"
+        while strawberry_info_name in collector.names:
+            strawberry_info_name = f"_{strawberry_info_name}"
+
+        original_info_name = parameter.name.value
+        updated_parameter = parameter.with_changes(
+            name=cst.Name(strawberry_info_name),
+            annotation=cst.Annotation(
+                cst.Attribute(
+                    value=cst.Name("strawberry"),
+                    attr=cst.Name("Info"),
+                )
+            ),
+        )
+        updated_params = self._replace_parameter(
+            updated_node.params, parameter, updated_parameter
+        )
+        updated_body = self._add_raw_info_alias(
+            updated_node.body,
+            original_info_name=original_info_name,
+            strawberry_info_name=strawberry_info_name,
+        )
+
+        AddImportsVisitor.add_needed_import(self.context, "strawberry")
+        RemoveImportsVisitor.remove_unused_import(
+            self.context, "graphql", "GraphQLResolveInfo"
+        )
+        RemoveImportsVisitor.remove_unused_import(
+            self.context, "graphql.type", "GraphQLResolveInfo"
+        )
+        annotation_name = (
+            get_full_name_for_node(parameter.annotation.annotation)
+            if parameter.annotation
+            else None
+        )
+        if annotation_name in self._graphql_info_imports:
+            module_name, asname = self._graphql_info_imports[annotation_name]
+            RemoveImportsVisitor.remove_unused_import(
+                self.context,
+                module_name,
+                "GraphQLResolveInfo",
+                asname=asname,
+            )
+
+        return updated_node.with_changes(params=updated_params, body=updated_body)
+
+    def _is_schema_extension_base(self, node: cst.BaseExpression) -> bool:
+        name = get_full_name_for_node(node)
+        if name is None:
+            return False
+        if name in self._schema_extension_names:
+            return True
+        return any(
+            name == f"{module_name}.extensions.SchemaExtension"
+            for module_name in self._strawberry_module_names
+        )
+
+    def _annotation_kind(self, annotation: cst.Annotation | None) -> str:
+        if annotation is None:
+            return "graphql"
+
+        name = get_full_name_for_node(annotation.annotation)
+        if name in self._strawberry_info_names:
+            return "strawberry"
+        if name in self._graphql_info_names or name in {
+            "graphql.GraphQLResolveInfo",
+            "graphql.type.GraphQLResolveInfo",
+            "Any",
+            "typing.Any",
+            "object",
+        }:
+            return "graphql"
+        if any(
+            name == f"{module_name}.Info"
+            for module_name in self._strawberry_module_names
+        ):
+            return "strawberry"
+        return "unknown"
+
+    @staticmethod
+    def _find_info_parameter(params: cst.Parameters) -> cst.Param | None:
+        parameters = [*params.posonly_params, *params.params, *params.kwonly_params]
+        return next(
+            (parameter for parameter in parameters if parameter.name.value == "info"),
+            parameters[3] if len(parameters) > 3 else None,
+        )
+
+    @staticmethod
+    def _replace_parameter(
+        params: cst.Parameters,
+        original: cst.Param,
+        replacement: cst.Param,
+    ) -> cst.Parameters:
+        def replace(parameters: Sequence[cst.Param]) -> tuple[cst.Param, ...]:
+            return tuple(
+                replacement if parameter is original else parameter
+                for parameter in parameters
+            )
+
+        return params.with_changes(
+            posonly_params=replace(params.posonly_params),
+            params=replace(params.params),
+            kwonly_params=replace(params.kwonly_params),
+        )
+
+    @staticmethod
+    def _add_raw_info_alias(
+        body: cst.BaseSuite,
+        *,
+        original_info_name: str,
+        strawberry_info_name: str,
+    ) -> cst.BaseSuite:
+        assignment = cst.SimpleStatementLine(
+            body=[
+                cst.Assign(
+                    targets=[cst.AssignTarget(cst.Name(original_info_name))],
+                    value=cst.Attribute(
+                        value=cst.Name(strawberry_info_name),
+                        attr=cst.Name("_raw_info"),
+                    ),
+                )
+            ]
+        )
+
+        if isinstance(body, cst.SimpleStatementSuite):
+            return cst.IndentedBlock(
+                body=[assignment, cst.SimpleStatementLine(body=body.body)]
+            )
+
+        assert isinstance(body, cst.IndentedBlock)
+        statements = list(body.body)
+        insertion_index = 1 if statements and _is_docstring(statements[0]) else 0
+        statements.insert(insertion_index, assignment)
+        return body.with_changes(body=statements)
+
+
+def _is_docstring(statement: cst.BaseStatement) -> bool:
+    return (
+        isinstance(statement, cst.SimpleStatementLine)
+        and len(statement.body) == 1
+        and isinstance(statement.body[0], cst.Expr)
+        and isinstance(
+            statement.body[0].value, (cst.SimpleString, cst.ConcatenatedString)
+        )
+    )
+
+
+__all__ = ["ConvertSchemaExtensionInfo"]

--- a/strawberry/extensions/base_extension.py
+++ b/strawberry/extensions/base_extension.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from enum import Enum
+from functools import cache
 from typing import TYPE_CHECKING, Any
 
 from strawberry.types import StreamExecutionResult
+from strawberry.types.fields.resolver import StrawberryResolver
 from strawberry.utils.await_maybe import AsyncIteratorOrIterator, AwaitableOrValue
 
 if TYPE_CHECKING:
-    from graphql import GraphQLResolveInfo
-
     from strawberry.types import ExecutionContext
 
 
@@ -66,7 +66,7 @@ class SchemaExtension:
         self,
         _next: Callable,
         root: Any,
-        info: GraphQLResolveInfo,
+        info: Any,
         *args: str,
         **kwargs: Any,
     ) -> AwaitableOrValue[object]:
@@ -79,6 +79,12 @@ class SchemaExtension:
     def _implements_resolve(cls) -> bool:
         """Whether the extension implements the resolve method."""
         return cls.resolve is not SchemaExtension.resolve
+
+    @classmethod
+    @cache
+    def _uses_strawberry_info(cls) -> bool:
+        """Whether ``resolve`` requests Strawberry's Info wrapper."""
+        return StrawberryResolver(cls.resolve).info_parameter is not None
 
 
 Hook = (

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -609,16 +609,27 @@ class Schema(BaseSchema):
         # Build a fresh middleware manager per request: the manager holds
         # references to extension instances, which are now constructed
         # per-request to avoid concurrency leaks (see #4369).
-        return MiddlewareManager(
-            *(
-                self._get_extension_middleware(extension)
-                for extension in extensions
-                if extension._implements_resolve()
-            )
-        )
+        middleware: list[SchemaExtension | Callable[..., Any]] = []
+        # graphql-core wraps each middleware around the ones already added.
+        inner_uses_strawberry_info: bool | None = None
+        for extension in extensions:
+            if extension._implements_resolve():
+                uses_strawberry_info = extension._uses_strawberry_info()
+                middleware.append(
+                    self._get_extension_middleware(
+                        extension,
+                        inner_uses_strawberry_info=inner_uses_strawberry_info,
+                    )
+                )
+                inner_uses_strawberry_info = uses_strawberry_info
+
+        return MiddlewareManager(*middleware)
 
     def _get_extension_middleware(
-        self, extension: SchemaExtension
+        self,
+        extension: SchemaExtension,
+        *,
+        inner_uses_strawberry_info: bool | None,
     ) -> SchemaExtension | Callable[..., Any]:
         if not extension._uses_strawberry_info():
             extension_type = type(extension)
@@ -646,31 +657,48 @@ class Schema(BaseSchema):
                 )
             return extension
 
+        extension_resolver = cast("Callable[..., Any]", extension.resolve)
+
         def middleware(
             next_: Callable[..., Any],
             root: Any,
-            raw_info: GraphQLResolveInfo,
+            raw_info: GraphQLResolveInfo | Info,
             *args: str,
             **kwargs: Any,
         ) -> Any:
-            field = self.get_field_for_type(
-                field_name=raw_info.field_name,
-                type_name=raw_info.parent_type.name,
+            if isinstance(raw_info, Info):
+                info = raw_info
+            else:
+                graphql_field = raw_info.parent_type.fields.get(raw_info.field_name)
+                field = cast(
+                    "StrawberryField | None",
+                    graphql_field.extensions.get(
+                        GraphQLCoreConverter.DEFINITION_BACKREF
+                    )
+                    if graphql_field
+                    else None,
+                )
+                info = self.config.info_class(_raw_info=raw_info, _field=field)
+
+            next_requires_graphql_info = inner_uses_strawberry_info is False or (
+                inner_uses_strawberry_info is None and info._field is None
             )
-            info = self.config.info_class(_raw_info=raw_info, _field=field)
+            if next_requires_graphql_info:
+                raw_next = next_
 
-            def adapted_next(
-                next_root: Any,
-                next_info: Info | GraphQLResolveInfo,
-                *next_args: str,
-                **next_kwargs: Any,
-            ) -> Any:
-                if isinstance(next_info, Info):
-                    next_info = next_info._raw_info
-                return next_(next_root, next_info, *next_args, **next_kwargs)
+                def adapted_next(
+                    next_root: Any,
+                    next_info: Info | GraphQLResolveInfo,
+                    *next_args: str,
+                    **next_kwargs: Any,
+                ) -> Any:
+                    if isinstance(next_info, Info):
+                        next_info = next_info._raw_info
+                    return raw_next(next_root, next_info, *next_args, **next_kwargs)
 
-            extension_resolver = cast("Callable[..., Any]", extension.resolve)
-            return extension_resolver(adapted_next, root, info, *args, **kwargs)
+                next_ = adapted_next
+
+            return extension_resolver(next_, root, info, *args, **kwargs)
 
         return middleware
 

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -63,6 +63,7 @@ from strawberry.types.execution import (
     PreExecutionError,
 )
 from strawberry.types.graphql import OperationType
+from strawberry.types.info import Info
 from strawberry.utils import IS_GQL_32, IS_GQL_33
 from strawberry.utils.aio import aclosing
 from strawberry.utils.await_maybe import await_maybe
@@ -124,6 +125,7 @@ DEFAULT_ALLOWED_OPERATION_TYPES = {
     OperationType.MUTATION,
     OperationType.SUBSCRIPTION,
 }
+_WARNED_GRAPHQL_INFO_EXTENSIONS: set[type[SchemaExtension]] = set()
 ProcessErrors: TypeAlias = (
     "Callable[[list[GraphQLError], ExecutionContext | None], None]"
 )
@@ -606,8 +608,66 @@ class Schema(BaseSchema):
         # references to extension instances, which are now constructed
         # per-request to avoid concurrency leaks (see #4369).
         return MiddlewareManager(
-            *(ext for ext in extensions if ext._implements_resolve())
+            *(
+                self._get_extension_middleware(extension)
+                for extension in extensions
+                if extension._implements_resolve()
+            )
         )
+
+    def _get_extension_middleware(
+        self, extension: SchemaExtension
+    ) -> SchemaExtension | Callable[..., Any]:
+        if not extension._uses_strawberry_info():
+            extension_type = type(extension)
+            resolver_module = extension_type.resolve.__module__
+            if (
+                extension_type not in _WARNED_GRAPHQL_INFO_EXTENSIONS
+                and not resolver_module.startswith("strawberry.extensions.")
+            ):
+                _WARNED_GRAPHQL_INFO_EXTENSIONS.add(extension_type)
+                warnings.warn(
+                    (
+                        f"{extension_type.__qualname__}.resolve receives "
+                        "GraphQLResolveInfo, which is deprecated. Annotate its "
+                        "`info` parameter as `strawberry.Info` to use Strawberry's "
+                        "Info API. Run `strawberry upgrade schema-extension-info .` "
+                        "for an automated migration. The raw graphql-core object "
+                        "remains available as `info._raw_info`. Support for the "
+                        "legacy behavior will be removed in Strawberry 2."
+                    ),
+                    DeprecationWarning,
+                    stacklevel=4,
+                )
+            return extension
+
+        def middleware(
+            next_: Callable[..., Any],
+            root: Any,
+            raw_info: GraphQLResolveInfo,
+            *args: str,
+            **kwargs: Any,
+        ) -> Any:
+            field = self.get_field_for_type(
+                field_name=raw_info.field_name,
+                type_name=raw_info.parent_type.name,
+            )
+            info = self.config.info_class(_raw_info=raw_info, _field=field)
+
+            def adapted_next(
+                next_root: Any,
+                next_info: Info | GraphQLResolveInfo,
+                *next_args: str,
+                **next_kwargs: Any,
+            ) -> Any:
+                if isinstance(next_info, Info):
+                    next_info = next_info._raw_info
+                return next_(next_root, next_info, *next_args, **next_kwargs)
+
+            extension_resolver = cast("Callable[..., Any]", extension.resolve)
+            return extension_resolver(adapted_next, root, info, *args, **kwargs)
+
+        return middleware
 
     def _create_execution_context(  # noqa: PLR0917
         self,

--- a/strawberry/schema/schema.py
+++ b/strawberry/schema/schema.py
@@ -6,6 +6,7 @@ from asyncio import ensure_future
 from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable, Iterable
 from functools import lru_cache
 from inspect import isawaitable
+from threading import Lock
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -126,6 +127,7 @@ DEFAULT_ALLOWED_OPERATION_TYPES = {
     OperationType.SUBSCRIPTION,
 }
 _WARNED_GRAPHQL_INFO_EXTENSIONS: set[type[SchemaExtension]] = set()
+_WARNED_GRAPHQL_INFO_EXTENSIONS_LOCK = Lock()
 ProcessErrors: TypeAlias = (
     "Callable[[list[GraphQLError], ExecutionContext | None], None]"
 )
@@ -621,11 +623,14 @@ class Schema(BaseSchema):
         if not extension._uses_strawberry_info():
             extension_type = type(extension)
             resolver_module = extension_type.resolve.__module__
-            if (
-                extension_type not in _WARNED_GRAPHQL_INFO_EXTENSIONS
-                and not resolver_module.startswith("strawberry.extensions.")
-            ):
-                _WARNED_GRAPHQL_INFO_EXTENSIONS.add(extension_type)
+            should_warn = False
+            if not resolver_module.startswith("strawberry.extensions."):
+                with _WARNED_GRAPHQL_INFO_EXTENSIONS_LOCK:
+                    if extension_type not in _WARNED_GRAPHQL_INFO_EXTENSIONS:
+                        _WARNED_GRAPHQL_INFO_EXTENSIONS.add(extension_type)
+                        should_warn = True
+
+            if should_warn:
                 warnings.warn(
                     (
                         f"{extension_type.__qualname__}.resolve receives "
@@ -634,7 +639,7 @@ class Schema(BaseSchema):
                         "Info API. Run `strawberry upgrade schema-extension-info .` "
                         "for an automated migration. The raw graphql-core object "
                         "remains available as `info._raw_info`. Support for the "
-                        "legacy behavior will be removed in Strawberry 2."
+                        "legacy behavior will be removed in Strawberry 1.0."
                     ),
                     DeprecationWarning,
                     stacklevel=4,

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -71,6 +71,7 @@ from strawberry.types.base import (
 from strawberry.types.cast import get_strawberry_type_cast
 from strawberry.types.enum import StrawberryEnumDefinition, has_enum_definition
 from strawberry.types.field import UNRESOLVED
+from strawberry.types.info import Info
 from strawberry.types.lazy_type import LazyType
 from strawberry.types.private import is_private
 from strawberry.types.scalar import ScalarWrapper, scalar
@@ -98,7 +99,6 @@ if TYPE_CHECKING:
     from strawberry.schema_directive import StrawberrySchemaDirective
     from strawberry.types.enum import EnumValue
     from strawberry.types.field import StrawberryField
-    from strawberry.types.info import Info
     from strawberry.types.scalar import ScalarDefinition
 
 
@@ -904,7 +904,11 @@ class GraphQLCoreConverter:
 
             return _get_basic_result
 
-        def _strawberry_info_from_graphql(info: GraphQLResolveInfo) -> Info:
+        def _strawberry_info_from_graphql(
+            info: GraphQLResolveInfo | Info,
+        ) -> Info:
+            if isinstance(info, Info):
+                return info
             return self.config.info_class(
                 _raw_info=info,
                 _field=field,
@@ -1048,7 +1052,9 @@ class GraphQLCoreConverter:
 
         _get_result_with_extensions = wrap_field_extensions()
 
-        def _resolver(_source: Any, info: GraphQLResolveInfo, **kwargs: Any) -> Any:
+        def _resolver(
+            _source: Any, info: GraphQLResolveInfo | Info, **kwargs: Any
+        ) -> Any:
             strawberry_info = _strawberry_info_from_graphql(info)
 
             if not field_exception_handlers:
@@ -1068,7 +1074,7 @@ class GraphQLCoreConverter:
             )
 
         async def _async_resolver(
-            _source: Any, info: GraphQLResolveInfo, **kwargs: Any
+            _source: Any, info: GraphQLResolveInfo | Info, **kwargs: Any
         ) -> Any:
             strawberry_info = _strawberry_info_from_graphql(info)
 

--- a/strawberry/types/info.py
+++ b/strawberry/types/info.py
@@ -58,6 +58,7 @@ class Info(Generic[ContextType, RootValueType]):
     """
 
     _raw_info: GraphQLResolveInfo
+    # graphql-core-only fields, such as introspection fields, have no StrawberryField.
     _field: StrawberryField | None
 
     def __class_getitem__(cls, types: type | tuple[type, ...]) -> type[Info]:

--- a/strawberry/types/info.py
+++ b/strawberry/types/info.py
@@ -58,7 +58,7 @@ class Info(Generic[ContextType, RootValueType]):
     """
 
     _raw_info: GraphQLResolveInfo
-    _field: StrawberryField
+    _field: StrawberryField | None
 
     def __class_getitem__(cls, types: type | tuple[type, ...]) -> type[Info]:
         """Workaround for when passing only one type.
@@ -115,11 +115,18 @@ class Info(Generic[ContextType, RootValueType]):
         self,
     ) -> FieldType:
         """The return type of the current field being resolved."""
+        if self._field is None:
+            raise ValueError(
+                "This graphql-core field has no Strawberry return type. "
+                "Use `info._raw_info.return_type` instead."
+            )
         return self._field.type
 
     @property
     def python_name(self) -> str:
         """The name of the current field being resolved in Python format."""
+        if self._field is None:
+            return self.field_name
         return self._field.python_name
 
     # TODO: create an abstraction on these fields
@@ -146,6 +153,8 @@ class Info(Generic[ContextType, RootValueType]):
     # Helper functions
     def get_argument_definition(self, name: str) -> StrawberryArgument | None:
         """Get the StrawberryArgument definition for the current field by name."""
+        if self._field is None:
+            return None
         try:
             return next(arg for arg in self._field.arguments if arg.python_name == name)
         except StopIteration:

--- a/tests/benchmarks/test_execute_with_extensions.py
+++ b/tests/benchmarks/test_execute_with_extensions.py
@@ -19,7 +19,9 @@ class SimpleExtension(SchemaExtension):
 
 
 class ResolveExtension(SchemaExtension):
-    async def resolve(self, _next, root, info, *args: Any, **kwargs: Any) -> Any:
+    async def resolve(
+        self, _next, root, info: strawberry.Info, *args: Any, **kwargs: Any
+    ) -> Any:
         result = _next(root, info, *args, **kwargs)
         if isawaitable(result):
             result = await result

--- a/tests/cli/test_upgrade.py
+++ b/tests/cli/test_upgrade.py
@@ -19,6 +19,57 @@ def test_upgrade_returns_error_code_if_codemod_does_not_exist(
     assert 'Upgrade named "a_random_codemod" does not exist' in result.stdout
 
 
+def test_upgrade_works_schema_extension_info(
+    cli_app: Typer, cli_runner: CliRunner, tmp_path: Path
+) -> None:
+    target = tmp_path / "extension.py"
+    target.write_text(
+        """from graphql import GraphQLResolveInfo
+from strawberry.extensions import SchemaExtension
+
+
+class MyExtension(SchemaExtension):
+    def resolve(self, next_, root, info: GraphQLResolveInfo, **kwargs):
+        return next_(root, info, **kwargs)
+"""
+    )
+
+    result = cli_runner.invoke(
+        cli_app,
+        ["upgrade", "schema-extension-info", str(target)],
+    )
+
+    assert result.exit_code == 1
+    assert "1 files changed\n  - 0 files skipped" in result.stdout
+    assert "strawberry_info: strawberry.Info" in target.read_text()
+    assert "info = strawberry_info._raw_info" in target.read_text()
+
+
+def test_upgrade_reports_schema_extension_info_warning(
+    cli_app: Typer, cli_runner: CliRunner, tmp_path: Path
+) -> None:
+    target = tmp_path / "extension.py"
+    target.write_text(
+        """from strawberry.extensions import SchemaExtension
+
+
+class MyExtension(SchemaExtension):
+    def resolve(self, next_, root, info: CustomInfo, **kwargs):
+        return next_(root, info, **kwargs)
+"""
+    )
+
+    result = cli_runner.invoke(
+        cli_app,
+        ["upgrade", "schema-extension-info", str(target)],
+    )
+
+    assert result.exit_code == 0
+    assert "Warnings:" in result.stdout
+    assert "not a recognized" in result.stdout
+    assert "0 files changed\n  - 1 files skipped" in result.stdout
+
+
 def test_upgrade_works_annotated_unions(
     cli_app: Typer, cli_runner: CliRunner, tmp_path: Path, snapshot: Snapshot
 ):

--- a/tests/codemods/test_schema_extension_info.py
+++ b/tests/codemods/test_schema_extension_info.py
@@ -1,0 +1,179 @@
+from libcst.codemod import CodemodTest
+
+from strawberry.codemods.schema_extension_info import ConvertSchemaExtensionInfo
+
+
+class TestConvertSchemaExtensionInfo(CodemodTest):
+    TRANSFORM = ConvertSchemaExtensionInfo
+
+    def test_converts_graphql_info_annotation(self) -> None:
+        before = """
+            from graphql import GraphQLResolveInfo
+            from strawberry.extensions import SchemaExtension
+
+
+            class MyExtension(SchemaExtension):
+                def resolve(self, next_, root, info: GraphQLResolveInfo, **kwargs):
+                    print(info.parent_type)
+                    return next_(root, info, **kwargs)
+        """
+
+        after = """
+            from strawberry.extensions import SchemaExtension
+            import strawberry
+
+
+            class MyExtension(SchemaExtension):
+                def resolve(self, next_, root, strawberry_info: strawberry.Info, **kwargs):
+                    info = strawberry_info._raw_info
+                    print(info.parent_type)
+                    return next_(root, info, **kwargs)
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_converts_unannotated_info_after_docstring(self) -> None:
+        before = '''
+            from strawberry.extensions import SchemaExtension
+
+
+            class MyExtension(SchemaExtension):
+                async def resolve(self, next_, root, info, *args, **kwargs):
+                    """Resolve a field."""
+                    return await next_(root, info, *args, **kwargs)
+        '''
+
+        after = '''
+            from strawberry.extensions import SchemaExtension
+            import strawberry
+
+
+            class MyExtension(SchemaExtension):
+                async def resolve(self, next_, root, strawberry_info: strawberry.Info, *args, **kwargs):
+                    """Resolve a field."""
+                    info = strawberry_info._raw_info
+                    return await next_(root, info, *args, **kwargs)
+        '''
+
+        self.assertCodemod(before, after)
+
+    def test_supports_aliased_imports_and_info_parameter_names(self) -> None:
+        before = """
+            from graphql import GraphQLResolveInfo as ResolveInfo
+            from strawberry.extensions import SchemaExtension as Extension
+
+
+            class MyExtension(Extension):
+                def resolve(self, next_, root, execution_info: ResolveInfo, **kwargs):
+                    return next_(root, execution_info, **kwargs)
+        """
+
+        after = """
+            from strawberry.extensions import SchemaExtension as Extension
+            import strawberry
+
+
+            class MyExtension(Extension):
+                def resolve(self, next_, root, strawberry_info: strawberry.Info, **kwargs):
+                    execution_info = strawberry_info._raw_info
+                    return next_(root, execution_info, **kwargs)
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_supports_qualified_schema_extension(self) -> None:
+        before = """
+            import strawberry
+
+
+            class MyExtension(strawberry.extensions.SchemaExtension):
+                def resolve(self, next_, root, info, **kwargs):
+                    return next_(root, info, **kwargs)
+        """
+
+        after = """
+            import strawberry
+
+
+            class MyExtension(strawberry.extensions.SchemaExtension):
+                def resolve(self, next_, root, strawberry_info: strawberry.Info, **kwargs):
+                    info = strawberry_info._raw_info
+                    return next_(root, info, **kwargs)
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_supports_schema_extension_defined_in_a_function(self) -> None:
+        before = """
+            from strawberry.extensions import SchemaExtension
+
+
+            def create_extension():
+                class MyExtension(SchemaExtension):
+                    def resolve(self, next_, root, info, **kwargs):
+                        return next_(root, info, **kwargs)
+
+                return MyExtension
+        """
+
+        after = """
+            from strawberry.extensions import SchemaExtension
+            import strawberry
+
+
+            def create_extension():
+                class MyExtension(SchemaExtension):
+                    def resolve(self, next_, root, strawberry_info: strawberry.Info, **kwargs):
+                        info = strawberry_info._raw_info
+                        return next_(root, info, **kwargs)
+
+                return MyExtension
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_does_not_change_strawberry_info_extension(self) -> None:
+        source = """
+            import strawberry
+            from strawberry.extensions import SchemaExtension
+
+
+            class MyExtension(SchemaExtension):
+                def resolve(self, next_, root, info: strawberry.Info, **kwargs):
+                    return next_(root, info, **kwargs)
+        """
+
+        self.assertCodemod(source, source)
+
+    def test_does_not_change_field_extensions(self) -> None:
+        source = """
+            from strawberry.extensions import FieldExtension
+
+
+            class MyExtension(FieldExtension):
+                def resolve(self, next_, root, info, **kwargs):
+                    return next_(root, info, **kwargs)
+        """
+
+        self.assertCodemod(source, source)
+
+    def test_reports_unrecognized_info_annotation(self) -> None:
+        source = """
+            from strawberry.extensions import SchemaExtension
+
+
+            class MyExtension(SchemaExtension):
+                def resolve(self, next_, root, info: CustomInfo, **kwargs):
+                    return next_(root, info, **kwargs)
+        """
+
+        self.assertCodemod(
+            source,
+            source,
+            expected_warnings=[
+                (
+                    "Skipped resolve: the annotation on `info` is not a recognized "
+                    "graphql-core Info type."
+                )
+            ],
+        )

--- a/tests/schema/extensions/schema_extensions/conftest.py
+++ b/tests/schema/extensions/schema_extensions/conftest.py
@@ -117,7 +117,9 @@ def async_extension() -> type[ExampleExtension]:
             self.called_hooks.append("get_results")
             return {"example": "example"}
 
-        async def resolve(self, _next, root, info, *args: str, **kwargs: Any):
+        async def resolve(
+            self, _next, root, info: strawberry.Info, *args: str, **kwargs: Any
+        ):
             self.called_hooks.append("resolve")
             return _next(root, info, *args, **kwargs)
 

--- a/tests/schema/extensions/schema_extensions/test_extensions.py
+++ b/tests/schema/extensions/schema_extensions/test_extensions.py
@@ -252,7 +252,9 @@ def sync_extension() -> type[ExampleExtension]:
             self.called_hooks.append("get_results")
             return {"example": "example"}
 
-        def resolve(self, _next, root, info, *args: str, **kwargs: Any):
+        def resolve(
+            self, _next, root, info: strawberry.Info, *args: str, **kwargs: Any
+        ):
             self.called_hooks.append("resolve")
             return _next(root, info, *args, **kwargs)
 

--- a/tests/schema/extensions/schema_extensions/test_info.py
+++ b/tests/schema/extensions/schema_extensions/test_info.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import warnings
+from typing import Any
+
+import pytest
+from graphql import GraphQLResolveInfo
+
+import strawberry
+from strawberry.extensions import SchemaExtension
+from strawberry.schema.config import StrawberryConfig
+from strawberry.utils.await_maybe import await_maybe
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def hello(self) -> str:
+        return "world"
+
+
+def test_resolve_receives_configured_strawberry_info() -> None:
+    class CustomInfo(strawberry.Info): ...
+
+    received_info: list[strawberry.Info] = []
+
+    class Extension(SchemaExtension):
+        def resolve(
+            self,
+            next_: Any,
+            root: Any,
+            info: strawberry.Info,
+            **kwargs: Any,
+        ) -> Any:
+            received_info.append(info)
+            return next_(root, info, **kwargs)
+
+    schema = strawberry.Schema(
+        query=Query,
+        extensions=[Extension],
+        config=StrawberryConfig(info_class=CustomInfo),
+    )
+
+    result = schema.execute_sync("{ hello }")
+
+    assert result.errors is None
+    assert result.data == {"hello": "world"}
+    assert len(received_info) == 1
+    assert isinstance(received_info[0], CustomInfo)
+    assert received_info[0].field_name == "hello"
+
+
+@pytest.mark.asyncio
+async def test_async_resolve_receives_strawberry_info() -> None:
+    received_info: list[strawberry.Info] = []
+
+    class Extension(SchemaExtension):
+        async def resolve(
+            self,
+            next_: Any,
+            root: Any,
+            info: strawberry.Info,
+            **kwargs: Any,
+        ) -> Any:
+            received_info.append(info)
+            return await await_maybe(next_(root, info, **kwargs))
+
+    schema = strawberry.Schema(query=Query, extensions=[Extension])
+    result = await schema.execute("{ hello }")
+
+    assert result.errors is None
+    assert result.data == {"hello": "world"}
+    assert len(received_info) == 1
+    assert isinstance(received_info[0], strawberry.Info)
+
+
+def test_strawberry_info_extension_can_pass_raw_info_to_next() -> None:
+    class Extension(SchemaExtension):
+        def resolve(
+            self,
+            next_: Any,
+            root: Any,
+            info: strawberry.Info,
+            **kwargs: Any,
+        ) -> Any:
+            return next_(root, info._raw_info, **kwargs)
+
+    schema = strawberry.Schema(query=Query, extensions=[Extension])
+    result = schema.execute_sync("{ hello }")
+
+    assert result.errors is None
+    assert result.data == {"hello": "world"}
+
+
+def test_strawberry_and_graphql_info_extensions_can_be_mixed() -> None:
+    received_info: list[tuple[str, object]] = []
+
+    class StrawberryInfoExtension(SchemaExtension):
+        def resolve(
+            self,
+            next_: Any,
+            root: Any,
+            info: strawberry.Info,
+            **kwargs: Any,
+        ) -> Any:
+            received_info.append(("strawberry", info))
+            return next_(root, info, **kwargs)
+
+    class GraphQLInfoExtension(SchemaExtension):
+        def resolve(
+            self,
+            next_: Any,
+            root: Any,
+            info: GraphQLResolveInfo,
+            **kwargs: Any,
+        ) -> Any:
+            received_info.append(("graphql", info))
+            return next_(root, info, **kwargs)
+
+    schema = strawberry.Schema(
+        query=Query,
+        extensions=[StrawberryInfoExtension, GraphQLInfoExtension],
+    )
+
+    with pytest.warns(DeprecationWarning, match="GraphQLInfoExtension.resolve"):
+        result = schema.execute_sync("{ hello }")
+
+    assert result.errors is None
+    assert {name for name, _ in received_info} == {"strawberry", "graphql"}
+    assert isinstance(dict(received_info)["strawberry"], strawberry.Info)
+    assert isinstance(dict(received_info)["graphql"], GraphQLResolveInfo)
+
+
+def test_legacy_info_warning_is_emitted_once_per_extension_class() -> None:
+    received_info: list[object] = []
+
+    class LegacyExtension(SchemaExtension):
+        def resolve(self, next_: Any, root: Any, info: Any, **kwargs: Any) -> Any:
+            received_info.append(info)
+            return next_(root, info, **kwargs)
+
+    schema = strawberry.Schema(query=Query, extensions=[LegacyExtension])
+
+    with warnings.catch_warnings(record=True) as caught_warnings:
+        warnings.simplefilter("always")
+        schema.execute_sync("{ hello }")
+        schema.execute_sync("{ hello }")
+
+    matching_warnings = [
+        warning
+        for warning in caught_warnings
+        if "LegacyExtension.resolve receives GraphQLResolveInfo" in str(warning.message)
+    ]
+    assert len(matching_warnings) == 1
+    assert all(isinstance(info, GraphQLResolveInfo) for info in received_info)
+
+
+def test_strawberry_info_extension_handles_graphql_core_only_fields() -> None:
+    received_info: dict[str, strawberry.Info] = {}
+
+    class Extension(SchemaExtension):
+        def resolve(
+            self,
+            next_: Any,
+            root: Any,
+            info: strawberry.Info,
+            **kwargs: Any,
+        ) -> Any:
+            received_info[info.field_name] = info
+            return next_(root, info, **kwargs)
+
+    schema = strawberry.Schema(query=Query, extensions=[Extension])
+    result = schema.execute_sync("{ __typename hello }")
+
+    assert result.errors is None
+    assert result.data == {"__typename": "Query", "hello": "world"}
+    assert set(received_info) == {"__typename", "hello"}
+    assert received_info["__typename"].python_name == "__typename"
+    assert received_info["__typename"].get_argument_definition("name") is None
+    with pytest.raises(ValueError, match="has no Strawberry return type"):
+        received_info["__typename"].return_type

--- a/tests/schema/extensions/schema_extensions/test_info.py
+++ b/tests/schema/extensions/schema_extensions/test_info.py
@@ -25,6 +25,14 @@ def test_resolve_receives_configured_strawberry_info() -> None:
     class CustomInfo(strawberry.Info): ...
 
     received_info: list[strawberry.Info] = []
+    resolver_info: list[strawberry.Info] = []
+
+    @strawberry.type
+    class InfoQuery:
+        @strawberry.field
+        def hello(self, info: strawberry.Info) -> str:
+            resolver_info.append(info)
+            return "world"
 
     class Extension(SchemaExtension):
         def resolve(
@@ -38,7 +46,7 @@ def test_resolve_receives_configured_strawberry_info() -> None:
             return next_(root, info, **kwargs)
 
     schema = strawberry.Schema(
-        query=Query,
+        query=InfoQuery,
         extensions=[Extension],
         config=StrawberryConfig(info_class=CustomInfo),
     )
@@ -50,6 +58,7 @@ def test_resolve_receives_configured_strawberry_info() -> None:
     assert len(received_info) == 1
     assert isinstance(received_info[0], CustomInfo)
     assert received_info[0].field_name == "hello"
+    assert received_info[0] is resolver_info[0]
 
 
 @pytest.mark.asyncio
@@ -94,7 +103,10 @@ def test_strawberry_info_extension_can_pass_raw_info_to_next() -> None:
     assert result.data == {"hello": "world"}
 
 
-def test_strawberry_and_graphql_info_extensions_can_be_mixed() -> None:
+@pytest.mark.parametrize("legacy_first", [False, True])
+def test_strawberry_and_graphql_info_extensions_can_be_mixed(
+    legacy_first: bool,
+) -> None:
     received_info: list[tuple[str, object]] = []
 
     class StrawberryInfoExtension(SchemaExtension):
@@ -119,20 +131,30 @@ def test_strawberry_and_graphql_info_extensions_can_be_mixed() -> None:
             received_info.append(("graphql", info))
             return next_(root, info, **kwargs)
 
-    schema = strawberry.Schema(
-        query=Query,
-        extensions=[StrawberryInfoExtension, GraphQLInfoExtension],
+    class OtherStrawberryInfoExtension(StrawberryInfoExtension): ...
+
+    strawberry_extensions = [
+        StrawberryInfoExtension,
+        OtherStrawberryInfoExtension,
+    ]
+    extensions = (
+        [GraphQLInfoExtension, *strawberry_extensions]
+        if legacy_first
+        else [*strawberry_extensions, GraphQLInfoExtension]
     )
+    schema = strawberry.Schema(query=Query, extensions=extensions)
 
     with pytest.warns(DeprecationWarning, match="GraphQLInfoExtension.resolve"):
         result = schema.execute_sync("{ hello }")
 
     assert result.errors is None
     assert {name for name, _ in received_info} == {"strawberry", "graphql"}
-    strawberry_info = dict(received_info)["strawberry"]
+    strawberry_info = [info for name, info in received_info if name == "strawberry"]
     graphql_info = dict(received_info)["graphql"]
-    assert isinstance(strawberry_info, strawberry.Info)
-    assert strawberry_info._raw_info is graphql_info
+    assert len(strawberry_info) == 2
+    assert isinstance(strawberry_info[0], strawberry.Info)
+    assert strawberry_info[0] is strawberry_info[1]
+    assert strawberry_info[0]._raw_info is graphql_info
 
 
 def test_legacy_info_warning_is_emitted_once_per_extension_class() -> None:

--- a/tests/schema/extensions/schema_extensions/test_info.py
+++ b/tests/schema/extensions/schema_extensions/test_info.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import warnings
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier
 from typing import Any
 
 import pytest
@@ -127,12 +129,15 @@ def test_strawberry_and_graphql_info_extensions_can_be_mixed() -> None:
 
     assert result.errors is None
     assert {name for name, _ in received_info} == {"strawberry", "graphql"}
-    assert isinstance(dict(received_info)["strawberry"], strawberry.Info)
-    assert isinstance(dict(received_info)["graphql"], GraphQLResolveInfo)
+    strawberry_info = dict(received_info)["strawberry"]
+    graphql_info = dict(received_info)["graphql"]
+    assert isinstance(strawberry_info, strawberry.Info)
+    assert strawberry_info._raw_info is graphql_info
 
 
 def test_legacy_info_warning_is_emitted_once_per_extension_class() -> None:
     received_info: list[object] = []
+    worker_count = 8
 
     class LegacyExtension(SchemaExtension):
         def resolve(self, next_: Any, root: Any, info: Any, **kwargs: Any) -> Any:
@@ -140,11 +145,16 @@ def test_legacy_info_warning_is_emitted_once_per_extension_class() -> None:
             return next_(root, info, **kwargs)
 
     schema = strawberry.Schema(query=Query, extensions=[LegacyExtension])
+    barrier = Barrier(worker_count)
+
+    def execute(_: int) -> Any:
+        barrier.wait()
+        return schema.execute_sync("{ hello }")
 
     with warnings.catch_warnings(record=True) as caught_warnings:
         warnings.simplefilter("always")
-        schema.execute_sync("{ hello }")
-        schema.execute_sync("{ hello }")
+        with ThreadPoolExecutor(max_workers=worker_count) as executor:
+            results = list(executor.map(execute, range(worker_count)))
 
     matching_warnings = [
         warning
@@ -152,7 +162,9 @@ def test_legacy_info_warning_is_emitted_once_per_extension_class() -> None:
         if "LegacyExtension.resolve receives GraphQLResolveInfo" in str(warning.message)
     ]
     assert len(matching_warnings) == 1
-    assert all(isinstance(info, GraphQLResolveInfo) for info in received_info)
+    assert all(result.errors is None for result in results)
+    assert all(not isinstance(info, strawberry.Info) for info in received_info)
+    assert all(info.field_name == "hello" for info in received_info)
 
 
 def test_strawberry_info_extension_handles_graphql_core_only_fields() -> None:

--- a/tests/schema/test_directives.py
+++ b/tests/schema/test_directives.py
@@ -348,7 +348,9 @@ def test_runs_directives_with_extensions():
         return value.upper()
 
     class ExampleExtension(SchemaExtension):
-        def resolve(self, _next, root, info, *args: str, **kwargs: Any):
+        def resolve(
+            self, _next, root, info: strawberry.Info, *args: str, **kwargs: Any
+        ):
             return _next(root, info, *args, **kwargs)
 
     schema = strawberry.Schema(
@@ -387,7 +389,9 @@ async def test_runs_directives_with_extensions_async():
         return value.upper()
 
     class ExampleExtension(SchemaExtension):
-        async def resolve(self, _next, root, info, *args: str, **kwargs: Any):
+        async def resolve(
+            self, _next, root, info: strawberry.Info, *args: str, **kwargs: Any
+        ):
             return await await_maybe(_next(root, info, *args, **kwargs))
 
     schema = strawberry.Schema(

--- a/tests/typecheckers/test_info.py
+++ b/tests/typecheckers/test_info.py
@@ -157,3 +157,30 @@ def example(info: strawberry.Info) -> None:
             ),
         ]
     )
+
+
+def test_schema_extension_resolve_accepts_strawberry_info():
+    code = """
+from typing import Any
+
+import strawberry
+from strawberry.extensions import SchemaExtension
+
+
+class Extension(SchemaExtension):
+    def resolve(
+        self,
+        _next: Any,
+        root: Any,
+        info: strawberry.Info,
+        *args: str,
+        **kwargs: Any,
+    ) -> Any:
+        return _next(root, info, *args, **kwargs)
+"""
+
+    results = typecheck(code)
+
+    assert results.pyright == snapshot([])
+    assert results.mypy == snapshot([])
+    assert results.ty == snapshot([])

--- a/tests/typecheckers/utils/mypy.py
+++ b/tests/typecheckers/utils/mypy.py
@@ -77,6 +77,9 @@ def run_mypy(
         )
         full_output = full_output.strip()
 
+        if not full_output:
+            return []
+
         results: list[Result] = []
 
         try:


### PR DESCRIPTION
## Summary

- allow `SchemaExtension.resolve` implementations annotated with `strawberry.Info` to receive the schema's configured Info class
- preserve raw `GraphQLResolveInfo` behavior temporarily while emitting a thread-safe, once-per-class deprecation warning
- reuse the same Info object through modern middleware and the field resolver, unwrapping only at legacy or graphql-core-only boundaries
- add a behavior-preserving `strawberry upgrade schema-extension-info .` codemod and report cases that need manual review
- document the migration, introspection-field behavior, and an LLM migration prompt

Legacy and Info-aware extensions can coexist in the same middleware chain during the migration period. The raw behavior is deprecated now and will be removed in Strawberry 1.0.

Info-aware middleware continues to run for graphql-core-only fields such as introspection fields. Those fields have no corresponding `StrawberryField`, so `Info._field` is optional and affected public properties have documented fallbacks.

Related to #4242.

## Tests

- `uv run pytest tests/schema -q`
- `uv run pytest tests/schema/extensions/schema_extensions tests/extensions -q`
- `uv run --isolated --with 'graphql-core==3.3.0rc0' pytest tests/schema/extensions/schema_extensions/test_info.py tests/schema/test_info.py -q`
- `uv run mypy --config-file mypy.ini strawberry/schema/schema.py strawberry/schema/schema_converter.py`
- `uv run pre-commit run --all-files`
- local CodSpeed comparison of `tests/benchmarks/test_execute_with_extensions.py` against the previous PR revision and `origin/main`
