### PR TITLE
Document ASV charts for future benchmark releases

### DIFF
--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -120,6 +120,9 @@ Stress sizes retain their parameter IDs, even though their measurement schedule
 changes. The stadium adds a smaller 1,800-seat PR case; the 45,000/90,000-seat cases
 are available as stress cases.
 
-The public overview at [speed.strawberry.rocks](https://speed.strawberry.rocks/)
-links the current CPU, native and memory measurements. The obsolete ASV harness,
-stored runs and historical charts are removed from the reporting repository.
+The dashboard at [speed.strawberry.rocks](https://speed.strawberry.rocks/) uses ASV
+to chart native walltime measurements from this pytest-codspeed suite. The
+[reporting workflow](https://github.com/strawberry-graphql/benchmarks) tracks main
+and future stable releases, retaining results from the modern suite after
+resetting obsolete history. Changed workloads or environments start separate
+series. Its methodology page links the CPU and memory measurements.


### PR DESCRIPTION
The benchmark dashboard continues to use ASV for native timing charts, including future stable releases. Update the benchmark README to describe the retained dashboard, the fresh history baseline, and separate series for changed workloads or environments.

Companion reporting implementation: https://github.com/strawberry-graphql/benchmarks/pull/31

Validation: repository pre-commit checks passed for the changed documentation. No release note, as requested for this benchmark infrastructure work.

## Summary by Sourcery

Document the benchmark dashboard and reporting approach for current and future stable releases.

Enhancements:
- Document the ASV benchmark dashboard’s ongoing native timing coverage, refreshed history baseline, release tracking, and separate series for changed workloads or environments.

Documentation:
- Update the benchmark README with links and methodology details for the retained public dashboard and its CPU and memory reporting.