### PR TITLE
Reduce DataLoader allocation and enqueue overhead

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,17 @@
+---
+release type: patch
+social_messages:
+  x: >-
+    {project_name} {version} is out! DataLoader now spends less time allocating
+    and enqueueing batch entries. https://strawberry.rocks/release/{version}
+  linkedin: >-
+    {project_name} {version} is out! We've reduced DataLoader's allocation and
+    enqueue overhead while preserving batching, caching, and cancellation
+    behavior. No application changes are needed.
+---
+
+This release fixes unnecessary allocation and enqueue overhead in DataLoader.
+
+Batch entries now use slotted dataclasses and avoid runtime generic construction.
+Batch selection also avoids repeated attribute lookups and length-method calls.
+Existing batching, caching, priming, and cancellation behavior is preserved.

--- a/strawberry/dataloader.py
+++ b/strawberry/dataloader.py
@@ -32,13 +32,13 @@ T = TypeVar("T")
 K = TypeVar("K")
 
 
-@dataclass
+@dataclass(slots=True)
 class LoaderTask(Generic[K, T]):
     key: K
     future: Future
 
 
-@dataclass
+@dataclass(slots=True)
 class Batch(Generic[K, T]):
     tasks: list[LoaderTask] = dataclasses.field(default_factory=list)
     dispatched: bool = False
@@ -47,7 +47,7 @@ class Batch(Generic[K, T]):
     )
 
     def add_task(self, key: Any, future: Future) -> None:
-        task = LoaderTask[K, T](key, future)
+        task: LoaderTask[K, T] = LoaderTask(key, future)
         self.tasks.append(task)
         future.add_done_callback(self._on_future_done)
 
@@ -223,19 +223,20 @@ class DataLoader(Generic[K, T]):
 def should_create_new_batch(loader: DataLoader, batch: Batch) -> bool:
     return bool(
         batch.dispatched
-        or (loader.max_batch_size and len(batch) >= loader.max_batch_size)
+        or (loader.max_batch_size and len(batch.tasks) >= loader.max_batch_size)
     )
 
 
 def get_current_batch(loader: DataLoader) -> Batch:
-    if loader.batch and not should_create_new_batch(loader, loader.batch):
-        return loader.batch
+    batch = loader.batch
+    if batch is not None and batch.tasks and not should_create_new_batch(loader, batch):
+        return batch
 
-    loader.batch = Batch()
+    batch = loader.batch = Batch()
 
-    dispatch(loader, loader.batch)
+    dispatch(loader, batch)
 
-    return loader.batch
+    return batch
 
 
 def dispatch(loader: DataLoader, batch: Batch) -> None:

--- a/tests/benchmarks/test_dataloader.py
+++ b/tests/benchmarks/test_dataloader.py
@@ -1,0 +1,27 @@
+import asyncio
+
+import pytest
+from pytest_codspeed.plugin import BenchmarkFixture
+
+from strawberry.dataloader import DataLoader
+
+
+async def load_values(keys: list[int]) -> list[int]:
+    # Yield like an async database driver, without artificial I/O latency.
+    await asyncio.sleep(0)
+    return keys
+
+
+async def load_many_values(count: int, cache: bool) -> list[int]:
+    loader = DataLoader(load_fn=load_values, cache=cache)
+    return await loader.load_many(range(count))
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("count", [1, 10, 100, 10_000])
+@pytest.mark.parametrize("cache", [False, True])
+def test_dataloader_batch(benchmark: BenchmarkFixture, count: int, cache: bool):
+    def run() -> list[int]:
+        return asyncio.run(load_many_values(count, cache))
+
+    assert benchmark(run) == list(range(count))

--- a/tests/test_dataloaders.py
+++ b/tests/test_dataloaders.py
@@ -53,10 +53,13 @@ async def test_gathering(mocker: MockerFixture):
 
 
 @pytest.mark.asyncio
-async def test_max_batch_size(mocker: MockerFixture):
+@pytest.mark.parametrize("cache", [False, True])
+async def test_max_batch_size(mocker: MockerFixture, cache: bool):
     mock_loader = mocker.Mock(side_effect=idx)
 
-    loader = DataLoader(load_fn=cast("IDXType", mock_loader), max_batch_size=2)
+    loader = DataLoader(
+        load_fn=cast("IDXType", mock_loader), max_batch_size=2, cache=cache
+    )
 
     [value_a, value_b, value_c] = await asyncio.gather(
         loader.load(1),
@@ -406,7 +409,8 @@ async def test_cancelled_future_with_failing_loader():
 
 
 @pytest.mark.asyncio
-async def test_all_futures_cancelled_skips_load_fn():
+@pytest.mark.parametrize("cache", [False, True])
+async def test_all_futures_cancelled_skips_load_fn(cache: bool):
     """When all futures in a batch are cancelled before dispatch, the load_fn
     should not be called at all.  This prevents wasted work like database
     queries whose results no one is waiting for.
@@ -418,7 +422,7 @@ async def test_all_futures_cancelled_skips_load_fn():
         call_count += 1
         return keys
 
-    loader = DataLoader(load_fn=counting_loader, cache=False)
+    loader = DataLoader(load_fn=counting_loader, cache=cache)
 
     future_a = cast("Future[Any]", loader.load(1))
     future_b = cast("Future[Any]", loader.load(2))
@@ -437,7 +441,8 @@ async def test_all_futures_cancelled_skips_load_fn():
 
 
 @pytest.mark.asyncio
-async def test_cancelled_futures_cancel_dispatch_task():
+@pytest.mark.parametrize("cache", [False, True])
+async def test_cancelled_futures_cancel_dispatch_task(cache: bool):
     """When all futures in a batch are cancelled, the underlying dispatch
     task should also be cancelled.  This is important for resource cleanup
     when using asyncio.TaskGroup or similar structured concurrency patterns.
@@ -447,7 +452,7 @@ async def test_cancelled_futures_cancel_dispatch_task():
         await asyncio.sleep(10)
         return keys
 
-    loader = DataLoader(load_fn=slow_loader, cache=False)
+    loader = DataLoader(load_fn=slow_loader, cache=cache)
 
     future_a = cast("Future[Any]", loader.load(1))
     future_b = cast("Future[Any]", loader.load(2))
@@ -475,7 +480,8 @@ async def test_cancelled_futures_cancel_dispatch_task():
 
 
 @pytest.mark.asyncio
-async def test_cancelled_futures_cancel_running_dispatch():
+@pytest.mark.parametrize("cache", [False, True])
+async def test_cancelled_futures_cancel_running_dispatch(cache: bool):
     """When all futures are cancelled after load_fn has already started,
     the dispatch task should still be cancelled, interrupting the in-progress
     load_fn via CancelledError.
@@ -488,7 +494,7 @@ async def test_cancelled_futures_cancel_running_dispatch():
         await asyncio.sleep(10)
         return keys
 
-    loader = DataLoader(load_fn=slow_loader, cache=False)
+    loader = DataLoader(load_fn=slow_loader, cache=cache)
 
     future_a = cast("Future[Any]", loader.load(1))
     future_b = cast("Future[Any]", loader.load(2))
@@ -517,7 +523,8 @@ async def test_cancelled_futures_cancel_running_dispatch():
 
 
 @pytest.mark.asyncio
-async def test_partial_cancellation_still_dispatches():
+@pytest.mark.parametrize("cache", [False, True])
+async def test_partial_cancellation_still_dispatches(cache: bool):
     """When only some futures in a batch are cancelled, the batch should
     still dispatch and deliver results for the non-cancelled futures.
     """
@@ -528,7 +535,7 @@ async def test_partial_cancellation_still_dispatches():
         call_count += 1
         return keys
 
-    loader = DataLoader(load_fn=counting_loader, cache=False)
+    loader = DataLoader(load_fn=counting_loader, cache=cache)
 
     future_a = cast("Future[Any]", loader.load(1))
     future_b = cast("Future[Any]", loader.load(2))
@@ -652,3 +659,70 @@ def test_works_when_created_in_a_different_loop(mocker: MockerFixture):
     assert data == 1
 
     mock_loader.assert_called_once_with([1])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cache", [False, True])
+async def test_batching_window(cache: bool):
+    calls: list[list[int]] = []
+
+    async def load(keys: list[int]) -> list[int]:
+        calls.append(keys)
+        return keys
+
+    loader = DataLoader(load_fn=load, cache=cache)
+    first = loader.load(1)
+    # Scheduling the dispatch task must still allow loads in this next turn
+    # to join the batch, before load_fn starts.
+    await asyncio.sleep(0)
+    second = loader.load(2)
+    assert calls == []
+    assert await asyncio.gather(first, second) == [1, 2]
+    assert await loader.load(3) == 3
+    assert calls == [[1, 2], [3]]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cache", [False, True])
+async def test_prime_empty_batch_then_load(cache: bool):
+    calls: list[list[int]] = []
+
+    async def load(keys: list[int]) -> list[int]:
+        calls.append(keys)
+        return keys
+
+    loader = DataLoader(load_fn=load, cache=cache, max_batch_size=2)
+    first = loader.load(1)
+    loader.prime(1, 10)
+    # A pending dispatch for the emptied batch must not affect later loads.
+    assert await loader.load_many([2, 3, 4]) == [2, 3, 4]
+    assert await first == 10
+    assert calls == [[2, 3], [4]]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cache", [False, True])
+async def test_partial_cancellation_during_load(cache: bool):
+    started = asyncio.Event()
+    finish = asyncio.Event()
+    calls: list[list[int]] = []
+
+    async def load(keys: list[int]) -> list[int]:
+        calls.append(keys)
+        started.set()
+        await finish.wait()
+        return keys
+
+    loader = DataLoader(load_fn=load, cache=cache)
+    first = cast("Future[int]", loader.load(1))
+    second = loader.load(2)
+    await started.wait()
+    first.cancel()
+    await asyncio.sleep(0)
+    finish.set()
+
+    assert await asyncio.wait_for(second, timeout=1) == 2
+    assert first.cancelled()
+    # A cancelled cached future must be replaced on the next load.
+    assert await asyncio.wait_for(loader.load(1), timeout=1) == 1
+    assert calls == [[1, 2], [1]]


### PR DESCRIPTION
DataLoader currently constructs a parameterized generic task object for every
uncached key. Use slotted batch/task records and plain, statically annotated task
construction to reduce that overhead. Keep the shared enqueue helpers and trim
batch-selection lookups without changing dispatch timing.

Add coverage for batching across event-loop turns, priming an entire pending
batch, and partial cancellation during a running load; exercise existing batch
limits and cancellation tests with both cache modes. Include small/large batch
benchmarks and a patch release note.

Validation: 786 tests passed across schema, Django, DataLoader, and the new
benchmark cases (14 skipped, 2 xfailed). All 36 DataLoader tests also pass against
main. Repository Ruff lint/format checks and mypy pass.

Against main f9bbe8e9 on CPython 3.14.1/macOS arm64, local median time for 10,000
keys falls from 30.07 to 23.65 ms without caching and 31.47 to 25.06 ms with an
empty enabled cache. Ten-key batches improve by 6–8%; single-key changes are small.
These measurements isolate DataLoader overhead with one async yield, not database
latency. The full CI version matrix remains to be run.

Review note: slots remove dynamic attributes and weak references from LoaderTask
and Batch, implementation records that are exported from the module.

## Summary by Sourcery

Optimize DataLoader’s internal batch and task handling to improve throughput without changing dispatch semantics.

Enhancements:
- Reduce DataLoader allocation and enqueue overhead while preserving batching, caching, priming, and cancellation behavior.

Tests:
- Expand DataLoader coverage across event-loop batching, batch priming, partial cancellation, batch limits, and both cache modes.
- Add small and large DataLoader performance benchmarks.

Chores:
- Add patch release notes for the DataLoader performance improvements.