### PR TITLE
Fix Channels HTTP encode_json overrides

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,19 @@
+---
+release type: patch
+social_messages:
+  x: >-
+    {project_name} {version} is out! Channels HTTP responses now respect custom
+    encode_json overrides returning str or bytes.
+    https://strawberry.rocks/release/{version}
+  linkedin: >-
+    {project_name} {version} is out! This release fixes custom JSON encoding for
+    Channels HTTP responses. Both synchronous and asynchronous consumers now
+    respect encode_json overrides returning str or bytes.
+---
+
+This release fixes Channels HTTP responses bypassing custom `encode_json`
+overrides.
+
+Both `GraphQLHTTPConsumer` and `SyncGraphQLHTTPConsumer` now use the encoding hook
+for single and batched JSON responses, including GraphQL errors. Bytes are sent
+unchanged, while strings are encoded as UTF-8.

--- a/strawberry/channels/handlers/http_handler.py
+++ b/strawberry/channels/handlers/http_handler.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import dataclasses
-import json
 from functools import cached_property
 from io import BytesIO
 from typing import TYPE_CHECKING, Any, TypeGuard
@@ -21,6 +20,7 @@ from django.core.files import uploadhandler
 from django.http.multipartparser import MultiPartParser
 
 from strawberry.http.async_base_view import AsyncBaseHTTPView
+from strawberry.http.base import BaseView
 from strawberry.http.sync_base_view import SyncBaseHTTPView
 from strawberry.http.temporal_response import TemporalResponse
 from strawberry.http.typevars import Context, RootValue
@@ -198,7 +198,9 @@ class SyncChannelsRequestAdapter(BaseChannelsRequestAdapter, SyncHTTPRequestAdap
         return self.request.form_data
 
 
-class BaseGraphQLHTTPConsumer(ChannelsConsumer, AsyncHttpConsumer):
+class BaseGraphQLHTTPConsumer(
+    ChannelsConsumer, AsyncHttpConsumer, BaseView[ChannelsRequest]
+):
     graphql_ide_html: str
     graphql_ide: GraphQL_IDE | None = "graphiql"
 
@@ -227,8 +229,9 @@ class BaseGraphQLHTTPConsumer(ChannelsConsumer, AsyncHttpConsumer):
         response_data: GraphQLHTTPResponse | list[GraphQLHTTPResponse],
         sub_response: TemporalResponse,
     ) -> ChannelsResponse:
+        content = self.encode_json(response_data)
         return ChannelsResponse(
-            content=json.dumps(response_data).encode(),
+            content=content.encode() if isinstance(content, str) else content,
             status=sub_response.status_code,
             headers={k.encode(): v.encode() for k, v in sub_response.headers.items()},
         )

--- a/tests/channels/test_http_handler.py
+++ b/tests/channels/test_http_handler.py
@@ -1,0 +1,70 @@
+import json
+
+import pytest
+from channels.testing import HttpCommunicator
+
+import strawberry
+from strawberry.channels import GraphQLHTTPConsumer, SyncGraphQLHTTPConsumer
+from strawberry.schema.config import StrawberryConfig
+from tests.views.schema import Query
+
+
+@pytest.mark.parametrize(
+    "consumer_class", [GraphQLHTTPConsumer, SyncGraphQLHTTPConsumer]
+)
+@pytest.mark.parametrize("return_bytes", [False, True], ids=["str", "bytes"])
+@pytest.mark.parametrize("batch", [False, True], ids=["single", "batch"])
+@pytest.mark.parametrize("with_error", [False, True], ids=["success", "error"])
+async def test_encode_json_override(consumer_class, return_bytes, batch, with_error):
+    encoded_inputs = []
+    encoded_outputs = []
+
+    class CustomConsumer(consumer_class):
+        def encode_json(self, data: object) -> str | bytes:
+            encoded_inputs.append(data)
+            # Distinct formatting and non-ASCII text expose bypasses or re-encoding.
+            content = json.dumps(data, ensure_ascii=False, indent=2) + "\n"
+            result = content.encode() if return_bytes else content
+            encoded_outputs.append(result)
+            return result
+
+    schema = strawberry.Schema(
+        query=Query,
+        config=StrawberryConfig(batching_config={"max_operations": 10}),
+    )
+    query = '{ teapot setHeader(name: "Strawberry") }'
+    if with_error:
+        query = "{ missingField }"
+    operation = {"query": query}
+    body = [operation, operation] if batch else operation
+    communicator = HttpCommunicator(
+        CustomConsumer.as_asgi(schema=schema),
+        "POST",
+        "/graphql",
+        body=json.dumps(body).encode(),
+        headers=[(b"content-type", b"application/json")],
+    )
+
+    response = await communicator.get_response()
+
+    assert len(encoded_inputs) == 1
+    assert len(encoded_outputs) == 1
+    output = encoded_outputs[0]
+    assert response["body"] == (output if return_bytes else output.encode())
+    if return_bytes:
+        assert response["body"] is output
+    assert response["status"] == (200 if with_error else 418)
+    headers = dict(response["headers"])
+    assert headers[b"Content-Type"] == b"application/json"
+    if not with_error:
+        assert headers[b"X-Name"] == b"Strawberry"
+    data = json.loads(response["body"])
+    assert data == encoded_inputs[0]
+    results = data if batch else [data]
+    assert len(results) == (2 if batch else 1)
+    for result in results:
+        if with_error:
+            assert result["data"] is None
+            assert "missingField" in result["errors"][0]["message"]
+        else:
+            assert result == {"data": {"teapot": "🫖", "setHeader": "Strawberry"}}

--- a/tests/channels/test_http_handler.py
+++ b/tests/channels/test_http_handler.py
@@ -1,21 +1,23 @@
 import json
 
 import pytest
-from channels.testing import HttpCommunicator
 
-import strawberry
-from strawberry.channels import GraphQLHTTPConsumer, SyncGraphQLHTTPConsumer
 from strawberry.schema.config import StrawberryConfig
 from tests.views.schema import Query
 
 
 @pytest.mark.parametrize(
-    "consumer_class", [GraphQLHTTPConsumer, SyncGraphQLHTTPConsumer]
+    "consumer_name", ["GraphQLHTTPConsumer", "SyncGraphQLHTTPConsumer"]
 )
 @pytest.mark.parametrize("return_bytes", [False, True], ids=["str", "bytes"])
 @pytest.mark.parametrize("batch", [False, True], ids=["single", "batch"])
 @pytest.mark.parametrize("with_error", [False, True], ids=["success", "error"])
-async def test_encode_json_override(consumer_class, return_bytes, batch, with_error):
+async def test_encode_json_override(consumer_name, return_bytes, batch, with_error):
+    from channels.testing import HttpCommunicator
+
+    import strawberry.channels
+
+    consumer_class = getattr(strawberry.channels, consumer_name)
     encoded_inputs = []
     encoded_outputs = []
 


### PR DESCRIPTION
Channels HTTP responses previously called `json.dumps` directly, bypassing custom `encode_json` overrides. Both synchronous and asynchronous consumers now use the established hook, passing bytes through unchanged and encoding strings as UTF-8. Status, headers, content type, and single/batch error handling are preserved.

Adds 16 regression cases covering both consumers, string and bytes overrides, single and batch responses, GraphQL errors, and custom status and headers. Includes a patch release note; the existing documentation already describes the hook.

Validation:
- Channels and shared HTTP suite (`pytest tests/channels tests/http -m channels -q`): 352 passed, 55 skipped, 16 xfailed, 2 xpassed.
- All 16 new cases fail with the previous response implementation restored in memory.
- Repository-wide Ruff lint, formatting, and mypy checks passed.
- `git diff --check` passed.

## Summary by Sourcery

Ensure Channels HTTP consumers use the established JSON encoding hook for all GraphQL responses.

Bug Fixes:
- Fix Channels HTTP responses so synchronous and asynchronous consumers respect custom `encode_json` overrides for single and batched responses, including GraphQL errors.
- Preserve custom JSON output returned as bytes or strings while retaining response status and headers.

Tests:
- Add regression coverage for both Channels consumers, string and bytes encoders, single and batched responses, GraphQL errors, and custom response metadata.