### PR TITLE
Validate schema directive applications

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,31 @@
+---
+release type: patch
+social_messages:
+  x: >-
+    {project_name} {version} is out! Schema directive locations and repeatability
+    are now validated when schemas are created. 🍓
+    https://strawberry.rocks/release/{version}
+  linkedin: >-
+    {project_name} {version} is out. Schema construction now validates custom schema
+    directive locations and repeatability, preventing invalid directive applications
+    from being silently omitted or emitted as invalid SDL. 🍓
+---
+
+This release fixes validation of schema directive applications.
+
+Strawberry now validates every supported type-system location during schema
+construction, including the distinctions between objects and interfaces and between
+output and input fields. Applying a directive outside its declared locations raises
+an actionable error that identifies the directive, actual location, and schema
+element.
+
+Applying a non-repeatable directive more than once to the same schema element now
+also raises an error. Repeatable directives retain their Python attachment order,
+and non-repeatable directives can still be reused on separate elements. Valid
+Federation applications such as multiple `@key` and `@tag` directives continue to
+work.
+
+This may expose invalid applications that Strawberry previously omitted from SDL or
+printed as SDL rejected by GraphQL tools. Move or remove those applications, add the
+intended location to the directive definition, or set `repeatable=True` when repeated
+applications are intentional.

--- a/docs/types/schema-directives.md
+++ b/docs/types/schema-directives.md
@@ -110,3 +110,31 @@ list of all the allowed locations:
 | ENUM_VALUE             | `strawberry.enum_value` | The definition of a enum value                           |
 | INPUT_OBJECT           | `strawberry.input`      | The definition of an input object type                   |
 | INPUT_FIELD_DEFINITION | `strawberry.field`      | The definition of a field on an input type               |
+
+Strawberry validates every schema directive application when the schema is
+created. The application must match one of the directive's declared locations;
+for example, `Location.OBJECT` does not include interfaces, and
+`Location.FIELD_DEFINITION` does not include input fields. A directive declared
+with several locations can be used at each of them.
+
+By default, a schema directive can be applied only once to a particular schema
+element. Set `repeatable=True` when defining a directive that can occur more
+than once:
+
+```python
+@strawberry.schema_directive(
+    locations=[Location.OBJECT],
+    repeatable=True,
+)
+class Tag:
+    name: str
+```
+
+Repeatable applications are printed in the order in which they were attached. A
+non-repeatable directive can still be reused on different schema elements.
+
+Schema construction now reports applications that previously could be omitted
+from printed SDL or produce SDL rejected by GraphQL tools. If an existing schema
+raises a location or repeatability error after upgrading, move or remove the
+invalid application, add the intended location to its definition, or mark a
+genuinely repeatable directive with `repeatable=True`.

--- a/strawberry/exceptions/__init__.py
+++ b/strawberry/exceptions/__init__.py
@@ -22,6 +22,10 @@ from .object_is_not_a_class import ObjectIsNotClassError
 from .object_is_not_an_enum import ObjectIsNotAnEnumError
 from .private_strawberry_field import PrivateStrawberryFieldError
 from .scalar_already_registered import ScalarAlreadyRegisteredError
+from .schema_directive import (
+    DuplicateSchemaDirectiveError,
+    InvalidSchemaDirectiveLocationError,
+)
 from .unresolved_field_type import UnresolvedFieldTypeError
 
 if TYPE_CHECKING:
@@ -194,12 +198,14 @@ class PermissionReturnedAwaitableInSyncContextError(Exception):
 
 __all__ = [
     "ConflictingArgumentsError",
+    "DuplicateSchemaDirectiveError",
     "DuplicatedTypeName",
     "FieldWithResolverAndDefaultFactoryError",
     "FieldWithResolverAndDefaultValueError",
     "InvalidArgumentTypeError",
     "InvalidCustomContext",
     "InvalidDefaultFactoryError",
+    "InvalidSchemaDirectiveLocationError",
     "InvalidStrawberryFieldAnnotationError",
     "InvalidSuperclassInterfaceError",
     "InvalidTypeForUnionMergeError",

--- a/strawberry/exceptions/schema_directive.py
+++ b/strawberry/exceptions/schema_directive.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from functools import cached_property
+from typing import TYPE_CHECKING, Any
+
+from .exception import StrawberryException
+from .utils.source_finder import SourceFinder
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+
+    from strawberry.schema_directive import Location
+
+    from .exception_source import ExceptionSource
+
+
+class _SchemaDirectiveApplicationError(StrawberryException):
+    def __init__(
+        self,
+        message: str,
+        *,
+        suggestion: str,
+        source: type | Callable[..., Any] | None,
+        source_attribute: str | None,
+        source_argument: str | None,
+    ) -> None:
+        self.rich_message = message
+        self.annotation_message = "directive applied here"
+        self.suggestion = suggestion
+        self.source = source
+        self.source_attribute = source_attribute
+        self.source_argument = source_argument
+
+        super().__init__(message)
+
+    @cached_property
+    def exception_source(self) -> ExceptionSource | None:
+        source_finder = SourceFinder()
+
+        if self.source_argument is not None and callable(self.source):
+            return source_finder.find_argument_from_object(
+                self.source, self.source_argument
+            )
+
+        if self.source_attribute is not None and isinstance(self.source, type):
+            return source_finder.find_class_attribute_from_object(
+                self.source, self.source_attribute
+            )
+
+        if isinstance(self.source, type):
+            return source_finder.find_class_from_object(self.source)
+
+        return None
+
+
+class InvalidSchemaDirectiveLocationError(_SchemaDirectiveApplicationError):
+    def __init__(
+        self,
+        directive_name: str,
+        location: Location,
+        element: str,
+        allowed_locations: Iterable[Location],
+        *,
+        source: type | Callable[..., Any] | None = None,
+        source_attribute: str | None = None,
+        source_argument: str | None = None,
+    ) -> None:
+        allowed = ", ".join(location.name for location in allowed_locations) or "none"
+        message = (
+            f"Schema directive '@{directive_name}' cannot be applied to "
+            f"{location.name} schema element '{element}'. Allowed locations: "
+            f"{allowed}."
+        )
+
+        super().__init__(
+            message,
+            suggestion=(
+                f"Add Location.{location.name} to the directive's locations or "
+                "move the directive to a supported schema element."
+            ),
+            source=source,
+            source_attribute=source_attribute,
+            source_argument=source_argument,
+        )
+
+
+class DuplicateSchemaDirectiveError(_SchemaDirectiveApplicationError):
+    def __init__(
+        self,
+        directive_name: str,
+        location: Location,
+        element: str,
+        *,
+        source: type | Callable[..., Any] | None = None,
+        source_attribute: str | None = None,
+        source_argument: str | None = None,
+    ) -> None:
+        message = (
+            f"Schema directive '@{directive_name}' is not repeatable and cannot be "
+            f"applied more than once to {location.name} schema element '{element}'."
+        )
+
+        super().__init__(
+            message,
+            suggestion=(
+                "Remove the duplicate application or define the directive with "
+                "repeatable=True."
+            ),
+            source=source,
+            source_attribute=source_attribute,
+            source_argument=source_argument,
+        )
+
+
+__all__ = [
+    "DuplicateSchemaDirectiveError",
+    "InvalidSchemaDirectiveLocationError",
+]

--- a/strawberry/federation/schema_directives.py
+++ b/strawberry/federation/schema_directives.py
@@ -173,7 +173,10 @@ class Inaccessible(FederationDirective):
 
 
 @schema_directive(
-    locations=[Location.SCHEMA], name="composeDirective", print_definition=False
+    locations=[Location.SCHEMA],
+    name="composeDirective",
+    repeatable=True,
+    print_definition=False,
 )
 class ComposeDirective(FederationDirective):
     name: str

--- a/strawberry/printer/printer.py
+++ b/strawberry/printer/printer.py
@@ -37,7 +37,7 @@ from graphql.utilities.print_schema import (
 from graphql.utilities.print_schema import print_directive as original_print_directive
 from graphql.utilities.print_schema import print_type as original_print_type
 
-from strawberry.schema_directive import Location, StrawberrySchemaDirective
+from strawberry.schema_directive import StrawberrySchemaDirective
 from strawberry.types.base import (
     StrawberryContainer,
     StrawberryObjectDefinition,
@@ -213,18 +213,9 @@ def print_field_directives(
     if not field:
         return ""
 
-    directives = (
-        directive
-        for directive in field.directives
-        if any(
-            location in [Location.FIELD_DEFINITION, Location.INPUT_FIELD_DEFINITION]
-            for location in directive.__strawberry_directive__.locations  # type: ignore
-        )
-    )
-
     return "".join(
         print_schema_directive(directive, schema=schema, extras=extras)
-        for directive in directives
+        for directive in field.directives
     )
 
 
@@ -406,22 +397,9 @@ def print_type_directives(
     if not strawberry_type:
         return ""
 
-    allowed_locations = (
-        [Location.INPUT_OBJECT] if strawberry_type.is_input else [Location.OBJECT]
-    )
-
-    directives = (
-        directive
-        for directive in strawberry_type.directives or []
-        if any(
-            location in allowed_locations
-            for location in directive.__strawberry_directive__.locations  # type: ignore[attr-defined]
-        )
-    )
-
     return "".join(
         print_schema_directive(directive, schema=schema, extras=extras)
-        for directive in directives
+        for directive in strawberry_type.directives or []
     )
 
 
@@ -527,18 +505,9 @@ def _print_type(type_: Any, schema: BaseSchema, *, extras: PrintExtras) -> str:
 
 
 def print_schema_directives(schema: BaseSchema, *, extras: PrintExtras) -> str:
-    directives = (
-        directive
-        for directive in schema.schema_directives
-        if any(
-            location == Location.SCHEMA
-            for location in directive.__strawberry_directive__.locations  # type: ignore
-        )
-    )
-
     return "".join(
         print_schema_directive(directive, schema=schema, extras=extras)
-        for directive in directives
+        for directive in schema.schema_directives
     )
 
 

--- a/strawberry/schema/directive_collector.py
+++ b/strawberry/schema/directive_collector.py
@@ -2,13 +2,27 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, cast
 
-from graphql import get_named_type
+from graphql import (
+    get_named_type,
+    is_enum_type,
+    is_input_object_type,
+    is_interface_type,
+    is_object_type,
+    is_scalar_type,
+    is_union_type,
+)
+
+from strawberry.exceptions import (
+    DuplicateSchemaDirectiveError,
+    InvalidSchemaDirectiveLocationError,
+)
+from strawberry.schema_directive import Location, StrawberrySchemaDirective
 
 from .compat import is_schema_directive
 from .schema_converter import GraphQLCoreConverter
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Callable, Iterable
 
     from graphql import GraphQLDirective, GraphQLNamedType, GraphQLType
 
@@ -41,6 +55,7 @@ class SchemaDirectiveCollector:
         # traversal order. Federation derives @link and @composeDirective from
         # these, so the order is kept independent of the definitions above.
         self.directives_in_use: list[object] = []
+        self._schema_directive_definitions: dict[str, StrawberrySchemaDirective] = {}
 
         self._graphql_types: list[GraphQLNamedType] = []
         self._seen_graphql_types: set[int] = set()
@@ -64,8 +79,13 @@ class SchemaDirectiveCollector:
 
     def add_schema_directives(self, directives: Iterable[object]) -> None:
         """Register directives applied to the schema definition itself."""
-        for directive in directives:
-            self._add_directive_type_of(directive)
+        self._record_directives(
+            directives,
+            location=Location.SCHEMA,
+            element="schema",
+            seen_directives=self._schema_directive_definitions,
+            record_in_use=False,
+        )
 
     def add_graphql_types(self, graphql_types: Iterable[GraphQLType | None]) -> None:
         for graphql_type in graphql_types:
@@ -98,15 +118,80 @@ class SchemaDirectiveCollector:
         for alias, canonical_type in self._aliases.items():
             self.graphql_directives[alias] = self.graphql_directives[canonical_type]
 
-    def _add_directive_type_of(self, directive: object) -> None:
-        directive_type = directive.__class__
-        if is_schema_directive(directive_type):
+    def _record_directives(
+        self,
+        directives: Iterable[object],
+        *,
+        location: Location,
+        element: str,
+        source: type | Callable[..., Any] | None = None,
+        source_attribute: str | None = None,
+        source_argument: str | None = None,
+        seen_directives: dict[str, StrawberrySchemaDirective] | None = None,
+        record_in_use: bool = True,
+    ) -> None:
+        seen_directives = seen_directives if seen_directives is not None else {}
+
+        for directive in directives:
+            if record_in_use:
+                self.directives_in_use.append(directive)
+
+            directive_type = directive.__class__
+            if not is_schema_directive(directive_type):
+                continue
+
+            definition = cast(
+                "StrawberrySchemaDirective",
+                cast("Any", directive_type).__strawberry_directive__,
+            )
+            directive_name = self._converter.config.name_converter.from_directive(
+                definition
+            )
+
+            if location not in definition.locations:
+                raise InvalidSchemaDirectiveLocationError(
+                    directive_name,
+                    location,
+                    element,
+                    definition.locations,
+                    source=source,
+                    source_attribute=source_attribute,
+                    source_argument=source_argument,
+                )
+
+            if (previous := seen_directives.get(directive_name)) is not None and (
+                not previous.repeatable or not definition.repeatable
+            ):
+                raise DuplicateSchemaDirectiveError(
+                    directive_name,
+                    location,
+                    element,
+                    source=source,
+                    source_attribute=source_attribute,
+                    source_argument=source_argument,
+                )
+
+            seen_directives.setdefault(directive_name, definition)
             self.add_directive_type(directive_type)
 
-    def _record_applied_directives(self, owner: object) -> None:
-        for directive in getattr(owner, "directives", None) or ():
-            self.directives_in_use.append(directive)
-            self._add_directive_type_of(directive)
+    def _record_applied_directives(
+        self,
+        owner: object,
+        *,
+        location: Location,
+        element: str,
+        source: type | Callable[..., Any] | None = None,
+        source_attribute: str | None = None,
+        source_argument: str | None = None,
+    ) -> None:
+        self._record_directives(
+            getattr(owner, "directives", None) or (),
+            location=location,
+            element=element,
+            source=source,
+            source_attribute=source_attribute,
+            source_argument=source_argument,
+        )
 
     def _queue_graphql_type(self, graphql_type: GraphQLType) -> None:
         named_type = get_named_type(graphql_type)
@@ -115,6 +200,23 @@ class SchemaDirectiveCollector:
 
         self._seen_graphql_types.add(id(named_type))
         self._graphql_types.append(named_type)
+
+    @staticmethod
+    def _get_type_location(graphql_type: GraphQLNamedType) -> Location | None:
+        if is_scalar_type(graphql_type):
+            return Location.SCALAR
+        if is_object_type(graphql_type):
+            return Location.OBJECT
+        if is_interface_type(graphql_type):
+            return Location.INTERFACE
+        if is_union_type(graphql_type):
+            return Location.UNION
+        if is_enum_type(graphql_type):
+            return Location.ENUM
+        if is_input_object_type(graphql_type):
+            return Location.INPUT_OBJECT
+
+        return None
 
     def _visit_graphql_type(self, graphql_type: GraphQLNamedType) -> None:
         # Resolve graphql-core's lazy thunks before reading the Strawberry
@@ -129,13 +231,73 @@ class SchemaDirectiveCollector:
             GraphQLCoreConverter.DEFINITION_BACKREF
         )
         if definition is not None:
-            self._record_applied_directives(definition)
-            for field in getattr(definition, "fields", ()):
-                self._record_applied_directives(field)
-                for argument in getattr(field, "arguments", ()):
-                    self._record_applied_directives(argument)
-            for value in getattr(definition, "values", ()):
-                self._record_applied_directives(value)
+            location = self._get_type_location(graphql_type)
+            source = getattr(definition, "origin", None)
+            source = source if isinstance(source, type) else None
+
+            if location is not None:
+                self._record_applied_directives(
+                    definition,
+                    location=location,
+                    element=graphql_type.name,
+                    source=source,
+                )
+
+            field_location = (
+                Location.INPUT_FIELD_DEFINITION
+                if is_input_object_type(graphql_type)
+                else Location.FIELD_DEFINITION
+            )
+            for field_name, graphql_field in graphql_fields.items():
+                field = graphql_field.extensions.get(
+                    GraphQLCoreConverter.DEFINITION_BACKREF
+                )
+                if field is None:
+                    continue
+
+                field_source = getattr(field, "origin", None)
+                field_source = field_source if isinstance(field_source, type) else None
+                field_element = f"{graphql_type.name}.{field_name}"
+                self._record_applied_directives(
+                    field,
+                    location=field_location,
+                    element=field_element,
+                    source=field_source,
+                    source_attribute=getattr(field, "python_name", None),
+                )
+
+                resolver = getattr(field, "base_resolver", None)
+                resolver_source = getattr(resolver, "wrapped_func", None)
+                for argument_name, graphql_argument in getattr(
+                    graphql_field, "args", {}
+                ).items():
+                    argument = graphql_argument.extensions.get(
+                        GraphQLCoreConverter.DEFINITION_BACKREF
+                    )
+                    if argument is None:
+                        continue
+
+                    self._record_applied_directives(
+                        argument,
+                        location=Location.ARGUMENT_DEFINITION,
+                        element=f"{field_element}({argument_name}:)",
+                        source=resolver_source,
+                        source_argument=getattr(argument, "python_name", None),
+                    )
+
+            for value_name, graphql_value in getattr(
+                graphql_type, "values", {}
+            ).items():
+                value = graphql_value.extensions.get(
+                    GraphQLCoreConverter.DEFINITION_BACKREF
+                )
+                if value is not None:
+                    self._record_applied_directives(
+                        value,
+                        location=Location.ENUM_VALUE,
+                        element=f"{graphql_type.name}.{value_name}",
+                        source=source,
+                    )
 
         for field in graphql_fields.values():
             self._queue_graphql_type(field.type)

--- a/tests/federation/printer/test_compose_directive.py
+++ b/tests/federation/printer/test_compose_directive.py
@@ -85,6 +85,9 @@ def test_schema_directives_and_compose_schema(monkeypatch):
 
     assert graphql_schema_calls == 1
     assert validated_schemas == [schema._schema]
+    compose_directive = schema._schema.get_directive("composeDirective")
+    assert compose_directive is not None
+    assert compose_directive.is_repeatable
     assert schema.as_str() == textwrap.dedent(expected_type).strip()
 
     result = schema.execute_sync(

--- a/tests/federation/printer/test_keys.py
+++ b/tests/federation/printer/test_keys.py
@@ -13,7 +13,13 @@ def test_keys_federation_2():
     class User:
         username: str
 
-    @strawberry.federation.type(keys=[Key(fields="upc", resolvable=True)], extend=True)
+    @strawberry.federation.type(
+        keys=[
+            Key(fields="upc", resolvable=True),
+            Key(fields="upc", resolvable=False),
+        ],
+        extend=True,
+    )
     class Product:
         upc: str = strawberry.federation.field(external=True)
         reviews: list["Review"]
@@ -37,7 +43,7 @@ def test_keys_federation_2():
           query: Query
         }
 
-        extend type Product @key(fields: "upc", resolvable: true) {
+        extend type Product @key(fields: "upc", resolvable: true) @key(fields: "upc", resolvable: false) {
           upc: String! @external
           reviews: [Review!]!
         }

--- a/tests/schema/extensions/test_input_mutation.py
+++ b/tests/schema/extensions/test_input_mutation.py
@@ -8,7 +8,7 @@ from strawberry.schema_directive import Location, schema_directive
 
 
 @schema_directive(
-    locations=[Location.FIELD_DEFINITION],
+    locations=[Location.INPUT_FIELD_DEFINITION],
     name="some_directive",
 )
 class SomeDirective:
@@ -71,7 +71,7 @@ schema = strawberry.Schema(query=Query, mutation=Mutation)
 
 def test_schema():
     expected = '''
-    directive @some_directive(some: String!, directive: String!) on FIELD_DEFINITION
+    directive @some_directive(some: String!, directive: String!) on INPUT_FIELD_DEFINITION
 
     input CreateFruitAsyncInput {
       name: String!

--- a/tests/schema/test_schema_directives.py
+++ b/tests/schema/test_schema_directives.py
@@ -14,7 +14,12 @@ from graphql import (
 
 import strawberry
 import strawberry.schema.schema as schema_module
-from strawberry.exceptions import DuplicatedTypeName, UnresolvedFieldTypeError
+from strawberry.exceptions import (
+    DuplicatedTypeName,
+    DuplicateSchemaDirectiveError,
+    InvalidSchemaDirectiveLocationError,
+    UnresolvedFieldTypeError,
+)
 from strawberry.schema.schema_converter import GraphQLCoreConverter
 from strawberry.schema_directive import Location
 
@@ -345,14 +350,17 @@ def test_registers_directives_from_all_type_system_attachment_points():
 
         return Directive
 
+    SchemaDirective = directive("onSchema", Location.SCHEMA)
+    ScalarDirective = directive("onScalar", Location.SCALAR)
+    ObjectDirective = directive("onObject", Location.OBJECT)
+    FieldDirective = directive("onField", Location.FIELD_DEFINITION)
+    ArgumentDirective = directive("onArgument", Location.ARGUMENT_DEFINITION)
     InterfaceDirective = directive("onInterface", Location.INTERFACE)
     UnionDirective = directive("onUnion", Location.UNION)
     EnumDirective = directive("onEnum", Location.ENUM)
     EnumValueDirective = directive("onEnumValue", Location.ENUM_VALUE)
-    ScalarDirective = directive("onScalar", Location.SCALAR)
     InputDirective = directive("onInput", Location.INPUT_OBJECT)
     InputFieldDirective = directive("onInputField", Location.INPUT_FIELD_DEFINITION)
-    ArgumentDirective = directive("onArgument", Location.ARGUMENT_DEFINITION)
 
     @strawberry.interface(directives=[InterfaceDirective()])
     class Node:
@@ -383,9 +391,9 @@ def test_registers_directives_from_all_type_system_attachment_points():
     class Filter:
         term: str = strawberry.field(directives=[InputFieldDirective()])
 
-    @strawberry.type
+    @strawberry.type(directives=[ObjectDirective()])
     class Query:
-        node: Node
+        node: Node = strawberry.field(directives=[FieldDirective()])
         result: Result
         choice: Choice
         custom_scalar: CustomScalar
@@ -398,19 +406,193 @@ def test_registers_directives_from_all_type_system_attachment_points():
         ) -> str:
             return filter.term + term
 
-    schema = strawberry.Schema(query=Query, types=[Item])
+    schema = strawberry.Schema(
+        query=Query,
+        types=[Item],
+        schema_directives=[SchemaDirective()],
+    )
     directive_names = {item.name for item in schema._schema.directives}
 
     assert {
+        "onSchema",
+        "onScalar",
+        "onObject",
+        "onField",
+        "onArgument",
         "onInterface",
         "onUnion",
         "onEnum",
         "onEnumValue",
-        "onScalar",
         "onInput",
         "onInputField",
-        "onArgument",
     } <= directive_names
+
+    sdl = schema.as_str()
+    assert "schema @onSchema {" in sdl
+    assert "scalar CustomScalar @onScalar" in sdl
+    assert "type Query @onObject {" in sdl
+    assert "node: Node! @onField" in sdl
+    assert "term: String! @onArgument" in sdl
+    assert "interface Node @onInterface" in sdl
+    assert "union Result @onUnion" in sdl
+    assert "enum Choice @onEnum" in sdl
+    assert "FIRST @onEnumValue" in sdl
+    assert "input Filter @onInput" in sdl
+    assert "term: String! @onInputField" in sdl
+    build_schema(sdl)
+
+
+def test_rejects_object_directive_on_interface():
+    @strawberry.schema_directive(locations=[Location.OBJECT])
+    class Marker: ...
+
+    @strawberry.interface(directives=[Marker()])
+    class Node:
+        id: strawberry.ID
+
+    @strawberry.type
+    class Query:
+        node: Node
+
+    with pytest.raises(
+        InvalidSchemaDirectiveLocationError,
+        match=(
+            r"Schema directive '@marker' cannot be applied to INTERFACE schema "
+            r"element 'Node'\. Allowed locations: OBJECT\."
+        ),
+    ):
+        strawberry.Schema(query=Query)
+
+
+def test_rejects_field_directive_on_schema():
+    @strawberry.schema_directive(locations=[Location.FIELD_DEFINITION])
+    class Marker: ...
+
+    @strawberry.type
+    class Query:
+        value: str
+
+    with pytest.raises(
+        InvalidSchemaDirectiveLocationError,
+        match=(
+            r"Schema directive '@marker' cannot be applied to SCHEMA schema "
+            r"element 'schema'\. Allowed locations: FIELD_DEFINITION\."
+        ),
+    ):
+        strawberry.Schema(query=Query, schema_directives=[Marker()])
+
+
+def test_rejects_output_field_directive_on_input_field():
+    @strawberry.schema_directive(locations=[Location.FIELD_DEFINITION])
+    class Marker: ...
+
+    @strawberry.input
+    class Filter:
+        value: str = strawberry.field(directives=[Marker()])
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def search(self, filter: Filter) -> str:
+            return filter.value
+
+    with pytest.raises(
+        InvalidSchemaDirectiveLocationError,
+        match=(
+            r"Schema directive '@marker' cannot be applied to "
+            r"INPUT_FIELD_DEFINITION schema element 'Filter.value'\. Allowed "
+            r"locations: FIELD_DEFINITION\."
+        ),
+    ):
+        strawberry.Schema(query=Query)
+
+
+def test_rejects_input_field_directive_on_output_field():
+    @strawberry.schema_directive(locations=[Location.INPUT_FIELD_DEFINITION])
+    class Marker: ...
+
+    @strawberry.type
+    class Query:
+        value: str = strawberry.field(directives=[Marker()])
+
+    with pytest.raises(
+        InvalidSchemaDirectiveLocationError,
+        match=(
+            r"Schema directive '@marker' cannot be applied to FIELD_DEFINITION "
+            r"schema element 'Query.value'\. Allowed locations: "
+            r"INPUT_FIELD_DEFINITION\."
+        ),
+    ):
+        strawberry.Schema(query=Query)
+
+
+def test_rejects_scalar_directive_on_union():
+    @strawberry.schema_directive(locations=[Location.SCALAR])
+    class Marker: ...
+
+    @strawberry.type
+    class Item:
+        name: str
+
+    @strawberry.type
+    class Other:
+        value: str
+
+    Result = Annotated[
+        Item | Other,
+        strawberry.union("Result", directives=[Marker()]),
+    ]
+
+    @strawberry.type
+    class Query:
+        result: Result
+
+    with pytest.raises(
+        InvalidSchemaDirectiveLocationError,
+        match=(
+            r"Schema directive '@marker' cannot be applied to UNION schema "
+            r"element 'Result'\. Allowed locations: SCALAR\."
+        ),
+    ):
+        strawberry.Schema(query=Query)
+
+
+def test_rejects_duplicate_non_repeatable_directive():
+    @strawberry.schema_directive(locations=[Location.FIELD_DEFINITION])
+    class Marker:
+        value: str
+
+    @strawberry.type
+    class Query:
+        value: str = strawberry.field(
+            directives=[Marker(value="first"), Marker(value="second")]
+        )
+
+    with pytest.raises(
+        DuplicateSchemaDirectiveError,
+        match=(
+            r"Schema directive '@marker' is not repeatable and cannot be applied "
+            r"more than once to FIELD_DEFINITION schema element 'Query.value'\."
+        ),
+    ):
+        strawberry.Schema(query=Query)
+
+
+def test_non_repeatable_directive_can_be_reused_on_separate_elements():
+    @strawberry.schema_directive(locations=[Location.FIELD_DEFINITION])
+    class Marker: ...
+
+    @strawberry.type
+    class Query:
+        first: str = strawberry.field(directives=[Marker()])
+        second: str = strawberry.field(directives=[Marker()])
+
+    schema = strawberry.Schema(query=Query)
+    sdl = schema.as_str()
+
+    assert "first: String! @marker" in sdl
+    assert "second: String! @marker" in sdl
+    build_schema(sdl)
 
 
 def test_directives_passed_as_one_shot_iterables_are_kept():

--- a/tests/test_printer/test_schema_directives.py
+++ b/tests/test_printer/test_schema_directives.py
@@ -294,7 +294,7 @@ def test_prints_directive_on_schema():
 
     @strawberry.type
     class Query:
-        first_name: str = strawberry.field(directives=[Tag(name="team-1")])
+        first_name: str
 
     schema = strawberry.Schema(query=Query, schema_directives=[Tag(name="team-1")])
 
@@ -314,7 +314,7 @@ def test_prints_directive_on_schema():
 
 
 def test_prints_multiple_directives_on_schema():
-    @strawberry.schema_directive(locations=[Location.SCHEMA])
+    @strawberry.schema_directive(locations=[Location.SCHEMA], repeatable=True)
     class Tag:
         name: str
 
@@ -327,7 +327,7 @@ def test_prints_multiple_directives_on_schema():
     )
 
     expected_output = """
-    directive @tag(name: String!) on SCHEMA
+    directive @tag(name: String!) repeatable on SCHEMA
 
     schema @tag(name: "team-1") @tag(name: "team-2") {
       query: Query
@@ -739,7 +739,7 @@ def test_print_directive_on_union():
     class B:
         b: int
 
-    @strawberry.schema_directive(locations=[Location.SCALAR])
+    @strawberry.schema_directive(locations=[Location.UNION])
     class Sensitive:
         reason: str
 
@@ -753,7 +753,7 @@ def test_print_directive_on_union():
         example: MyUnion
 
     expected_output = """
-    directive @sensitive(reason: String!) on SCALAR
+    directive @sensitive(reason: String!) on UNION
 
     type A {
       a: Int!


### PR DESCRIPTION
## Summary

- validate attached schema directives against every supported type-system location during schema construction
- reject duplicate applications of non-repeatable directives per GraphQL name and schema element
- preserve repeatable directive order and valid reuse on separate elements
- simplify the SDL printer to emit validated applications without location filtering
- preserve schema-directive discovery, registration, introspection, and Federation behavior from #4598
- add source-aware errors, focused regression coverage, documentation, and a patch release note

## Compatibility

This intentionally surfaces schema directive applications that were previously omitted from SDL or emitted as SDL rejected by GraphQL tools. Generated input mutation fields now require directives attached to them to declare INPUT_FIELD_DEFINITION.

## Test plan

- affected schema, printer, and Federation suites: 858 passed, 27 skipped, 2 xfailed
- focused graphql-core 3.2.6, 3.2.11, and 3.3.0rc0 compatibility checks
- rebased focused suite: 123 passed, 5 skipped
- ruff check and format check
- targeted mypy
- pre-commit on all files

## Summary by Sourcery

Validate schema directive locations and repeatability during schema construction to prevent invalid applications from being omitted or emitted as invalid SDL.

Bug Fixes:
- Validate schema directive applications against their declared GraphQL locations during schema construction.
- Reject duplicate applications of non-repeatable directives on the same schema element while preserving valid repeatable and cross-element reuse.
- Report actionable, source-aware errors for invalid directive locations and duplicate applications.

Enhancements:
- Simplify SDL printing to emit the validated directive applications directly.
- Preserve Federation directive behavior, including repeatable compose directives and multiple key applications.

Documentation:
- Document schema directive location and repeatability validation, including upgrade guidance for newly exposed invalid applications.

Tests:
- Add regression coverage for directive validation across schema, type, field, argument, enum value, input field, and Federation scenarios.

Chores:
- Add patch release notes for schema directive validation changes.