### PR TITLE
Reduce awaitable detection overhead

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,19 @@
+---
+release type: patch
+social_messages:
+  x: >-
+    {project_name} {version} is out! This release fixes avoidable overhead when
+    checking resolver results for awaitability.
+    https://strawberry.rocks/release/{version}
+  linkedin: >-
+    {project_name} {version} is out. This release fixes avoidable overhead in
+    awaitable detection while preserving support for synchronous results,
+    coroutines, and custom awaitables.
+---
+
+This release fixes avoidable function-call overhead when checking resolver results
+for awaitability.
+
+Strawberry performs the existing graphql-core checks directly, preserving attribute
+access order, side effects, and exception behavior. The existing fast path for
+built-in scalar and container types is unchanged.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,18 +2,17 @@
 release type: patch
 social_messages:
   x: >-
-    {project_name} {version} is out! This release fixes avoidable overhead when
-    checking resolver results for awaitability.
+    {project_name} {version} is out! A small optimization reduces overhead when
+    running your GraphQL queries, with no code changes needed. 🍓
     https://strawberry.rocks/release/{version}
   linkedin: >-
-    {project_name} {version} is out. This release fixes avoidable overhead in
-    awaitable detection while preserving support for synchronous results,
-    coroutines, and custom awaitables.
+    {project_name} {version} is out. Strawberry now does a little less work when
+    handling GraphQL resolver results. Your existing synchronous and asynchronous
+    resolvers continue to work as before, with no code changes needed. 🍓
 ---
 
-This release fixes avoidable function-call overhead when checking resolver results
-for awaitability.
+This release fixes unnecessary overhead when handling resolver results.
 
-Strawberry performs the existing graphql-core checks directly, preserving attribute
-access order, side effects, and exception behavior. The existing fast path for
-built-in scalar and container types is unchanged.
+Strawberry now does a little less work to check whether a result needs to be
+awaited. This small optimization works automatically with your existing
+synchronous and asynchronous resolvers, with no code changes needed.

--- a/strawberry/execution/is_awaitable.py
+++ b/strawberry/execution/is_awaitable.py
@@ -7,9 +7,9 @@ large result sets containing primitive values.
 
 from __future__ import annotations
 
+from inspect import CO_ITERABLE_COROUTINE
+from types import CoroutineType, GeneratorType
 from typing import Any
-
-from graphql.pyutils.is_awaitable import is_awaitable as graphql_core_is_awaitable
 
 __all__ = ["optimized_is_awaitable"]
 
@@ -43,7 +43,7 @@ def optimized_is_awaitable(value: Any) -> bool:
 
     Performance characteristics:
     - Fast path for primitives: O(1) type lookup
-    - Falls back to graphql-core's is_awaitable for other types
+    - Checks other types directly, preserving graphql-core's check order
 
     Args:
         value: The value to check
@@ -55,5 +55,13 @@ def optimized_is_awaitable(value: Any) -> bool:
     if type(value) in _NON_AWAITABLE_TYPES:
         return False
 
-    # Fallback to graphql-core's implementation for other types
-    return graphql_core_is_awaitable(value)
+    # Keep graphql-core's order: isinstance can access a custom __class__, and
+    # hasattr can invoke a descriptor. Reordering changes their side effects.
+    return (
+        isinstance(value, CoroutineType)
+        or (
+            isinstance(value, GeneratorType)
+            and bool(value.gi_code.co_flags & CO_ITERABLE_COROUTINE)
+        )
+        or hasattr(value, "__await__")
+    )

--- a/tests/execution/test_is_awaitable.py
+++ b/tests/execution/test_is_awaitable.py
@@ -1,0 +1,161 @@
+import asyncio
+import types
+from collections.abc import Generator
+from typing import Any
+
+import pytest
+from graphql.pyutils import is_awaitable
+
+from strawberry.execution import optimized_is_awaitable
+
+
+class CustomAwaitable:
+    def __await__(self) -> Generator[None, None, int]:
+        yield
+        return 1
+
+
+class AwaitableInt(int, CustomAwaitable):
+    pass
+
+
+class AsyncIterable:
+    def __aiter__(self) -> Any:
+        return self
+
+    async def __anext__(self) -> int:
+        raise StopAsyncIteration
+
+
+@types.coroutine
+def generator_coroutine() -> Generator[None, None, int]:
+    yield
+    return 1
+
+
+async def native_coroutine() -> int:
+    return 1
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        None,
+        False,
+        1,
+        1.2,
+        "x",
+        b"x",
+        bytearray(),
+        [],
+        (),
+        {},
+        set(),
+        frozenset(),
+        object(),
+        CustomAwaitable(),
+        AwaitableInt(1),
+        AsyncIterable(),
+    ],
+)
+def test_values(value: Any) -> None:
+    assert optimized_is_awaitable(value) is is_awaitable(value)
+
+
+@pytest.mark.parametrize(
+    "factory", [native_coroutine, generator_coroutine, lambda: (x for x in [])]
+)
+def test_coroutines_and_generators(factory: Any) -> None:
+    value = factory()
+    try:
+        assert optimized_is_awaitable(value) is is_awaitable(value)
+    finally:
+        value.close()
+
+
+@pytest.mark.asyncio
+async def test_future_and_task() -> None:
+    future = asyncio.get_running_loop().create_future()
+    task = asyncio.create_task(native_coroutine())
+    try:
+        for value in (future, task):
+            assert optimized_is_awaitable(value) is is_awaitable(value) is True
+        future.set_result(1)
+        assert await future == await task == 1
+        for value in (future, task):
+            assert optimized_is_awaitable(value) is True
+    finally:
+        if not task.done():
+            task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+        future.cancel()
+
+
+@pytest.mark.parametrize("attribute", ["__class__", "__await__"])
+@pytest.mark.parametrize("error", [None, AttributeError, RuntimeError])
+@pytest.mark.parametrize("spoof", [None, types.CoroutineType, types.GeneratorType])
+def test_attribute_order_and_exceptions(attribute: str, error: Any, spoof: Any) -> None:
+    class Unusual:
+        def __getattribute__(self, name: str) -> Any:
+            events.append(name)
+            if name == attribute and error:
+                raise error("descriptor failed")
+            if name == "__class__" and spoof:
+                return spoof
+            if name == "__await__":
+                return None  # graphql-core checks presence, not callability
+            return object.__getattribute__(self, name)
+
+    def observe(detector: Any) -> tuple[Any, list[str]]:
+        events.clear()
+        try:
+            result = detector(Unusual())
+        except (AttributeError, RuntimeError) as exc:
+            result = (type(exc), str(exc))
+        return result, events.copy()
+
+    events: list[str] = []
+    assert observe(optimized_is_awaitable) == observe(is_awaitable)
+
+
+@pytest.mark.parametrize("error", [None, AttributeError, RuntimeError])
+def test_await_descriptor(error: Any) -> None:
+    events: list[str] = []
+
+    class Descriptor:
+        @property
+        def __await__(self) -> Any:
+            events.append("await")
+            if error:
+                raise error("failed")
+            return None
+
+    if error is RuntimeError:
+        with pytest.raises(RuntimeError, match="failed"):
+            optimized_is_awaitable(Descriptor())
+    else:
+        assert optimized_is_awaitable(Descriptor()) is (error is None)
+    assert events == ["await"]
+
+
+def test_orm_like_dynamic_attributes() -> None:
+    accesses: list[str] = []
+
+    class Model:
+        def __getattr__(self, name: str) -> Any:
+            accesses.append(name)
+            raise AttributeError(name)
+
+    assert optimized_is_awaitable(Model()) is False
+    assert accesses == ["__await__"]
+
+
+@pytest.mark.parametrize(
+    "base", [int, float, str, bytes, bytearray, list, tuple, dict, set, frozenset]
+)
+def test_primitive_subclasses(base: type) -> None:
+    subclass = type(
+        "AwaitablePrimitive", (base,), {"__await__": CustomAwaitable.__await__}
+    )
+    value = subclass()
+    assert optimized_is_awaitable(value) is is_awaitable(value) is True


### PR DESCRIPTION
Remove an extra Python function call when checking non-primitive resolver results for awaitability. Inline graphql-core's existing checks after Strawberry's exact-type fast path, preserving their order so custom `__class__` and `__await__` attributes retain the same side effects and exception behavior.

The CodSpeed baselines from #4617 are now on main. This PR is rebased onto main and contains only the detector change, regression tests, and a patch release note.

The tests cover native coroutines, generator coroutines and ordinary generators, pending/completed Futures and Tasks, custom awaitables, awaitable scalar/container subclasses, async iterables, ORM-like dynamic attributes, descriptors, spoofed classes, and exception/access-order equivalence with graphql-core. No resolver, scheduling, parsing, validation, or transport behavior changes.

### Performance evidence

The restored implementation is byte-for-byte identical to the candidate measured locally against main `38c6bdb3307daf6cc040b863131f88880670707e`. Both variants used Python 3.14.1 and graphql-core 3.2.11 on an Apple M1 Max. Measurements warmed both variants, alternated their order across 13 paired rounds, and held the shared exclusive benchmark lock. Fixtures and schema construction were outside timings.

| Detector workload | Baseline median ± MAD | Candidate median ± MAD | Paired change median ± MAD |
|---|---:|---:|---:|
| Primitive-heavy | 34.48 ± 0.20 ns | 34.28 ± 0.34 ns | -0.44 ± 0.52% |
| Object-heavy | 98.59 ± 0.70 ns | 86.43 ± 0.62 ns | -12.29 ± 0.24% |
| Native coroutine | 53.83 ± 0.13 ns | 41.08 ± 0.11 ns | -23.59 ± 0.35% |
| Custom awaitable | 117.16 ± 0.22 ns | 103.89 ± 0.17 ns | -11.67 ± 0.52% |
| Mixed | 53.57 ± 0.15 ns | 50.15 ± 0.15 ns | -6.32 ± 0.31% |

Negative changes mean faster. Full synchronous and asynchronous GraphQL execution changes were within noise; these results do not establish a request-level speedup. The desktop had background load, and only Python 3.14.1 was measured. The benchmark workloads in #4617 provide ongoing CI coverage rather than a timing assertion in unit tests.

### Validation

- Detector and benchmark tests: 60 passed with RuntimeWarnings treated as errors.
- Detector, schema and execution suites passed with graphql-core 3.2.11, 3.2.6 and 3.3.0rc0.
- Repository Ruff lint and formatting checks passed.
- Mypy: no issues in 242 source files.

## Summary by Sourcery

Optimize resolver-result awaitability checks without changing execution behavior.

Enhancements:
- Reduce awaitability detection overhead for non-primitive resolver results while preserving graphql-core compatibility and behavior.

Tests:
- Add comprehensive regression coverage for awaitable types, dynamic attributes, descriptors, spoofed classes, and exception/access-order equivalence.