### PR TITLE
Reduce overhead for plain fields and no-argument resolvers

### DIFF
--- a/.github/workflows/strawberry-django-compatibility.yml
+++ b/.github/workflows/strawberry-django-compatibility.yml
@@ -55,6 +55,16 @@ jobs:
           python-version: "3.14"
           cache-dependency-glob: strawberry-django/uv.lock
 
+      - name: Backport upstream compatibility test corrections
+        if: steps.strawberry-django.outputs.version == '0.88.1'
+        working-directory: strawberry-django
+        run: |
+          # https://github.com/strawberry-graphql/strawberry-django/pull/955
+          # Correct stale pagination and SDL-order expectations in this release.
+          # Only tests are replaced; the released integration code is unchanged.
+          git fetch --depth=1 origin 44ee3815700e2572b6851880210c94cefe6ff449
+          git checkout FETCH_HEAD -- tests/relay/test_fields.py tests/projects/test_schema.py
+
       - name: Install Strawberry Django
         run: uv sync --locked --project strawberry-django --python 3.14
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,3 +18,7 @@ Plain fields avoid temporary argument containers. Standard no-argument
 resolvers without field extensions or applicable exception handlers skip
 argument conversion and only construct `Info` when requested. Custom field
 subclasses retain their existing resolution behavior.
+
+This release also fixes lazy type aliases inside lists and other containers
+when postponed annotations are enabled. These aliases resolve without requiring
+another field to have resolved the referenced type first.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,20 @@
+---
+release type: patch
+social_messages:
+  x: >-
+    {project_name} {version} is out! This release reduces execution overhead for
+    plain fields and no-argument resolvers that do not request Info.
+    https://strawberry.rocks/release/{version}
+  linkedin: >-
+    {project_name} {version} is out. Strawberry now does less work when resolving
+    plain fields and no-argument resolvers that do not request Info, reducing
+    overhead when returning collections of objects.
+---
+
+This release fixes unnecessary execution overhead for plain fields and
+no-argument resolvers that do not request `Info`.
+
+Plain fields avoid temporary argument containers. Standard no-argument
+resolvers without field extensions or applicable exception handlers skip
+argument conversion and only construct `Info` when requested. Custom field
+subclasses retain their existing resolution behavior.

--- a/docs/types/schema-configurations.md
+++ b/docs/types/schema-configurations.md
@@ -126,6 +126,11 @@ class CustomInfo(Info):
 schema = strawberry.Schema(query=Query, config=StrawberryConfig(info_class=CustomInfo))
 ```
 
+Strawberry constructs `Info` when it is needed by a resolver, field extension,
+custom field, or exception handler. Plain fields and standard no-argument
+resolvers that do not request it can skip construction. A custom `Info`
+constructor should therefore not be used as a hook for every field execution.
+
 ### enable_experimental_incremental_execution
 
 <Note>

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -70,7 +70,7 @@ from strawberry.types.base import (
 )
 from strawberry.types.cast import get_strawberry_type_cast
 from strawberry.types.enum import StrawberryEnumDefinition, has_enum_definition
-from strawberry.types.field import UNRESOLVED
+from strawberry.types.field import UNRESOLVED, StrawberryField
 from strawberry.types.lazy_type import LazyType
 from strawberry.types.private import is_private
 from strawberry.types.scalar import ScalarWrapper, scalar
@@ -97,7 +97,6 @@ if TYPE_CHECKING:
     from strawberry.schema.exception_handlers import ExceptionHandler
     from strawberry.schema_directive import StrawberrySchemaDirective
     from strawberry.types.enum import EnumValue
-    from strawberry.types.field import StrawberryField
     from strawberry.types.info import Info
     from strawberry.types.scalar import ScalarDefinition
 
@@ -894,6 +893,15 @@ class GraphQLCoreConverter:
         field_exception_handlers = self._get_field_exception_handlers(field)
 
         if field.is_basic_field and not field_exception_handlers:
+            if type(field) is StrawberryField:
+
+                def _get_basic_field(
+                    _source: Any, info: GraphQLResolveInfo, **kwargs: Any
+                ) -> Any:
+                    return field.default_resolver(_source, field.python_name)
+
+                _get_basic_field._is_default = True  # type: ignore
+                return _get_basic_field
 
             def _get_basic_result(_source: Any, *args: str, **kwargs: Any) -> Any:
                 # Call `get_result` without an info object or any args or
@@ -903,6 +911,45 @@ class GraphQLCoreConverter:
             _get_basic_result._is_default = True  # type: ignore
 
             return _get_basic_result
+
+        # Only standard fields without middleware can omit Info and argument
+        # conversion. Custom fields may use Info in get_result even when their
+        # resolver does not request it. Inspect after extension.apply above.
+        if (
+            type(field) is StrawberryField
+            and not field.extensions
+            and not field_exception_handlers
+            and (resolver := field.base_resolver) is not None
+            and not field.arguments
+            and resolver.info_parameter is None
+        ):
+            has_self = resolver.self_parameter is not None
+            parent_parameter = resolver.parent_parameter
+            root_parameter = resolver.root_parameter
+
+            def _get_no_arguments_result(
+                _source: Any, info: GraphQLResolveInfo, **_kwargs: Any
+            ) -> Any:
+                args = (_source,) if has_self else ()
+                kwargs = {}
+                if parent_parameter is not None:
+                    kwargs[parent_parameter.name] = _source
+                if root_parameter is not None:
+                    kwargs[root_parameter.name] = _source
+                return resolver(*args, **kwargs)
+
+            if field.is_async:
+
+                async def _get_no_arguments_result_async(
+                    _source: Any, info: GraphQLResolveInfo, **kwargs: Any
+                ) -> Any:
+                    return await await_maybe(_get_no_arguments_result(_source, info))
+
+                _get_no_arguments_result_async._is_default = False  # type: ignore
+                return _get_no_arguments_result_async
+
+            _get_no_arguments_result._is_default = False  # type: ignore
+            return _get_no_arguments_result
 
         def _strawberry_info_from_graphql(info: GraphQLResolveInfo) -> Info:
             return self.config.info_class(

--- a/strawberry/schema/schema_converter.py
+++ b/strawberry/schema/schema_converter.py
@@ -894,11 +894,13 @@ class GraphQLCoreConverter:
 
         if field.is_basic_field and not field_exception_handlers:
             if type(field) is StrawberryField:
+                default_resolver = field.default_resolver
+                python_name = field.python_name
 
                 def _get_basic_field(
                     _source: Any, info: GraphQLResolveInfo, **kwargs: Any
                 ) -> Any:
-                    return field.default_resolver(_source, field.python_name)
+                    return default_resolver(_source, python_name)
 
                 _get_basic_field._is_default = True  # type: ignore
                 return _get_basic_field

--- a/strawberry/utils/typing.py
+++ b/strawberry/utils/typing.py
@@ -198,10 +198,24 @@ def _get_namespace_from_ast(
 
     extra: dict[str, Any] = {}
 
-    if isinstance(expr, ast.Expr) and isinstance(
-        expr.value, (ast.BinOp, ast.Subscript)
-    ):
+    if isinstance(expr, ast.Expr):
         extra.update(_get_namespace_from_ast(expr.value, globalns, localns))
+    elif isinstance(expr, ast.Name):
+        # Aliases can hide lazy references inside containers such as list[Alias].
+        # Supply their target before Python recursively evaluates the container.
+        alias = (localns or {}).get(expr.id, (globalns or {}).get(expr.id))
+        if get_origin(alias) is Annotated:
+            type_arg, *metadata = get_args(alias)
+            if isinstance(type_arg, ForwardRef):
+                type_name = type_arg.__forward_arg__
+                already_resolved = (globalns and type_name in globalns) or (
+                    localns and type_name in localns
+                )
+                if not already_resolved:
+                    for annotation in metadata:
+                        if isinstance(annotation, StrawberryLazyReference):
+                            extra[type_name] = annotation.resolve_forward_ref(type_arg)
+                            break
     elif isinstance(expr, ast.BinOp):
         for elt in (expr.left, expr.right):
             extra.update(_get_namespace_from_ast(elt, globalns, localns))

--- a/tests/schema/test_resolver_fast_paths.py
+++ b/tests/schema/test_resolver_fast_paths.py
@@ -1,0 +1,272 @@
+from collections.abc import AsyncGenerator
+from operator import getitem
+from typing import Any, Optional
+
+import pytest
+
+import strawberry
+from strawberry.extensions import FieldExtension
+from strawberry.schema.config import StrawberryConfig
+from strawberry.types.field import StrawberryField
+
+
+def test_basic_descriptor_is_read_once_per_alias():
+    reads = []
+
+    @strawberry.type
+    class Query:
+        value: int = strawberry.field(name="renamed")
+
+    class Source:
+        @property
+        def value(self):
+            reads.append("value")
+            return len(reads)
+
+    result = strawberry.Schema(Query).execute_sync(
+        "{ first: renamed second: renamed }", root_value=Source()
+    )
+    assert result.errors is None
+    assert result.data == {"first": 1, "second": 2}
+    assert reads == ["value", "value"]
+
+
+@pytest.mark.parametrize("default_resolver", [getattr, dict.get, getitem])
+@pytest.mark.parametrize("missing", [False, True])
+def test_basic_default_resolver_semantics(default_resolver, missing):
+    calls = []
+
+    def resolve(source, name):
+        calls.append(name)
+        return default_resolver(source, name)
+
+    @strawberry.type
+    class Query:
+        value: Optional[int] = strawberry.field(name="renamed")
+
+    source = {} if missing else {"value": 42}
+    if default_resolver is getattr:
+        source = type("Source", (), source)()
+
+    result = strawberry.Schema(
+        Query, config=StrawberryConfig(default_resolver=resolve)
+    ).execute_sync("{ alias: renamed }", root_value=source)
+    assert calls == ["value"]
+    assert result.data == {"alias": None if missing else 42}
+    if missing and default_resolver is not dict.get:
+        assert len(result.errors) == 1
+        assert result.errors[0].path == ["alias"]
+        assert isinstance(
+            result.errors[0].original_error,
+            AttributeError if default_resolver is getattr else KeyError,
+        )
+    else:
+        assert result.errors is None
+
+
+def test_custom_field_get_result_keeps_info_and_fresh_arguments():
+    calls = []
+
+    class CustomField(StrawberryField):
+        def get_result(self, source, info, args, kwargs):
+            calls.append((self.python_name, info, args, kwargs))
+            result = super().get_result(source, info, args, kwargs)
+            args.append("mutated after call")
+            kwargs["mutated"] = True
+            return result + 1
+
+    @strawberry.type
+    class Query:
+        basic: int = CustomField()
+
+        @CustomField()
+        def resolved(self) -> int:
+            return self.basic
+
+    result = strawberry.Schema(Query).execute_sync(
+        "{ a: basic b: basic c: resolved d: resolved }", root_value=Query(basic=10)
+    )
+    assert result.errors is None
+    assert result.data == dict.fromkeys("abcd", 11)
+    assert [call[0] for call in calls] == ["basic", "basic", "resolved", "resolved"]
+    assert calls[0][1] is calls[1][1] is None
+    assert [call[1].path.key for call in calls[2:]] == ["c", "d"]
+    assert len({id(call[2]) for call in calls}) == 4
+    assert len({id(call[3]) for call in calls}) == 4
+
+
+def test_custom_info_constructed_only_when_requested():
+    constructed = []
+    invoked = []
+
+    class CustomInfo(strawberry.Info):
+        def __init__(self, **kwargs: Any):
+            super().__init__(**kwargs)
+            constructed.append(self)
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def plain(self) -> int:
+            invoked.append("plain")
+            return 1
+
+        @strawberry.field
+        def requested(self, details: strawberry.Info) -> str:
+            invoked.append("requested")
+            assert isinstance(details, CustomInfo)
+            assert details.context == {"key": 2}
+            assert details.root_value is root
+            assert details.python_name == "requested"
+            return details.path.key
+
+    root = Query()
+    result = strawberry.Schema(
+        Query, config=StrawberryConfig(info_class=CustomInfo)
+    ).execute_sync(
+        "{ plain alias: requested }", root_value=root, context_value={"key": 2}
+    )
+    assert result.errors is None
+    assert result.data == {"plain": 1, "alias": "alias"}
+    assert invoked == ["plain", "requested"]
+    assert len(constructed) == 1
+
+
+def test_extension_apply_and_resolve_keep_custom_field_behavior():
+    calls = []
+
+    class Extension(FieldExtension):
+        def apply(self, field):
+            calls.append("apply")
+
+        def resolve(self, next_, source, info, **kwargs: Any):
+            calls.append(("extension", info.path.key))
+            return next_(source, info, **kwargs) + 1
+
+    @strawberry.type
+    class Query:
+        @strawberry.field(extensions=[Extension()])
+        def value(self) -> int:
+            calls.append("resolver")
+            return 1
+
+    result = strawberry.Schema(Query).execute_sync("{ alias: value }")
+    assert result.errors is None
+    assert result.data == {"alias": 2}
+    assert calls == ["apply", ("extension", "alias"), "resolver"]
+
+
+async def test_sync_returning_awaitable_and_async_resolver_called_once():
+    calls = []
+
+    async def result():
+        calls.append("awaited")
+        return 3
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def sync(self) -> int:
+            calls.append("sync")
+            return result()
+
+        @strawberry.field
+        async def async_(self) -> int:
+            calls.append("async")
+            return 4
+
+    execution = await strawberry.Schema(Query).execute("{ sync async: async_ }")
+    assert execution.errors is None
+    assert execution.data == {"sync": 3, "async": 4}
+    assert sorted(calls) == ["async", "awaited", "sync"]
+
+
+async def test_subscription_invoked_once_and_payload_resolvers_once_per_event():
+    calls = []
+
+    @strawberry.type
+    class Item:
+        value: int
+
+        @strawberry.field
+        def doubled(self) -> int:
+            calls.append("payload")
+            return self.value * 2
+
+    @strawberry.type
+    class Query:
+        value: int = 1
+
+    @strawberry.type
+    class Subscription:
+        @strawberry.subscription
+        async def items(self) -> AsyncGenerator[Item, None]:
+            calls.append("subscription")
+            yield Item(value=1)
+            yield Item(value=2)
+
+    stream = await strawberry.Schema(Query, subscription=Subscription).subscribe(
+        "subscription { items { value doubled } }"
+    )
+    results = [result async for result in stream]
+    assert all(result.errors is None for result in results)
+    assert [result.data for result in results] == [
+        {"items": {"value": 1, "doubled": 2}},
+        {"items": {"value": 2, "doubled": 4}},
+    ]
+    assert calls == ["subscription", "payload", "payload"]
+
+
+@strawberry.input
+class RecursiveInput:
+    value: int
+    children: list["RecursiveInput"] = strawberry.field(default_factory=list)
+
+
+def test_recursive_input_keeps_generic_conversion():
+    seen = []
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def total(self, item: RecursiveInput) -> int:
+            seen.append(item)
+            return item.value + sum(child.value for child in item.children)
+
+    result = strawberry.Schema(Query).execute_sync(
+        "{ total(item: {value: 1, children: [{value: 2}]}) }"
+    )
+    assert result.errors is None
+    assert result.data == {"total": 3}
+    assert isinstance(seen[0], RecursiveInput)
+    assert isinstance(seen[0].children[0], RecursiveInput)
+
+
+async def test_schema_middleware_can_forward_extra_keywords():
+    from strawberry.extensions import SchemaExtension
+
+    class Middleware(SchemaExtension):
+        def resolve(self, next_, root, info, *args: Any, **kwargs: Any):
+            return next_(root, info, *args, **kwargs, unused="ignored")
+
+    @strawberry.type
+    class Query:
+        basic: int = 1
+
+        @strawberry.field
+        def resolved(self) -> int:
+            return 2
+
+        @strawberry.field
+        async def async_resolved(self) -> int:
+            return 3
+
+    schema = strawberry.Schema(Query, extensions=[Middleware])
+    result = schema.execute_sync("{ basic resolved }", root_value=Query())
+    assert result.errors is None
+    assert result.data == {"basic": 1, "resolved": 2}
+    result = await schema.execute(
+        "{ basic resolved asyncResolved }", root_value=Query()
+    )
+    assert result.errors is None
+    assert result.data == {"basic": 1, "resolved": 2, "asyncResolved": 3}

--- a/tests/utils/test_typing.py
+++ b/tests/utils/test_typing.py
@@ -1,6 +1,8 @@
 import typing
 from typing import Annotated, ClassVar, ForwardRef, Optional, Union
 
+import pytest
+
 import strawberry
 from strawberry.types.lazy_type import LazyType
 from strawberry.utils.typing import eval_type, get_optional_annotation, is_classvar
@@ -95,6 +97,46 @@ def test_eval_type_with_deferred_annotations():
             LazyType("datetime", "datetime"),
             strawberry.lazy("datetime"),
         ]
+    )
+
+
+@pytest.mark.parametrize("use_localns", [False, True])
+@pytest.mark.parametrize(
+    ("expression", "expected"),
+    [
+        ("Alias", lambda value: value),
+        ("list[Alias]", lambda value: list[value]),
+        ("Optional[Alias]", lambda value: Optional[value]),
+        ("list[Alias] | None", lambda value: Optional[list[value]]),
+        ("dict[str, list[Alias]]", lambda value: dict[str, list[value]]),
+    ],
+)
+def test_eval_type_nested_lazy_alias(expression, expected, use_localns):
+    lazy = strawberry.lazy("tests.utils.test_typing")
+    namespace = {
+        "Alias": Annotated["Fruit", lazy, "metadata"],
+        "Optional": Optional,
+    }
+    globalns, localns = ({}, namespace) if use_localns else (namespace, {})
+
+    result = eval_type(ForwardRef(expression), globalns, localns)
+
+    assert result == expected(
+        Annotated[LazyType("Fruit", "tests.utils.test_typing"), lazy, "metadata"]
+    )
+
+
+@pytest.mark.parametrize("use_localns", [False, True])
+def test_eval_type_lazy_alias_preserves_existing_type(use_localns):
+    class ExistingType: ...
+
+    lazy = strawberry.lazy("tests.utils.test_typing")
+    namespace = {"Alias": Annotated["Fruit", lazy], "Fruit": ExistingType}
+    globalns, localns = ({}, namespace) if use_localns else (namespace, {})
+
+    assert (
+        eval_type(ForwardRef("list[Alias]"), globalns, localns)
+        == list[Annotated[ExistingType, lazy]]
     )
 
 


### PR DESCRIPTION
Plain fields allocate argument containers just to read a value, while no-argument resolvers construct `Info` and perform argument conversion even when neither is needed. This change reduces that overhead for standard fields, preserving custom field subclasses, extensions, permissions and applicable exception handlers.

Resolver metadata is collected during schema construction. Execution preserves self/root/parent binding, schema middleware keywords, configured default resolvers, synchronous and asynchronous results, and subscriptions. Regression tests cover these contracts, and the documentation explains when custom `Info` constructors run.

Lazy type aliases inside containers now supply their lazy references before Python evaluates the annotation. A schema using `list[Alias]` works without another field first populating the namespace. Tests cover global and local aliases, optional and nested containers, extra annotation metadata, and existing runtime types.

For Strawberry Django 0.88.1, the compatibility job backports only the two corrected test files from [upstream PR #955](https://github.com/strawberry-graphql/strawberry-django/pull/955), pinned to commit `44ee3815700e2572b6851880210c94cefe6ff449`. They update stale Relay pagination expectations and compare schema definitions independently of top-level ordering. The full suite runs against the published integration code. The backport applies only to that exact release; there are no skips or expected-failure exemptions.

The existing CodSpeed benchmarks cover the execution workloads. This PR adds no benchmark fixtures or measurement changes.

Validation:

- 1,519 relevant core tests passed, with 14 skips and 4 expected failures.
- All 20 focused typing checks passed after adding the final metadata and runtime-type cases; the original failing alias test also passes in isolation.
- The full Django compatibility suite passed: 1,243 tests, 11 skips.
- Mypy, Ruff, formatting, whitespace checks and applicable pre-commit hooks passed.
- On commit `617be2b3`, the full Python 3.10–3.15 matrix, Windows tests, integrations, typing checks, coverage and required CI gate [passed](https://github.com/strawberry-graphql/strawberry/actions/runs/34169078087). The [Django compatibility workflow](https://github.com/strawberry-graphql/strawberry/actions/runs/34169078111) also passed.
- CodSpeed passed with 69 benchmarks classified as untouched and 33 skipped. It reports no performance changes above its reporting threshold on this head; this result does not establish an overall performance gain.
