### PR TITLE
Use compact separators in default JSON encoders

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,23 @@
+---
+release type: patch
+social_messages:
+  x: >-
+    {project_name} {version} is out! Smaller JSON responses with compact default
+    encoding, preserving Unicode escaping and custom encoders.
+    https://strawberry.rocks/release/{version}
+  linkedin: >-
+    {project_name} {version} is out. Strawberry's default JSON encoders now omit
+    optional separator spaces to reduce response sizes. Unicode escaping,
+    Django-specific serialization, and custom encoder overrides are preserved.
+---
+
+This release fixes unnecessary whitespace in responses produced by Strawberry's
+shared default JSON encoders, reducing their size without changing decoded data.
+
+The encoders now omit spaces after commas and colons. This also applies to
+WebSocket messages and SSE/multipart JSON payloads that use these encoders;
+protocol framing is unchanged. Unicode escaping, Django's `DjangoJSONEncoder`,
+and custom `encode_json` overrides retain their existing behavior.
+
+Channels' ordinary HTTP responses still use their separate serialization path
+and are unaffected by this change.

--- a/strawberry/django/views.py
+++ b/strawberry/django/views.py
@@ -133,7 +133,7 @@ class BaseView:
         )
 
     def encode_json(self, data: object) -> str | bytes:
-        return json.dumps(data, cls=DjangoJSONEncoder)
+        return json.dumps(data, cls=DjangoJSONEncoder, separators=(",", ":"))
 
 
 class GraphQLView(

--- a/strawberry/http/base.py
+++ b/strawberry/http/base.py
@@ -63,7 +63,7 @@ class BaseView(Generic[Request]):
         return json.loads(data)
 
     def encode_json(self, data: object) -> str | bytes:
-        return json.dumps(data)
+        return json.dumps(data, separators=(",", ":"))
 
     def parse_query_params(self, params: QueryParams) -> dict[str, Any]:
         params = dict(params)

--- a/tests/django/test_json.py
+++ b/tests/django/test_json.py
@@ -1,0 +1,58 @@
+import datetime
+import json
+from decimal import Decimal
+from uuid import UUID
+
+import pytest
+from django.core.serializers.json import DjangoJSONEncoder
+from django.http import HttpResponse
+
+from strawberry.django.views import AsyncGraphQLView, GraphQLView
+from tests.views.schema import schema
+
+
+@pytest.mark.parametrize("view_class", [GraphQLView, AsyncGraphQLView])
+@pytest.mark.parametrize("batch", [False, True])
+def test_default_json_encoding_preserves_django_types(view_class, batch):
+    payload = {
+        "data": {
+            "amount": Decimal("12.30"),
+            "created": datetime.datetime(
+                2026, 9, 6, 12, 30, tzinfo=datetime.timezone.utc
+            ),
+            "id": UUID("12345678-1234-5678-1234-567812345678"),
+            "message": "café 🍓, :",
+        },
+        "errors": [{"message": "Something failed", "path": ["field", 0]}],
+    }
+    expected = (
+        '{"data":{"amount":"12.30","created":"2026-09-06T12:30:00Z",'
+        '"id":"12345678-1234-5678-1234-567812345678",'
+        r'"message":"caf\u00e9 \ud83c\udf53, :"},'
+        '"errors":[{"message":"Something failed","path":["field",0]}]}'
+    )
+    data = [payload, payload] if batch else payload
+    expected = f"[{expected},{expected}]" if batch else expected
+
+    response = view_class(schema=schema).create_response(data, HttpResponse())
+
+    assert response.content.decode() == expected
+    assert json.loads(response.content) == json.loads(
+        json.dumps(data, cls=DjangoJSONEncoder)
+    )
+
+
+@pytest.mark.parametrize("view_class", [GraphQLView, AsyncGraphQLView])
+@pytest.mark.parametrize("as_bytes", [False, True])
+def test_custom_json_encoder_is_authoritative(view_class, as_bytes):
+    class CustomView(view_class):
+        def encode_json(self, data: object) -> str | bytes:
+            encoded = json.dumps(data, ensure_ascii=False, indent=2)
+            return encoded.encode() if as_bytes else encoded
+
+    payload = {"data": {"message": "café 🍓"}}
+    response = CustomView(schema=schema).create_response(payload, HttpResponse())
+
+    assert (
+        response.content == json.dumps(payload, ensure_ascii=False, indent=2).encode()
+    )

--- a/tests/django/test_json.py
+++ b/tests/django/test_json.py
@@ -4,16 +4,22 @@ from decimal import Decimal
 from uuid import UUID
 
 import pytest
-from django.core.serializers.json import DjangoJSONEncoder
-from django.http import HttpResponse
 
-from strawberry.django.views import AsyncGraphQLView, GraphQLView
 from tests.views.schema import schema
 
 
-@pytest.mark.parametrize("view_class", [GraphQLView, AsyncGraphQLView])
+@pytest.fixture(params=["GraphQLView", "AsyncGraphQLView"])
+def view_class(request):
+    from strawberry.django import views
+
+    return getattr(views, request.param)
+
+
 @pytest.mark.parametrize("batch", [False, True])
 def test_default_json_encoding_preserves_django_types(view_class, batch):
+    from django.core.serializers.json import DjangoJSONEncoder
+    from django.http import HttpResponse
+
     payload = {
         "data": {
             "amount": Decimal("12.30"),
@@ -42,9 +48,10 @@ def test_default_json_encoding_preserves_django_types(view_class, batch):
     )
 
 
-@pytest.mark.parametrize("view_class", [GraphQLView, AsyncGraphQLView])
 @pytest.mark.parametrize("as_bytes", [False, True])
 def test_custom_json_encoder_is_authoritative(view_class, as_bytes):
+    from django.http import HttpResponse
+
     class CustomView(view_class):
         def encode_json(self, data: object) -> str | bytes:
             encoded = json.dumps(data, ensure_ascii=False, indent=2)

--- a/tests/http/test_http.py
+++ b/tests/http/test_http.py
@@ -34,23 +34,47 @@ async def test_the_http_handler_uses_the_views_decode_json_method(
     assert spy.call_count == 1
 
 
-async def test_the_http_handler_supports_bytes_encoded_json(
-    http_client: HttpClient, mocker
+@pytest.mark.parametrize("as_bytes", [False, True])
+async def test_the_http_handler_preserves_custom_encoded_json(
+    http_client: HttpClient, mocker, request, as_bytes: bool
 ):
-    """Check that http handlers correctly deal with byte return type from `encode_json`"""
+    if request.node.get_closest_marker("channels"):
+        pytest.skip("Channels HTTP responses use a separate serialization path")
 
-    def patched_encode_json(self, data: object) -> bytes:
-        return json.dumps(data).encode()
+    def patched_encode_json(self, data: object) -> str | bytes:
+        encoded = json.dumps(data, ensure_ascii=False, indent=2)
+        return encoded.encode() if as_bytes else encoded
 
     mocker.patch("strawberry.http.base.BaseView.encode_json", patched_encode_json)
+    if request.node.get_closest_marker("django"):
+        mocker.patch(
+            "strawberry.django.views.BaseView.encode_json", patched_encode_json
+        )
 
-    response = await http_client.query(query="{ hello }")
+    response = await http_client.query(query='{ hello(name: "café 🍓") }')
     assert response.status_code == 200
     assert response.headers["content-type"].split(";")[0] == "application/json"
 
     data = response.json["data"]
     assert isinstance(data, dict)
-    assert data["hello"] == "Hello world"
+    assert data["hello"] == "Hello café 🍓"
+    assert response.text == json.dumps(response.json, ensure_ascii=False, indent=2)
+
+
+@pytest.mark.parametrize("query", ['{ hello(name: "café 🍓, :") }', "{ alwaysFail }"])
+async def test_default_http_json_is_compact(http_client: HttpClient, request, query):
+    if request.node.get_closest_marker("channels"):
+        pytest.skip("Channels HTTP responses use a separate serialization path")
+
+    response = await http_client.query(query=query)
+
+    assert response.status_code == 200
+    assert response.text == json.dumps(response.json, separators=(",", ":"))
+    if "hello" in query:
+        assert response.json["data"] == {"hello": "Hello café 🍓, :"}
+        assert r"\u00e9 \ud83c\udf53" in response.text
+    else:
+        assert response.json["errors"]
 
 
 async def test_exception(http_client: HttpClient, mocker):

--- a/tests/http/test_json.py
+++ b/tests/http/test_json.py
@@ -1,0 +1,32 @@
+import json
+
+import pytest
+
+from strawberry.http.base import BaseView
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        (
+            {"data": {"message": "café 🍓, :", "values": [1, True, None]}},
+            r'{"data":{"message":"caf\u00e9 \ud83c\udf53, :","values":[1,true,null]}}',
+        ),
+        (
+            {
+                "data": None,
+                "errors": [{"message": "Something failed", "path": ["x", 0]}],
+            },
+            '{"data":null,"errors":[{"message":"Something failed","path":["x",0]}]}',
+        ),
+        (
+            [{"data": {"ok": True}}, {"errors": [{"message": "Failed"}]}],
+            '[{"data":{"ok":true}},{"errors":[{"message":"Failed"}]}]',
+        ),
+    ],
+)
+def test_default_json_encoding(payload: object, expected: str) -> None:
+    encoded = BaseView().encode_json(payload)
+
+    assert encoded == expected
+    assert json.loads(encoded) == json.loads(json.dumps(payload)) == payload

--- a/tests/http/test_streaming.py
+++ b/tests/http/test_streaming.py
@@ -5,8 +5,37 @@ from strawberry.http.base import BaseView
 from strawberry.http.streaming import (
     MultipartSubscriptionTransport,
     MultipartTransport,
+    SSETransport,
 )
 from strawberry.subscriptions import MULTIPART_SUBSCRIPTION_PROTOCOL
+
+
+def test_compact_json_preserves_stream_framing() -> None:
+    view = BaseView()
+
+    def encode(data: object) -> str:
+        encoded = view.encode_json(data)
+        assert isinstance(encoded, str)
+        return encoded
+
+    payload = {"data": {"message": "café\n🍓"}}
+    encoded = r'{"data":{"message":"caf\u00e9\n\ud83c\udf53"}}'
+    multipart = MultipartTransport()
+    subscription = MultipartSubscriptionTransport()
+    sse = SSETransport()
+
+    assert multipart.encode_multipart_data(payload, encode) == (
+        "\r\nContent-Type: application/json; charset=utf-8\r\n"
+        f"Content-Length: {len(encoded.encode())}\r\n\r\n{encoded}\r\n---"
+    )
+    wrapped = '{"payload":' + encoded + "}"
+    assert subscription.encode_next(payload, encode) == (
+        "\r\nContent-Type: application/json; charset=utf-8\r\n"
+        f"Content-Length: {len(wrapped.encode())}\r\n\r\n{wrapped}\r\n--graphql"
+    )
+    assert sse.encode_next(payload, encode) == f"event: next\r\ndata: {encoded}\r\n\r\n"
+    assert sse.encode_complete() == "event: complete\r\ndata: \r\n\r\n"
+    assert sse.heartbeat_message(encode) == ": ping\r\n\r\n"
 
 
 def test_multipart_transport_encode_multipart_data_uses_utf8_byte_length() -> None:


### PR DESCRIPTION
Default JSON responses currently include optional spaces after commas and colons. This change adds `separators=(",", ":")` to the shared HTTP encoder and Django encoder to reduce response size without changing decoded data.

DjangoJSONEncoder, Unicode escaping, and custom `encode_json` overrides remain unchanged. WebSocket messages and SSE/multipart payloads using these hooks also become compact, while protocol framing and multipart byte lengths remain correct. Channels' separate ordinary HTTP serialization path is unchanged.

This is a patch-level formatting change. Consumers comparing exact response bytes, including snapshots and hashes, may need updates. Includes regression coverage and a patch release note.

### Measurements

Isolated encoder-only measurements against upstream main `b78fb6b1`, using CPython 3.14.1 on macOS arm64. Medians of nine alternating paired rounds; 100,000 calls per round for small payloads and 200 for large payloads. The small payload contains a Unicode greeting and a boolean; the large payload contains 1,000 user records.

| Encoder | Payload | Bytes before / after | Encoding time before / after |
| --- | --- | --- | --- |
| Shared | Small | 63 / 59 (6.35% smaller) | 1.080 / 1.441 microseconds |
| Shared | Large | 152,691 / 139,690 (8.51% smaller) | 652.618 / 652.343 microseconds |
| Django | Small | 63 / 59 (6.35% smaller) | 1.448 / 1.459 microseconds |
| Django | Large | 152,691 / 139,690 (8.51% smaller) | 656.775 / 651.589 microseconds |

Explicit separators bypass CPython's cached default encoder, adding approximately 0.36 microseconds for the small shared-encoder payload. Large-payload and Django timing differences were small relative to observed variation. These results demonstrate uncompressed size savings, not improved request latency.

### Validation

- HTTP, Django, WebSocket, Channels, ASGI, FastAPI, Litestar and Sanic suites: 2,894 passed, 274 skipped, 158 xfailed, 24 non-strict xpassed; no failures.
- Incremental multipart, SSE and streaming tests with GraphQL 3.3.0rc0: 368 passed, 172 skipped, 43 xfailed; no failures.
- Repository-wide Ruff lint, formatting and mypy checks passed.
- Tests cover exact output, decoded equivalence, Unicode escaping, error and batch payloads, Django Decimal/datetime/UUID serialization, custom string/byte encoders, and streaming framing.

## Summary by Sourcery

Use compact separators in default JSON encoders to reduce response sizes while preserving serialization behavior and transport framing.

Bug Fixes:
- Remove unnecessary whitespace from the shared and Django default JSON encoders to reduce response sizes without changing decoded data.

Enhancements:
- Preserve existing Unicode escaping, Django type serialization, custom encoder overrides, and streaming protocol framing while applying compact JSON to supported HTTP, WebSocket, SSE, and multipart payloads.

Documentation:
- Add patch release notes documenting compact JSON output, affected transports, preserved behavior, and the unaffected Channels HTTP path.

Tests:
- Add regression coverage for compact output, decoded equivalence, Unicode and Django-specific serialization, custom encoders, batch and error payloads, and streaming framing byte lengths.